### PR TITLE
GitSync: fix spurious "sync-depth is deprecated" messages (bug 610708)

### DIFF
--- a/pym/portage/sync/modules/git/__init__.py
+++ b/pym/portage/sync/modules/git/__init__.py
@@ -21,8 +21,6 @@ class CheckGitConfig(CheckSyncConfig):
 
 	def _check_depth(self, attr):
 		d = getattr(self.repo, attr)
-		# default
-		setattr(self.repo, attr, 1)
 
 		if d is not None:
 			try:
@@ -33,8 +31,6 @@ class CheckGitConfig(CheckSyncConfig):
 					% (attr.replace('_', '-'), d),
 					level=self.logger.ERROR, noiselevel=-1)
 			else:
-				if d == 0:
-					d = None
 				setattr(self.repo, attr, d)
 
 

--- a/pym/portage/sync/modules/git/git.py
+++ b/pym/portage/sync/modules/git/git.py
@@ -53,9 +53,14 @@ class GitSync(NewBase):
 		if self.settings.get("PORTAGE_QUIET") == "1":
 			git_cmd_opts += " --quiet"
 		if self.repo.clone_depth is not None:
-			git_cmd_opts += " --depth %d" % self.repo.clone_depth
+			if self.repo.clone_depth != 0:
+				git_cmd_opts += " --depth %d" % self.repo.clone_depth
 		elif self.repo.sync_depth is not None:
-			git_cmd_opts += " --depth %d" % self.repo.sync_depth
+			if self.repo.sync_depth != 0:
+				git_cmd_opts += " --depth %d" % self.repo.sync_depth
+		else:
+			# default
+			git_cmd_opts += " --depth 1"
 		if self.repo.module_specific_options.get('sync-git-clone-extra-opts'):
 			git_cmd_opts += " %s" % self.repo.module_specific_options['sync-git-clone-extra-opts']
 		git_cmd = "%s clone%s %s ." % (self.bin_command, git_cmd_opts,


### PR DESCRIPTION
The CheckGitConfig._check_depth method must not set the sync_depth
attribute, or else it will trigger "sync-depth is deprecated" messages.

Fixes: b3f6297a791a ("repos.conf: rename sync-depth option to clone-depth")
X-Gentoo-Bug: 610708
X-Gentoo-Bug-Url: https://bugs.gentoo.org/show_bug.cgi?id=610708