### PR TITLE
Add 3 more packages to RDEPEND.suspect to prevent further abuse

### DIFF
--- a/repoman/pym/repoman/qa_data.py
+++ b/repoman/pym/repoman/qa_data.py
@@ -326,6 +326,7 @@ suspect_rdepend = frozenset([
 	"sys-devel/m4",
 	"sys-devel/pmake",
 	"virtual/linux-sources",
+	"virtual/linuxtv-dvb-headers",
 	"virtual/pkgconfig",
 	"x11-misc/bdftopcf",
 	"x11-misc/imake",

--- a/repoman/pym/repoman/qa_data.py
+++ b/repoman/pym/repoman/qa_data.py
@@ -299,6 +299,7 @@ suspect_rdepend = frozenset([
 	"dev-lang/swig",
 	"dev-lang/yasm",
 	"dev-perl/extutils-pkgconfig",
+	"dev-qt/linguist-tools",
 	"dev-util/byacc",
 	"dev-util/cmake",
 	"dev-util/ftjam",

--- a/repoman/pym/repoman/qa_data.py
+++ b/repoman/pym/repoman/qa_data.py
@@ -327,6 +327,7 @@ suspect_rdepend = frozenset([
 	"sys-devel/pmake",
 	"virtual/linux-sources",
 	"virtual/linuxtv-dvb-headers",
+	"virtual/os-headers",
 	"virtual/pkgconfig",
 	"x11-misc/bdftopcf",
 	"x11-misc/imake",


### PR DESCRIPTION
There are still a few packages left that put linguist-tools, linuxtv-dvb-headers, and os-headers to RDEPEND.
https://qa-reports.gentoo.org/output/genrdeps/rindex/dev-qt/linguist-tools:
```
app-text/cutemarked-0.11.3
```
https://qa-reports.gentoo.org/output/genrdeps/rindex/virtual/linuxtv-dvb-headers:
```
media-libs/libdvb-0.5.5.1-r3
media-tv/mythtv-0.27.5_p20151025:dvb
media-tv/mythtv-0.27.6_p20160318:dvb
media-tv/mythtv-0.27_p20140321:dvb
media-tv/mythtv-0.28:dvb
media-video/mplayer-1.2-r2:dvb
media-video/mplayer-1.2.1:dvb
media-video/mplayer-1.2_pre20150214-r1:dvb
media-video/mplayer-1.3.0:dvb
media-video/mplayer-9999:dvb
media-video/mpv-0.18.0-r1:dvb
media-video/mpv-0.22.0-r1:dvb
media-video/mpv-0.23.0:dvb
media-video/mpv-0.9.2-r1:dvb
media-video/mpv-9999:dvb
```
https://qa-reports.gentoo.org/output/genrdeps/rindex/virtual/os-headers:
```
media-libs/avidemux-plugins-2.6.8:oss
media-libs/avidemux-plugins-9999:oss
net-misc/nstx-1.1_beta6-r3
```
Hope this helps eliminate these remaining abuses.