### PR TITLE
Use __future__ to enable floating-point division of integers in Python 2

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -2,7 +2,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import errno
 import math
@@ -264,7 +264,7 @@ def quickpkg_main(options, args, eout):
 			size_str = "0"
 		else:
 			power_of_2 = math.log(size, 2)
-			power_of_2 = 10*int(power_of_2/10)
+			power_of_2 = 10*(power_of_2//10)
 			unit = units.get(power_of_2)
 			if unit:
 				size = float(size)/(2**power_of_2)

--- a/pym/_emerge/Scheduler.py
+++ b/pym/_emerge/Scheduler.py
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from __future__ import print_function, unicode_literals
+from __future__ import division, print_function, unicode_literals
 
 from collections import deque
 import gc

--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from __future__ import print_function, unicode_literals
+from __future__ import division, print_function, unicode_literals
 
 import errno
 import logging
@@ -1499,14 +1499,14 @@ def action_info(settings, trees, myopts, myfiles):
 
 	vm_info = get_vm_info()
 	if "ram.total" in vm_info:
-		line = "%-9s %10d total" % ("KiB Mem:", vm_info["ram.total"] / 1024)
+		line = "%-9s %10d total" % ("KiB Mem:", vm_info["ram.total"] // 1024)
 		if "ram.free" in vm_info:
-			line += ",%10d free" % (vm_info["ram.free"] / 1024,)
+			line += ",%10d free" % (vm_info["ram.free"] // 1024,)
 		append(line)
 	if "swap.total" in vm_info:
-		line = "%-9s %10d total" % ("KiB Swap:", vm_info["swap.total"] / 1024)
+		line = "%-9s %10d total" % ("KiB Swap:", vm_info["swap.total"] // 1024)
 		if "swap.free" in vm_info:
-			line += ",%10d free" % (vm_info["swap.free"] / 1024,)
+			line += ",%10d free" % (vm_info["swap.free"] // 1024,)
 		append(line)
 
 	lastSync = portage.grabfile(os.path.join(

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from __future__ import print_function, unicode_literals
+from __future__ import division, print_function, unicode_literals
 
 import collections
 import errno
@@ -8446,7 +8446,7 @@ def _backtrack_depgraph(settings, trees, myopts, myparams, myaction, myfiles, sp
 	debug = "--debug" in myopts
 	mydepgraph = None
 	max_retries = myopts.get('--backtrack', 10)
-	max_depth = max(1, (max_retries + 1) / 2)
+	max_depth = max(1, (max_retries + 1) // 2)
 	allow_backtracking = max_retries > 0
 	backtracker = Backtracker(max_depth)
 	backtracked = 0

--- a/pym/_emerge/sync/old_tree_timestamp.py
+++ b/pym/_emerge/sync/old_tree_timestamp.py
@@ -1,5 +1,7 @@
-# Copyright 2010 Gentoo Foundation
+# Copyright 2010-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+from __future__ import division
 
 import locale
 import logging
@@ -27,16 +29,16 @@ def whenago(seconds):
 	out = []
 
 	if sec > 60:
-		mins = sec / 60
+		mins = sec // 60
 		sec = sec % 60
 	if mins > 60:
-		hrs = mins / 60
+		hrs = mins // 60
 		mins = mins % 60
 	if hrs > 24:
-		days = hrs / 24
+		days = hrs // 24
 		hrs = hrs % 24
 	if days > 365:
-		years = days / 365
+		years = days // 365
 		days = days % 365
 
 	if years:

--- a/pym/portage/_emirrordist/FetchTask.py
+++ b/pym/portage/_emirrordist/FetchTask.py
@@ -1,5 +1,7 @@
-# Copyright 2013 Gentoo Foundation
+# Copyright 2013-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+from __future__ import division
 
 import collections
 import errno
@@ -242,7 +244,7 @@ class FetchTask(CompositeTask):
 		remaining_tries = self.config.options.tries - len(self._tried_uris)
 		if remaining_tries > 0:
 
-			if remaining_tries <= self.config.options.tries / 2:
+			if remaining_tries <= self.config.options.tries // 2:
 				while self._primaryuri_stack:
 					uri = self._primaryuri_stack.pop()
 					if uri not in self._tried_uris:

--- a/pym/portage/_sets/dbapi.py
+++ b/pym/portage/_sets/dbapi.py
@@ -1,5 +1,7 @@
-# Copyright 2007-2012 Gentoo Foundation
+# Copyright 2007-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+from __future__ import division
 
 import time
 

--- a/pym/portage/cache/sqlite.py
+++ b/pym/portage/cache/sqlite.py
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 import re
 import sys
@@ -174,7 +174,7 @@ class database(fs_template.FsBased):
 		cursor.execute("PRAGMA page_size")
 		page_size=int(cursor.fetchone()[0])
 		# number of pages, sqlite default is 2000
-		cache_size = cache_bytes / page_size
+		cache_size = cache_bytes // page_size
 		cursor.execute("PRAGMA cache_size = %d" % cache_size)
 		cursor.execute("PRAGMA cache_size")
 		actual_cache_size = int(cursor.fetchone()[0])

--- a/pym/portage/dbapi/vartree.py
+++ b/pym/portage/dbapi/vartree.py
@@ -1,7 +1,7 @@
 # Copyright 1998-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 __all__ = [
 	"vardbapi", "vartree", "dblink"] + \
@@ -1043,7 +1043,7 @@ class vardbapi(dbapi):
 			from md5 import new as _new_hash
 
 		_hash_bits = 16
-		_hex_chars = int(_hash_bits / 4)
+		_hex_chars = _hash_bits // 4
 
 		def __init__(self, vardb):
 			self._vardb = vardb

--- a/pym/portage/localization.py
+++ b/pym/portage/localization.py
@@ -2,6 +2,8 @@
 # Copyright 2004-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+from __future__ import division
+
 import locale
 import math
 

--- a/pym/portage/output.py
+++ b/pym/portage/output.py
@@ -1,6 +1,8 @@
 # Copyright 1998-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+from __future__ import division
+
 __docformat__ = "epytext"
 
 import errno
@@ -778,14 +780,14 @@ class TermProgressBar(ProgressBar):
 				"<=>" + ((max_bar_width - bar_width) * " ") + "]")
 			return image
 		else:
-			percentage = int(100 * float(curval) / maxval)
+			percentage = 100 * curval // maxval
 			max_bar_width = bar_space - 1
 			_percent = ("%d%% " % percentage).rjust(percentage_str_width)
 			image = "%s%s" % (self._desc, _percent)
 
 			if cols < min_columns:
 				return image
-			offset = float(curval) / maxval
+			offset = curval / maxval
 			bar_width = int(offset * max_bar_width)
 			image = image + "[" + (bar_width * "=") + \
 				">" + ((max_bar_width - bar_width) * " ") + "]"

--- a/pym/portage/util/_eventloop/EventLoop.py
+++ b/pym/portage/util/_eventloop/EventLoop.py
@@ -1,5 +1,7 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+from __future__ import division
 
 import errno
 import logging
@@ -211,7 +213,7 @@ class EventLoop(object):
 					if timeout is None:
 						wait_timeout = None
 					else:
-						wait_timeout = float(timeout) / 1000
+						wait_timeout = timeout / 1000
 					# NOTE: In order to avoid a possible infinite wait when
 					# wait_timeout is None, the previous _run_timeouts()
 					# call must have returned False *with* _thread_condition
@@ -657,6 +659,6 @@ class _epoll_adapter(object):
 			if timeout is None or timeout < 0:
 				timeout = -1
 			elif timeout != 0:
-				 timeout = float(timeout) / 1000
+				timeout = timeout / 1000
 
 		return self._epoll_obj.poll(timeout)

--- a/pym/portage/util/_eventloop/PollSelectAdapter.py
+++ b/pym/portage/util/_eventloop/PollSelectAdapter.py
@@ -1,5 +1,7 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+from __future__ import division
 
 from .PollConstants import PollConstants
 import select
@@ -64,7 +66,7 @@ class PollSelectAdapter(object):
 			if timeout is not None and timeout < 0:
 				timeout = None
 			if timeout is not None:
-				select_args.append(float(timeout) / 1000)
+				select_args.append(timeout / 1000)
 
 		select_events = select.select(*select_args)
 		poll_events = []


### PR DESCRIPTION
The current version of this patch includes specifically:
1. enabling consistent Python 3 division behavior in all files where I found `/`,
2. replacing `/` with `//` where it seemed like integer division is desired,
3. removing `int()` and `float()` conversions that were no longer necessary after division behavior changes.

I'd dare say this is minor yet we want that for the next release. @Arfrever suggested that it fixes the issue of rounding download sizes down in Python 2.
