### PR TITLE
setup.py: enable libc bindings optionally (bug 594744)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 install: "pip install lxml"
 
 script:
+    - printf "[build_ext]\nportage-ext-modules=true" >> setup.cfg
     - ./setup.py test
     - ./setup.py install --root=/tmp/install-root
     # prevent repoman tests from trying to fetch metadata.xsd

--- a/README
+++ b/README
@@ -13,6 +13,25 @@ Dependencies
 Python and Bash should be the only hard dependencies. Python 2.7 is the
 minimum supported version.
 
+Native Extensions
+=================
+
+Portage includes some optional native extensions which can be built
+in the source tree by running the following command:
+
+    python setup.py build_ext --inplace --portage-ext-modules
+
+The following setup.cfg settings can be used to enable building of
+native extensions for all invocations of the build_ext command (the
+build_ext command is invoked automatically by other build commands):
+
+   [build_ext]
+   portage-ext-modules=true
+
+Currently, the native extensions only include libc bindings which are
+used to validate LC_CTYPE and LC_COLLATE behavior for EAPI 6. If the
+native extensions have not been built, then portage will use ctypes
+instead.
 
 Licensing and Legalese
 =======================

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 from distutils.core import setup, Command, Extension
 from distutils.command.build import build
+from distutils.command.build_ext import build_ext as _build_ext
 from distutils.command.build_scripts import build_scripts
 from distutils.command.clean import clean
 from distutils.command.install import install
@@ -624,6 +625,25 @@ def get_manpages():
 				yield [os.path.join('$mandir', topdir, 'man%s' % g), mans]
 
 
+class build_ext(_build_ext):
+	user_options = _build_ext.user_options + [
+		('portage-ext-modules', None,
+		 "enable portage's C/C++ extensions (cross-compiling is not supported)"),
+	]
+
+	boolean_options = _build_ext.boolean_options + [
+		'portage-ext-modules',
+	]
+
+	def initialize_options(self):
+		_build_ext.initialize_options(self)
+		self.portage_ext_modules = None
+
+	def run(self):
+		if self.portage_ext_modules:
+			_build_ext.run(self)
+
+
 setup(
 	name = 'portage',
 	version = '2.3.1',
@@ -651,6 +671,7 @@ setup(
 
 	cmdclass = {
 		'build': x_build,
+		'build_ext': build_ext,
 		'build_man': build_man,
 		'build_scripts': x_build_scripts,
 		'build_scripts_bin': x_build_scripts_bin,


### PR DESCRIPTION
The libc bindings are optional, since ctypes is used as a fallback when
they are not available. The libc bindings do not support cross-
compilation, therefore it is useful to be able to build them
conditionally. This patch adds an option to enable them conditionally,
which the ebuild can use by adding the following code to the
python_prepare_all function:

    if use native-extensions; then
        printf "[build_ext]\nportage-ext-modules=true" >> \
            setup.cfg || die
    fi

X-Gentoo-Bug: 594744
X-Gentoo-Bug-URL: https://bugs.gentoo.org/594744