### PR TITLE
repoman: skip QA checks in manifest mode (bug 586864)

### DIFF
--- a/repoman/pym/repoman/scanner.py
+++ b/repoman/pym/repoman/scanner.py
@@ -294,6 +294,8 @@ class Scanner(object):
 
 			if self.generate_manifest:
 				manifest.Manifest(**self.kwargs).update_manifest(checkdir)
+				if self.options.mode == 'manifest':
+					continue
 			checkdirlist = os.listdir(checkdir)
 
 			dynamic_data = {


### PR DESCRIPTION
repoman: skip QA checks in manifest mode (bug 586864)

The relevent Scanner loop control logic broke in commit 4062c69dc27a
because it was relying on the return value from the Manifest module's
"check" method.

Fixes: 4062c69dc27a ("repoman: Move manifest generation to modules/commit/manifest.py")
X-Gentoo-Bug: 586864
X-Gentoo-Bug-url: https://bugs.gentoo.org/show_bug.cgi?id=586864