### PR TITLE
repoman: fix del of out of scope name in hg_scan

### DIFF
--- a/pym/repoman/scan.py
+++ b/pym/repoman/scan.py
@@ -168,4 +168,5 @@ class Changes(object):
 			with repoman_popen("hg status --no-status --removed .") as f:
 				removed = f.readlines()
 			self.removed = ["./" + elem.rstrip() for elem in removed]
-		del changed, new, removed
+			del removed
+		del changed, new


### PR DESCRIPTION
I was getting failures in a mercurial managed overlay:
```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python2.7/repoman", line 37, in <module>
    repoman_main(sys.argv[1:])
  File "/usr/lib64/python2.7/site-packages/repoman/main.py", line 102, in repoman_main
    vcs_settings, mydir, env)
  File "/usr/lib64/python2.7/site-packages/repoman/scanner.py", line 162, in __init__
    self.changed.scan(self.vcs_settings)
  File "/usr/lib64/python2.7/site-packages/repoman/scan.py", line 87, in scan
    vcscheck()
  File "/usr/lib64/python2.7/site-packages/repoman/scan.py", line 170, in scan_hg
    del changed, new, removed
UnboundLocalError: local variable 'removed' referenced before assignment
```