### PR TITLE
doebuild_environment: disable ccache/distcc/icecc when necessary (bug 594982)

### DIFF
--- a/pym/portage/package/ebuild/doebuild.py
+++ b/pym/portage/package/ebuild/doebuild.py
@@ -478,13 +478,13 @@ def doebuild_environment(myebuild, mydo, myroot=None, settings=None,
 			possible_libexecdirs = (libdir, "lib", "libexec")
 			masquerades = []
 			if distcc:
-				masquerades.append("distcc")
+				masquerades.append(("distcc", "distcc"))
 			if icecream:
-				masquerades.append("icecc")
+				masquerades.append(("icecream", "icecc"))
 			if ccache:
-				masquerades.append("ccache")
+				masquerades.append(("ccache", "ccache"))
 
-			for m in masquerades:
+			for feature, m in masquerades:
 				for l in possible_libexecdirs:
 					p = os.path.join(os.sep, eprefix_lstrip,
 							"usr", l, m, "bin")
@@ -494,6 +494,7 @@ def doebuild_environment(myebuild, mydo, myroot=None, settings=None,
 				else:
 					writemsg(("Warning: %s requested but no masquerade dir"
 						+ "can be found in /usr/lib*/%s/bin\n") % (m, m))
+					mysettings.features.remove(feature)
 
 		if 'MAKEOPTS' not in mysettings:
 			nproc = get_cpu_count()

--- a/pym/portage/package/ebuild/prepare_build_dirs.py
+++ b/pym/portage/package/ebuild/prepare_build_dirs.py
@@ -154,12 +154,10 @@ def _prepare_features_dirs(mysettings):
 
 	features_dirs = {
 		"ccache":{
-			"path_dir": "%s/usr/%s/ccache/bin" % (EPREFIX, libdir),
 			"basedir_var":"CCACHE_DIR",
 			"default_dir":os.path.join(mysettings["PORTAGE_TMPDIR"], "ccache"),
 			"always_recurse":False},
 		"distcc":{
-			"path_dir": "%s/usr/%s/distcc/bin" % (EPREFIX, libdir),
 			"basedir_var":"DISTCC_DIR",
 			"default_dir":os.path.join(mysettings["BUILD_PREFIX"], ".distcc"),
 			"subdirs":("lock", "state"),
@@ -180,10 +178,6 @@ def _prepare_features_dirs(mysettings):
 				basedir = kwargs["default_dir"]
 				mysettings[kwargs["basedir_var"]] = basedir
 			try:
-				path_dir = kwargs["path_dir"]
-				if not os.path.isdir(path_dir):
-					raise DirectoryNotFound(path_dir)
-
 				mydirs = [mysettings[kwargs["basedir_var"]]]
 				if "subdirs" in kwargs:
 					for subdir in kwargs["subdirs"]:


### PR DESCRIPTION
Fixes: a41c0f8b9081 ("doebuild: Support finding lib* for ccache/distcc/icecc masquerade dir")
X-Gentoo-Bug: 594982
X-Gentoo-Bug-URL: https://bugs.gentoo.org/594982