### PR TITLE
repos.conf: support strict-misc-digests attribute (bug 600128)

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -1,4 +1,4 @@
-.TH "PORTAGE" "5" "Nov 2015" "Portage VERSION" "Portage"
+.TH "PORTAGE" "5" "Nov 2016" "Portage VERSION" "Portage"
 .SH NAME
 portage \- the heart of Gentoo
 .SH "DESCRIPTION"
@@ -960,6 +960,13 @@ since operations performed by these tools are inherently
 .TP
 .B priority
 Specifies priority of given repository.
+.TP
+.B strict\-misc\-digests
+This setting determines whether digests are checked for files declared
+in the Manifest with MISC type (includes ChangeLog and metadata.xml
+files). Defaults to true.
+.br
+Valid values: true, false.
 .TP
 .B sync\-cvs\-repo
 Specifies CVS repository.

--- a/pym/portage/manifest.py
+++ b/pym/portage/manifest.py
@@ -129,7 +129,7 @@ class Manifest(object):
 	def __init__(self, pkgdir, distdir=None, fetchlist_dict=None,
 		manifest1_compat=DeprecationWarning, from_scratch=False, thin=False,
 		allow_missing=False, allow_create=True, hashes=None,
-		find_invalid_path_char=None):
+		find_invalid_path_char=None, strict_misc_digests=True):
 		""" Create new Manifest instance for package in pkgdir.
 		    Do not parse Manifest file if from_scratch == True (only for internal use)
 			The fetchlist_dict parameter is required only for generation of
@@ -173,6 +173,7 @@ class Manifest(object):
 			self.guessType = guessManifestFileType
 		self.allow_missing = allow_missing
 		self.allow_create = allow_create
+		self.strict_misc_digests = strict_misc_digests
 
 	def getFullname(self):
 		""" Returns the absolute path to the Manifest file for this instance """
@@ -461,7 +462,8 @@ class Manifest(object):
 			fetchlist_dict=self.fetchlist_dict, from_scratch=True,
 			thin=self.thin, allow_missing=self.allow_missing,
 			allow_create=self.allow_create, hashes=self.hashes,
-			find_invalid_path_char=self._find_invalid_path_char)
+			find_invalid_path_char=self._find_invalid_path_char,
+			strict_misc_digests=self.strict_misc_digests)
 		pn = os.path.basename(self.pkgdir.rstrip(os.path.sep))
 		cat = self._pkgdir_category()
 

--- a/pym/portage/package/ebuild/digestcheck.py
+++ b/pym/portage/package/ebuild/digestcheck.py
@@ -48,7 +48,7 @@ def digestcheck(myfiles, mysettings, strict=False, justmanifest=None, mf=None):
 				eout.ebegin(_("checking auxfile checksums ;-)"))
 				mf.checkTypeHashes("AUX", hash_filter=hash_filter)
 				eout.eend(0)
-			if mf.fhashdict.get("MISC"):
+			if mf.strict_misc_digests and mf.fhashdict.get("MISC"):
 				eout.ebegin(_("checking miscfile checksums ;-)"))
 				mf.checkTypeHashes("MISC", ignoreMissingFiles=True,
 					hash_filter=hash_filter)


### PR DESCRIPTION
This setting determines whether digests are checked for files declared
in the Manifest with MISC type (includes ChangeLog and metadata.xml
files). Defaults to true.

The current GLEP 60 draft specifies that non-strict handling of MISC
digests should be supported.

X-Gentoo-Bug: 600128
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=600128