### PR TITLE
bin/*, misc/emerge-delta-webrsync: migrate to [[.

### DIFF
--- a/bin/ebuild-helpers/dodoc
+++ b/bin/ebuild-helpers/dodoc
@@ -8,7 +8,7 @@ if ___eapi_dodoc_supports_-r; then
 	__PORTAGE_HELPER='dodoc' exec doins "$@"
 fi
 
-if [ $# -lt 1 ] ; then
+if [[ $# -lt 1 ]] ; then
 	__helpers_die "${0##*/}: at least one argument needed"
 	exit 1
 fi
@@ -18,18 +18,18 @@ if ! ___eapi_has_prefix_variables; then
 fi
 
 dir="${ED}usr/share/doc/${PF}/${_E_DOCDESTTREE_}"
-if [ ! -d "${dir}" ] ; then
+if [[ ! -d "${dir}" ]] ; then
 	install -d "${dir}"
 fi
 
 ret=0
 for x in "$@" ; do
-	if [ -d "${x}" ] ; then
+	if [[ -d "${x}" ]] ; then
 		eqawarn "QA Notice: dodoc argument '${x}' is a directory"
-	elif [ -s "${x}" ] ; then
+	elif [[ -s "${x}" ]] ; then
 		install -m0644 "${x}" "${dir}" || { ((ret|=1)); continue; }
 		ecompress --queue "${dir}/${x##*/}"
-	elif [ ! -e "${x}" ] ; then
+	elif [[ ! -e "${x}" ]] ; then
 		echo "!!! ${0##*/}: $x does not exist" 1>&2
 		((ret|=1))
 	fi

--- a/bin/ebuild-helpers/doexe
+++ b/bin/ebuild-helpers/doexe
@@ -22,16 +22,16 @@ TMP=$(mktemp -d "${T}/.doexe_tmp_XXXXXX")
 ret=0
 
 for x in "$@" ; do
-	if [ -L "${x}" ] ; then
+	if [[ -L "${x}" ]] ; then
 		cp "$x" "$TMP"
 		mysrc=$TMP/${x##*/}
-	elif [ -d "${x}" ] ; then
+	elif [[ -d "${x}" ]] ; then
 		__vecho "doexe: warning, skipping directory ${x}"
 		continue
 	else
 		mysrc="${x}"
 	fi
-	if [ -e "$mysrc" ] ; then
+	if [[ -e "$mysrc" ]] ; then
 		install $EXEOPTIONS "$mysrc" "$ED$_E_EXEDESTTREE_"
 	else
 		echo "!!! ${0##*/}: $mysrc does not exist" 1>&2

--- a/bin/ebuild-helpers/doinfo
+++ b/bin/ebuild-helpers/doinfo
@@ -19,9 +19,9 @@ fi
 
 install -m0644 "$@" "${ED}usr/share/info"
 rval=$?
-if [ $rval -ne 0 ] ; then
+if [[ $rval -ne 0 ]] ; then
 	for x in "$@" ; do
-		[ -e "$x" ] || echo "!!! ${0##*/}: $x does not exist" 1>&2
+		[[ -e "$x" ]] || echo "!!! ${0##*/}: $x does not exist" 1>&2
 	done
 	__helpers_die "${0##*/} failed"
 fi

--- a/bin/ebuild-helpers/doins
+++ b/bin/ebuild-helpers/doins
@@ -7,7 +7,7 @@ source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 helper=${__PORTAGE_HELPER:-${0##*/}}
 
 if [[ ${helper} == dodoc ]] ; then
-	if [ $# -eq 0 ] ; then
+	if [[ $# -eq 0 ]] ; then
 		# default_src_install may call dodoc with no arguments
 		# when DOC is defined but empty, so simply return
 		# sucessfully in this case.
@@ -18,7 +18,7 @@ if [[ ${helper} == dodoc ]] ; then
 	export INSDESTTREE=usr/share/doc/${PF}/${_E_DOCDESTTREE_}
 fi
 
-if [ $# -lt 1 ] ; then
+if [[ $# -lt 1 ]] ; then
 	__helpers_die "${helper}: at least one argument needed"
 	exit 1
 fi
@@ -58,14 +58,14 @@ mkdir -p "$TMP"/{1,2}
 _doins() {
 	local mysrc="$1" mydir="$2" cleanup="" rval
 
-	if [ -L "$mysrc" ] ; then
+	if [[ -L "$mysrc" ]] ; then
 		# Our fake $DISTDIR contains symlinks that should
 		# not be reproduced inside $D. In order to ensure
 		# that things like dodoc "$DISTDIR"/foo.pdf work
 		# as expected, we dereference symlinked files that
 		# refer to absolute paths inside
 		# $PORTAGE_ACTUAL_DISTDIR/.
-		if [ $PRESERVE_SYMLINKS = y ] && \
+		if [[ $PRESERVE_SYMLINKS = y ]] && \
 			! [[ $(readlink "$mysrc") == "$PORTAGE_ACTUAL_DISTDIR"/* ]] ; then
 			rm -rf "${ED}$INSDESTTREE/$mydir/${mysrc##*/}" || return $?
 			cp -P "$mysrc" "${ED}$INSDESTTREE/$mydir/${mysrc##*/}"
@@ -80,7 +80,7 @@ _doins() {
 	install ${INSOPTIONS} "${mysrc}" "${ED}${INSDESTTREE}/${mydir}"
 	rval=$?
 	[[ -n ${cleanup} ]] && rm -f "${cleanup}"
-	[ $rval -ne 0 ] && echo "!!! ${helper}: $mysrc does not exist" 1>&2
+	[[ $rval -ne 0 ]] && echo "!!! ${helper}: $mysrc does not exist" 1>&2
 	return $rval
 }
 
@@ -99,7 +99,7 @@ failed=0
 for x in "$@" ; do
 	if [[ $PRESERVE_SYMLINKS = n && -d $x ]] || \
 		[[ $PRESERVE_SYMLINKS = y && -d $x && ! -L $x ]] ; then
-		if [ "${DOINSRECUR}" == "n" ] ; then
+		if [[ "${DOINSRECUR}" == "n" ]] ; then
 			if [[ ${helper} == dodoc ]] ; then
 				echo "!!! ${helper}: $x is a directory" 1>&2
 				((failed|=1))
@@ -107,10 +107,10 @@ for x in "$@" ; do
 			continue
 		fi
 
-		while [ "$x" != "${x%/}" ] ; do
+		while [[ "$x" != "${x%/}" ]] ; do
 			x=${x%/}
 		done
-		if [ "$x" = "${x%/*}" ] ; then
+		if [[ "$x" = "${x%/*}" ]] ; then
 			pushd "$PWD" >/dev/null
 		else
 			pushd "${x%/*}" >/dev/null
@@ -122,7 +122,7 @@ for x in "$@" ; do
 		# name of the symlink will be used for the name
 		# of the installed directory, as discussed in
 		# bug #239529.
-		while [ -L "$x" ] ; do
+		while [[ -L "$x" ]] ; do
 			pushd "$(readlink "$x")" >/dev/null
 			x=${PWD##*/}
 			pushd "${PWD%/*}" >/dev/null

--- a/bin/ebuild-helpers/domo
+++ b/bin/ebuild-helpers/domo
@@ -5,7 +5,7 @@
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
 mynum=${#}
-if [ ${mynum} -lt 1 ] ; then
+if [[ ${mynum} -lt 1 ]] ; then
 	__helpers_die "${0}: at least one argument needed"
 	exit 1
 fi
@@ -14,17 +14,17 @@ if ! ___eapi_has_prefix_variables; then
 	ED=${D}
 fi
 
-if [ ! -d "${ED}${DESTTREE}/share/locale" ] ; then
+if [[ ! -d "${ED}${DESTTREE}/share/locale" ]] ; then
 	install -d "${ED}${DESTTREE}/share/locale/"
 fi
 
 ret=0
 
 for x in "$@" ; do
-	if [ -e "${x}" ] ; then
+	if [[ -e "${x}" ]] ; then
 		mytiny="${x##*/}"
 		mydir="${ED}${DESTTREE}/share/locale/${mytiny%.*}/LC_MESSAGES"
-		if [ ! -d "${mydir}" ] ; then
+		if [[ ! -d "${mydir}" ]] ; then
 			install -d "${mydir}"
 		fi
 		install -m0644 "${x}" "${mydir}/${MOPREFIX}.mo"

--- a/bin/ebuild-helpers/dosed
+++ b/bin/ebuild-helpers/dosed
@@ -24,8 +24,8 @@ mysed="s:${ED}::g"
 
 for x in "$@" ; do
 	y=$ED${x#/}
-	if [ -e "${y}" ] ; then
-		if [ -f "${y}" ] ; then
+	if [[ -e "${y}" ]] ; then
+		if [[ -f "${y}" ]] ; then
 			file_found=1
 			sed -i -e "${mysed}" "${y}"
 		else
@@ -38,7 +38,7 @@ for x in "$@" ; do
 	fi
 done
 
-if [ $file_found = 0 ] ; then
+if [[ $file_found = 0 ]] ; then
 	echo "!!! ${0##*/}: $y does not exist" 1>&2
 	((ret|=1))
 fi

--- a/bin/ebuild-helpers/ecompress
+++ b/bin/ebuild-helpers/ecompress
@@ -42,9 +42,9 @@ decompress_args() {
 		((i++))
 	done
 
-	if [ $decompress_count -gt 0 ] ; then
+	if [[ $decompress_count -gt 0 ]] ; then
 		${binary} "${decompress_args[@]}"
-		if [ $? -ne 0 ] ; then
+		if [[ $? -ne 0 ]] ; then
 			# Apparently decompression failed for one or more files, so
 			# drop those since we don't want to compress them twice.
 			new_args=()
@@ -143,7 +143,7 @@ case $1 in
 			filtered_args[$i]=$x
 			((i++))
 		done
-		[ $i -eq 0 ] && exit 0
+		[[ $i -eq 0 ]] && exit 0
 		set -- "${filtered_args[@]}"
 
 		# If a compressed version of the file already exists, simply

--- a/bin/ebuild-helpers/ecompressdir
+++ b/bin/ebuild-helpers/ecompressdir
@@ -98,7 +98,7 @@ funk_up_dir() {
 		# absolute symlinks to files that aren't merged
 		# yet (bug #405327).
 		if [[ ${olddest} == /* ]] ; then
-			[ -e "${D}${olddest}" ] && continue
+			[[ -e "${D}${olddest}" ]] && continue
 			skip_dir_dest=${T}/ecompress-skip/${olddest#${EPREFIX}}
 		else
 			skip_dir_dest=${T}/ecompress-skip/${actual_dir#${ED}}/${brokenlink%/*}/${olddest}

--- a/bin/ebuild-helpers/prepstrip
+++ b/bin/ebuild-helpers/prepstrip
@@ -138,7 +138,7 @@ save_elf_debug() {
 
 	mkdir -p "${y%/*}"
 
-	if [ -f "${inode_debug}" ] ; then
+	if [[ -f "${inode_debug}" ]] ; then
 		ln "${inode_debug}" "${y}" || die "ln failed unexpectedly"
 	else
 		if [[ -n ${splitdebug} ]] ; then
@@ -151,7 +151,7 @@ save_elf_debug() {
 		fi
 		# Only do the following if the debug file was
 		# successfully created (see bug #446774).
-		if [ $? -eq 0 ] ; then
+		if [[ $? -eq 0 ]] ; then
 			local args="a-x,o-w"
 			[[ -g ${x} || -u ${x} ]] && args+=",go-r"
 			chmod ${args} "${y}"
@@ -168,8 +168,8 @@ save_elf_debug() {
 		local buildid_dir="${ED}usr/lib/debug/.build-id/${buildid:0:2}"
 		local buildid_file="${buildid_dir}/${buildid:2}"
 		mkdir -p "${buildid_dir}"
-		[ -L "${buildid_file}".debug ] || ln -s "../../${x:${#D}}.debug" "${buildid_file}.debug"
-		[ -L "${buildid_file}" ] || ln -s "/${x:${#D}}" "${buildid_file}"
+		[[ -L "${buildid_file}".debug ]] || ln -s "../../${x:${#D}}.debug" "${buildid_file}.debug"
+		[[ -L "${buildid_file}" ]] || ln -s "/${x:${#D}}" "${buildid_file}"
 	fi
 }
 
@@ -193,7 +193,7 @@ process_elf() {
 		unset lockfile
 	fi
 
-	[ -f "${inode_link}_stripped" ] && already_stripped=true || already_stripped=false
+	[[ -f "${inode_link}_stripped" ]] && already_stripped=true || already_stripped=false
 
 	if ! ${already_stripped} ; then
 		if ${PRESERVE_XATTR} ; then

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -244,7 +244,7 @@ inherit() {
 	local B_RDEPEND
 	local B_PDEPEND
 	local B_HDEPEND
-	while [ "$1" ]; do
+	while [[ "$1" ]]; do
 		location=""
 		potential_location=""
 
@@ -288,12 +288,12 @@ inherit() {
 
 			# Retain the old data and restore it later.
 			unset B_IUSE B_REQUIRED_USE B_DEPEND B_RDEPEND B_PDEPEND B_HDEPEND
-			[ "${IUSE+set}"       = set ] && B_IUSE="${IUSE}"
-			[ "${REQUIRED_USE+set}" = set ] && B_REQUIRED_USE="${REQUIRED_USE}"
-			[ "${DEPEND+set}"     = set ] && B_DEPEND="${DEPEND}"
-			[ "${RDEPEND+set}"    = set ] && B_RDEPEND="${RDEPEND}"
-			[ "${PDEPEND+set}"    = set ] && B_PDEPEND="${PDEPEND}"
-			[ "${HDEPEND+set}"    = set ] && B_HDEPEND="${HDEPEND}"
+			[[ "${IUSE+set}"       = set ]] && B_IUSE="${IUSE}"
+			[[ "${REQUIRED_USE+set}" = set ]] && B_REQUIRED_USE="${REQUIRED_USE}"
+			[[ "${DEPEND+set}"     = set ]] && B_DEPEND="${DEPEND}"
+			[[ "${RDEPEND+set}"    = set ]] && B_RDEPEND="${RDEPEND}"
+			[[ "${PDEPEND+set}"    = set ]] && B_PDEPEND="${PDEPEND}"
+			[[ "${HDEPEND+set}"    = set ]] && B_HDEPEND="${HDEPEND}"
 			unset IUSE REQUIRED_USE DEPEND RDEPEND PDEPEND HDEPEND
 			#turn on glob expansion
 			set +f
@@ -307,30 +307,30 @@ inherit() {
 
 			# If each var has a value, append it to the global variable E_* to
 			# be applied after everything is finished. New incremental behavior.
-			[ "${IUSE+set}"         = set ] && E_IUSE+="${E_IUSE:+ }${IUSE}"
-			[ "${REQUIRED_USE+set}" = set ] && E_REQUIRED_USE+="${E_REQUIRED_USE:+ }${REQUIRED_USE}"
-			[ "${DEPEND+set}"       = set ] && E_DEPEND+="${E_DEPEND:+ }${DEPEND}"
-			[ "${RDEPEND+set}"      = set ] && E_RDEPEND+="${E_RDEPEND:+ }${RDEPEND}"
-			[ "${PDEPEND+set}"      = set ] && E_PDEPEND+="${E_PDEPEND:+ }${PDEPEND}"
-			[ "${HDEPEND+set}"      = set ] && E_HDEPEND+="${E_HDEPEND:+ }${HDEPEND}"
+			[[ "${IUSE+set}"         = set ]] && E_IUSE+="${E_IUSE:+ }${IUSE}"
+			[[ "${REQUIRED_USE+set}" = set ]] && E_REQUIRED_USE+="${E_REQUIRED_USE:+ }${REQUIRED_USE}"
+			[[ "${DEPEND+set}"       = set ]] && E_DEPEND+="${E_DEPEND:+ }${DEPEND}"
+			[[ "${RDEPEND+set}"      = set ]] && E_RDEPEND+="${E_RDEPEND:+ }${RDEPEND}"
+			[[ "${PDEPEND+set}"      = set ]] && E_PDEPEND+="${E_PDEPEND:+ }${PDEPEND}"
+			[[ "${HDEPEND+set}"      = set ]] && E_HDEPEND+="${E_HDEPEND:+ }${HDEPEND}"
 
-			[ "${B_IUSE+set}"     = set ] && IUSE="${B_IUSE}"
-			[ "${B_IUSE+set}"     = set ] || unset IUSE
+			[[ "${B_IUSE+set}"     = set ]] && IUSE="${B_IUSE}"
+			[[ "${B_IUSE+set}"     = set ]] || unset IUSE
 			
-			[ "${B_REQUIRED_USE+set}"     = set ] && REQUIRED_USE="${B_REQUIRED_USE}"
-			[ "${B_REQUIRED_USE+set}"     = set ] || unset REQUIRED_USE
+			[[ "${B_REQUIRED_USE+set}"     = set ]] && REQUIRED_USE="${B_REQUIRED_USE}"
+			[[ "${B_REQUIRED_USE+set}"     = set ]] || unset REQUIRED_USE
 
-			[ "${B_DEPEND+set}"   = set ] && DEPEND="${B_DEPEND}"
-			[ "${B_DEPEND+set}"   = set ] || unset DEPEND
+			[[ "${B_DEPEND+set}"   = set ]] && DEPEND="${B_DEPEND}"
+			[[ "${B_DEPEND+set}"   = set ]] || unset DEPEND
 
-			[ "${B_RDEPEND+set}"  = set ] && RDEPEND="${B_RDEPEND}"
-			[ "${B_RDEPEND+set}"  = set ] || unset RDEPEND
+			[[ "${B_RDEPEND+set}"  = set ]] && RDEPEND="${B_RDEPEND}"
+			[[ "${B_RDEPEND+set}"  = set ]] || unset RDEPEND
 
-			[ "${B_PDEPEND+set}"  = set ] && PDEPEND="${B_PDEPEND}"
-			[ "${B_PDEPEND+set}"  = set ] || unset PDEPEND
+			[[ "${B_PDEPEND+set}"  = set ]] && PDEPEND="${B_PDEPEND}"
+			[[ "${B_PDEPEND+set}"  = set ]] || unset PDEPEND
 
-			[ "${B_HDEPEND+set}"  = set ] && HDEPEND="${B_HDEPEND}"
-			[ "${B_HDEPEND+set}"  = set ] || unset HDEPEND
+			[[ "${B_HDEPEND+set}"  = set ]] && HDEPEND="${B_HDEPEND}"
+			[[ "${B_HDEPEND+set}"  = set ]] || unset HDEPEND
 
 			#turn on glob expansion
 			set +f
@@ -365,7 +365,7 @@ inherit() {
 # code will be eval'd:
 # src_unpack() { base_src_unpack; }
 EXPORT_FUNCTIONS() {
-	if [ -z "$ECLASS" ]; then
+	if [[ -z "$ECLASS" ]]; then
 		die "EXPORT_FUNCTIONS without a defined ECLASS"
 	fi
 	eval $__export_funcs_var+=\" $*\"
@@ -410,8 +410,8 @@ __source_all_bashrcs() {
 		__source_env_files --no-qa "${PM_EBUILD_HOOK_DIR}"
 	fi
 
-	[ ! -z "${OCC}" ] && export CC="${OCC}"
-	[ ! -z "${OCXX}" ] && export CXX="${OCXX}"
+	[[ ! -z "${OCC}" ]] && export CC="${OCC}"
+	[[ ! -z "${OCXX}" ]] && export CXX="${OCXX}"
 }
 
 # @FUNCTION: __source_env_files
@@ -483,14 +483,14 @@ fi
 if [[ -n ${QA_INTERCEPTORS} ]] ; then
 	for BIN in ${QA_INTERCEPTORS}; do
 		BIN_PATH=$(type -Pf ${BIN})
-		if [ "$?" != "0" ]; then
+		if [[ "$?" != "0" ]]; then
 			BODY="echo \"*** missing command: ${BIN}\" >&2; return 127"
 		else
 			BODY="${BIN_PATH} \"\$@\"; return \$?"
 		fi
 		if [[ ${EBUILD_PHASE} == depend ]] ; then
 			FUNC_SRC="${BIN}() {
-				if [ \$ECLASS_DEPTH -gt 0 ]; then
+				if [[ \$ECLASS_DEPTH -gt 0 ]]; then
 					eqawarn \"QA Notice: '${BIN}' called in global scope: eclass \${ECLASS}\"
 				else
 					eqawarn \"QA Notice: '${BIN}' called in global scope: \${CATEGORY}/\${PF}\"
@@ -525,7 +525,7 @@ trap 'exit 1' SIGTERM
 
 if ! has "$EBUILD_PHASE" clean cleanrm depend && \
 	! [[ $EMERGE_FROM = ebuild && $EBUILD_PHASE = setup ]] && \
-	[ -f "${T}"/environment ] ; then
+	[[ -f "${T}"/environment ]] ; then
 	# The environment may have been extracted from environment.bz2 or
 	# may have come from another version of ebuild.sh or something.
 	# In any case, preprocess it to prevent any potential interference.
@@ -547,9 +547,9 @@ if ! has "$EBUILD_PHASE" clean cleanrm depend && \
 	export SANDBOX_ON=0
 	for x in SANDBOX_DENY SANDBOX_PREDICT SANDBOX_READ SANDBOX_WRITE ; do
 		y="PORTAGE_${x}"
-		if [ -z "${!x}" ] ; then
+		if [[ -z "${!x}" ]] ; then
 			export ${x}="${!y}"
-		elif [ -n "${!y}" ] && [ "${!y}" != "${!x}" ] ; then
+		elif [[ -n "${!y}" ]] && [[ "${!y}" != "${!x}" ]] ; then
 			# filter out dupes
 			export ${x}="$(printf "${!y}:${!x}" | tr ":" "\0" | \
 				sort -z -u | tr "\0" ":")"
@@ -620,7 +620,7 @@ if ! has "$EBUILD_PHASE" clean cleanrm ; then
 			rm "$PORTAGE_BUILDDIR/.ebuild_changed"
 		fi
 
-		[ "${EAPI+set}" = set ] || EAPI=0
+		[[ "${EAPI+set}" = set ]] || EAPI=0
 
 		# export EAPI for helpers (especially since we unset it above)
 		export EAPI
@@ -692,7 +692,7 @@ fi
 
 # unset USE_EXPAND variables that contain only the special "*" token
 for x in ${USE_EXPAND} ; do
-	[ "${!x}" == "*" ] && unset ${x}
+	[[ "${!x}" == "*" ]] && unset ${x}
 done
 unset x
 
@@ -705,8 +705,8 @@ if [[ $EBUILD_PHASE = depend ]] ; then
 	export SANDBOX_ON="0"
 	set -f
 
-	if [ -n "${dbkey}" ] ; then
-		if [ ! -d "${dbkey%/*}" ]; then
+	if [[ -n "${dbkey}" ]] ; then
+		if [[ ! -d "${dbkey%/*}" ]]; then
 			install -d -g ${PORTAGE_GID} -m2775 "${dbkey%/*}"
 		fi
 		# Make it group writable. 666&~002==664
@@ -723,7 +723,7 @@ if [[ $EBUILD_PHASE = depend ]] ; then
 	fi
 
 	# The extra $(echo) commands remove newlines.
-	if [ -n "${dbkey}" ] ; then
+	if [[ -n "${dbkey}" ]] ; then
 		> "${dbkey}"
 		for f in ${auxdbkeys} ; do
 			echo $(echo ${!f}) >> "${dbkey}" || exit $?

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -31,7 +31,7 @@ argv0=$0
 # Use portageq from the same directory/prefix as the current script, so
 # that we don't have to rely on PATH including the current EPREFIX.
 scriptpath=${BASH_SOURCE[0]}
-if [ -x "${scriptpath%/*}/portageq" ]; then
+if [[ -x "${scriptpath%/*}/portageq" ]]; then
 	portageq=${scriptpath%/*}/portageq
 elif type -P portageq > /dev/null ; then
 	portageq=portageq
@@ -59,7 +59,7 @@ repo_sync_type=$(__repo_attr "${repo_name}" sync-type)
 
 # If PORTAGE_NICENESS is overriden via the env then it will
 # still pass through the portageq call and override properly.
-if [ -n "${PORTAGE_NICENESS}" ]; then
+if [[ -n "${PORTAGE_NICENESS}" ]]; then
 	renice $PORTAGE_NICENESS $$ > /dev/null
 fi
 
@@ -120,7 +120,7 @@ get_utc_second_from_string() {
 get_portage_timestamp() {
 	local portage_current_timestamp=0
 
-	if [ -f "${repo_location}/metadata/timestamp.x" ]; then
+	if [[ -f "${repo_location}/metadata/timestamp.x" ]]; then
 		portage_current_timestamp=$(cut -f 1 -d " " "${repo_location}/metadata/timestamp.x" )
 	fi
 
@@ -132,9 +132,9 @@ fetch_file() {
 	local FILE="$2"
 	local opts
 
-	if [ "${FETCHCOMMAND/wget/}" != "${FETCHCOMMAND}" ]; then
+	if [[ "${FETCHCOMMAND/wget/}" != "${FETCHCOMMAND}" ]]; then
 		opts="--continue $(nvecho -q)"
-	elif [ "${FETCHCOMMAND/curl/}" != "${FETCHCOMMAND}" ]; then
+	elif [[ "${FETCHCOMMAND/curl/}" != "${FETCHCOMMAND}" ]]; then
 		opts="--continue-at - $(nvecho -s -f)"
 	else
 		rm -f "${DISTDIR}/${FILE}"
@@ -161,9 +161,9 @@ check_file_digest() {
 	if type -P md5sum > /dev/null; then
 		local md5sum_output=$(md5sum "${file}")
 		local digest_content=$(< "${digest}")
-		[ "${md5sum_output%%[[:space:]]*}" = "${digest_content%%[[:space:]]*}" ] && r=0
+		[[ "${md5sum_output%%[[:space:]]*}" = "${digest_content%%[[:space:]]*}" ]] && r=0
 	elif type -P md5 > /dev/null; then
-		[ "$(md5 -q "${file}")" == "$(cut -d ' ' -f 1 "${digest}")" ] && r=0
+		[[ "$(md5 -q "${file}")" == "$(cut -d ' ' -f 1 "${digest}")" ]] && r=0
 	else
 		eecho "cannot check digest: no suitable md5/md5sum binaries found"
 	fi
@@ -176,7 +176,7 @@ check_file_signature() {
 	local file="$2"
 	local r=1
 
-	if [ ${WEBSYNC_VERIFY_SIGNATURE} != 0 ]; then
+	if [[ ${WEBSYNC_VERIFY_SIGNATURE} != 0 ]]; then
 
 		__vecho "Checking signature ..."
 
@@ -252,7 +252,7 @@ sync_local() {
 		emerge --metadata
 	fi
 	local post_sync=${PORTAGE_CONFIGROOT}etc/portage/bin/post_sync
-	[ -x "${post_sync}" ] && "${post_sync}"
+	[[ -x "${post_sync}" ]] && "${post_sync}"
 	# --quiet suppresses output if there are no relevant news items
 	has news ${FEATURES} && emerge --check-news --quiet
 	return 0
@@ -292,13 +292,13 @@ do_snapshot() {
 			local digest="${file}.md5sum"
 			local signature="${file}.gpgsig"
 
-			if [ -s "${DISTDIR}/${file}" -a -s "${DISTDIR}/${digest}" -a -s "${DISTDIR}/${signature}" ] ; then
+			if [[ -s "${DISTDIR}/${file}" && -s "${DISTDIR}/${digest}" && -s "${DISTDIR}/${signature}" ]]; then
 				check_file_digest "${DISTDIR}/${digest}" "${DISTDIR}/${file}" && \
 				check_file_signature "${DISTDIR}/${signature}" "${DISTDIR}/${file}" && \
 				have_files=1
 			fi
 
-			if [ ${have_files} -eq 0 ] ; then
+			if [[ ${have_files} -eq 0 ]] ; then
 				fetch_file "${mirror}/snapshots/${digest}" "${digest}" && \
 				fetch_file "${mirror}/snapshots/${signature}" "${signature}" && \
 				fetch_file "${mirror}/snapshots/${file}" "${file}" && \
@@ -312,13 +312,13 @@ do_snapshot() {
 			# we want to try and retrieve
 			# from a different mirror
 			#
-			if [ ${have_files} -eq 1 ]; then
+			if [[ ${have_files} -eq 1 ]]; then
 
 				__vecho "Getting snapshot timestamp ..."
 				local snapshot_timestamp=$(get_snapshot_timestamp "${DISTDIR}/${file}")
 
-				if [ ${ignore_timestamp} == 0 ]; then
-					if [ ${snapshot_timestamp} -lt $(get_portage_timestamp) ]; then
+				if [[ ${ignore_timestamp} == 0 ]]; then
+					if [[ ${snapshot_timestamp} -lt $(get_portage_timestamp) ]]; then
 						wecho "portage is newer than snapshot"
 						have_files=0
 					fi
@@ -329,7 +329,7 @@ do_snapshot() {
 					# Check that this snapshot
 					# is what it claims to be ...
 					#
-					if [ ${snapshot_timestamp} -lt ${utc_seconds} ] || \
+					if [[ ${snapshot_timestamp} -lt ${utc_seconds} ]] || \
 						[ ${snapshot_timestamp} -gt $((${utc_seconds}+ 2*86400)) ]; then
 
 						wecho "snapshot timestamp is not in acceptable period"
@@ -338,7 +338,7 @@ do_snapshot() {
 				fi
 			fi
 
-			if [ ${have_files} -eq 1 ]; then
+			if [[ ${have_files} -eq 1 ]]; then
 				break
 			else
 				#
@@ -348,10 +348,10 @@ do_snapshot() {
 			fi
 		done
 
-		[ ${have_files} -eq 1 ] && break
+		[[ ${have_files} -eq 1 ]] && break
 	done
 
-	if [ ${have_files} -eq 1 ]; then
+	if [[ ${have_files} -eq 1 ]]; then
 		sync_local "${DISTDIR}/${file}" && r=0
 	else
 		__vecho "${date} snapshot was not found"
@@ -386,7 +386,7 @@ do_latest_snapshot() {
 	# Daily snapshots are created at 00:45 and are not
 	# available until after 01:00. Don't waste time trying
 	# to fetch a snapshot before it's been created.
-	if [ ${start_hour} -lt 1 ] ; then
+	if [[ ${start_hour} -lt 1 ]] ; then
 		(( start_time -= 86400 ))
 	fi
 	local snapshot_date=$(get_date_part ${start_time} "%Y%m%d")
@@ -398,19 +398,19 @@ do_latest_snapshot() {
 		# snapshots are created at 00:45
 		(( approx_snapshot_time = snapshot_date_seconds + 86400 + 2700 ))
 		(( timestamp_difference = existing_timestamp - approx_snapshot_time ))
-		[ ${timestamp_difference} -lt 0 ] && (( timestamp_difference = -1 * timestamp_difference ))
+		[[ ${timestamp_difference} -lt 0 ]] && (( timestamp_difference = -1 * timestamp_difference ))
 		snapshot_date=$(get_date_part ${snapshot_date_seconds} "%Y%m%d")
 
 		timestamp_problem=""
-		if [ ${timestamp_difference} -eq 0 ]; then
+		if [[ ${timestamp_difference} -eq 0 ]]; then
 			timestamp_problem="is identical to"
-		elif [ ${timestamp_difference} -lt ${min_time_diff} ]; then
+		elif [[ ${timestamp_difference} -lt ${min_time_diff} ]]; then
 			timestamp_problem="is possibly identical to"
-		elif [ ${approx_snapshot_time} -lt ${existing_timestamp} ] ; then
+		elif [[ ${approx_snapshot_time} -lt ${existing_timestamp} ]]; then
 			timestamp_problem="is newer than"
 		fi
 
-		if [ -n "${timestamp_problem}" ]; then
+		if [[ -n "${timestamp_problem}" ]]; then
 			ewarn "Latest snapshot date: ${snapshot_date}"
 			ewarn
 			ewarn "Approximate snapshot timestamp: ${approx_snapshot_time}"
@@ -492,7 +492,7 @@ main() {
 	cd "${TMPDIR}" || exit 1
 
 	${keep} || DISTDIR=${TMPDIR}
-	[ ! -d "${DISTDIR}" ] && mkdir -p "${DISTDIR}"
+	[[ ! -d "${DISTDIR}" ]] && mkdir -p "${DISTDIR}"
 
 	if ${keep} && [[ ! -w ${DISTDIR} ]] ; then
 		eecho "DISTDIR is not writable: ${DISTDIR}"

--- a/bin/etc-update
+++ b/bin/etc-update
@@ -124,8 +124,8 @@ scan() {
 		find_opts+=( "$name_opt" )
 		find_opts+=( ! -name '.*~' ! -iname '.*.bak' -print )
 
-		if [ ! -w "${path}" ] ; then
-			[ -e "${path}" ] || continue
+		if [[ ! -w "${path}" ]] ; then
+			[[ -e "${path}" ]] || continue
 			die "Need write access to ${path}"
 		fi
 
@@ -361,7 +361,7 @@ read_int() {
 }
 
 do_file() {
-	interactive_echo() { [ "${OVERWRITE_ALL}" != "yes" ] && [ "${DELETE_ALL}" != "yes" ] && echo; }
+	interactive_echo() { [[ "${OVERWRITE_ALL}" != "yes" ]] && [[ "${DELETE_ALL}" != "yes" ]] && echo; }
 	interactive_echo
 	local -i my_input
 	local -i linecnt
@@ -519,12 +519,12 @@ do_cfg() {
 		case ${my_input} in
 			1)	echo "Replacing ${ofile} with ${file}"
 				do_mv_ln ${mv_opts} "${file}" "${ofile}"
-				[ -n "${OVERWRITE_ALL}" ] && my_input=-1
+				[[ -n "${OVERWRITE_ALL}" ]] && my_input=-1
 				continue
 				;;
 			2)	echo "Deleting ${file}"
 				rm ${rm_opts} "${file}"
-				[ -n "${DELETE_ALL}" ] && my_input=-1
+				[[ -n "${DELETE_ALL}" ]] && my_input=-1
 				continue
 				;;
 			3)	do_merge "${file}" "${ofile}"
@@ -663,10 +663,10 @@ die() {
 	trap SIGINT
 	local msg=$1 exitcode=${2:-1}
 
-	if [ ${exitcode} -eq 0 ] ; then
+	if [[ ${exitcode} -eq 0 ]] ; then
 		${QUIET} || printf 'Exiting: %b\n' "${msg}"
 		scan > /dev/null
-		! ${QUIET} && [ ${count} -gt 0 ] && echo "NOTE: ${count} updates remaining"
+		! ${QUIET} && [[ ${count} -gt 0 ]] && echo "NOTE: ${count} updates remaining"
 	else
 		error "${msg}"
 	fi

--- a/bin/install-qa-check.d/10ignored-flags
+++ b/bin/install-qa-check.d/10ignored-flags
@@ -40,7 +40,7 @@ ignored_flag_check() {
 
 		if [[ -f "${T}"/scanelf-ignored-CFLAGS.log ]] ; then
 
-			if [ "${QA_STRICT_FLAGS_IGNORED-unset}" = unset ] ; then
+			if [[ "${QA_STRICT_FLAGS_IGNORED-unset}" = unset ]] ; then
 				for x in "${QA_FLAGS_IGNORED[@]}" ; do
 					sed -e "s#^${x#/}\$##" -i "${T}"/scanelf-ignored-CFLAGS.log
 				done
@@ -69,7 +69,7 @@ ignored_flag_check() {
 		f=$(scanelf -qyRF '#k%p' -k .hash "${ED}")
 		if [[ -n ${f} ]] ; then
 			echo "${f}" > "${T}"/scanelf-ignored-LDFLAGS.log
-			if [ "${QA_STRICT_FLAGS_IGNORED-unset}" = unset ] ; then
+			if [[ "${QA_STRICT_FLAGS_IGNORED-unset}" = unset ]] ; then
 				for x in "${QA_FLAGS_IGNORED[@]}" ; do
 					sed -e "s#^${x#/}\$##" -i "${T}"/scanelf-ignored-LDFLAGS.log
 				done

--- a/bin/install-qa-check.d/80multilib-strict
+++ b/bin/install-qa-check.d/80multilib-strict
@@ -24,7 +24,7 @@ multilib_strict_check() {
 				set +o noglob
 				set -${shopts}
 			fi
-			if [ "${QA_STRICT_MULTILIB_PATHS-unset}" = unset ] ; then
+			if [[ "${QA_STRICT_MULTILIB_PATHS-unset}" = unset ]] ; then
 				local x
 				for x in "${QA_MULTILIB_PATHS[@]}" ; do
 					sed -e "s#^${x#/}\$##" -i "${T}/multilib-strict.log"

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -7,8 +7,8 @@ source "${PORTAGE_BIN_PATH}/eapi.sh" || exit 1
 # We need this next line for "die" and "assert". It expands
 # It _must_ preceed all the calls to die and assert.
 shopt -s expand_aliases
-alias save_IFS='[ "${IFS:-unset}" != "unset" ] && old_IFS="${IFS}"'
-alias restore_IFS='if [ "${old_IFS:-unset}" != "unset" ]; then IFS="${old_IFS}"; unset old_IFS; else unset IFS; fi'
+alias save_IFS='[[ "${IFS:-unset}" != "unset" ]] && old_IFS="${IFS}"'
+alias restore_IFS='if [[ "${old_IFS:-unset}" != "unset" ]]; then IFS="${old_IFS}"; unset old_IFS; else unset IFS; fi'
 
 assert() {
 	local x pipestatus=${PIPESTATUS[*]}
@@ -66,7 +66,7 @@ __dump_trace() {
 	(( n = ${#FUNCNAME[@]} - 1 ))
 	(( p = ${#BASH_ARGV[@]} ))
 	while (( n > 0 )) ; do
-		[ "${FUNCNAME[${n}]}" == "__qa_call" ] && break
+		[[ "${FUNCNAME[${n}]}" == "__qa_call" ]] && break
 		(( p -= ${BASH_ARGC[${n}]} ))
 		(( n-- ))
 	done
@@ -133,7 +133,7 @@ die() {
 	fi
 
 	set +e
-	if [ -n "${QA_INTERCEPTORS}" ] ; then
+	if [[ -n "${QA_INTERCEPTORS}" ]] ; then
 		# die was called from inside inherit. We need to clean up
 		# QA_INTERCEPTORS since sed is called below.
 		unset -f ${QA_INTERCEPTORS}
@@ -143,7 +143,7 @@ die() {
 	# setup spacing to make output easier to read
 	(( n = ${#FUNCNAME[@]} - 1 ))
 	while (( n > 0 )) ; do
-		[ "${FUNCNAME[${n}]}" == "__qa_call" ] && break
+		[[ "${FUNCNAME[${n}]}" == "__qa_call" ]] && break
 		(( n-- ))
 	done
 	(( n == 0 )) && (( n = ${#FUNCNAME[@]} - 1 ))
@@ -218,9 +218,9 @@ die() {
 			eerror "For convenience, a symlink to the build log is located at '${T}/build.${log_ext}'."
 		fi
 	fi
-	if [ -f "${T}/environment" ] ; then
+	if [[ -f "${T}/environment" ]] ; then
 		eerror "The ebuild environment file is located at '${T}/environment'."
-	elif [ -d "${T}" ] ; then
+	elif [[ -d "${T}" ]] ; then
 		{
 			set
 			export
@@ -249,7 +249,7 @@ __vecho() {
 # Internal logging function, don't use this in ebuilds
 __elog_base() {
 	local messagetype
-	[ -z "${1}" -o -z "${T}" -o ! -d "${T}/logging" ] && return 1
+	[[ -z "${1}" || -z "${T}" || ! -d "${T}/logging" ]] && return 1
 	case "${1}" in
 		INFO|WARN|ERROR|LOG|QA)
 			messagetype="${1}"
@@ -400,7 +400,7 @@ __set_colors() {
 	# Now, ${ENDCOL} will move us to the end of the
 	# column;  irregardless of character width
 	ENDCOL=$'\e[A\e['$(( COLS - 8 ))'C'
-	if [ -n "${PORTAGE_COLORMAP}" ] ; then
+	if [[ -n "${PORTAGE_COLORMAP}" ]] ; then
 		eval ${PORTAGE_COLORMAP}
 	else
 		GOOD=$'\e[32;01m'
@@ -468,7 +468,7 @@ has() {
 
 	local x
 	for x in "$@"; do
-		[ "${x}" = "${needle}" ] && return 0
+		[[ "${x}" = "${needle}" ]] && return 0
 	done
 	return 1
 }

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -22,16 +22,16 @@ install_symlink_html_docs() {
 	fi
 	cd "${ED}" || die "cd failed"
 	#symlink the html documentation (if DOC_SYMLINKS_DIR is set in make.conf)
-	if [ -n "${DOC_SYMLINKS_DIR}" ] ; then
+	if [[ -n "${DOC_SYMLINKS_DIR}" ]] ; then
 		local mydocdir docdir
 		for docdir in "${HTMLDOC_DIR:-does/not/exist}" "${PF}/html" "${PF}/HTML" "${P}/html" "${P}/HTML" ; do
-			if [ -d "usr/share/doc/${docdir}" ] ; then
+			if [[ -d "usr/share/doc/${docdir}" ]]; then
 				mydocdir="/usr/share/doc/${docdir}"
 			fi
 		done
-		if [ -n "${mydocdir}" ] ; then
+		if [[ -n "${mydocdir}" ]]; then
 			local mysympath
-			if [ -z "${SLOT}" -o "${SLOT%/*}" = "0" ] ; then
+			if [[ -z "${SLOT}" || "${SLOT%/*}" = "0" ]]; then
 				mysympath="${DOC_SYMLINKS_DIR}/${CATEGORY}/${PN}"
 			else
 				mysympath="${DOC_SYMLINKS_DIR}/${CATEGORY}/${PN}-${SLOT%/*}"
@@ -46,8 +46,8 @@ install_symlink_html_docs() {
 # replacement for "readlink -f" or "realpath"
 READLINK_F_WORKS=""
 canonicalize() {
-	if [[ -z ${READLINK_F_WORKS} ]] ; then
-		if [[ $(readlink -f -- /../ 2>/dev/null) == "/" ]] ; then
+	if [[ -z ${READLINK_F_WORKS} ]]; then
+		if [[ $(readlink -f -- /../ 2>/dev/null) == "/" ]]; then
 			READLINK_F_WORKS=true
 		else
 			READLINK_F_WORKS=false
@@ -235,18 +235,18 @@ install_qa_check() {
 			arch=${l%%;*}; l=${l#*;}
 			obj="/${l%%;*}"; l=${l#*;}
 			soname=${l%%;*}; l=${l#*;}
-			rpath=${l%%;*}; l=${l#*;}; [ "${rpath}" = "  -  " ] && rpath=""
+			rpath=${l%%;*}; l=${l#*;}; [[ "${rpath}" = "  -  " ]] && rpath=""
 			needed=${l%%;*}; l=${l#*;}
 			echo "${obj} ${needed}"	>> "${PORTAGE_BUILDDIR}"/build-info/NEEDED
 			echo "${arch:3};${obj};${soname};${rpath};${needed}" >> "${PORTAGE_BUILDDIR}"/build-info/NEEDED.ELF.2
 		done }
 
-		[ -n "${QA_SONAME_NO_SYMLINK}" ] && \
+		[[ -n "${QA_SONAME_NO_SYMLINK}" ]] && \
 			echo "${QA_SONAME_NO_SYMLINK}" > \
 			"${PORTAGE_BUILDDIR}"/build-info/QA_SONAME_NO_SYMLINK
 
 		if has binchecks ${RESTRICT} && \
-			[ -s "${PORTAGE_BUILDDIR}/build-info/NEEDED.ELF.2" ] ; then
+			[[ -s "${PORTAGE_BUILDDIR}/build-info/NEEDED.ELF.2" ]] ; then
 			eqawarn "QA Notice: RESTRICT=binchecks prevented checks on these ELF files:"
 			eqawarn "$(while read -r x; do x=${x#*;} ; x=${x%%;*} ; echo "${x#${EPREFIX}}" ; done < "${PORTAGE_BUILDDIR}"/build-info/NEEDED.ELF.2)"
 		fi
@@ -301,7 +301,7 @@ install_mask() {
 }
 
 preinst_mask() {
-	if [ -z "${D}" ]; then
+	if [[ -z "${D}" ]]; then
 		 eerror "${FUNCNAME}: D is unset"
 		 return 1
 	fi
@@ -331,7 +331,7 @@ preinst_mask() {
 }
 
 preinst_sfperms() {
-	if [ -z "${D}" ]; then
+	if [[ -z "${D}" ]]; then
 		 eerror "${FUNCNAME}: D is unset"
 		 return 1
 	fi
@@ -345,7 +345,7 @@ preinst_sfperms() {
 		local i
 		find "${ED}" -type f -perm -4000 -print0 | \
 		while read -r -d $'\0' i ; do
-			if [ -n "$(find "$i" -perm -2000)" ] ; then
+			if [[ -n "$(find "$i" -perm -2000)" ]]; then
 				ebegin ">>> SetUID and SetGID: [chmod o-r] /${i#${ED}}"
 				chmod o-r "$i"
 				eend $?
@@ -357,7 +357,7 @@ preinst_sfperms() {
 		done
 		find "${ED}" -type f -perm -2000 -print0 | \
 		while read -r -d $'\0' i ; do
-			if [ -n "$(find "$i" -perm -4000)" ] ; then
+			if [[ -n "$(find "$i" -perm -4000)" ]]; then
 				# This case is already handled
 				# by the SetUID check above.
 				true
@@ -371,7 +371,7 @@ preinst_sfperms() {
 }
 
 preinst_suid_scan() {
-	if [ -z "${D}" ]; then
+	if [[ -z "${D}" ]]; then
 		 eerror "${FUNCNAME}: D is unset"
 		 return 1
 	fi
@@ -390,7 +390,7 @@ preinst_suid_scan() {
 		addwrite "${sfconf}"
 		__vecho ">>> Performing suid scan in ${ED}"
 		for i in $(find "${ED}" -type f \( -perm -4000 -o -perm -2000 \) ); do
-			if [ -s "${sfconf}" ]; then
+			if [[ -s "${sfconf}" ]]; then
 				install_path=/${i#${ED}}
 				if grep -q "^${install_path}\$" "${sfconf}" ; then
 					__vecho "- ${install_path} is an approved suid file"
@@ -415,7 +415,7 @@ preinst_suid_scan() {
 }
 
 preinst_selinux_labels() {
-	if [ -z "${D}" ]; then
+	if [[ -z "${D}" ]]; then
 		 eerror "${FUNCNAME}: D is unset"
 		 return 1
 	fi
@@ -423,8 +423,8 @@ preinst_selinux_labels() {
 		# SELinux file labeling (needs to execute after preinst)
 		# only attempt to label if setfiles is executable
 		# and 'context' is available on selinuxfs.
-		if [ -f /selinux/context -o -f /sys/fs/selinux/context ] && \
-			[ -x /usr/sbin/setfiles -a -x /usr/sbin/selinuxconfig ]; then
+		if [[ -f /selinux/context || -f /sys/fs/selinux/context ]] && \
+			[[ -x /usr/sbin/setfiles && -x /usr/sbin/selinuxconfig ]]; then
 			__vecho ">>> Setting SELinux security labels"
 			(
 				eval "$(/usr/sbin/selinuxconfig)" || \
@@ -475,7 +475,7 @@ __dyn_package() {
 	# Sandbox is disabled in case the user wants to use a symlink
 	# for $PKGDIR and/or $PKGDIR/All.
 	export SANDBOX_ON="0"
-	[ -z "${PORTAGE_BINPKG_TMPFILE}" ] && \
+	[[ -z "${PORTAGE_BINPKG_TMPFILE}" ]] && \
 		die "PORTAGE_BINPKG_TMPFILE is unset"
 	mkdir -p "${PORTAGE_BINPKG_TMPFILE%/*}" || die "mkdir failed"
 	tar $tar_options -cf - $PORTAGE_BINPKG_TAR_OPTS -C "${PROOT}" . | \
@@ -484,7 +484,7 @@ __dyn_package() {
 	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
 		"${PORTAGE_PYTHON:-/usr/bin/python}" "$PORTAGE_BIN_PATH"/xpak-helper.py recompose \
 		"$PORTAGE_BINPKG_TMPFILE" "$PORTAGE_BUILDDIR/build-info"
-	if [ $? -ne 0 ]; then
+	if [[ $? -ne 0 ]]; then
 		rm -f "${PORTAGE_BINPKG_TMPFILE}"
 		die "Failed to append metadata to the tbz2 file"
 	fi
@@ -496,7 +496,7 @@ __dyn_package() {
 		md5_hash=$(md5 "${PORTAGE_BINPKG_TMPFILE}")
 		md5_hash=${md5_hash##* }
 	fi
-	[ -n "${md5_hash}" ] && \
+	[[ -n "${md5_hash}" ]] && \
 		echo ${md5_hash} > "${PORTAGE_BUILDDIR}"/build-info/BINPKGMD5
 	__vecho ">>> Done."
 
@@ -583,7 +583,7 @@ install_hooks() {
 	local ret=0
 	shopt -s nullglob
 	for fp in "${hooks_dir}"/*; do
-		if [ -x "$fp" ]; then
+		if [[ -x "$fp" ]]; then
 			"$fp"
 			ret=$(( $ret | $? ))
 		fi
@@ -596,9 +596,9 @@ eqatag() {
 	__eqatag "${@}"
 }
 
-if [ -n "${MISC_FUNCTIONS_ARGS}" ]; then
+if [[ -n "${MISC_FUNCTIONS_ARGS}" ]]; then
 	__source_all_bashrcs
-	[ "$PORTAGE_DEBUG" == "1" ] && set -x
+	[[ "$PORTAGE_DEBUG" == "1" ]] && set -x
 	for x in ${MISC_FUNCTIONS_ARGS}; do
 		${x}
 	done

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -124,7 +124,7 @@ __filter_readonly_variables() {
 			LC_NUMERIC LC_PAPER LC_TIME"
 	fi
 	if ! has --allow-extra-vars $* ; then
-		if [ "${EMERGE_FROM}" = binary ] ; then
+		if [[ "${EMERGE_FROM}" = binary ]] ; then
 			# preserve additional variables from build time,
 			# while excluding untrusted variables
 			filtered_vars+=" ${binpkg_untrusted_vars}"
@@ -151,7 +151,7 @@ __preprocess_ebuild_env() {
 	# indicating that the environment may contain stale FEATURES and
 	# SANDBOX_{DENY,PREDICT,READ,WRITE} variables that should be filtered out.
 	# Otherwise, we don't need to filter the environment.
-	[ -f "${T}/environment.raw" ] || return 0
+	[[ -f "${T}/environment.raw" ]] || return 0
 
 	__filter_readonly_variables $_portage_filter_opts < "${T}"/environment \
 		>> "$T/environment.filtered" || return $?
@@ -183,7 +183,7 @@ __preprocess_ebuild_env() {
 		>> "$T/environment.success" || exit $?
 	) > "${T}/environment.filtered"
 	local retval
-	if [ -e "${T}/environment.success" ] ; then
+	if [[ -e "${T}/environment.success" ]] ; then
 		__filter_readonly_variables --filter-features < \
 			"${T}/environment.filtered" > "${T}/environment"
 		retval=$?
@@ -236,7 +236,7 @@ __dyn_unpack() {
 		__vecho ">>> WORKDIR is up-to-date, keeping..."
 		return 0
 	fi
-	if [ ! -d "${WORKDIR}" ]; then
+	if [[ ! -d "${WORKDIR}" ]]; then
 		install -m${PORTAGE_WORKDIR_MODE:-0700} -d "${WORKDIR}" || die "Failed to create dir '${WORKDIR}'"
 	fi
 	cd "${WORKDIR}" || die "Directory change failed: \`cd '${WORKDIR}'\`"
@@ -250,10 +250,10 @@ __dyn_unpack() {
 }
 
 __dyn_clean() {
-	if [ -z "${PORTAGE_BUILDDIR}" ]; then
+	if [[ -z "${PORTAGE_BUILDDIR}" ]]; then
 		echo "Aborting clean phase because PORTAGE_BUILDDIR is unset!"
 		return 1
-	elif [ ! -d "${PORTAGE_BUILDDIR}" ] ; then
+	elif [[ ! -d "${PORTAGE_BUILDDIR}" ]] ; then
 		return 0
 	fi
 	if has chflags $FEATURES ; then
@@ -280,7 +280,7 @@ __dyn_clean() {
 		rm -rf "${WORKDIR}"
 	fi
 
-	if [ -f "${PORTAGE_BUILDDIR}/.unpacked" ]; then
+	if [[ -f "${PORTAGE_BUILDDIR}/.unpacked" ]]; then
 		find "${PORTAGE_BUILDDIR}" -type d ! -regex "^${WORKDIR}" | sort -r | tr "\n" "\0" | $XARGS -0 rmdir &>/dev/null
 	fi
 
@@ -298,7 +298,7 @@ __dyn_clean() {
 
 __abort_handler() {
 	local msg
-	if [ "$2" != "fail" ]; then
+	if [[ "$2" != "fail" ]]; then
 		msg="${EBUILD}: ${1} aborted; exiting."
 	else
 		msg="${EBUILD}: ${1} failed; exiting."
@@ -480,7 +480,7 @@ __dyn_test() {
 	trap "__abort_test" SIGINT SIGQUIT
 	__start_distcc
 
-	if [ -d "${S}" ]; then
+	if [[ -d "${S}" ]]; then
 		cd "${S}"
 	else
 		cd "${WORKDIR}"
@@ -513,7 +513,7 @@ __dyn_test() {
 }
 
 __dyn_install() {
-	[ -z "$PORTAGE_BUILDDIR" ] && die "${FUNCNAME}: PORTAGE_BUILDDIR is unset"
+	[[ -z "$PORTAGE_BUILDDIR" ]] && die "${FUNCNAME}: PORTAGE_BUILDDIR is unset"
 	if has noauto $FEATURES ; then
 		rm -f "${PORTAGE_BUILDDIR}/.installed"
 	elif [[ -e $PORTAGE_BUILDDIR/.installed ]] ; then
@@ -650,7 +650,7 @@ __dyn_install() {
 	${PORTAGE_BZIP2_COMMAND} -f9 environment
 
 	cp "${EBUILD}" "${PF}.ebuild"
-	[ -n "${PORTAGE_REPO_NAME}" ]  && echo "${PORTAGE_REPO_NAME}" > repository
+	[[ -n "${PORTAGE_REPO_NAME}" ]]  && echo "${PORTAGE_REPO_NAME}" > repository
 	if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT}
 	then
 		>> DEBUGBUILD
@@ -714,7 +714,7 @@ __dyn_help() {
 	fi
 	echo "  merge to    : ${ROOT}"
 	echo
-	if [ -n "$USE" ]; then
+	if [[ -n "$USE" ]]; then
 		echo "Additionally, support for the following optional features will be enabled:"
 		echo
 		echo "  ${USE}"
@@ -727,7 +727,7 @@ __dyn_help() {
 # Translate a known ebuild(1) argument into the precise
 # name of it's corresponding ebuild phase.
 __ebuild_arg_to_phase() {
-	[ $# -ne 1 ] && die "expected exactly 1 arg, got $#: $*"
+	[[ $# -ne 1 ]] && die "expected exactly 1 arg, got $#: $*"
 	local arg=$1
 	local phase_func=""
 
@@ -782,7 +782,7 @@ __ebuild_arg_to_phase() {
 }
 
 __ebuild_phase_funcs() {
-	[ $# -ne 2 ] && die "expected exactly 2 args, got $#: $*"
+	[[ $# -ne 2 ]] && die "expected exactly 2 args, got $#: $*"
 	local eapi=$1
 	local phase_func=$2
 	local all_phases="src_compile pkg_config src_configure pkg_info
@@ -930,7 +930,7 @@ __ebuild_main() {
 			ewarn  "pkg_${1}() is not defined: '${EBUILD##*/}'"
 		fi
 		export SANDBOX_ON="0"
-		if [ "${PORTAGE_DEBUG}" != "1" ] || [ "${-/x/}" != "$-" ]; then
+		if [[ "${PORTAGE_DEBUG}" != "1" ]] || [[ "${-/x/}" != "$-" ]]; then
 			__ebuild_phase_with_hooks pkg_${1}
 		else
 			set -x
@@ -971,7 +971,7 @@ __ebuild_main() {
 				addwrite "$DISTCC_DIR"
 
 			x=LIBDIR_$ABI
-			[ -z "$PKG_CONFIG_PATH" -a -n "$ABI" -a -n "${!x}" ] && \
+			[[ -z "$PKG_CONFIG_PATH" && -n "$ABI" && -n "${!x}" ]] && \
 				export PKG_CONFIG_PATH=${EPREFIX}/usr/${!x}/pkgconfig
 
 			if has noauto $FEATURES && \
@@ -989,7 +989,7 @@ __ebuild_main() {
 			fi
 
 			cd "$PORTAGE_BUILDDIR"
-			if [ ! -d build-info ] ; then
+			if [[ ! -d build-info ]] ; then
 				mkdir build-info
 				cp "$EBUILD" "build-info/$PF.ebuild"
 			fi
@@ -1001,7 +1001,7 @@ __ebuild_main() {
 			;;
 		esac
 
-		if [ "${PORTAGE_DEBUG}" != "1" ] || [ "${-/x/}" != "$-" ]; then
+		if [[ "${PORTAGE_DEBUG}" != "1" ]] || [[ "${-/x/}" != "$-" ]]; then
 			__dyn_${1}
 		else
 			set -x
@@ -1015,7 +1015,7 @@ __ebuild_main() {
 		#for example, awking and piping a file in /tmp requires a temp file to be created
 		#in /etc.  If pkg_setup is in the sandbox, both our lilo and apache ebuilds break.
 		export SANDBOX_ON="0"
-		if [ "${PORTAGE_DEBUG}" != "1" ] || [ "${-/x/}" != "$-" ]; then
+		if [[ "${PORTAGE_DEBUG}" != "1" ]] || [[ "${-/x/}" != "$-" ]]; then
 			__dyn_${1}
 		else
 			set -x

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -17,14 +17,14 @@ declare -a PORTAGE_DOCOMPRESS=( /usr/share/{doc,info,man} )
 declare -a PORTAGE_DOCOMPRESS_SKIP=( /usr/share/doc/${PF}/html )
 
 into() {
-	if [ "$1" == "/" ]; then
+	if [[ "$1" == "/" ]]; then
 		export DESTTREE=""
 	else
 		export DESTTREE=$1
 		if ! ___eapi_has_prefix_variables; then
 			local ED=${D}
 		fi
-		if [ ! -d "${ED}${DESTTREE}" ]; then
+		if [[ ! -d "${ED}${DESTTREE}" ]]; then
 			install -d "${ED}${DESTTREE}"
 			local ret=$?
 			if [[ $ret -ne 0 ]] ; then
@@ -36,14 +36,14 @@ into() {
 }
 
 insinto() {
-	if [ "$1" == "/" ]; then
+	if [[ "$1" == "/" ]]; then
 		export INSDESTTREE=""
 	else
 		export INSDESTTREE=$1
 		if ! ___eapi_has_prefix_variables; then
 			local ED=${D}
 		fi
-		if [ ! -d "${ED}${INSDESTTREE}" ]; then
+		if [[ ! -d "${ED}${INSDESTTREE}" ]]; then
 			install -d "${ED}${INSDESTTREE}"
 			local ret=$?
 			if [[ $ret -ne 0 ]] ; then
@@ -55,14 +55,14 @@ insinto() {
 }
 
 exeinto() {
-	if [ "$1" == "/" ]; then
+	if [[ "$1" == "/" ]]; then
 		export _E_EXEDESTTREE_=""
 	else
 		export _E_EXEDESTTREE_="$1"
 		if ! ___eapi_has_prefix_variables; then
 			local ED=${D}
 		fi
-		if [ ! -d "${ED}${_E_EXEDESTTREE_}" ]; then
+		if [[ ! -d "${ED}${_E_EXEDESTTREE_}" ]]; then
 			install -d "${ED}${_E_EXEDESTTREE_}"
 			local ret=$?
 			if [[ $ret -ne 0 ]] ; then
@@ -74,14 +74,14 @@ exeinto() {
 }
 
 docinto() {
-	if [ "$1" == "/" ]; then
+	if [[ "$1" == "/" ]]; then
 		export _E_DOCDESTTREE_=""
 	else
 		export _E_DOCDESTTREE_="$1"
 		if ! ___eapi_has_prefix_variables; then
 			local ED=${D}
 		fi
-		if [ ! -d "${ED}usr/share/doc/${PF}/${_E_DOCDESTTREE_}" ]; then
+		if [[ ! -d "${ED}usr/share/doc/${PF}/${_E_DOCDESTTREE_}" ]]; then
 			install -d "${ED}usr/share/doc/${PF}/${_E_DOCDESTTREE_}"
 			local ret=$?
 			if [[ $ret -ne 0 ]] ; then
@@ -216,7 +216,7 @@ use() {
 }
 
 use_with() {
-	if [ -z "$1" ]; then
+	if [[ -z "$1" ]]; then
 		echo "!!! use_with() called without a parameter." >&2
 		echo "!!! use_with <USEFLAG> [<flagname> [value]]" >&2
 		return 1
@@ -238,7 +238,7 @@ use_with() {
 }
 
 use_enable() {
-	if [ -z "$1" ]; then
+	if [[ -z "$1" ]]; then
 		echo "!!! use_enable() called without a parameter." >&2
 		echo "!!! use_enable <USEFLAG> [<flagname> [value]]" >&2
 		return 1
@@ -266,7 +266,7 @@ unpack() {
 	local suffix suffix_insensitive
 	local myfail
 	local eapi=${EAPI:-0}
-	[ -z "$*" ] && die "Nothing passed to the 'unpack' command"
+	[[ -z "$*" ]] && die "Nothing passed to the 'unpack' command"
 
 	for x in "$@"; do
 		__vecho ">>> Unpacking ${x} to ${PWD}"
@@ -398,7 +398,7 @@ unpack() {
 			7z)
 				local my_output
 				my_output="$(7z x -y "${srcdir}${x}")"
-				if [ $? -ne 0 ]; then
+				if [[ $? -ne 0 ]]; then
 					echo "${my_output}" >&2
 					die "$myfail"
 				fi
@@ -457,7 +457,7 @@ unpack() {
 					type -P deb2targz > /dev/null; then
 					y=${x##*/}
 					local created_symlink=0
-					if [ ! "$srcdir$x" -ef "$y" ] ; then
+					if [[ ! "$srcdir$x" -ef "$y" ]] ; then
 						# deb2targz always extracts into the same directory as
 						# the source file, so create a symlink in the current
 						# working directory if necessary.
@@ -471,7 +471,7 @@ unpack() {
 						__helpers_die "$myfail"
 						return 1
 					fi
-					if [ $created_symlink = 1 ] ; then
+					if [[ $created_symlink = 1 ]] ; then
 						# Clean up the symlink so the ebuild
 						# doesn't inadvertently install it.
 						rm -f "$y"
@@ -566,7 +566,7 @@ econf() {
 	fi
 
 	: ${ECONF_SOURCE:=.}
-	if [ -x "${ECONF_SOURCE}/configure" ]; then
+	if [[ -x "${ECONF_SOURCE}/configure" ]]; then
 		if [[ -n $CONFIG_SHELL && \
 			"$(head -n1 "$ECONF_SOURCE/configure")" =~ ^'#!'[[:space:]]*/bin/sh([[:space:]]|$) ]] ; then
 			# preserve timestamp, see bug #440304
@@ -578,7 +578,7 @@ econf() {
 			touch -r "${ECONF_SOURCE}/configure._portage_tmp_.${pid}" "${ECONF_SOURCE}/configure" || die
 			rm -f "${ECONF_SOURCE}/configure._portage_tmp_.${pid}"
 		fi
-		if [ -e "${EPREFIX}"/usr/share/gnuconfig/ ]; then
+		if [[ -e "${EPREFIX}"/usr/share/gnuconfig/ ]]; then
 			find "${WORKDIR}" -type f '(' \
 			-name config.guess -o -name config.sub ')' -print0 | \
 			while read -r -d $'\0' x ; do
@@ -654,7 +654,7 @@ econf() {
 
 		if ! "${ECONF_SOURCE}/configure" "$@" ; then
 
-			if [ -s config.log ]; then
+			if [[ -s config.log ]]; then
 				echo
 				echo "!!! Please attach the following file when seeking support:"
 				echo "!!! ${PWD}/config.log"
@@ -662,7 +662,7 @@ econf() {
 			__helpers_die "econf failed"
 			return 1
 		fi
-	elif [ -f "${ECONF_SOURCE}/configure" ]; then
+	elif [[ -f "${ECONF_SOURCE}/configure" ]]; then
 		die "configure is not executable"
 	else
 		die "no configure script found"
@@ -685,15 +685,15 @@ einstall() {
 		CONF_LIBDIR="${!LIBDIR_VAR}"
 	fi
 	unset LIBDIR_VAR
-	if [ -n "${CONF_LIBDIR}" ] && [ "${CONF_PREFIX:+set}" = set ]; then
+	if [[ -n "${CONF_LIBDIR}" ]] && [[ "${CONF_PREFIX:+set}" = set ]]; then
 		EI_DESTLIBDIR="${D}/${CONF_PREFIX}/${CONF_LIBDIR}"
 		EI_DESTLIBDIR="$(__strip_duplicate_slashes "${EI_DESTLIBDIR}")"
 		LOCAL_EXTRA_EINSTALL="libdir=${EI_DESTLIBDIR} ${LOCAL_EXTRA_EINSTALL}"
 		unset EI_DESTLIBDIR
 	fi
 
-	if [ -f ./[mM]akefile -o -f ./GNUmakefile ] ; then
-		if [ "${PORTAGE_DEBUG}" == "1" ]; then
+	if [[ -f ./[mM]akefile || -f ./GNUmakefile ]] ; then
+		if [[ "${PORTAGE_DEBUG}" == "1" ]]; then
 			${MAKE:-make} -n prefix="${ED}usr" \
 				datadir="${ED}usr/share" \
 				infodir="${ED}usr/share/info" \
@@ -723,7 +723,7 @@ einstall() {
 }
 
 __eapi0_pkg_nofetch() {
-	[ -z "${SRC_URI}" ] && return
+	[[ -z "${SRC_URI}" ]] && return
 
 	elog "The following are listed in SRC_URI for ${PN}:"
 	local x
@@ -737,7 +737,7 @@ __eapi0_src_unpack() {
 }
 
 __eapi0_src_compile() {
-	if [ -x ./configure ] ; then
+	if [[ -x ./configure ]] ; then
 		econf
 	fi
 	__eapi2_src_compile
@@ -781,7 +781,7 @@ __eapi2_src_configure() {
 }
 
 __eapi2_src_compile() {
-	if [ -f Makefile ] || [ -f GNUmakefile ] || [ -f makefile ]; then
+	if [[ -f Makefile ]] || [[ -f GNUmakefile ]] || [[ -f makefile ]]; then
 		emake || die "emake failed"
 	fi
 }
@@ -837,7 +837,7 @@ has_version() {
 	fi
 	atom=$1
 	shift
-	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
+	[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
 
 	if ${host_root} ; then
 		if ! ___eapi_best_version_and_has_version_support_--host-root; then
@@ -896,7 +896,7 @@ best_version() {
 	fi
 	atom=$1
 	shift
-	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
+	[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
 
 	if ${host_root} ; then
 		if ! ___eapi_best_version_and_has_version_support_--host-root; then

--- a/misc/emerge-delta-webrsync
+++ b/misc/emerge-delta-webrsync
@@ -28,7 +28,7 @@ eecho() { echo "${argv0##*/}: error: $*" 1>&2 ; }
 # Use portageq from the same directory/prefix as the current script, so
 # that we don't have to rely on PATH including the current EPREFIX.
 scriptpath=${BASH_SOURCE[0]}
-if [ -x "${scriptpath%/*}/portageq" ]; then
+if [[ -x "${scriptpath%/*}/portageq" ]]; then
 	portageq=${scriptpath%/*}/portageq
 elif type -P portageq > /dev/null ; then
 	portageq=portageq
@@ -53,8 +53,8 @@ if [[ -z ${repo_location} ]]; then
 	exit 1
 fi
 
-if [ -z "$NICENESS_PULLED" ]; then
-	if [ -n "${PORTAGE_NICENESS}" ]; then
+if [[ -z "$NICENESS_PULLED" ]]; then
+	if [[ -n "${PORTAGE_NICENESS}" ]]; then
 		export NICENESS_PULLED=asdf
 		exec nice -n "${PORTAGE_NICENESS}" "$0" "$@"
 		echo "failed setting PORTAGE_NICENESS to '$PORTAGE_NICENESS', disabling"
@@ -64,7 +64,7 @@ fi
 STATE_DIR="${EPREFIX}/var/delta-webrsync/"
 
 # hack.  bug 92224
-if [ "${FETCHCOMMAND/getdelta.sh}" != "${FETCHCOMMAND}" ]; then
+if [[ "${FETCHCOMMAND/getdelta.sh}" != "${FETCHCOMMAND}" ]]; then
 	# evil evil evil evil
 	eval "$(grep "^FETCHCOMMAND=" "${EPREFIX}/usr/share/portage/config/make.globals")"
 fi
@@ -200,7 +200,7 @@ get_utc_second_from_string() {
 get_portage_timestamp() {
 	local portage_current_timestamp=0
 
-	if [ -f "${repo_location}/metadata/timestamp.x" ]; then
+	if [[ -f "${repo_location}/metadata/timestamp.x" ]]; then
 		portage_current_timestamp=$(cut -f 1 -d " " "${repo_location}/metadata/timestamp.x" )
 	fi
 
@@ -224,9 +224,9 @@ fetch_file() {
 	local FILE="$2"
 	local opts
 
-	if [ "${FETCHCOMMAND/wget/}" != "${FETCHCOMMAND}" ]; then
+	if [[ "${FETCHCOMMAND/wget/}" != "${FETCHCOMMAND}" ]]; then
 		opts="--continue $(nvecho -q)"
-	elif [ "${FETCHCOMMAND/curl/}" != "${FETCHCOMMAND}" ]; then
+	elif [[ "${FETCHCOMMAND/curl/}" != "${FETCHCOMMAND}" ]]; then
 		opts="--continue-at - $(nvecho -s -f)"
 	else
 		rm -f "${DISTDIR}/${FILE}"
@@ -253,9 +253,9 @@ check_file_digest() {
 	if type -P md5sum > /dev/null; then
 		local md5sum_output=$(md5sum "${file}")
 		local digest_content=$(< "${digest}")
-		[ "${md5sum_output%%[[:space:]]*}" = "${digest_content%%[[:space:]]*}" ] && r=0
+		[[ "${md5sum_output%%[[:space:]]*}" = "${digest_content%%[[:space:]]*}" ]] && r=0
 	elif type -P md5 > /dev/null; then
-		[ "$(md5 -q "${file}")" == "$(cut -d ' ' -f 1 "${digest}")" ] && r=0
+		[[ "$(md5 -q "${file}")" == "$(cut -d ' ' -f 1 "${digest}")" ]] && r=0
 	else
 		eecho "cannot check digest: no suitable md5/md5sum binaries found"
 	fi
@@ -341,7 +341,7 @@ sync_local() {
 		emerge --metadata
 	fi
 	local post_sync=${PORTAGE_CONFIGROOT}etc/portage/bin/post_sync
-	[ -x "${post_sync}" ] && "${post_sync}"
+	[[ -x "${post_sync}" ]] && "${post_sync}"
 	# --quiet suppresses output if there are no relevant news items
 	has news ${FEATURES} && emerge --check-news --quiet
 	return 0
@@ -376,13 +376,13 @@ do_snapshot() {
 			local digest="${file}.md5sum"
 			local signature="${file}.gpgsig"
 
-			if [ -s "${DISTDIR}/${file}" -a -s "${DISTDIR}/${digest}" -a -s "${DISTDIR}/${signature}" ] ; then
+			if [[ -s "${DISTDIR}/${file}" && -s "${DISTDIR}/${digest}" && -s "${DISTDIR}/${signature}" ]]; then
 				check_file_digest "${DISTDIR}/${digest}" "${DISTDIR}/${file}" && \
 				check_file_signature "${DISTDIR}/${signature}" "${DISTDIR}/${file}" && \
 				have_files=1
 			fi
 
-			if [ ${have_files} -eq 0 ] ; then
+			if [[ ${have_files} -eq 0 ]] ; then
 				fetch_file "${mirror}/snapshots/${digest}" "${digest}" && \
 				fetch_file "${mirror}/snapshots/${signature}" "${signature}" && \
 				fetch_file "${mirror}/snapshots/${file}" "${file}" && \
@@ -396,13 +396,13 @@ do_snapshot() {
 			# we want to try and retrieve
 			# from a different mirror
 			#
-			if [ ${have_files} -eq 1 ]; then
+			if [[ ${have_files} -eq 1 ]]; then
 
 				__vecho "Getting snapshot timestamp ..."
 				local snapshot_timestamp=$(get_snapshot_timestamp "${DISTDIR}/${file}")
 
-				if [ ${ignore_timestamp} == 0 ]; then
-					if [ ${snapshot_timestamp} -lt $(get_portage_timestamp) ]; then
+				if [[ ${ignore_timestamp} == 0 ]]; then
+					if [[ ${snapshot_timestamp} -lt $(get_portage_timestamp) ]]; then
 						wecho "portage is newer than snapshot"
 						have_files=0
 					fi
@@ -413,8 +413,8 @@ do_snapshot() {
 					# Check that this snapshot
 					# is what it claims to be ...
 					#
-					if [ ${snapshot_timestamp} -lt ${utc_seconds} ] || \
-						[ ${snapshot_timestamp} -gt $((${utc_seconds}+ 2*86400)) ]; then
+					if [[ ${snapshot_timestamp} -lt ${utc_seconds} ]] || \
+						[[ ${snapshot_timestamp} -gt $((${utc_seconds}+ 2*86400)) ]]; then
 
 						wecho "snapshot timestamp is not in acceptable period"
 						have_files=0
@@ -422,7 +422,7 @@ do_snapshot() {
 				fi
 			fi
 
-			if [ ${have_files} -eq 1 ]; then
+			if [[ ${have_files} -eq 1 ]]; then
 				break
 			else
 				#
@@ -432,10 +432,10 @@ do_snapshot() {
 			fi
 		done
 
-		[ ${have_files} -eq 1 ] && break
+		[[ ${have_files} -eq 1 ]] && break
 	done
 
-	if [ ${have_files} -eq 1 ]; then
+	if [[ ${have_files} -eq 1 ]]; then
 		sync_local "${DISTDIR}/${file}" && r=0
 	else
 		__vecho "${date} snapshot was not found"
@@ -469,7 +469,7 @@ do_latest_snapshot() {
 	# Daily snapshots are created at 00:45 and are not
 	# available until after 01:00. Don't waste time trying
 	# to fetch a snapshot before it's been created.
-	if [ ${start_hour} -lt 1 ] ; then
+	if [[ ${start_hour} -lt 1 ]] ; then
 		(( start_time -= 86400 ))
 	fi
 	local snapshot_date=$(get_date_part ${start_time} "%Y%m%d")
@@ -481,19 +481,19 @@ do_latest_snapshot() {
 		# snapshots are created at 00:45
 		(( approx_snapshot_time = snapshot_date_seconds + 86400 + 2700 ))
 		(( timestamp_difference = existing_timestamp - approx_snapshot_time ))
-		[ ${timestamp_difference} -lt 0 ] && (( timestamp_difference = -1 * timestamp_difference ))
+		[[ ${timestamp_difference} -lt 0 ]] && (( timestamp_difference = -1 * timestamp_difference ))
 		snapshot_date=$(get_date_part ${snapshot_date_seconds} "%Y%m%d")
 
 		timestamp_problem=""
-		if [ ${timestamp_difference} -eq 0 ]; then
+		if [[ ${timestamp_difference} -eq 0 ]]; then
 			timestamp_problem="is identical to"
-		elif [ ${timestamp_difference} -lt ${min_time_diff} ]; then
+		elif [[ ${timestamp_difference} -lt ${min_time_diff} ]]; then
 			timestamp_problem="is possibly identical to"
-		elif [ ${approx_snapshot_time} -lt ${existing_timestamp} ] ; then
+		elif [[ ${approx_snapshot_time} -lt ${existing_timestamp} ]] ; then
 			timestamp_problem="is newer than"
 		fi
 
-		if [ -n "${timestamp_problem}" ]; then
+		if [[ -n "${timestamp_problem}" ]]; then
 			ewarn "Latest snapshot date: ${snapshot_date}"
 			ewarn
 			ewarn "Approximate snapshot timestamp: ${approx_snapshot_time}"
@@ -578,9 +578,9 @@ potentials="$(ls -1 portage-2[[:digit:]][[:digit:]][[:digit:]][[:digit:]][[:digi
 for basef in ${potentials}; do
 	chksum=''
 	found="dar"
-	if [ -e "${STATE_DIR}/${basef}.md5sum" ]; then
+	if [[ -e "${STATE_DIR}/${basef}.md5sum" ]]; then
 		chksum="${STATE_DIR}/${basef}.md5sum"
-	elif [ -e "${basef}.md5sum" ]; then
+	elif [[ -e "${basef}.md5sum" ]]; then
 		chksum="${DISTDIR}/${basef}.md5sum"
 	else
 		echo "attempting to get md5sum for $basef"
@@ -590,7 +590,7 @@ for basef in ${potentials}; do
 		fi
 		chksum="${basef}.md5sum"
 	fi
-	if [ -e "${basef}" ]; then
+	if [[ -e "${basef}" ]]; then
 		dfile="${DISTDIR}/${basef}"
 	else
 		dfile="${STATE_DIR}/${basef}"
@@ -732,7 +732,7 @@ if [[ -n $got_umd5 ]]; then
 fi
 
 unset need_last_sync
-if [ "$verified" == "1" ]; then
+if [[ "$verified" == "1" ]]; then
 	need_last_sync="dar"
 	if [[ ${WEBSYNC_VERIFY_SIGNATURE} == 1 ]] ; then
 		# BUG: Signature verification will fail if the local bzip2
@@ -784,7 +784,7 @@ else
 	mv "${TMPDIR}/portage-${final_date}.tar.bz2" "${DISTDIR}/"
 fi
 
-if [ -z "${need_last_sync}" ]; then
+if [[ -z "${need_last_sync}" ]]; then
 	if [[ ${WEBSYNC_VERIFY_SIGNATURE} == 1 ]] ; then
 		check_file_signature "${DISTDIR}/portage-${final_date}.tar.bz2.gpgsig" "${dfile}" || exit 1
 	fi


### PR DESCRIPTION
Right now, there are lots of inconsistencies in the Portage codebase. Some scripts still use the builtin `[` command for performing tests whilst some others have been migrated to its improved counterpart, the two brackets `[[`. Sometimes a script uses a mix of the two which is inconsistent. `[[` clearly outnumbers `[` in the codebase so we should migrate to the former. This PR attempts to bring coherence and converts parts still using `[` to `[[`.

See [1] to understand the difference between the two.

Please review.

[1]: http://mywiki.wooledge.org/BashFAQ/031