### PR TITLE
Add a deprecation warning for ruby 1.9

### DIFF
--- a/pym/repoman/qa_data.py
+++ b/pym/repoman/qa_data.py
@@ -343,6 +343,7 @@ suspect_virtual = {
 ruby_deprecated = frozenset([
 	"ruby_targets_ree18",
 	"ruby_targets_ruby18",
+	"ruby_targets_ruby19",
 ])
 
 


### PR DESCRIPTION
Ruby 1.9 was package masked and will be removed soon. Let's extend repoman's deprecation warning to it.