### PR TITLE
env-update: skip os.access call when ldconfig is None (bug 606832)

### DIFF
--- a/pym/portage/util/env_update.py
+++ b/pym/portage/util/env_update.py
@@ -312,7 +312,9 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env,
 	else:
 		ldconfig = os.path.join(eroot, "sbin", "ldconfig")
 
-	if not (os.access(ldconfig, os.X_OK) and os.path.isfile(ldconfig)):
+	if ldconfig is None:
+		pass
+	elif not (os.access(ldconfig, os.X_OK) and os.path.isfile(ldconfig)):
 		ldconfig = None
 
 	# Only run ldconfig as needed


### PR DESCRIPTION
Since commit 1bc49bead14ddd31c94921fe9c3d1972f0737056, env_update
would raise the following exception with crossdev configurations
when ${CHOST}-ldconfig is not available:

    TypeError: access: can't specify None for path argument

Fixes: 1bc49bead14d ("env-update: call ldconfig if found in EROOT")
X-Gentoo-Bug: 606832
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=606832