### PR TITLE
config.setcpv: fix handling of IUSE changes (bug 611896)

### DIFF
--- a/pym/portage/package/ebuild/config.py
+++ b/pym/portage/package/ebuild/config.py
@@ -1623,6 +1623,10 @@ class config(object):
 		elif previous_penv:
 			has_changed = True
 
+		if not (previous_iuse == iuse and
+			previous_iuse_effective is not None == eapi_attrs.iuse_effective):
+			has_changed = True
+
 		if has_changed:
 			self.reset(keeping_pkg=1)
 
@@ -1645,8 +1649,7 @@ class config(object):
 
 		# If reset() has not been called, it's safe to return
 		# early if IUSE has not changed.
-		if not has_changed and previous_iuse == iuse and \
-			(previous_iuse_effective is not None == eapi_attrs.iuse_effective):
+		if not has_changed:
 			return
 
 		# Filter out USE flags that aren't part of IUSE. This has to


### PR DESCRIPTION
Fix setcpv to correctly regenerate USE when the IUSE differs from
the previous setcpv call. Changes in IUSE affect USE_EXPAND
wildcard expansion in the regenerate method.

X-Gentoo-bug: 611896
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=611896