### PR TITLE
preserve-libs: handle manually removed libraries better (bug 599240)

### DIFF
--- a/pym/portage/dbapi/vartree.py
+++ b/pym/portage/dbapi/vartree.py
@@ -4252,6 +4252,20 @@ class dblink(object):
 		#if we have a file containing previously-merged config file md5sums, grab it.
 		self.vartree.dbapi._fs_lock()
 		try:
+			# This prunes any libraries from the registry that no longer
+			# exist on disk, in case they have been manually removed.
+			# This has to be done prior to merge, since after merge it
+			# is non-trivial to distinguish these files from files
+			# that have just been merged.
+			plib_registry = self.vartree.dbapi._plib_registry
+			if plib_registry:
+				plib_registry.lock()
+				try:
+					plib_registry.load()
+					plib_registry.store()
+				finally:
+					plib_registry.unlock()
+
 			# Always behave like --noconfmem is enabled for downgrades
 			# so that people who don't know about this option are less
 			# likely to get confused when doing upgrade/downgrade cycles.


### PR DESCRIPTION
Before a package is merged, prune any libraries from the registry that no
longer exist on disk, in case they have been manually removed. This has
to be done prior to merge, since after merge it is non-trivial to
distinguish these files from files that have just been merged.

The performance impact of this change is negligible. It uses one lstat
call for each preserved library, and the plib_registry.store() call does
not actually write to disk unless it has found something to remove from
the registry.

X-Gentoo-Bug: 599240
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=599240