### PR TITLE
emaint: specify multiple repos when doing emaint sync --repo

### DIFF
--- a/man/emaint.1
+++ b/man/emaint.1
@@ -91,7 +91,8 @@ Sync repositories which have their auto\-sync setting set yes, true.
 Sync all repositories which have a sync\-uri specified.
 .TP
 .B \-r, \-\-repo REPO
-Sync the repository specified.
+Sync the repositories specified. A space separated list of repository names can
+be supplied.
 .TP
 .BR "\-\-sync-submodule <glsa|news|profiles>"
 Restrict sync to the specified submodule(s). This option may be

--- a/pym/portage/emaint/main.py
+++ b/pym/portage/emaint/main.py
@@ -34,6 +34,7 @@ class OptionItem(object):
 		self.type = opt.get('type')
 		self.dest = opt.get('dest')
 		self.choices = opt.get('choices')
+		self.nargs = opt.get('nargs')
 
 	@property
 	def pargs(self):
@@ -60,6 +61,8 @@ class OptionItem(object):
 			kwargs['dest'] = self.dest
 		if self.choices is not None:
 			kwargs['choices'] = self.choices
+		if self.nargs is not None:
+			kwargs['nargs'] = self.nargs
 		return kwargs
 
 def usage(module_controller):

--- a/pym/portage/emaint/modules/sync/__init__.py
+++ b/pym/portage/emaint/modules/sync/__init__.py
@@ -21,7 +21,7 @@ module_spec = {
 					"short": "-r", "long": "--repo",
 					"help": "(sync module only): -r, --repo  Sync the specified repo",
 					'status': "Syncing %s",
-					'action': 'store',
+					'nargs': '+',
 					'func': 'repo',
 					},
 				'allrepos': {

--- a/pym/portage/emaint/modules/sync/sync.py
+++ b/pym/portage/emaint/modules/sync/sync.py
@@ -122,9 +122,11 @@ class SyncRepos(object):
 			repos = repos.split()
 		available = self._get_repos(auto_sync_only=False)
 		selected = self._match_repos(repos, available)
-		if not selected:
+		if len(selected) < len(repos):
+			selected_repo_names = [repo.name for repo in selected]
+			missing_repo_names = set(repos) - set(selected_repo_names)
 			msgs = [red(" * ") + "Emaint sync, The specified repos were not found: %s"
-				% (bold(", ".join(repos))) + "\n   ...returning"
+				% (bold(", ".join(missing_repo_names))) + "\n   ...returning"
 				]
 			if return_messages:
 				return (False, msgs)


### PR DESCRIPTION
A list of space separated repo names can be specified when doing
emaint sync --repo, similar to what is possible with emerge --sync.

Sync will fail if one of the repos is missing.