### PR TITLE
logs.py: print the log files in check() instead of calling clean()

### DIFF
--- a/pym/portage/emaint/modules/logs/logs.py
+++ b/pym/portage/emaint/modules/logs/logs.py
@@ -18,9 +18,9 @@ class CleanLogs(object):
 
 	short_desc = "Clean PORT_LOGDIR logs"
 
+	@staticmethod
 	def name():
 		return "logs"
-	name = staticmethod(name)
 
 
 	def can_progressbar(self, func):
@@ -28,11 +28,53 @@ class CleanLogs(object):
 
 
 	def check(self, **kwargs):
+		msgs = []
 		if kwargs:
 			options = kwargs.get('options', None)
-			if options:
-				options['pretend'] = True
-		return self.clean(**kwargs)
+			settings = kwargs.get('settings', None)
+			if not settings:
+				settings = portage.settings
+		else:
+			settings = portage.settings
+		if options:
+			return_messages = options.get("return-messages", False)
+		else:
+			return_messages = False
+
+		logdir = settings.get("PORT_LOGDIR", None)
+		if logdir is None or not os.path.isdir(logdir):
+			if return_messages:
+				msgs.append(ERROR_MESSAGES[78])
+				msgs.append("See the make.conf(5) man page for PORT_LOGDIR usage instructions.")
+				return (False, msgs)
+			else:
+				return (False, None)
+
+		clean_cmd = settings.get("PORT_LOGDIR_CLEAN", "")
+		if not clean_cmd:
+			msgs.append("PORT_LOGDIR_CLEAN variable not set.")
+			msgs.append("See the make.conf(5) man page for PORT_LOGDIR_CLEAN usage instructions.")
+		clean_cmd = shlex_split(clean_cmd)
+		if options and "NUM" in options and options["NUM"] is not None:
+			mtime = "-mtime +%d" % (options["NUM"])
+		elif "-mtime" in clean_cmd:
+			mtime = "-mtime %s" % (clean_cmd[clean_cmd.index("-mtime") + 1])
+		else:
+			mtime = None
+		print_cmd = 'find ${PORT_LOGDIR} -type f ! -name "summary.log*" %s' % \
+			("" if mtime is None else mtime)
+		print_cmd = shlex_split(print_cmd)
+		rval = self._clean_logs(print_cmd, settings)
+		if rval != os.EX_OK:
+			if return_messages:
+				msgs.extend(self._convert_errors(rval))
+				return (False, msgs)
+			else:
+				return (False, None)
+
+		if return_messages:
+			return (True, msgs)
+		return (True, None)
 
 
 	def clean(self, **kwargs):


### PR DESCRIPTION
CleanLogs.check() will print the log files instead of calling
CleanLogs.clean() with the --pretend option set.

The --pretend option removes the -delete argument from the
PORT_LOGDIR_CLEAN command. This does not work if the clean command is
not 'find ... -delete', which would lead to the clean command getting
executed when doing emaint logs --check.

Also the CleanLogs.name() function now uses the @staticmethod decorator.