### PR TITLE
action_sync: fix TypeError: 'int' object is not subscriptable (bug 606588)

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -2000,11 +2000,9 @@ def action_sync(emerge_config, trees=DeprecationWarning,
 	syncer = SyncRepos(emerge_config)
 
 
-	retvals = syncer.auto_sync(options={'return-messages': False})
+	success, msgs = syncer.auto_sync(options={'return-messages': False})
 
-	if retvals:
-		return retvals[0][1]
-	return os.EX_OK
+	return os.EX_OK if success else 1
 
 
 def action_uninstall(settings, trees, ldpath_mtimes,

--- a/pym/portage/emaint/modules/sync/sync.py
+++ b/pym/portage/emaint/modules/sync/sync.py
@@ -236,8 +236,8 @@ class SyncRepos(object):
 
 		if retvals:
 			msgs.extend(self.rmessage(retvals, 'sync'))
-			for repo, returncode in retvals:
-				if returncode != os.EX_OK:
+			for repo, retval in retvals:
+				if retval != os.EX_OK:
 					returncode = False
 					break
 		else:


### PR DESCRIPTION
Handle the tuple returned from SyncRepos._sync since commit
f143e58dd3fd80ab67121e7a62e8cf47151d3907. Also fix the
SyncRepos._sync method to prevent corruption of the returncode
variable.

Fixes: f143e58dd3fd ("emaint: exit with non-zero status code when module fails (bug 567478)")
X-Gentoo-Bug: 606588
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=606588