### PR TITLE
env-update should call ldconfig if found in EROOT

### DIFF
--- a/pym/portage/util/env_update.py
+++ b/pym/portage/util/env_update.py
@@ -306,13 +306,17 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env,
 		if not libdir_contents_changed:
 			makelinks = False
 
-	ldconfig = "/sbin/ldconfig"
 	if "CHOST" in settings and "CBUILD" in settings and \
 		settings["CHOST"] != settings["CBUILD"]:
 		ldconfig = find_binary("%s-ldconfig" % settings["CHOST"])
+	else:
+		ldconfig = os.path.join(eroot, "sbin", "ldconfig")
+
+	if not (os.access(ldconfig, os.X_OK) and os.path.isfile(ldconfig)):
+		ldconfig = None
 
 	# Only run ldconfig as needed
-	if makelinks and ldconfig and not eprefix:
+	if makelinks and ldconfig:
 		# ldconfig has very different behaviour between FreeBSD and Linux
 		if ostype == "Linux" or ostype.lower().endswith("gnu"):
 			# We can't update links if we haven't cleaned other versions first, as


### PR DESCRIPTION
prefix-standalone has a glibc installed by portage with ldconfig
under EROOT/sbin.  It should be called during env-update.

For prefix-rpath, host glibc is used and env-update should not
care about ldconfig.  In this case, no ldconfig is in EROOT/sbin
and ldconfig is skipped.

X-Gentoo-Bug: 532100
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=532100