### PR TITLE
depgraph: fix 'SonameAtom' object is not subscriptable (bug 606464)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -1449,10 +1449,7 @@ class depgraph(object):
 						continue
 
 					for parent, atom in self._dynamic_config._parent_atoms.get(other, []):
-						atom_set = InternalPackageSet(
-							initial_atoms=(atom,), allow_repo=True)
-						if not atom_set.findAtomForPackage(pkg,
-							modified_use=self._pkg_use_enabled(pkg)):
+						if not atom.match(pkg.with_use(self._pkg_use_enabled(pkg))):
 							self._dynamic_config._conflict_missed_update[pkg].setdefault(
 								"slot conflict", set())
 							self._dynamic_config._conflict_missed_update[pkg]["slot conflict"].add(


### PR DESCRIPTION
Fixes: 11467fc64099 ("depgraph: soname dependency resolution (bug 282639)")
X-Gentoo-Bug: 606464
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=606464