### PR TITLE
depgraph: avoid missed update with slot operator and circ dep (bug 612874)

### DIFF
--- a/pym/portage/tests/resolver/test_slot_operator_exclusive_slots.py
+++ b/pym/portage/tests/resolver/test_slot_operator_exclusive_slots.py
@@ -107,3 +107,42 @@ class SlotOperatorExclusiveSlotsTestCase(TestCase):
 					test_case.fail_msg)
 		finally:
 			playground.cleanup()
+
+
+		world = ["media-libs/mesa"]
+
+		test_cases = (
+
+			# Test bug #612874, where a direct circular dependency
+			# between llvm-3.9.1 and clang-3.9.1-r100 causes a
+			# missed update from llvm:0 to llvm:4. Since llvm:4 does
+			# not have a dependency on clang, the upgrade from llvm:0
+			# to llvm:4 makes the installed sys-devel/clang-3.9.1-r100
+			# instance eligible for removal by emerge --depclean, which
+			# explains why clang does not appear in the mergelist.
+			ResolverPlaygroundTestCase(
+				["@world"],
+				options = {"--update": True, "--deep": True},
+				success = True,
+				ambiguous_merge_order = True,
+				mergelist = [
+					'sys-devel/llvm-4.0.0',
+					(
+						'media-libs/mesa-17.0.1',
+						'[uninstall]sys-devel/llvm-3.9.1',
+						'!sys-devel/llvm:0',
+					)
+				],
+			),
+
+		)
+
+		playground = ResolverPlayground(ebuilds=ebuilds,
+			installed=installed, world=world)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True,
+					test_case.fail_msg)
+		finally:
+			playground.cleanup()

--- a/pym/portage/tests/util/test_digraph.py
+++ b/pym/portage/tests/util/test_digraph.py
@@ -133,6 +133,8 @@ class DigraphTest(TestCase):
 		for x in g, f:
 			self.assertEqual(bool(x), True)
 			self.assertEqual(x.contains("A"), True)
+			self.assertEqual(x.has_edge("B", "A"), True)
+			self.assertEqual(x.has_edge("A", "B"), False)
 			self.assertEqual(x.firstzero(), "B")
 			self.assertRaises(KeyError, x.remove, "Z")
 			x.delnode("Z")

--- a/pym/portage/util/digraph.py
+++ b/pym/portage/util/digraph.py
@@ -93,6 +93,15 @@ class digraph(object):
 			del self.nodes[node]
 		self.order = order
 
+	def has_edge(self, child, parent):
+		"""
+		Return True if the given edge exists.
+		"""
+		try:
+			return child in self.nodes[parent][0]
+		except KeyError:
+			return False
+
 	def remove_edge(self, child, parent):
 		"""
 		Remove edge in the direction from child to parent. Note that it is


### PR DESCRIPTION
Fix check_reverse_dependencies to ignore direct circular dependencies,
since these dependencies tend to prevent updates of packages. This
solves a missed update from llvm:0 to llvm:4 when clang is not in the
world file, as demonstrated by the included test case.

X-Gentoo-bug: 612874
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=612874