### PR TITLE
EventLoop: add run_until_complete method (bug 591760)

### DIFF
--- a/pym/portage/util/_eventloop/EventLoop.py
+++ b/pym/portage/util/_eventloop/EventLoop.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import division
@@ -576,6 +576,21 @@ class EventLoop(object):
 
 		del self._poll_event_handlers[f]
 		return True
+
+	def run_until_complete(self, future):
+		"""
+		Run until the Future is done.
+
+		@type future: asyncio.Future
+		@param future: a Future to wait for
+		@rtype: object
+		@return: the Future's result
+		@raise: the Future's exception
+		"""
+		while not future.done():
+			self.iteration()
+
+		return future.result()
 
 _can_poll_device = None
 


### PR DESCRIPTION
EventLoop: add run_until_complete method (bug 591760)

This emulates the asyncio.AbstractEventLoop.run_until_complete(future)
interface, which will make it possible to reduce latency in situations
where it is desirable for a loop to exit at the earliest opportunity.

The most tangible benefit of this change is that it provides a
migration path to asyncio, which will allow us to rely on a standard
library instead of our own internal event loop implementation.

In order to migrate to asyncio, more work is planned:

* Migrate all internal use of the EventLoop.iteration method to the new
run_until_complete(future) method, and remove the EventLoop.iteration
method (or make it private as long as it's needed to implement
run_until_complete for older python versions).

* Implement all EventLoop methods using asyncio.AbstractEventLoop
methods (but keep existing implementations for use with older python).

X-Gentoo-bug: 591760
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=591760