### PR TITLE
Add sync-git-clone-extra-opts and sync-git-pull-extra-opts to repos.conf

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -968,6 +968,12 @@ Specifies CVS repository.
 Specifies clone depth to use for DVCS repositories. Defaults to 1 (only
 the newest commit). If set to 0, the depth is unlimited.
 .TP
+.B sync\-git\-clone\-extra\-opts
+Extra options to give to git when cloning repository (git clone).
+.TP
+.B sync\-git\-pull\-extra\-opts
+Extra options to give to git when updating repository (git pull).
+.TP
 .B sync\-hooks\-only\-on\-change
 If set to true, then sync of a given repository will not trigger postsync
 hooks unless hooks would have executed for a master repository or the

--- a/pym/portage/sync/modules/git/__init__.py
+++ b/pym/portage/sync/modules/git/__init__.py
@@ -50,7 +50,10 @@ module_spec = {
 					'exists and is a valid Git repository',
 			},
 			'validate_config': CheckGitConfig,
-			'module_specific_options': (),
+			'module_specific_options': (
+				'sync-git-clone-extra-opts',
+				'sync-git-pull-extra-opts',
+				),
 		}
 	}
 }

--- a/pym/portage/sync/modules/git/git.py
+++ b/pym/portage/sync/modules/git/git.py
@@ -54,6 +54,8 @@ class GitSync(NewBase):
 			git_cmd_opts += " --quiet"
 		if self.repo.sync_depth is not None:
 			git_cmd_opts += " --depth %d" % self.repo.sync_depth
+		if self.repo.module_specific_options.get('sync-git-clone-extra-opts'):
+			git_cmd_opts += " %s" % self.repo.module_specific_options['sync-git-clone-extra-opts']
 		git_cmd = "%s clone%s %s ." % (self.bin_command, git_cmd_opts,
 			portage._shell_quote(sync_uri))
 		writemsg_level(git_cmd + "\n")
@@ -79,6 +81,8 @@ class GitSync(NewBase):
 		git_cmd_opts = ""
 		if self.settings.get("PORTAGE_QUIET") == "1":
 			git_cmd_opts += " --quiet"
+		if self.repo.module_specific_options.get('sync-git-pull-extra-opts'):
+			git_cmd_opts += " %s" % self.repo.module_specific_options['sync-git-pull-extra-opts']
 		git_cmd = "%s pull%s" % (self.bin_command, git_cmd_opts)
 		writemsg_level(git_cmd + "\n")
 


### PR DESCRIPTION
This feature would allow adding options to 'git clone' and 'git pull' when synchronizing a portage repo.