### PR TITLE
isolated-functions.sh: eliminate loop in has()

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -463,14 +463,12 @@ hasv() {
 }
 
 has() {
-	local needle=$1
+	local needle=$'\a'"$1"$'\a'
 	shift
+	local IFS=$'\a'
+	local haystack=$'\a'"$@"$'\a'
 
-	local x
-	for x in "$@"; do
-		[ "${x}" = "${needle}" ] && return 0
-	done
-	return 1
+	[[ "${haystack}" == *"${needle}"* ]]
 }
 
 __repo_attr() {


### PR DESCRIPTION
Looping is slow and clutters debug log.
Still this wouldn't matter that much if has() wasn't one of the most used functions.

Thus this patch should bring a general improvement.

---

I sent this patch to the mailing-list: https://archives.gentoo.org/gentoo-portage-dev/message/1fc26219c97bfce6b3586ae6c3479075, but the mail-bot is not sending me replies, so I cannot work with it, thus I'm posting it here.

To reply to the @zmedico's message:

> We used to have a similar implementation, but it was changed to a loop
in order to be 100% compatible with PMS. As far as I know, the only way
to implement it in a way that truely respects whitespace in elements is
with a loop.
> 
> BTW, your version would have to use this in order to respect word
broundaries:
>
    [[ " ${haystack} " == *" ${needle} "* ]]
>
However, that still doesn't completely respect whitespace. Consider:
>
    has " b c " a b c d e
>
I'm not aware of any cases in which we actually need to respect
whitespace in the has function, but according to PMS is should respect
whitespace IIRC.

I'm using `IFS=$'\a'`, so spaces do not matter anymore. This will provide same results as the loop unless needle or haystack contain `\a`, which is not likely to happen.