### PR TITLE
repoman commit: Prefix commit message template with cat/PN

### DIFF
--- a/bin/repoman
+++ b/bin/repoman
@@ -2696,16 +2696,21 @@ else:
 		# We've read the content so the file is no longer needed.
 		commitmessagefile = None
 	if not commitmessage or not commitmessage.strip():
+		msg_prefix = ""
+		if repolevel > 1:
+			msg_prefix = "/".join(reposplit[1:]) + ": "
+
 		try:
 			editor = os.environ.get("EDITOR")
 			if editor and utilities.editor_is_executable(editor):
 				commitmessage = utilities.get_commit_message_with_editor(
-					editor, message=qa_output)
+					editor, message=qa_output, prefix=msg_prefix)
 			else:
 				commitmessage = utilities.get_commit_message_with_stdin()
 		except KeyboardInterrupt:
 			exithandler()
-		if not commitmessage or not commitmessage.strip():
+		if (not commitmessage or not commitmessage.strip()
+				or commitmessage.strip() == msg_prefix):
 			print("* no commit message?  aborting commit.")
 			sys.exit(1)
 	commitmessage = commitmessage.rstrip()

--- a/pym/repoman/utilities.py
+++ b/pym/repoman/utilities.py
@@ -399,7 +399,7 @@ def editor_is_executable(editor):
 	return os.access(filename, os.X_OK) and os.path.isfile(filename)
 
 
-def get_commit_message_with_editor(editor, message=None):
+def get_commit_message_with_editor(editor, message=None, prefix=""):
 	"""
 	Execute editor with a temporary file as it's argument
 	and return the file content afterwards.
@@ -408,13 +408,16 @@ def get_commit_message_with_editor(editor, message=None):
 	@type: string
 	@param message: An iterable of lines to show in the editor.
 	@type: iterable
+	@param prefix: Suggested prefix for the commit message summary line.
+	@type: string
 	@rtype: string or None
 	@return: A string on success or None if an error occurs.
 	"""
 	fd, filename = mkstemp()
 	try:
 		os.write(fd, _unicode_encode(_(
-			"\n# Please enter the commit message " + \
+			prefix +
+			"\n\n# Please enter the commit message " + \
 			"for your changes.\n# (Comment lines starting " + \
 			"with '#' will not be included)\n"),
 			encoding=_encodings['content'], errors='backslashreplace'))


### PR DESCRIPTION
Tried to make it clean yet helpful. Long story short:

* if committing inside package, prepends `app-foo/bar:`,
* if committing inside category, prepends `app-foo:`,
* if committing the whole repo, doesn't add any prefix.

I've also made it abort the commit if user leaves commit message unchanged (consisting only of the prefix). And I've added extra empty line for readability.