### PR TITLE
bug 598116

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -8236,6 +8236,11 @@ class depgraph(object):
 									child.endswith("~"):
 									continue
 								stack.append(os.path.join(p, child))
+			#If the directory is empty add a file with name  pattern file_name.default
+                        if last_file_path == None:
+                                last_file_path=file_path+"/"+file_name+".default"
+                                with open(last_file_path,"a+") as default:
+                                        default.write("#"+file_name)
 
 			return last_file_path
 

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -8238,7 +8238,7 @@ class depgraph(object):
 								stack.append(os.path.join(p, child))
 			#If the directory is empty add a file with name  pattern file_name.default
                         if last_file_path == None:
-                                last_file_path=file_path+"/"+file_name+".default"
+                                last_file_path=file_path+"/"+autonmask"
                                 with open(last_file_path,"a+") as default:
                                         default.write("#"+file_name)
 

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -8238,7 +8238,7 @@ class depgraph(object):
 								stack.append(os.path.join(p, child))
 			#If the directory is empty add a file with name  pattern file_name.default
                         if last_file_path == None:
-                                last_file_path=file_path+"/"+autonmask"
+                                last_file_path=file_path+"/autonmask"
                                 with open(last_file_path,"a+") as default:
                                         default.write("#"+file_name)
 


### PR DESCRIPTION
https://bugs.gentoo.org/598116 "Autounmask fails when there is no file in /etc/portage/package.*/"; Portage Development, Core; UNCO; terabit.funtoo:dev-portage