### PR TITLE
bin/socks5-server.py: convert address from bytes to str (bug 604474)

### DIFF
--- a/bin/socks5-server.py
+++ b/bin/socks5-server.py
@@ -83,6 +83,11 @@ class Socks5Server(object):
 				data = yield from reader.readexactly(1)
 				addr_len, = struct.unpack('!B', data)
 				addr = yield from reader.readexactly(addr_len)
+				try:
+					addr = addr.decode('idna')
+				except UnicodeDecodeError:
+					rpl = 0x04  # host unreachable
+
 			elif atyp == 0x04:  # IPv6
 				data = yield from reader.readexactly(16)
 				addr = socket.inet_ntop(socket.AF_INET6, data)


### PR DESCRIPTION
Use the idna codec to decode the destination address that is read
from the client. This fixes a "TypeError: must be str, not bytes"
exception raised from getaddrinfo with Python 3.4.5.

X-Gentoo-Bug: 604474
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=604474