### PR TITLE
etc-update: fix hang when using_editor is set, bug #544440

### DIFF
--- a/bin/etc-update
+++ b/bin/etc-update
@@ -649,10 +649,21 @@ do_distconf() {
 		elif [[ -L ${efile} || -L ${file} ]] ; then
 			# not the same file types
 			continue
-		elif diff_command "${file}" "${efile}" &> /dev/null; then
-			# replace identical copy
-			mv "${file}" "${efile}"
-			break
+		else
+			local ret=
+			if [[ ${using_editor} == 0 ]] ; then
+				diff_command "${file}" "${efile}" &> /dev/null
+				ret=$?
+			else
+				# fall back to plain diff
+				diff -q "${file}" "${efile}" &> /dev/null
+				ret=$?
+			fi
+			if [[ ${ret} == 0 ]] ; then
+				# replace identical copy
+				mv "${file}" "${efile}"
+				break
+			fi
 		fi
 	done
 }


### PR DESCRIPTION
Don't try to use an interactive editor to obtain the difference between
files.  Fall back to plain `diff -q` in this case.

X-Gentoo-Bug: 544440
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=544440