### PR TITLE
emerge: fix --usepkg when ebuild is not available (bug 613360)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -6062,7 +6062,8 @@ class depgraph(object):
 										identical_binary = True
 										break
 
-						if not identical_binary and pkg.built:
+						if (not identical_binary and pkg.built and
+							(use_ebuild_visibility or matched_packages)):
 								# If the ebuild no longer exists or it's
 								# keywords have been dropped, reject built
 								# instances (installed or binary).

--- a/pym/portage/tests/resolver/test_binary_pkg_ebuild_visibility.py
+++ b/pym/portage/tests/resolver/test_binary_pkg_ebuild_visibility.py
@@ -104,6 +104,32 @@ class BinaryPkgEbuildVisibilityTestCase(TestCase):
 					'[binary]app-misc/foo-3',
 				],
 			),
+
+			# The default behavior is to enforce ebuild visibility as
+			# long as a visible package is available to satisfy the
+			# current atom. In the following test case, ebuild visibility
+			# is ignored in order to satisfy the =app-misc/foo-3 atom.
+			ResolverPlaygroundTestCase(
+				["=app-misc/foo-3"],
+				options = {
+					"--usepkg": True,
+				},
+				success = True,
+				mergelist = [
+					'[binary]app-misc/foo-3',
+				],
+			),
+
+			# Verify that --use-ebuild-visibility works with --usepkg
+			# when no other visible package is available.
+			ResolverPlaygroundTestCase(
+				["=app-misc/foo-3"],
+				options = {
+					"--use-ebuild-visibility": "y",
+					"--usepkg": True,
+				},
+				success = False,
+			),
 		)
 
 		playground = ResolverPlayground(binpkgs=binpkgs, ebuilds=ebuilds,


### PR DESCRIPTION
Fix emerge --usepkg to use a binary package when the corresponding
ebuild is not available (and --use-ebuild-visibility is not enabled),
in cases when no other package is available to satisfy the dependency.
This reverts an unintended behavior change from commit
e309323f156528a8a79a1f755e1326e8880346b7.

Fixes: e309323f1565 ("emerge: fix --use-ebuild-visibility to reject binary packages (bug 612960)")
X-Gentoo-bug: 613360
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=613360