### PR TITLE
portageq: allow disabling regex matching of maintainer emails #604164

### DIFF
--- a/bin/portageq
+++ b/bin/portageq
@@ -1082,6 +1082,8 @@ def pquery(parser, opts, args):
 		maintainer_emails = []
 		for x in opts.maintainer_email:
 			maintainer_emails.extend(x.split(","))
+		if opts.no_regex: # Escape regex-special characters for an exact match
+			maintainer_emails = [re.escape(x) for x in maintainer_emails]
 		xml_matchers.append(MaintainerEmailMatcher(maintainer_emails))
 	if opts.orphaned:
 		xml_matchers.append(match_orphaned)
@@ -1238,6 +1240,11 @@ def add_pquery_arguments(parser):
 					"longopt": "--maintainer-email",
 					"action": "append",
 					"help": "comma-separated list of maintainer email regexes to search for"
+				},
+				{
+					"longopt": "--no-regex",
+					"action": "store_true",
+					"help": "Use exact matching instead of regex matching for --maintainer-email"
 				},
 				{
 					"longopt": "--orphaned",


### PR DESCRIPTION
When the email address of a maintainer contains unescaped
regex-special characters (such as '+'), the maintainer-email match may
return undesirable results.

Add a command line option '--no-regex' to use re.escape() with list
comprehension on maintainer emails when constructing the matcher
regex. This way, an exact string match can be made rather than a regex
match.

X-Gentoo-bug: 604164
X-Gentoo-bug-url: https://bugs.gentoo.org/604164