### PR TITLE
use_reduce: reserve missing_white_space_check for invalid tokens (bug 611838)

### DIFF
--- a/pym/portage/dep/__init__.py
+++ b/pym/portage/dep/__init__.py
@@ -677,8 +677,6 @@ def use_reduce(depstr, uselist=[], masklist=[], matchall=False, excludeall=[], i
 			need_simple_token = True
 			stack[level].append(token)	
 		else:
-			missing_white_space_check(token, pos)
-
 			if need_bracket:
 				raise InvalidDependString(
 					_("expected: '(', got: '%s', token %s") % (token, pos+1))
@@ -698,12 +696,14 @@ def use_reduce(depstr, uselist=[], masklist=[], matchall=False, excludeall=[], i
 						token = token_class(token, eapi=eapi,
 							is_valid_flag=is_valid_flag)
 					except InvalidAtom as e:
+						missing_white_space_check(token, pos)
 						raise InvalidDependString(
 							_("Invalid atom (%s), token %s") \
 							% (e, pos+1), errors=(e,))
 					except SystemExit:
 						raise
 					except Exception as e:
+						missing_white_space_check(token, pos)
 						raise InvalidDependString(
 							_("Invalid token '%s', token %s") % (token, pos+1))
 


### PR DESCRIPTION
Since it's possible for a URI to contain parenthesis, only call
missing_white_space_check for tokens that fail to validate with
token_class. The missing_white_space_check function only serves
to clarify exception messages, so it must not be allowed to
reject valid tokens.

X-Gentoo-Bug: 611838
X-Gentoo-Bug-Url: https://bugs.gentoo.org/show_bug.cgi?id=611838