### PR TITLE
repoman: Disable SRC_URI.mirror warnings when there is only 1 mirror

### DIFF
--- a/repoman/pym/repoman/modules/scan/fetch/fetches.py
+++ b/repoman/pym/repoman/modules/scan/fetch/fetches.py
@@ -36,6 +36,12 @@ class FetchChecks(ScanBase):
 		self.thirdpartymirrors = {}
 		profile_thirdpartymirrors = self.repo_settings.repoman_settings.thirdpartymirrors().items()
 		for mirror_alias, mirrors in profile_thirdpartymirrors:
+			# Skip thirdpartymirrors that do not list more than one mirror
+			# anymore. There is no point in using mirror:// there and this
+			# means that the thirdpartymirrors entry will most likely
+			# be removed anyway.
+			if len(mirrors) <= 1:
+				continue
 			for mirror in mirrors:
 				if not mirror.endswith("/"):
 					mirror += "/"


### PR DESCRIPTION
Disable SRC_URI.mirror warnings when the thirdpartymirrors entry
consists of no more than 1 mirror. In this case, the mirror:// is really
no different than direct URL, and it most likely means the entry is only
kept for backwards compatibility.