### PR TITLE
repoman: deduplicate dependency.syntax errors (bug 591184)

### DIFF
--- a/repoman/pym/repoman/modules/scan/depend/_depend_checks.py
+++ b/repoman/pym/repoman/modules/scan/depend/_depend_checks.py
@@ -1,5 +1,6 @@
 # -*- coding:utf-8 -*-
 
+import collections
 
 from _emerge.Package import Package
 
@@ -160,7 +161,12 @@ def _depend_checks(ebuild, pkg, portdb, qatracker, repo_metadata):
 			check_slotop(mydepstr, pkg.iuse.is_valid_flag,
 				badsyntax, mytype, qatracker, ebuild.relative_path)
 
+	dedup = collections.defaultdict(set)
 	for m, b in badsyntax:
+		if b in dedup[m]:
+			continue
+		dedup[m].add(b)
+
 		if m.endswith("DEPEND"):
 			qacat = "dependency.syntax"
 		else:


### PR DESCRIPTION
X-Gentoo-bug: 591184
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=591184