### PR TITLE
Update cnf/make.conf.example.${ARCH}.diff patches wrt 98f930d4d

### DIFF
--- a/cnf/make.conf.example.alpha.diff
+++ b/cnf/make.conf.example.alpha.diff
@@ -15,7 +15,7 @@
 +#CHOST="alphaev67-unknown-linux-gnu"
 +CHOST="alpha-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +50,18 @@

--- a/cnf/make.conf.example.amd64-fbsd.diff
+++ b/cnf/make.conf.example.amd64-fbsd.diff
@@ -9,7 +9,7 @@
 +#
 +CHOST="x86_64-gentoo-freebsd7.1"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +44,35 @@

--- a/cnf/make.conf.example.amd64.diff
+++ b/cnf/make.conf.example.amd64.diff
@@ -9,7 +9,7 @@
 +#
 +CHOST="x86_64-pc-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +44,35 @@

--- a/cnf/make.conf.example.arm.diff
+++ b/cnf/make.conf.example.arm.diff
@@ -17,7 +17,7 @@
 +#
 +CHOST="armv4l-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +52,22 @@

--- a/cnf/make.conf.example.hppa.diff
+++ b/cnf/make.conf.example.hppa.diff
@@ -16,7 +16,7 @@
 +#CHOST="hppa1.1-unknown-linux-gnu"
 +#CHOST="hppa2.0-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,14 +51,38 @@

--- a/cnf/make.conf.example.ia64.diff
+++ b/cnf/make.conf.example.ia64.diff
@@ -11,7 +11,7 @@
 +
 +CHOST="ia64-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -76,7 +83,7 @@

--- a/cnf/make.conf.example.m68k.diff
+++ b/cnf/make.conf.example.m68k.diff
@@ -11,7 +11,7 @@
 +#
 +CHOST="m68k-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -41,7 +48,7 @@

--- a/cnf/make.conf.example.mips.diff
+++ b/cnf/make.conf.example.mips.diff
@@ -11,7 +11,7 @@
 +
 +CHOST="mips-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +46,15 @@

--- a/cnf/make.conf.example.ppc.diff
+++ b/cnf/make.conf.example.ppc.diff
@@ -11,7 +11,7 @@
 +
 +CHOST="powerpc-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +46,56 @@

--- a/cnf/make.conf.example.ppc64.diff
+++ b/cnf/make.conf.example.ppc64.diff
@@ -11,7 +11,7 @@
 +
 +CHOST="powerpc64-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,9 +46,38 @@

--- a/cnf/make.conf.example.s390.diff
+++ b/cnf/make.conf.example.s390.diff
@@ -11,7 +11,7 @@
 +
 +CHOST="s390-ibm-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -76,7 +83,7 @@

--- a/cnf/make.conf.example.sh.diff
+++ b/cnf/make.conf.example.sh.diff
@@ -17,7 +17,7 @@
 +#
 +CHOST="sh4-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +52,15 @@

--- a/cnf/make.conf.example.sparc-fbsd.diff
+++ b/cnf/make.conf.example.sparc-fbsd.diff
@@ -11,7 +11,7 @@
 +# profile and of freebsd-lib package.
 +CHOST="sparc64-gentoo-freebsd6.2"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -76,7 +83,7 @@

--- a/cnf/make.conf.example.sparc.diff
+++ b/cnf/make.conf.example.sparc.diff
@@ -13,7 +13,7 @@
 +#
 +# CHOST="sparc-unknown-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +48,34 @@

--- a/cnf/make.conf.example.x86-fbsd.diff
+++ b/cnf/make.conf.example.x86-fbsd.diff
@@ -14,7 +14,7 @@
 +# profile and of freebsd-lib package.
 +CHOST="i686-gentoo-freebsd6.1"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +49,34 @@

--- a/cnf/make.conf.example.x86.diff
+++ b/cnf/make.conf.example.x86.diff
@@ -13,7 +13,7 @@
 +# All K6's are i586.
 +CHOST="i686-pc-linux-gnu"
 +
- # Host and optimization settings 
+ # Host and optimization settings
  # ==============================
  #
 @@ -39,10 +48,65 @@


### PR DESCRIPTION
Otherwise they fail to apply, which makes portage-9999 fail at prepare
phase.

With this change:
```
~/Work/github/portage/cnf $ for ARCH in alpha amd64 arm hppa ia64 m68k mips ppc64 ppc s390 sh sparc x86 amd64-fbsd sparc-fbsd x86-fbsd; do patch make.conf.example make.conf.example.${ARCH}.diff; git co -- . ; done
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
patching file make.conf.example
```