### PR TITLE
repoman: add inherit deprecated for gstreamer and clutter eclasses

### DIFF
--- a/pym/repoman/checks/ebuilds/checks.py
+++ b/pym/repoman/checks/ebuilds/checks.py
@@ -427,6 +427,7 @@ class InheritDeprecated(LineCheck):
 		"gst-plugins-good": "gstreamer",
 		"gst-plugins-ugly": "gstreamer",
 		"gst-plugins10": "gstreamer",
+		"clutter": "gnome2",
 	}
 
 	_inherit_re = re.compile(r'^\s*inherit\s(.*)$')

--- a/pym/repoman/checks/ebuilds/checks.py
+++ b/pym/repoman/checks/ebuilds/checks.py
@@ -422,6 +422,11 @@ class InheritDeprecated(LineCheck):
 		"python": "python-r1 / python-single-r1 / python-any-r1",
 		"ruby": "ruby-ng",
 		"x-modular": "xorg-2",
+		"gst-plugins-bad": "gstreamer",
+		"gst-plugins-base": "gstreamer",
+		"gst-plugins-good": "gstreamer",
+		"gst-plugins-ugly": "gstreamer",
+		"gst-plugins10": "gstreamer",
 	}
 
 	_inherit_re = re.compile(r'^\s*inherit\s(.*)$')


### PR DESCRIPTION
Hi there,

All ebuilds using gst-* eclasses gone from the tree, except for gnonlin that is going to be treecleaned with older pitivi releases.

clutter.eclass lived a brief life and all of its usage should be covered by gnome2.eclass.