### PR TITLE
grabfile_package: support -* in profile "packages" files (bug 610670)

### DIFF
--- a/pym/portage/util/__init__.py
+++ b/pym/portage/util/__init__.py
@@ -478,13 +478,20 @@ def grabfile_package(myfilename, compatlevel=0, recursive=0,
 		eapi = read_corresponding_eapi_file(
 			myfilename, default=eapi_default)
 	mybasename = os.path.basename(myfilename)
+	is_packages_file = mybasename == 'packages'
 	atoms = []
 	for pkg, source_file in pkgs:
 		pkg_orig = pkg
 		# for packages and package.mask files
 		if pkg[:1] == "-":
+			if is_packages_file and pkg == '-*':
+				if remember_source_file:
+					atoms.append((pkg, source_file))
+				else:
+					atoms.append(pkg)
+				continue
 			pkg = pkg[1:]
-		if pkg[:1] == '*' and mybasename == 'packages':
+		if pkg[:1] == '*' and is_packages_file:
 			pkg = pkg[1:]
 		try:
 			pkg = Atom(pkg, allow_wildcard=allow_wildcard,


### PR DESCRIPTION
Support -* in order to make it easier to create profiles for
minimal systems (especially those built entirely from binary
packages).

X-Gentoo-Bug: 610670
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=610670