### PR TITLE
Fix sync_uri parsing for paths beginning with file://

### DIFF
--- a/pym/portage/sync/modules/git/git.py
+++ b/pym/portage/sync/modules/git/git.py
@@ -47,7 +47,7 @@ class GitSync(NewBase):
 
 		sync_uri = self.repo.sync_uri
 		if sync_uri.startswith("file://"):
-			sync_uri = sync_uri[6:]
+			sync_uri = sync_uri[7:]
 
 		git_cmd_opts = ""
 		if self.settings.get("PORTAGE_QUIET") == "1":

--- a/pym/portage/sync/modules/rsync/rsync.py
+++ b/pym/portage/sync/modules/rsync/rsync.py
@@ -111,7 +111,7 @@ class RsyncSync(NewBase):
 
 		if syncuri.startswith("file://"):
 			self.proto = "file"
-			dosyncuri = syncuri[6:]
+			dosyncuri = syncuri[7:]
 			is_synced, exitcode, updatecache_flg = self._do_rsync(
 				dosyncuri, timestamp, opts)
 			self._process_exitcode(exitcode, dosyncuri, out, 1)

--- a/pym/portage/tests/sync/test_sync_local.py
+++ b/pym/portage/tests/sync/test_sync_local.py
@@ -41,7 +41,7 @@ class SyncLocalTestCase(TestCase):
 			[test_repo]
 			location = %(EPREFIX)s/var/repositories/test_repo
 			sync-type = %(sync-type)s
-			sync-uri = file:/%(EPREFIX)s/var/repositories/test_repo_sync
+			sync-uri = file://%(EPREFIX)s/var/repositories/test_repo_sync
 			auto-sync = %(auto-sync)s
 			%(repo_extra_keys)s
 		""")


### PR DESCRIPTION
Portage allows file URLs, i.e. paths beginning with 'file://',
in sync_uri. According to RFC-1738 [1](https://tools.ietf.org/html/rfc1738#section-3.10) a file URL must take the form
'file://<host>/foo/bar' or 'file:///foo/bar', when 'host' is omitted
(in this case localhost is assumed).

Portage incorrectly parses file URLs because it leaves the second slash
from the 'file://' prefix as a part of the URL. Additionally test suite
incorrectly uses file URLs beginning with 'file:/' instead of 'file://'.

This patch adjusts string offset so that file URLs are parsed correctly:

> > > sync_uri='/foo/bar/baz'
> > > ('file://' + sync_uri)[6:]
> > > '//foo/bar/baz'
> > > ('file://' + sync_uri)[6:] == sync_uri
> > > False
> > > ('file://' + sync_uri)[7:]
> > > '/foo/bar/baz'
> > > ('file://' + sync_uri)[7:] == sync_uri
> > > True

Additionally test suite is updated to use file URLs of the form
'file:///foo/bar' as required by the aforementioned RFC.
