### PR TITLE
emerge-webrsync: use gkeys to verify gpg signatures (bug 597918)

### DIFF
--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -66,13 +66,24 @@ fi
 do_verbose=0
 do_debug=0
 keep=false
+insecure=false
+
+insecure_bypass_msg() {
+	wecho "The --insecure option can be used to bypass this step."
+	insecure_warning_msg
+}
+
+insecure_warning_msg() {
+	wecho "The --insecure option prevents detection of"
+	wecho "man-in-the-middle attacks!"
+}
 
 if has webrsync-gpg ${FEATURES} ; then
-	WEBSYNC_VERIFY_SIGNATURE=1
+	VERIFY_SIGNATURE_LEGACY_MODE=1
 else
-	WEBSYNC_VERIFY_SIGNATURE=0
+	VERIFY_SIGNATURE_LEGACY_MODE=0
 fi
-if [ ${WEBSYNC_VERIFY_SIGNATURE} != 0 -a -z "${PORTAGE_GPG_DIR}" ]; then
+if [ ${VERIFY_SIGNATURE_LEGACY_MODE} != 0 -a -z "${PORTAGE_GPG_DIR}" ]; then
 	eecho "please set PORTAGE_GPG_DIR in make.conf"
 	exit 1
 fi
@@ -176,7 +187,7 @@ check_file_signature() {
 	local file="$2"
 	local r=1
 
-	if [ ${WEBSYNC_VERIFY_SIGNATURE} != 0 ]; then
+	if [ ${VERIFY_SIGNATURE_LEGACY_MODE} != 0 ]; then
 
 		__vecho "Checking signature ..."
 
@@ -186,6 +197,17 @@ check_file_signature() {
 			eecho "cannot check signature: gpg binary not found"
 			exit 1
 		fi
+	elif ! ${insecure}; then
+		__vecho "Checking signature ..."
+
+		# gkeys requires that the signature file be in the same directory
+		# as the snapshot
+		if [[ ${signature} != ${file}.gpgsig ]]; then
+			# this should not happen
+			eecho "assertion failed: ${signature} != ${file}.gpgsig"
+			exit 1
+		fi
+		gkeys verify -C gentoo -n snapshot -F "${file}" && r=0
 	else
 		r=0
 	fi
@@ -445,6 +467,7 @@ usage() {
 
 	Options:
 	  --revert=yyyymmdd   Revert to snapshot
+	  --insecure          Disable OpenPGP signature verification
 	  -k, --keep          Keep snapshots in DISTDIR (don't delete)
 	  -q, --quiet         Only output errors
 	  -v, --verbose       Enable verbose output
@@ -467,6 +490,7 @@ main() {
 		local v=${arg#*=}
 		case ${arg} in
 			-h|--help)    usage ;;
+			--insecure)   insecure=true ;;
 			-k|--keep)    keep=true ;;
 			-q|--quiet)   PORTAGE_QUIET=1 ;;
 			-v|--verbose) do_verbose=1 ;;
@@ -510,6 +534,25 @@ main() {
 		echo "adjust sync-type and sync-uri attributes to refer to rsync." >&2
 		echo "emerge-webrsync exiting due to abnormal sync-type setting." >&2
 		exit 1
+	fi
+
+	if ${insecure}; then
+		insecure_warning_msg
+	elif [[ ${VERIFY_SIGNATURE_LEGACY_MODE} == 1 ]]; then
+		wecho "FEATURES=webrsync-gpg is deprecated."
+		wecho "By default, the new gkeys verification mode will be used"
+		wecho "when FEATURES=webrsync-gpg is not enabled."
+	else
+		if ! type -P gkeys >/dev/null; then
+			eecho "gkeys: command not found"
+			eecho "Please try again after installing gkeys: emerge app-crypt/gkeys"
+			insecure_bypass_msg
+			exit 1
+		elif ! gkeys refresh-key -C gentoo -n snapshot; then
+			eecho "gkeys refresh-key failed"
+			insecure_bypass_msg
+			exit 1
+		fi
 	fi
 
 	[[ ${do_debug} -eq 1 ]] && set -x

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1,4 +1,4 @@
-.TH "MAKE.CONF" "5" "Feb 2016" "Portage VERSION" "Portage"
+.TH "MAKE.CONF" "5" "Oct 2016" "Portage VERSION" "Portage"
 .SH "NAME"
 make.conf \- custom settings for Portage
 .SH "SYNOPSIS"
@@ -663,7 +663,9 @@ Portage would have to waste time validating ownership for each and every sync
 operation.
 .TP
 .B webrsync-gpg
-Enable GPG verification when using \fIemerge\-webrsync\fR.
+Enable legacy GPG verification mode when using \fIemerge\-webrsync\fR.
+This feature is deprecated. By default, the new \fBgkeys\fR(1) verification
+mode will be used when this feature is not enabled.
 .TP
 .B xattr
 Preserve extended attributes (filesystem-stored metadata) when installing


### PR DESCRIPTION
emerge-webrsync: use gkeys to verify OpenPGP signatures (bug 597918)

Use gkeys to verify OpenPGP signatures by default. Refresh the gentoo
snapshot signing key before signature verification, in order to ensure
that the latest revocation data is available. Add an --insecure option
which disables signature verification. Warn about man-in-the-middle
attacks when the --insecure option is used. Deprecate the pre-existing
webrsync-gpg feature since it requires manual gpg configuration.

X-Gentoo-Bug: 597918
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=597918
Acked-by: Brian Dolbec <dolsen@gentoo.org>