### PR TITLE
bin/phase-helpers.sh: Added code from eapply_user to handle multiple calls

### DIFF
--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -981,6 +981,11 @@ fi
 
 if ___eapi_has_eapply; then
 	eapply() {
+		# keep path in __dyn_prepare in sync!
+		local tagfile=${T}/.portage_patches_applied
+		[[ -f ${tagfile} ]] && return
+		>> "${tagfile}"
+
 		local failed patch_cmd=patch
 		local -x LC_COLLATE=POSIX
 


### PR DESCRIPTION
Minor change, untested but should be safe. I am not sure if there was a reason this was omitted in the first place, I assume there might have been. It would be nice if eapply could be made to be called more than once without issue, like eapply_user.

That will allow other eclasses that implement src_prepare to simply call default to fire off the default containing both eapply and eapply_user. If more than on eclass calls default, it could attempt to apply patches twice and fail. This is an attempt to prevent such issues, while allowing eclasses to inherit/call the default src_prepare without having to re-implement common stuff, calls to eapply_user, etc.

Seems to be a harmless change, and not sure there is a case for multiple runs of eapply. If that is needed maybe it can be further reduced to just set that file path. And not check/return if the file exists, so not preventing multiple runs but keeping a record that it was run. Then other eclasses can check it it exists. Or have some function to call to see if eapply has been run.

I get there might be a need to call eapply manually. Though ideally all switch to using PATCHES variable, so the only time/place eapply is called is within the eclasses not ebuilds. Really should not need eapply or eapply_user in an ebuild at all. Could even have repoman look out for eapply/eapply_user in ebuilds or something to prevent it from being there. So it is only called from eclass, default or custom src_prepare.