### PR TITLE
install-qa-check.d/60openrc: make sure initscrips aren't using #!/sbin/runscript

### DIFF
--- a/bin/install-qa-check.d/60openrc
+++ b/bin/install-qa-check.d/60openrc
@@ -12,6 +12,12 @@ openrc_check() {
 			if [[ ${d} == /etc/init.d && ${i} != *.sh ]] ; then
 				# skip non-shell-script for bug #451386
 				[[ $(head -n1 "${i}") =~ ^#!.*[[:space:]/](runscript|sh)$ ]] || continue
+				if [[ $(head -n1 "${i}") == '#!/sbin/runscript' ]] ; then
+					eqawarn "QA Notice: #!/sbin/runscript is deprecated, use #!/sbin/openrc-run instead:"
+					while read -r ;
+						do eqawarn "   ${REPLY}"
+					done <<<  ${i#${ED/%//}}
+				fi
 			fi
 			bash -n "${i}" || die "The init.d file has syntax errors: ${i}"
 		done


### PR DESCRIPTION
Now that everything in the tree uses openrc-run, block using runscript