### PR TITLE
PopenProcess: suppress ResourceWarning subprocess "still running" (bug 608594)

### DIFF
--- a/pym/portage/util/_async/PopenProcess.py
+++ b/pym/portage/util/_async/PopenProcess.py
@@ -1,4 +1,4 @@
-# Copyright 2012 Gentoo Foundation
+# Copyright 2012-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.SubProcess import SubProcess
@@ -31,3 +31,10 @@ class PopenProcess(SubProcess):
 		self._reg_id = None
 		self._waitpid_cb(pid, condition)
 		self.wait()
+
+	def _set_returncode(self, wait_retval):
+		SubProcess._set_returncode(self, wait_retval)
+		if self.proc.returncode is None:
+			# Suppress warning messages like this:
+			# ResourceWarning: subprocess 1234 is still running
+			self.proc.returncode = self.returncode


### PR DESCRIPTION
Override the _set_returncode method to set the Popen.returncode
attribute, in order to suppress Python 3.6 ResourceWarnings which
erroneously report that the subprocess is still running.

X-Gentoo-Bug: 608594
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=608594