### PR TITLE
repoman: fix vcsstatus for working with subversion workingcopies

### DIFF
--- a/pym/repoman/vcs/vcsstatus.py
+++ b/pym/repoman/vcs/vcsstatus.py
@@ -67,7 +67,7 @@ class VCSStatus(object):
 		try:
 			myf = repoman_popen(
 				"svn status --depth=files --verbose " +
-				portage._shell_quote(self.checkdir))
+				portage._shell_quote(checkdir))
 			myl = myf.readlines()
 			myf.close()
 		except IOError:


### PR DESCRIPTION
Commit d22abc6a686eaf204cab31387928ba85605a729b broke repoman for usage with subversion working copies.

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.4/repoman", line 37, in <module>
    repoman_main(sys.argv[1:])
  File "/usr/lib64/python3.4/site-packages/repoman/main.py", line 104, in repoman_main
    qatracker, can_force = scanner.scan_pkgs(can_force)
  File "/usr/lib64/python3.4/site-packages/repoman/scanner.py", line 260, in scan_pkgs
    self.status_check.check(self.check['ebuild_notadded'], checkdir, checkdir_relative, xpkg)
  File "/usr/lib64/python3.4/site-packages/repoman/vcs/vcsstatus.py", line 25, in check
    vcscheck(checkdir, checkdir_relative, xpkg)
  File "/usr/lib64/python3.4/site-packages/repoman/vcs/vcsstatus.py", line 70, in check_svn
    portage._shell_quote(self.checkdir))
AttributeError: 'VCSStatus' object has no attribute 'checkdir