### PR TITLE
emerge: sync given repos even if auto-sync is false (bug 610328)

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -1999,9 +1999,13 @@ def action_sync(emerge_config, trees=DeprecationWarning,
 			action=action, args=[], trees=trees, opts=opts)
 
 	syncer = SyncRepos(emerge_config)
-
 	return_messages = "--quiet" not in emerge_config.opts
-	success, msgs = syncer.auto_sync(options={'return-messages': return_messages})
+	options = {'return-messages' : return_messages}
+	if emerge_config.args:
+		options['repo'] = emerge_config.args
+		success, msgs = syncer.repo(options=options)
+	else:
+		success, msgs = syncer.auto_sync(options=options)
 	if return_messages:
 		print_results(msgs)
 


### PR DESCRIPTION
The auto-sync attribute is more useful for emerge --sync with zero repo arguments. When specific repo arguments are given to emerge --sync, it makes sense to sync those repos regardless of the auto-sync attribute.

X-Gentoo-Bug: 610328
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=610328