### PR TITLE
update egencache outdated header

### DIFF
--- a/bin/egencache
+++ b/bin/egencache
@@ -769,7 +769,7 @@ class GenChangeLogs(object):
 		output.write(textwrap.dedent('''\
 			# ChangeLog for %s
 			# Copyright 1999-%s Gentoo Foundation; Distributed under the GPL v2
-			# $Header: $
+			# $Id$
 
 			''' % (cp, time.strftime('%Y'))))
 


### PR DESCRIPTION
egencache --update-changelogs writes into
the ChangeLog header the text $Header: $
instead of $Id$, should be updated