### PR TITLE
New changes metamanifest

### DIFF
--- a/pym/portage/const.py
+++ b/pym/portage/const.py
@@ -238,7 +238,7 @@ MANIFEST2_HASH_FUNCTIONS = ("SHA256", "SHA512", "WHIRLPOOL")
 MANIFEST2_HASH_DEFAULTS = frozenset(["SHA256", "SHA512", "WHIRLPOOL"])
 MANIFEST2_REQUIRED_HASH  = "SHA256"
 
-MANIFEST2_IDENTIFIERS    = ("AUX", "MISC", "DIST", "EBUILD")
+MANIFEST2_IDENTIFIERS    = ("AUX", "MISC", "DIST", "EBUILD", "MANIFEST", "ECLASS", "DATA", "OTHER", "EXEC")
 
 # The EPREFIX for the current install is hardcoded here, but access to this
 # constant should be minimal, in favor of access via the EPREFIX setting of

--- a/pym/portage/manifest.py
+++ b/pym/portage/manifest.py
@@ -57,18 +57,27 @@ def manifest2AuxfileFilter(filename):
 def manifest2MiscfileFilter(filename):
 	return not (filename == "Manifest" or filename.endswith(".ebuild"))
 
-def guessManifestFileType(filename):
+def guessManifestFileType(filename, is_pkg = True):
 	""" Perform a best effort guess of which type the given filename is, avoid using this if possible """
 	if filename.startswith("files" + os.sep + "digest-"):
-		return None
+		ftype = None
 	if filename.startswith("files" + os.sep):
-		return "AUX"
+		ftype = "AUX"
 	elif filename.endswith(".ebuild"):
-		return "EBUILD"
+		ftype = "EBUILD"
+	elif filename.endswith("Manifest"):
+		ftype = "MANIFEST"
+	elif filename.endswith(".eclass"):
+		ftype = "ECLASS"
 	elif filename in ["ChangeLog", "metadata.xml"]:
-		return "MISC"
+		ftype = "MISC"
+	elif filename.endswith(".sh"):
+		ftype = "EXEC"
+	elif is_pkg:
+		ftype = "DIST"
 	else:
-		return "DIST"
+		ftype = "OTHER"
+	return ftype
 
 def guessThinManifestFileType(filename):
 	type = guessManifestFileType(filename)

--- a/pym/portage/manifest.py
+++ b/pym/portage/manifest.py
@@ -166,8 +166,8 @@ class Manifest(object):
 			list(self.hashes) if hashname not in hashfunc_map)
 		self.hashes.add("size")
 		self.hashes.add(MANIFEST2_REQUIRED_HASH)
-		for t in MANIFEST2_IDENTIFIERS:
-			self.fhashdict[t] = {}
+		for ftype in MANIFEST2_IDENTIFIERS:
+			self.fhashdict[ftype] = {}
 		if not from_scratch:
 			self._read()
 		if fetchlist_dict != None:
@@ -458,6 +458,7 @@ class Manifest(object):
 		distfiles to raise a FileNotFound exception for (if no file or existing
 		checksums are available), and defaults to all distfiles when not
 		specified."""
+
 		if not self.allow_create:
 			return
 		if checkExisting:

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -164,11 +164,10 @@ class MetaManifest(manifest.Manifest):
 				except UnicodeDecodeError:
                         	        continue
 				fpath = os.path.join(eclass_dir, f)
-				ftype = guessManifestFileType(fpath)
+				ftype = guessManifestFileType(fpath, is_pkg=False)
 				f = fpath.replace(self.pkgdir, "")
-				if not f.endswith("MetaManifest"):
+				if not f.endswith("Manifest"):
 					self.fhashdict[ftype][f] = perform_multiple_checksums(fpath, self.hashes)
-		print(self.fhashdict, 10)
 
 	def create_cat(self):
 		'''Creates a MetaManifest file in the selected category'''

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -172,19 +172,19 @@ class MetaManifest(manifest.Manifest):
 	def create_cat(self):
 		'''Creates a MetaManifest file in the selected category'''
 		catdir = self.pkgdir
-		self.fhashdict = {}
-		self.fhashdict["MANIFEST"] = {}
-		for catdir, catdir_dir, pkg_files in os.walk(catdir):
-			for f in pkg_files:
-				try:
-					f = _unicode_decode(f,encoding=_encodings['fs'], errors='strict')
-					catdir = _unicode_decode(catdir,encoding=_encodings['fs'], errors='strict')
-				except UnicodeDecodeError:
-					continue
-				if f == "Manifest" :
-					fpath = os.path.join(catdir, f)
-					f = fpath.replace(self.pkgdir, "")
-					self.fhashdict["MANIFEST"][f] = perform_multiple_checksums(fpath, self.hashes) 
+		for ftype in MANIFEST2_IDENTIFIERS:
+                        self.fhashdict[ftype] = {}
+		for pkg_dir in os.listdir(catdir):
+			pkg_dir = os.path.join(catdir, pkg_dir)
+			if os.path.isdir(pkg_dir):
+				for file in os.listdir(pkg_dir):
+					fpath = os.path.join(pkg_dir, file)
+					if os.path.isfile(fpath) and fpath.endswith('Manifest'):
+						new_mf = MetaManifest(fpath.replace('Manifest', ""))
+						new_mf.verify_manifest()
+						f = fpath.replace(self.pkgdir, "")
+						self.fhashdict["MANIFEST"][f] = perform_multiple_checksums(fpath, self.hashes)
+
 	def create_profile(self):
 		'''Creates a MetaManifest file in the profiles directory'''
 		profiledir = self.pkgdir

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -1,0 +1,185 @@
+
+from __future__ import unicode_literals
+
+import argparse
+import errno
+import io
+import logging
+import re
+import stat
+import subprocess
+import sys
+import warnings
+
+import portage
+portage.proxy.lazyimport.lazyimport(globals(),
+        'portage.checksum:hashfunc_map,perform_multiple_checksums,' + \
+                'verify_all,_apply_hash_filter,_filter_unaccelarated_hashes',
+        'portage.repository.config:_find_invalid_path_char',
+        'portage.util:write_atomic,writemsg_level',
+)
+
+from portage import os
+from portage import _encodings
+from portage import _unicode_decode
+from portage import _unicode_encode
+import manifest
+from portage.exception import DigestException, FileNotFound, \
+        InvalidDataType, MissingParameter, PermissionDenied, \
+        PortageException, PortagePackageException
+from const import (MANIFEST1_HASH_FUNCTIONS, MANIFEST2_HASH_DEFAULTS,
+        MANIFEST2_HASH_FUNCTIONS, MANIFEST2_IDENTIFIERS, MANIFEST2_REQUIRED_HASH)
+from portage.localization import _
+
+if sys.hexversion >= 0x3000000:
+	# pylint: disable=W0622
+	_unicode = str
+	basestring = str
+else:
+	_unicode = unicode
+
+def guessManifestFileType(filename):
+        """ Perform a best effort guess of which type the given filename is, avoid using this if possible """
+        if filename.startswith("files" + os.sep + "digest-"):
+                return None
+        elif filename.startswith("files" + os.sep):
+                return "AUX"
+        elif filename.endswith(".ebuild"):
+                return "EBUILD"
+        elif filename == "Manifest" or filename == "MetaManifest":
+                return "MANIFEST"
+        elif filename.endswith(".eclass"):
+                return "ECLASS"
+        elif filename in ["ChangeLog", "metadata.xml"]:
+                return "MISC"
+        elif filename.endswith(".sh"):
+	        return "EXEC"
+        else:
+                return "OTHER"
+
+class MetaManifest(manifest.Manifest):
+
+	def getFullname(self):
+                """ Returns the absolute path to the Manifest file for this instance """
+                return os.path.join(self.pkgdir, "MetaManifest")
+
+	def sign(self):
+		'''Signs MetaManifest file with the default PORTAGE_GPG_KEY''' 
+		filename = self.getFullname()
+		portage_settings = portage.config(clone=portage.settings)
+		portage_portdbapi = portage.portdbapi(portage_settings)
+		gpgcmd = portage_settings.get("PORTAGE_GPG_SIGNING_COMMAND")
+		if gpgcmd in [None, '']:
+			raise portage.exception.MissingParameter(
+				"PORTAGE_GPG_SIGNING_COMMAND is unset! Is make.globals missing?")
+		if "${PORTAGE_GPG_KEY}" in gpgcmd and "PORTAGE_GPG_KEY" not in portage_settings:
+			raise portage.exception.MissingParameter("PORTAGE_GPG_KEY is unset!")
+		if "${PORTAGE_GPG_DIR}" in gpgcmd:
+			if "PORTAGE_GPG_DIR" not in portage_settings:
+				portage_settings["PORTAGE_GPG_DIR"] = os.path.expanduser("~/.gnupg")
+			else:
+				portage_settings["PORTAGE_GPG_DIR"] = os.path.expanduser(portage_settings["PORTAGE_GPG_DIR"])
+			if not os.access(portage_settings["PORTAGE_GPG_DIR"], os.X_OK):
+				raise portage.exception.InvalidLocation(
+					"Unable to access directory: PORTAGE_GPG_DIR='%s'" %
+					portage_settings["PORTAGE_GPG_DIR"])
+		gpgvars = {"FILE": filename}
+		for k in ("PORTAGE_GPG_DIR", "PORTAGE_GPG_KEY"):
+			v = portage_settings.get(k)
+			if v is not None:
+				gpgvars[k] = v
+		gpgcmd = portage.util.varexpand(gpgcmd, mydict=gpgvars)
+		gpgcmd = portage.util.shlex_split(gpgcmd)
+		gpgcmd = [portage._unicode_encode(arg, encoding=portage._encodings['fs'], errors='strict') for arg in gpgcmd]
+		return_code = subprocess.call(gpgcmd)
+		if return_code == os.EX_OK:
+			os.rename(filename + ".asc", filename)
+		else:
+			raise portage.exception.PortageException("!!! gpg exited with '" + str(return_code) + "' status")
+
+	def create(self):
+		'''Creates a MetaManifest file'''
+		dir = self.pkgdir
+		if dir.endswith("profiles/"):
+			self.create_profile()
+		elif dir.endswith("eclass/"):
+			self.create_eclass()
+		else:
+			self.create_cat()
+
+	def create_eclass(self):
+		'''Creates a MetaManifest file in the eclass directory'''
+		eclass_dir = self.pkgdir
+		self.fhashdict = {}
+		for ftype in MANIFEST2_IDENTIFIERS:
+			self.fhashdict[ftype] = {}
+
+		for eclass_dir, eclassdir_dir, files in os.walk(eclass_dir):
+			print(eclass_dir, eclassdir_dir, files)
+			for f in files:
+				try:
+                                        f = _unicode_decode(f,encoding=_encodings['fs'], errors='strict')
+                                        eclass_dir = _unicode_decode(eclass_dir,encoding=_encodings['fs'], errors='strict')
+				except UnicodeDecodeError:
+                        	        continue
+				fpath = os.path.join(eclass_dir, f)
+				ftype = guessManifestFileType(fpath)
+				f = fpath.replace(self.pkgdir, "")
+				if not f.endswith("MetaManifest"):
+					self.fhashdict[ftype][f] = perform_multiple_checksums(fpath, self.hashes)
+		print(self.fhashdict, 10)
+
+	def create_cat(self):
+		'''Creates a MetaManifest file in the selected category'''
+		catdir = self.pkgdir
+		self.fhashdict = {}
+		self.fhashdict["MANIFEST"] = {}
+		for catdir, catdir_dir, pkg_files in os.walk(catdir):
+			for f in pkg_files:
+				try:
+					f = _unicode_decode(f,encoding=_encodings['fs'], errors='strict')
+					catdir = _unicode_decode(catdir,encoding=_encodings['fs'], errors='strict')
+				except UnicodeDecodeError:
+					continue
+				if f == "Manifest" :
+					fpath = os.path.join(catdir, f)
+					f = fpath.replace(self.pkgdir, "")
+					self.fhashdict["MANIFEST"][f] = perform_multiple_checksums(fpath, self.hashes) 
+	def create_profile(self):
+		'''Creates a MetaManifest file in the profiles directory'''
+		profiledir = self.pkgdir
+		for ftype in MANIFEST2_IDENTIFIERS:
+                        self.fhashdict[ftype] = {}
+		for profiledir, profiledir_dir, files in os.walk(profiledir):
+			for f in files:
+				try:
+					f = _unicode_decode(f,encoding=_encodings['fs'], errors='strict')
+					profiledir = _unicode_decode(profiledir,encoding=_encodings['fs'], errors='strict')
+				except UnicodeDecodeError:
+					continue
+				fpath = os.path.join(profiledir, f)
+				ftype = guessManifestFileType(fpath)
+				if ftype == "OTHER":
+					ftype = "DATA"
+				f = fpath.replace(self.pkgdir, "")
+				if not f.endswith("MetaManifest"):
+					self.fhashdict[ftype][f] = perform_multiple_checksums(fpath, self.hashes)
+
+
+
+if __name__ == '__main__':
+	try:
+
+		parser = argparse.ArgumentParser(description='Process some integers.')
+		parser.add_argument('directory', metavar='d', type=str,
+			help='the selected directory')
+		args = parser.parse_args()
+		meta_manifest = MetaManifest(args.directory)
+		meta_manifest.create()
+		meta_manifest.write(sign=True)
+
+	except KeyboardInterrupt:
+		print('interrupted ...', file=sys.stderr)
+		exit(1)
+
+

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -128,6 +128,27 @@ class MetaManifest(manifest.Manifest):
 		else:
 			self.create_cat()
 
+	def create_master(self):
+		'''Creates a MetaManifest file from all the MetaManifest files of the repository'''
+		self.find_reporoot()
+		myrepodir = self.reporoot
+		self.pkgdir = self.reporoot
+		self.fhashdict = {}
+		for ftype in MANIFEST2_IDENTIFIERS:
+			self.fhashdict[ftype] = {}
+		for file in os.listdir(myrepodir):
+			fpath = os.path.join(myrepodir, file)
+			if os.path.isfile(fpath):
+				if not fpath.endswith('Manifest'):
+					ftype = guessManifestFileType(fpath, is_pkg=False)
+					self.fhashdict[ftype][f] = perform_multiple_checksums(fpath, self.hashes)
+			else:
+				for mf in os.listdir(fpath):
+					mfpath = os.path.join(fpath, mf)
+					if mfpath.endswith('Manifest'):
+						f = mfpath.replace(self.reporoot, "")
+						self.fhashdict["MANIFEST"][f] = perform_multiple_checksums(mfpath, self.hashes) 
+
 	def create_eclass(self):
 		'''Creates a MetaManifest file in the eclass directory'''
 		eclass_dir = self.pkgdir

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -117,11 +117,14 @@ class MetaManifest(manifest.Manifest):
 
 	def create(self):
 		'''Creates a MetaManifest file'''
-		dir = self.pkgdir
-		if dir.endswith("profiles/"):
+		repodir = self.pkgdir
+		repotype = self.find_repotype(repodir)
+		if repotype == 'profile':
 			self.create_profile()
-		elif dir.endswith("eclass/"):
+		elif repotype == 'eclass':
 			self.create_eclass()
+		elif repotype == 'root':
+			self.create_master()
 		else:
 			self.create_cat()
 

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -157,7 +157,6 @@ class MetaManifest(manifest.Manifest):
 			self.fhashdict[ftype] = {}
 
 		for eclass_dir, eclassdir_dir, files in os.walk(eclass_dir):
-			print(eclass_dir, eclassdir_dir, files)
 			for f in files:
 				try:
                                         f = _unicode_decode(f,encoding=_encodings['fs'], errors='strict')

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -198,11 +198,11 @@ class MetaManifest(manifest.Manifest):
 				except UnicodeDecodeError:
 					continue
 				fpath = os.path.join(profiledir, f)
-				ftype = guessManifestFileType(fpath)
+				ftype = guessManifestFileType(fpath, is_pkg=False)
 				if ftype == "OTHER":
 					ftype = "DATA"
 				f = fpath.replace(self.pkgdir, "")
-				if not f.endswith("MetaManifest"):
+				if not f.endswith("Manifest"):
 					self.fhashdict[ftype][f] = perform_multiple_checksums(fpath, self.hashes)
 
 

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -19,15 +19,21 @@ portage.proxy.lazyimport.lazyimport(globals(),
         'portage.util:write_atomic,writemsg_level',
 )
 
+from gkeys.gkeysinterface import GkeysInterface
+from gkeys.config import GKeysConfig
+from pyGPG.gpg import GPG
+from gkeys.lib import GkeysGPG
+
+from portage import manifest
 from portage import os
 from portage import _encodings
 from portage import _unicode_decode
 from portage import _unicode_encode
-import manifest
+from portage.manifest import guessManifestFileType
 from portage.exception import DigestException, FileNotFound, \
         InvalidDataType, MissingParameter, PermissionDenied, \
         PortageException, PortagePackageException
-from const import (MANIFEST1_HASH_FUNCTIONS, MANIFEST2_HASH_DEFAULTS,
+from portage.const import (MANIFEST1_HASH_FUNCTIONS, MANIFEST2_HASH_DEFAULTS,
         MANIFEST2_HASH_FUNCTIONS, MANIFEST2_IDENTIFIERS, MANIFEST2_REQUIRED_HASH)
 from portage.localization import _
 
@@ -38,30 +44,9 @@ if sys.hexversion >= 0x3000000:
 else:
 	_unicode = unicode
 
-def guessManifestFileType(filename):
-        """ Perform a best effort guess of which type the given filename is, avoid using this if possible """
-        if filename.startswith("files" + os.sep + "digest-"):
-                return None
-        elif filename.startswith("files" + os.sep):
-                return "AUX"
-        elif filename.endswith(".ebuild"):
-                return "EBUILD"
-        elif filename == "Manifest" or filename == "MetaManifest":
-                return "MANIFEST"
-        elif filename.endswith(".eclass"):
-                return "ECLASS"
-        elif filename in ["ChangeLog", "metadata.xml"]:
-                return "MISC"
-        elif filename.endswith(".sh"):
-	        return "EXEC"
-        else:
-                return "OTHER"
 
 class MetaManifest(manifest.Manifest):
-
-	def getFullname(self):
-                """ Returns the absolute path to the Manifest file for this instance """
-                return os.path.join(self.pkgdir, "MetaManifest")
+	'''Subclass of the Manifest class for Manifest files outside the packages'''
 
 	def sign(self):
 		'''Signs MetaManifest file with the default PORTAGE_GPG_KEY''' 

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -69,10 +69,10 @@ class MetaManifest(manifest.Manifest):
 					"Unable to access directory: PORTAGE_GPG_DIR='%s'" %
 					portage_settings["PORTAGE_GPG_DIR"])
 		gpgvars = {"FILE": filename}
-		for k in ("PORTAGE_GPG_DIR", "PORTAGE_GPG_KEY"):
-			v = portage_settings.get(k)
-			if v is not None:
-				gpgvars[k] = v
+		for setting in ("PORTAGE_GPG_DIR", "PORTAGE_GPG_KEY"):
+			keyvar = portage_settings.get(setting)
+			if keyvar is not None:
+				gpgvars[setting] = keyvar
 		gpgcmd = portage.util.varexpand(gpgcmd, mydict=gpgvars)
 		gpgcmd = portage.util.shlex_split(gpgcmd)
 		gpgcmd = [portage._unicode_encode(arg, encoding=portage._encodings['fs'], errors='strict') for arg in gpgcmd]

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -205,6 +205,20 @@ class MetaManifest(manifest.Manifest):
 				if not f.endswith("Manifest"):
 					self.fhashdict[ftype][f] = perform_multiple_checksums(fpath, self.hashes)
 
+	def checkFileHashes(self, ftype, fname, ignoreMissing=False, hash_filter=None):
+                digests = _filter_unaccelarated_hashes(self.fhashdict[ftype][fname])
+                if hash_filter is not None:
+                        digests = _apply_hash_filter(digests, hash_filter)
+                try:
+                        if ftype not in ('DIST'):
+                                ok, reason = verify_all(self._getAbsname(ftype, fname), digests)
+                                if not ok:
+                                        raise DigestException(tuple([self._getAbsname(ftype, fname)]+list(reason)))
+                                return ok, reason
+                except FileNotFound as e:
+                        if not ignoreMissing:
+                                raise
+                        return False, _("File Not Found: '%s'") % str(e)
 
 
 if __name__ == '__main__':

--- a/pym/portage/meta-manifest.py
+++ b/pym/portage/meta-manifest.py
@@ -82,6 +82,39 @@ class MetaManifest(manifest.Manifest):
 		else:
 			raise portage.exception.PortageException("!!! gpg exited with '" + str(return_code) + "' status")
 
+	def find_reporoot(self):
+		'''Finds reporoot'''
+		repodir = self.pkgdir
+		while len(set(['metadata', 'eclass', 'profiles']).intersection(os.listdir(repodir))) == 0:
+			myrepo = repodir.split(os.path.sep)[1:-1]
+			if myrepo[-1] not in myrepo[:-1]:
+				repodir = repodir.replace(("/" +  myrepo[-1]), "")
+			else:
+				raise("Invalid path")
+		self.reporoot = repodir
+
+	def find_repolevel(self, path):
+		'''Finds repolevel'''
+		self.find_reporoot()
+		path = path.replace(self.reporoot, "")
+		myrepo = path.split(os.path.sep)
+		repolevel = len(myrepo)
+		return repolevel
+
+	def find_repotype(self, path):
+		'''Finds the type of the repo directory'''
+		if len(set(['metadata', 'eclass', 'profiles']).intersection(os.listdir(path))) > 0:
+			return 'root'
+		elif path.endswith("eclass/"):
+			return 'eclass'
+		elif path.endswith("profiles/"):
+			return 'profile'
+		else:
+			if self.find_repolevel(path) == 2:
+				return 'category'
+			else:
+				return 'package'
+
 	def create(self):
 		'''Creates a MetaManifest file'''
 		dir = self.pkgdir


### PR DESCRIPTION
This PR is for a GSoC project based on [GLEP:58](https://wiki.gentoo.org/wiki/GLEP:58)

Added more `MANIFEST_IDENTIFIERS` in `pym/portage/const.py` according to [GLEP:60](https://wiki.gentoo.org/wiki/GLEP:60)

Modified `guessManifestType()` for the new `MANIFEST_IDENTIFIERS` and reduced the return statements

Updated some variable names in `/pym/portage/manifest.py`

Added a new file `/pym/portage/meta-manifest.py` which includes a subclass of Manifest for manifest files outside of the packages (ex. /profiles, categories etc)

Added 4 `create_` functions for it, `create_cat()` that creates a metamanifest for categories that includes the manifest files of all packages after verifying them, `create_profile` and `create_eclass` that create a metamanifest for the `/profiles` and `/eclass` directories, and `create_master` that creates a metamanifest file that includes all the metamanifests above and all files in the root directory.

Added signature and manifest verification to the metamanifest files which verifies package manifests only if a boolean is passed and ignores missing categories or packages if the whole directory is missing.

Modified the `checkFileHashes()` method in the subclass to ignore `DIST` files because otherwise package manifests wouldn't be verifiable. 

Added some methods to help me identify things like the repolevel, reporoot and repotype.

Modified the `create()` function to choose which `create_` function to use based on the repotype.

Instructions on how to use the script: https://goo.gl/i0LIay
Test cases: https://wiki.gentoo.org/wiki/User:Aeroniero
