### PR TITLE
action_metadata: handle missing _md5_ key (bug 568934)

### DIFF
--- a/pym/portage/metadata.py
+++ b/pym/portage/metadata.py
@@ -149,7 +149,7 @@ def action_metadata(settings, portdb, myopts, porttrees=None):
 					src[dest_chf_key] = dest_chf_getter(ebuild_hash)
 
 				if dest is not None:
-					if not (dest[dest_chf_key] == src[dest_chf_key] and \
+					if not (dest.get(dest_chf_key) == src[dest_chf_key] and \
 						tree_data.eclass_db.validate_and_rewrite_cache(
 							dest['_eclasses_'], tree_data.dest_db.validation_chf,
 							tree_data.dest_db.store_eclass_paths) is not None and \


### PR DESCRIPTION
Since commit 9abbda7d054761ae6c333d3e6d420632b9658b6d, users with
FEATURES=metadata-transfer enabled would receive a KeyError when
an existing cache entry contained \_mtime_ instead of \_md5_. Fix
it to simply overwrite the cache entry in this case.

Fixes: 9abbda7d0547 ("portage.cache: write md5 instead of mtime (bug 568934)")
X-Gentoo-Bug: 568934
X-Gentoo-Bug-url: https://bugs.gentoo.org/show_bug.cgi?id=568934