### PR TITLE
Status.check: suppress ResourceWarning subprocess "still running" (bug 608594)

### DIFF
--- a/repoman/pym/repoman/modules/vcs/git/status.py
+++ b/repoman/pym/repoman/modules/vcs/git/status.py
@@ -29,15 +29,14 @@ class Status(object):
 		@param xpkg: string of the package being checked
 		@returns: boolean
 		'''
-		myf = repoman_popen(
+		with repoman_popen(
 			"git ls-files --others %s" %
-			(portage._shell_quote(checkdir_relative),))
-		for l in myf:
-			if l[:-1][-7:] == ".ebuild":
-				self.qatracker.add_error(
-					"ebuild.notadded",
-					os.path.join(xpkg, os.path.basename(l[:-1])))
-		myf.close()
+			(portage._shell_quote(checkdir_relative),)) as myf:
+			for l in myf:
+				if l[:-1][-7:] == ".ebuild":
+					self.qatracker.add_error(
+						"ebuild.notadded",
+						os.path.join(xpkg, os.path.basename(l[:-1])))
 		return True
 
 	@staticmethod


### PR DESCRIPTION
Use repoman_popen context manager, in order to suppress Python 3.6
ResourceWarnings which report that the subprocess is still running.

X-Gentoo-Bug: 608594
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=608594