### PR TITLE
spawn: instantiate userpriv_groups before fork (bug 582098)

### DIFF
--- a/pym/portage/process.py
+++ b/pym/portage/process.py
@@ -305,6 +305,10 @@ def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
 	if unshare_net or unshare_ipc:
 		find_library("c")
 
+	# Force instantiation of portage.data.userpriv_groups before the
+	# fork, so that the result is cached in the main process.
+	bool(groups)
+
 	parent_pid = os.getpid()
 	pid = None
 	try:


### PR DESCRIPTION
Make spawn force instantiation of portage.data.userpriv_groups in the
main process, in order to avoid redundant instantiation in child
processes. This mitigates the impact of "Bad file descriptor" errors
reported in bug 582098, by avoiding redundant instantiation of
userpriv_groups in child processes. It may even solve the problem
completely, if the "Bad file descriptor" errors are triggered by
interactions between garbage collection and the file descriptor
operations performed in the _exec function by the _setup_pipes call.

X-Gentoo-Bug: 582098
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=582098