### PR TITLE
ebuild.sh: start phases in temporary HOME if available (bug 595028)

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -167,9 +167,14 @@ export SANDBOX_ON=0
 
 # Ensure that $PWD is sane whenever possible, to protect against
 # exploitation of insecure search path for python -c in ebuilds.
-# See bug #239560 and bug #469338.
-cd "${PORTAGE_PYM_PATH}" || \
-	die "PORTAGE_PYM_PATH does not exist: '${PORTAGE_PYM_PATH}'"
+# See bug #239560, bug #469338, and bug #595028.
+if [[ -d ${HOME} ]]; then
+	# Use portage's temporary HOME directory if available.
+	cd "${HOME}" || die
+else
+	cd "${PORTAGE_PYM_PATH}" || \
+		die "PORTAGE_PYM_PATH does not exist: '${PORTAGE_PYM_PATH}'"
+fi
 
 #if no perms are specified, dirs/files will have decent defaults
 #(not secretive, but not stupid)

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -261,6 +261,11 @@ __dyn_clean() {
 		chflags -R nosunlnk,nouunlnk "${PORTAGE_BUILDDIR}" 2>/dev/null
 	fi
 
+	# Some kernels, such as Solaris, return EINVAL when an attempt
+	# is made to remove the current working directory.
+	cd "${PORTAGE_PYM_PATH}" || \
+		die "PORTAGE_PYM_PATH does not exist: '${PORTAGE_PYM_PATH}'"
+
 	rm -rf "${PORTAGE_BUILDDIR}/image" "${PORTAGE_BUILDDIR}/homedir"
 	rm -f "${PORTAGE_BUILDDIR}/.installed"
 
@@ -288,9 +293,6 @@ __dyn_clean() {
 	# result in it wiping the users distfiles directory (bad).
 	rm -rf "${PORTAGE_BUILDDIR}/distdir"
 
-	# Some kernels, such as Solaris, return EINVAL when an attempt
-	# is made to remove the current working directory.
-	cd "$PORTAGE_BUILDDIR"/../..
 	rmdir "$PORTAGE_BUILDDIR" 2>/dev/null
 
 	true


### PR DESCRIPTION
This will avoid undesirable interactions with the python sitedir,
as reported in bug 574002. Since the temporary HOME is not guaranteed
to exist for some phases, use PORTAGE_PYM_PATH as a fallback. Also,
use PORTAGE_PYM_PATH inside __dyn_clean, since HOME is removed there.

X-Gentoo-Bug: 595028
X-Gentoo-Bug-URL: https://bugs.gentoo.org/595028

@floppym