### PR TITLE
chpathtool.py: fix byte comparison logic for python3 (bug 587198)

### DIFF
--- a/bin/chpathtool.py
+++ b/bin/chpathtool.py
@@ -89,7 +89,7 @@ def chpath_inplace(filename, is_text_file, old, new):
 		if not in_byte:
 			break
 
-		if in_byte == old[matched_byte_count]:
+		if in_byte == old[matched_byte_count:matched_byte_count+1]:
 			matched_byte_count += 1
 			if matched_byte_count == len_old:
 				modified = True


### PR DESCRIPTION
Fix chpathtool.py so that it won't try to compare a byte string with an
integer in python3. This change is also compatible with python2.

X-Gentoo-Bug: 587198
X-Gentoo-Bug-url: https://bugs.gentoo.org/show_bug.cgi?id=587198