### PR TITLE
repoman: Check for empty files in filesdir.

### DIFF
--- a/repoman/man/repoman.1
+++ b/repoman/man/repoman.1
@@ -1,4 +1,4 @@
-.TH "REPOMAN" "1" "Dec 2016" "Repoman VERSION" "Repoman"
+.TH "REPOMAN" "1" "Feb 2017" "Repoman VERSION" "Repoman"
 .SH NAME
 repoman \- Gentoo's program to enforce a minimal level of quality assurance in
 packages added to the portage tree
@@ -327,6 +327,9 @@ error or digest verification failure.
 .TP
 .B file.UTF8
 File is not UTF8 compliant
+.TP
+.B file.empty
+Empty file in the files directory
 .TP
 .B file.executable
 Ebuilds, digests, metadata.xml, Manifest, and ChangeLog do not need the

--- a/repoman/pym/repoman/modules/scan/fetch/fetches.py
+++ b/repoman/pym/repoman/modules/scan/fetch/fetches.py
@@ -130,6 +130,9 @@ class FetchChecks(ScanBase):
 					self.qatracker.add_error(
 						"file.size", "(%d KiB) %s/files/%s" % (
 							mystat.st_size // 1024, xpkg, y))
+				elif mystat.st_size == 0:
+					self.qatracker.add_error(
+						"file.empty", "%s/files/%s" % (xpkg, y))
 
 				index = self.repo_settings.repo_config.find_invalid_path_char(y)
 				if index != -1:

--- a/repoman/pym/repoman/qa_data.py
+++ b/repoman/pym/repoman/qa_data.py
@@ -67,6 +67,8 @@ qahelp = {
 		"Files in the files directory must be under 20 KiB"),
 	"file.size.fatal": (
 		"Files in the files directory must be under 60 KiB"),
+	"file.empty": (
+		"Empty file in the files directory"),
 	"file.name": (
 		"File/dir name must be composed"
 		" of only the following chars: %s " % allowed_filename_chars),
@@ -262,6 +264,7 @@ qawarnings = set((
 	"ebuild.minorsyn",
 	"ebuild.badheader",
 	"ebuild.patches",
+	"file.empty",
 	"file.size",
 	"inherit.unused",
 	"inherit.deprecated",


### PR DESCRIPTION
This checks for files with zero size in filesdir. The QA script at
https://qa-reports.gentoo.org/output/find-binary-files.txt reports a
couple of them which at least in part are blunders.