### PR TITLE
cache.fs_template: set 0o644 defaut perms

### DIFF
--- a/pym/portage/cache/fs_template.py
+++ b/pym/portage/cache/fs_template.py
@@ -24,7 +24,7 @@ class FsBased(template.database):
 
 	def __init__(self, *args, **config):
 
-		for x, y in (("gid", -1), ("perms", -1)):
+		for x, y in (("gid", -1), ("perms", 0o644)):
 			if x in config:
 				# Since Python 3.4, chown requires int type (no proxies).
 				setattr(self, "_" + x, int(config[x]))


### PR DESCRIPTION
Fixes 5652bc88514b ("flat_hash: use mkstemp in _setitem)
X-Gentoo-Bug: 594358
X-Gentoo-Bug-URL: https://bugs.gentoo.org/594358