### PR TITLE
Emerge sync patch

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -68,6 +68,7 @@ from portage._global_updates import _global_updates
 from portage.sync.old_tree_timestamp import old_tree_timestamp_warn
 from portage.localization import _
 from portage.metadata import action_metadata
+from portage.emaint.main import print_results
 
 from _emerge.clear_caches import clear_caches
 from _emerge.countdown import countdown
@@ -1999,8 +2000,10 @@ def action_sync(emerge_config, trees=DeprecationWarning,
 
 	syncer = SyncRepos(emerge_config)
 
-
-	success, msgs = syncer.auto_sync(options={'return-messages': False})
+	return_messages = "--quiet" not in emerge_config.opts
+	success, msgs = syncer.auto_sync(options={'return-messages': return_messages})
+	if return_messages:
+		print_results(msgs)
 
 	return os.EX_OK if success else 1
 

--- a/pym/portage/emaint/modules/sync/sync.py
+++ b/pym/portage/emaint/modules/sync/sync.py
@@ -123,9 +123,8 @@ class SyncRepos(object):
 		available = self._get_repos(auto_sync_only=False)
 		selected = self._match_repos(repos, available)
 		if not selected:
-			msgs = [red(" * ") + "Emaint sync, The specified repos were not found: %s"
-				% (bold(", ".join(repos))) + "\n   ...returning"
-				]
+			msgs = [red(" * ") + "The specified repos were not found: %s" %
+				(bold(", ".join(repos))) + "\n   ...returning"]
 			if return_messages:
 				return (False, msgs)
 			return (False, None)
@@ -208,7 +207,7 @@ class SyncRepos(object):
 		selected_repos = [repo for repo in selected_repos if repo.sync_type is not None]
 		msgs = []
 		if not selected_repos:
-			msgs.append("Emaint sync, nothing to sync... returning")
+			msgs.append("Nothing to sync... returning")
 			if return_messages:
 				msgs.extend(self.rmessage([('None', os.EX_OK)], 'sync'))
 				return (True, msgs)


### PR DESCRIPTION
I really need feedback on this, the patch if very large.

I was on the fence about doing the checks in _get_repos(), and in the end I chose to do them in _sync(). I felt that generating the messages and returning is best done inside the same function instead of passing messages from _get_repos(), deciding if I should return failure, calling _sync(), concatenating the messages from _sync() then returning.

If I were to do the checks in _get_repos(), then _get_repos would have to return something like (exit_with_failure, selected_repos, msgs). exit_with_failure is True only if selected_repos is empty because all repos had an error, False otherwise (repos are empty because no repos are defined/have auto-sync, or there are valid repos to sync).

all_repos(), auto_sync() and repo() will have to inspect exit_with_failure and exit with failure if need be.

If you think having the checks in _get_repos() is better, I can make the changes.