### PR TITLE
repos.conf: rename sync-depth option to clone-depth

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -925,6 +925,10 @@ Valid values: yes, no, true, false.
 If unset, the repo will be treated as set
 yes, true.
 .TP
+.B clone\-depth
+Specifies clone depth to use for DVCS repositories. Defaults to 1 (only
+the newest commit). If set to 0, the depth is unlimited.
+.TP
 .B eclass\-overrides
 Makes given repository inherit eclasses from specified repositories.
 .br
@@ -972,8 +976,7 @@ Valid values: true, false.
 Specifies CVS repository.
 .TP
 .B sync\-depth
-Specifies clone depth to use for DVCS repositories. Defaults to 1 (only
-the newest commit). If set to 0, the depth is unlimited.
+This is a deprecated alias for the \fBclone\-depth\fR option.
 .TP
 .B sync\-git\-clone\-extra\-opts
 Extra options to give to git when cloning repository (git clone).

--- a/pym/portage/repository/config.py
+++ b/pym/portage/repository/config.py
@@ -75,7 +75,8 @@ class RepoConfig(object):
 	"""Stores config of one repository"""
 
 	__slots__ = ('aliases', 'allow_missing_manifest', 'allow_provide_virtual',
-		'auto_sync', 'cache_formats', 'create_manifest', 'disable_manifest',
+		'auto_sync', 'cache_formats', 'clone_depth',
+		'create_manifest', 'disable_manifest',
 		'eapi', 'eclass_db', 'eclass_locations', 'eclass_overrides',
 		'find_invalid_path_char', 'force', 'format', 'local_config', 'location',
 		'main_repo', 'manifest_hashes', 'masters', 'missing_repo_name',
@@ -168,7 +169,13 @@ class RepoConfig(object):
 			auto_sync = auto_sync.strip().lower()
 		self.auto_sync = auto_sync
 
+		self.clone_depth = repo_opts.get('clone-depth')
 		self.sync_depth = repo_opts.get('sync-depth')
+
+		if self.sync_depth is not None:
+			warnings.warn(_("repos.conf: sync-depth is deprecated,"
+				" use clone-depth instead"))
+
 		self.sync_hooks_only_on_change = repo_opts.get(
 			'sync-hooks-only-on-change', 'false').lower() == 'true'
 
@@ -505,7 +512,8 @@ class RepoConfigLoader(object):
 					if repos_conf_opts is not None:
 						# Selectively copy only the attributes which
 						# repos.conf is allowed to override.
-						for k in ('aliases', 'auto_sync', 'eclass_overrides',
+						for k in ('aliases', 'auto_sync',
+							'clone_depth', 'eclass_overrides',
 							'force', 'masters', 'priority', 'strict_misc_digests',
 							'sync_depth', 'sync_hooks_only_on_change',
 							'sync_type', 'sync_umask', 'sync_uri', 'sync_user',
@@ -929,8 +937,8 @@ class RepoConfigLoader(object):
 
 	def config_string(self):
 		bool_keys = ("strict_misc_digests",)
-		str_or_int_keys = ("auto_sync", "format", "location",
-			"main_repo", "priority",
+		str_or_int_keys = ("auto_sync", "clone_depth", "format", "location",
+			"main_repo", "priority", "sync_depth",
 			"sync_type", "sync_umask", "sync_uri", 'sync_user')
 		str_tuple_keys = ("aliases", "eclass_overrides", "force")
 		repo_config_tuple_keys = ("masters",)

--- a/pym/portage/sync/modules/git/__init__.py
+++ b/pym/portage/sync/modules/git/__init__.py
@@ -16,22 +16,26 @@ class CheckGitConfig(CheckSyncConfig):
 		self.checks.append('check_depth')
 
 	def check_depth(self):
-		d = self.repo.sync_depth
+		for attr in ('clone_depth', 'sync_depth'):
+			self._check_depth(attr)
+
+	def _check_depth(self, attr):
+		d = getattr(self.repo, attr)
 		# default
-		self.repo.sync_depth = 1
+		setattr(self.repo, attr, 1)
 
 		if d is not None:
 			try:
 				d = int(d)
 			except ValueError:
 				writemsg_level("!!! %s\n" %
-					_("sync-depth value is not a number: '%s'")
-					% (d),
+					_("%s value is not a number: '%s'")
+					% (attr.replace('_', '-'), d),
 					level=self.logger.ERROR, noiselevel=-1)
 			else:
 				if d == 0:
 					d = None
-				self.repo.sync_depth = d
+				setattr(self.repo, attr, d)
 
 
 module_spec = {

--- a/pym/portage/sync/modules/git/git.py
+++ b/pym/portage/sync/modules/git/git.py
@@ -52,7 +52,9 @@ class GitSync(NewBase):
 		git_cmd_opts = ""
 		if self.settings.get("PORTAGE_QUIET") == "1":
 			git_cmd_opts += " --quiet"
-		if self.repo.sync_depth is not None:
+		if self.repo.clone_depth is not None:
+			git_cmd_opts += " --depth %d" % self.repo.clone_depth
+		elif self.repo.sync_depth is not None:
 			git_cmd_opts += " --depth %d" % self.repo.sync_depth
 		if self.repo.module_specific_options.get('sync-git-clone-extra-opts'):
 			git_cmd_opts += " %s" % self.repo.module_specific_options['sync-git-clone-extra-opts']


### PR DESCRIPTION
Since sync-depth actually controls clone depth, rename it
to clone-depth, and show a warning message when the sync-depth
option has been specified:

     UserWarning: repos.conf: sync-depth is deprecated, use clone-depth instead

This makes it feasible to change the meaning of sync-depth in
the future (it could be used to control git pull depth).

X-Gentoo-Bug: 552814
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=552814