### PR TITLE
QA: use pngfix to find broken PNG files.

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 #
 # Miscellaneous shell functions that make use of the ebuild env but don't need
@@ -859,6 +859,33 @@ install_qa_check() {
 		fi
 
 		[[ ${abort} == yes ]] && die "multilib-strict check failed!"
+	fi
+
+	local pngfix=$(type -P pngfix)
+	if [[ -n ${pngfix} ]] ; then
+		local pngout=()
+		local next
+
+		while read -r -a pngout ; do
+			local error
+
+			case "${pngout[1]}" in
+				CHK)
+					error='invalid checksum'
+					;;
+				TFB)
+					error='broken IDAT window length'
+					;;
+			esac
+
+			if [[ -n ${error} ]] ; then
+				if [[ -z ${next} ]] ; then
+					eqawarn "QA Notice: broken .png files found:"
+					next=1
+				fi
+				eqawarn "   ${pngout[@]:7}: ${error}"
+			fi
+		done < <(find "${ED}" -type f -name '*.png' -exec "${pngfix}" {} +)
 	fi
 }
 


### PR DESCRIPTION
This was requested by graphics team a while ago, I think. Though their version was much more complex and relied on imagemagick. This one uses `pngfix` form libpng.
