### PR TITLE
Add emerge --autounmask-continue option (bug 582624)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1,4 +1,4 @@
-.TH "EMERGE" "1" "Feb 2016" "Portage VERSION" "Portage"
+.TH "EMERGE" "1" "Jul 2016" "Portage VERSION" "Portage"
 .SH "NAME"
 emerge \- Command\-line interface to the Portage system
 .SH "SYNOPSIS"
@@ -360,6 +360,18 @@ the specified configuration file(s), or enable the
 \fB\-\-autounmask\-write\fR option. The
 \fBEMERGE_DEFAULT_OPTS\fR variable may be used to
 disable this option by default in \fBmake.conf\fR(5).
+.TP
+.BR "\-\-autounmask\-continue [ y | n ]"
+Automatically apply autounmask changes to configuration
+files, and continue to execute the specified command. If
+the dependency calculation is not entirely successful, then
+emerge will simply abort without modifying any configuration
+files.
+\fBWARNING:\fR
+This option is intended to be used only with great caution,
+since it is possible for it to make nonsensical configuration
+changes which may lead to system breakage. Therefore, it is
+advisable to use \fB\-\-ask\fR together with this option.
 .TP
 .BR "\-\-autounmask\-only [ y | n ]"
 Instead of doing any package building, just unmask

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -127,6 +127,7 @@ def insert_optional_args(args):
 		'--alert'                : y_or_n,
 		'--ask'                  : y_or_n,
 		'--autounmask'           : y_or_n,
+		'--autounmask-continue'  : y_or_n,
 		'--autounmask-only'      : y_or_n,
 		'--autounmask-keep-masks': y_or_n,
 		'--autounmask-unrestricted-atoms' : y_or_n,
@@ -321,6 +322,11 @@ def parse_opts(tmpcmdline, silent=False):
 
 		"--autounmask": {
 			"help"    : "automatically unmask packages",
+			"choices" : true_y_or_n
+		},
+
+		"--autounmask-continue": {
+			"help"    : "write autounmask changes and continue",
 			"choices" : true_y_or_n
 		},
 
@@ -750,6 +756,9 @@ def parse_opts(tmpcmdline, silent=False):
 
 	if myoptions.autounmask in true_y:
 		myoptions.autounmask = True
+
+	if myoptions.autounmask_continue in true_y:
+		myoptions.autounmask_continue = True
 
 	if myoptions.autounmask_only in true_y:
 		myoptions.autounmask_only = True

--- a/pym/portage/tests/emerge/test_simple.py
+++ b/pym/portage/tests/emerge/test_simple.py
@@ -109,6 +109,16 @@ pkg_preinst() {
 				"LICENSE": "GPL-2",
 				"MISC_CONTENT": install_something,
 			},
+			"dev-libs/C-1": {
+				"EAPI" : "6",
+				"KEYWORDS": "~x86",
+				"RDEPEND": "dev-libs/D[flag]",
+			},
+			"dev-libs/D-1": {
+				"EAPI" : "6",
+				"KEYWORDS": "~x86",
+				"IUSE" : "flag",
+			},
 			"virtual/foo-0": {
 				"EAPI" : "5",
 				"KEYWORDS": "x86",
@@ -300,6 +310,11 @@ pkg_preinst() {
 			emerge_cmd + ("-p", "--unmerge", "-q", eroot + "usr"),
 			emerge_cmd + ("--unmerge", "--quiet", "dev-libs/A"),
 			emerge_cmd + ("-C", "--quiet", "dev-libs/B"),
+
+			emerge_cmd + ("--autounmask-continue", "dev-libs/C",),
+			# Verify that the above --autounmask-continue command caused
+			# USE=flag to be applied correctly to dev-libs/D.
+			portageq_cmd + ("match", eroot, "dev-libs/D[flag]"),
 
 			# Test cross-prefix usage, including chpathtool for binpkgs.
 			({"EPREFIX" : cross_prefix},) + \


### PR DESCRIPTION
This option will cause emerge to automatically apply autounmask changes
to configuration files, and continue to execute the specified command.
If the dependency calculation is not entirely successful, then emerge
will simply abort without modifying any configuration files.

This sort of behavior can be very useful in a continuous integration
setting, where the emerge invocation might be inside of a container that
is later discarded (so there is no threat of negative consequences).
It's also safe for general use, when combined with the --ask option.

X-Gentoo-Bug: 582624
X-Gentoo-Bug-url: https://bugs.gentoo.org/show_bug.cgi?id=582624