### PR TITLE
depgraph: fix missed llvm update (bug 584626)

### DIFF
--- a/pym/portage/tests/resolver/soname/test_slot_conflict_reinstall.py
+++ b/pym/portage/tests/resolver/soname/test_slot_conflict_reinstall.py
@@ -89,6 +89,7 @@ class SonameSlotConflictReinstallTestCase(TestCase):
 					"--ignore-soname-deps": "n",
 					"--update": True,
 					"--usepkgonly": True,
+					"--backtrack": 10,
 				},
 				success = True,
 				mergelist = [

--- a/pym/portage/tests/resolver/test_slot_conflict_rebuild.py
+++ b/pym/portage/tests/resolver/test_slot_conflict_rebuild.py
@@ -91,7 +91,7 @@ class SlotConflictRebuildTestCase(TestCase):
 			# upgrade and we don't want to trigger unnecessary rebuilds.
 			ResolverPlaygroundTestCase(
 				["@world"],
-				options = {"--update": True, "--deep": True},
+				options = {"--update": True, "--deep": True, "--backtrack": 4},
 				success = True,
 				mergelist = ["app-misc/D-2", "app-misc/E-0"]),
 

--- a/pym/portage/tests/resolver/test_slot_operator_reverse_deps.py
+++ b/pym/portage/tests/resolver/test_slot_operator_reverse_deps.py
@@ -79,7 +79,11 @@ class SlotOperatorReverseDepsTestCase(TestCase):
 				["@world"],
 				options = {"--update": True, "--deep": True},
 				success = True,
-				mergelist = [],
+				mergelist = [
+					'sys-devel/llvm-3.8.0-r2',
+					'sys-devel/clang-3.8.0-r100',
+					'media-libs/mesa-11.2.2',
+				],
 			),
 
 			ResolverPlaygroundTestCase(

--- a/pym/portage/tests/resolver/test_slot_operator_reverse_deps.py
+++ b/pym/portage/tests/resolver/test_slot_operator_reverse_deps.py
@@ -1,0 +1,109 @@
+# Copyright 2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+	ResolverPlayground,
+	ResolverPlaygroundTestCase,
+)
+
+class SlotOperatorReverseDepsTestCase(TestCase):
+
+	def testSlotOperatorReverseDeps(self):
+
+		ebuilds = {
+
+			"media-libs/mesa-11.2.2" : {
+				"EAPI": "6",
+				"SLOT": "0",
+				"RDEPEND": ">=sys-devel/llvm-3.6.0:="
+			},
+
+			"sys-devel/clang-3.7.1-r100" : {
+				"EAPI": "6",
+				"SLOT": "0/3.7",
+				"RDEPEND": "~sys-devel/llvm-3.7.1"
+			},
+
+			"sys-devel/clang-3.8.0-r100" : {
+				"EAPI": "6",
+				"SLOT": "0/3.8",
+				"RDEPEND": "~sys-devel/llvm-3.8.0"
+			},
+
+			"sys-devel/llvm-3.7.1-r2" : {
+				"EAPI": "6",
+				"SLOT": "0/3.7.1",
+				"PDEPEND": "=sys-devel/clang-3.7.1-r100"
+			},
+
+			"sys-devel/llvm-3.8.0-r2" : {
+				"EAPI": "6",
+				"SLOT": "0/3.8.0",
+				"PDEPEND": "=sys-devel/clang-3.8.0-r100"
+			},
+
+		}
+
+		installed = {
+
+			"media-libs/mesa-11.2.2" : {
+				"EAPI": "6",
+				"SLOT": "0",
+				"RDEPEND": ">=sys-devel/llvm-3.6.0:0/3.7.1="
+			},
+
+			"sys-devel/clang-3.7.1-r100" : {
+				"EAPI": "6",
+				"SLOT": "0/3.7",
+				"RDEPEND": "~sys-devel/llvm-3.7.1"
+			},
+
+			"sys-devel/llvm-3.7.1-r2" : {
+				"EAPI": "6",
+				"SLOT": "0/3.7.1",
+				"PDEPEND": "=sys-devel/clang-3.7.1-r100"
+			},
+
+		}
+
+		world = ["media-libs/mesa"]
+
+		test_cases = (
+
+			# Test bug #584626, where an llvm update is missed due to
+			# the check_reverse_dependencies function seeing that
+			# updating llvm will break a dependency of the installed
+			# version of clang (though a clang update is available).
+			ResolverPlaygroundTestCase(
+				["@world"],
+				options = {"--update": True, "--deep": True},
+				success = True,
+				mergelist = [],
+			),
+
+			ResolverPlaygroundTestCase(
+				["@world"],
+				options = {
+					"--update": True,
+					"--deep": True,
+					"--ignore-built-slot-operator-deps": "y",
+				},
+				success = True,
+				mergelist = [
+					'sys-devel/llvm-3.8.0-r2',
+					'sys-devel/clang-3.8.0-r100',
+				],
+			),
+
+		)
+
+		playground = ResolverPlayground(ebuilds=ebuilds,
+			installed=installed, world=world, debug=False)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True,
+					test_case.fail_msg)
+		finally:
+			playground.cleanup()


### PR DESCRIPTION
Fix check_reverse_dependencies to ignore dependencies of parent packages
for which updates are desirable, and add required  _want_update_pkg
support for DependencyArg parents. This solves a missed llvm update by
ignoring a reverse dependency from the installed instance of clang,
since an update to a newer version of clang is desirable.

In order to cope with this change, there are 2 existing unit tests
that require larger --backtrack settings in order to succeed.

X-Gentoo-Bug: 584626
X-Gentoo-Bug-url: https://bugs.gentoo.org/show_bug.cgi?id=584626