### PR TITLE
depgraph: fix slot operator rebuild for llvm:0 to llvm:4 upgrade (bug 612772)

### DIFF
--- a/pym/portage/tests/resolver/test_slot_operator_exclusive_slots.py
+++ b/pym/portage/tests/resolver/test_slot_operator_exclusive_slots.py
@@ -1,0 +1,109 @@
+# Copyright 2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+	ResolverPlayground,
+	ResolverPlaygroundTestCase,
+)
+
+class SlotOperatorExclusiveSlotsTestCase(TestCase):
+
+	def testSlotOperatorExclusiveSlots(self):
+
+		ebuilds = {
+
+			"media-libs/mesa-17.0.1" : {
+				"EAPI": "6",
+				"SLOT": "0",
+				"RDEPEND": "<sys-devel/llvm-5:="
+			},
+
+			"sys-devel/clang-4.0.0" : {
+				"EAPI": "6",
+				"SLOT": "4",
+				"RDEPEND": ("~sys-devel/llvm-4.0.0:4= "
+					"!sys-devel/llvm:0 !sys-devel/clang:0"),
+			},
+
+			"sys-devel/clang-3.9.1-r100" : {
+				"EAPI": "6",
+				"SLOT": "0/3.9.1",
+				"RDEPEND": "~sys-devel/llvm-3.9.1",
+			},
+
+			"sys-devel/llvm-4.0.0" : {
+				"EAPI": "6",
+				"SLOT": "4",
+				"RDEPEND": "!sys-devel/llvm:0",
+			},
+
+			"sys-devel/llvm-3.9.1" : {
+				"EAPI": "6",
+				"SLOT": "0/3.91",
+				"RDEPEND": "!sys-devel/llvm:0",
+				"PDEPEND": "=sys-devel/clang-3.9.1-r100",
+			},
+
+		}
+
+		installed = {
+
+			"media-libs/mesa-17.0.1" : {
+				"EAPI": "6",
+				"SLOT": "0",
+				"RDEPEND": "<sys-devel/llvm-5:0/3.9.1="
+			},
+
+			"sys-devel/clang-3.9.1-r100" : {
+				"EAPI": "6",
+				"SLOT": "0/3.9.1",
+				"RDEPEND": "~sys-devel/llvm-3.9.1",
+			},
+
+			"sys-devel/llvm-3.9.1" : {
+				"EAPI": "6",
+				"SLOT": "0/3.9.1",
+				"RDEPEND": "!sys-devel/llvm:0",
+				"PDEPEND": "=sys-devel/clang-3.9.1-r100",
+			},
+
+		}
+
+		world = ["sys-devel/clang", "media-libs/mesa"]
+
+		test_cases = (
+
+			# Test bug #612772, where slot operator rebuilds are not
+			# properly triggered (for things like mesa) during a
+			# llvm:0 to llvm:4 upgrade with clang, resulting in
+			# unsolved blockers.
+			ResolverPlaygroundTestCase(
+				["@world"],
+				options = {"--update": True, "--deep": True},
+				success = True,
+				ambiguous_merge_order = True,
+				mergelist = [
+					'sys-devel/llvm-4.0.0',
+					'media-libs/mesa-17.0.1',
+					(
+						'sys-devel/clang-4.0.0',
+						'[uninstall]sys-devel/llvm-3.9.1',
+						'!sys-devel/llvm:0',
+						'[uninstall]sys-devel/clang-3.9.1-r100',
+						'!sys-devel/clang:0',
+					)
+				],
+			),
+
+		)
+
+		playground = ResolverPlayground(ebuilds=ebuilds,
+			installed=installed, world=world)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True,
+					test_case.fail_msg)
+		finally:
+			playground.cleanup()


### PR DESCRIPTION
Fix check_reverse_dependencies to ignore dependencies of parent packages
that could be uninstalled in order to solve a blocker conflict. This case
is similar to the one from bug 584626, except that the relevant parent
package is in an older slot which is blocked by a newer slot. In this
case, the _upgrade_available method returns False, because the package
in the older slot is the highest version version available for its
slot. Therefore, a new _in_blocker_conflict method is needed to detect
parent packages that cold be uninstalled. The included unit test fails
without this fix.

Since the _in_blocker_conflict method requires information that is
collected by the _validate_blockers method, the _validate_blockers
method now has to be called before the _process_slot_conflict and
_slot_operator_trigger_reinstalls methods.

X-Gentoo-bug: 612772
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=612772