### PR TITLE
unpack: fix txz unpack support (bug 600660)

### DIFF
--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -518,8 +518,11 @@ unpack() {
 						"suffix '${suffix}' which is unofficially supported" \
 						"with EAPI '${EAPI}'. Instead use 'txz'."
 				fi
-				if ___eapi_supports_txz; then
-					__unpack_tar "xz -d" || return 1
+				if ___eapi_unpack_supports_txz; then
+					if ! tar xof "$srcdir$x"; then
+						__helpers_die "$myfail"
+						return 1
+					fi
 				else
 					__vecho "unpack ${x}: file format not recognized. Ignoring."
 				fi


### PR DESCRIPTION
Since txz unpack support was added in commit
daa65a336102050396482f08c77524fe99e48c9f, it has been non-functional,
as follows:

phase-helpers.sh: line 521: ___eapi_supports_txz: command not found
unpack portage-2.3.2.txz: file format not recognized. Ignoring.

Fixes: daa65a336102 ("Add tentative EAPI6 .txz unpack support")
X-Gentoo-Bug: 600660
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=600660