### PR TITLE
 EventLoop: implement call_soon for asyncio compat (bug 591760)

### DIFF
--- a/bin/emirrordist
+++ b/bin/emirrordist
@@ -2,6 +2,7 @@
 # Copyright 2013-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+import signal
 import sys
 
 import portage
@@ -10,4 +11,11 @@ portage._disable_legacy_globals()
 from portage._emirrordist.main import emirrordist_main
 
 if __name__ == "__main__":
+
+	def debug_signal(_signum, _frame):
+		import pdb
+		pdb.set_trace()
+
+	signal.signal(signal.SIGUSR1, debug_signal)
+
 	sys.exit(emirrordist_main(sys.argv[1:]))

--- a/pym/portage/_emirrordist/MirrorDistTask.py
+++ b/pym/portage/_emirrordist/MirrorDistTask.py
@@ -24,15 +24,16 @@ if sys.hexversion >= 0x3000000:
 
 class MirrorDistTask(CompositeTask):
 
-	__slots__ = ('_config', '_terminated', '_term_check_id')
+	__slots__ = ('_config', '_fetch_iterator', '_term_rlock',
+		'_term_callback_handle')
 
 	def __init__(self, config):
 		CompositeTask.__init__(self, scheduler=config.event_loop)
 		self._config = config
-		self._terminated = threading.Event()
+		self._term_rlock = threading.RLock()
+		self._term_callback_handle = None
 
 	def _start(self):
-		self._term_check_id = self.scheduler.idle_add(self._termination_check)
 		fetch = TaskScheduler(iter(FetchIterator(self._config)),
 			max_jobs=self._config.options.jobs,
 			max_load=self._config.options.load_average,
@@ -203,17 +204,31 @@ class MirrorDistTask(CompositeTask):
 		logging.info("added %i files" % added_file_count)
 		logging.info("added %i bytes total" % added_byte_count)
 
-	def terminate(self):
-		self._terminated.set()
+	def _cleanup(self):
+		"""
+		Cleanup any callbacks that have been registered with the global
+		event loop.
+		"""
+		# The self._term_callback_handle attribute requires locking
+		# since it's modified by the thread safe terminate method.
+		with self._term_rlock:
+			if self._term_callback_handle not in (None, False):
+				self._term_callback_handle.cancel()
+			# This prevents the terminate method from scheduling
+			# any more callbacks (since _cleanup must eliminate all
+			# callbacks in order to ensure complete cleanup).
+			self._term_callback_handle = False
 
-	def _termination_check(self):
-		if self._terminated.is_set():
-			self.cancel()
-			self.wait()
-		return True
+	def terminate(self):
+		with self._term_rlock:
+			if self._term_callback_handle is None:
+				self._term_callback_handle = self.scheduler.call_soon_threadsafe(
+					self._term_callback)
+
+	def _term_callback(self):
+		self.cancel()
+		self.wait()
 
 	def _wait(self):
 		CompositeTask._wait(self)
-		if self._term_check_id is not None:
-			self.scheduler.source_remove(self._term_check_id)
-			self._term_check_id = None
+		self._cleanup()

--- a/pym/portage/_emirrordist/MirrorDistTask.py
+++ b/pym/portage/_emirrordist/MirrorDistTask.py
@@ -32,9 +32,11 @@ class MirrorDistTask(CompositeTask):
 		self._config = config
 		self._term_rlock = threading.RLock()
 		self._term_callback_handle = None
+		self._fetch_iterator = None
 
 	def _start(self):
-		fetch = TaskScheduler(iter(FetchIterator(self._config)),
+		self._fetch_iterator = FetchIterator(self._config)
+		fetch = TaskScheduler(iter(self._fetch_iterator),
 			max_jobs=self._config.options.jobs,
 			max_load=self._config.options.load_average,
 			event_loop=self._config.event_loop)
@@ -226,6 +228,8 @@ class MirrorDistTask(CompositeTask):
 					self._term_callback)
 
 	def _term_callback(self):
+		if self._fetch_iterator is not None:
+			self._fetch_iterator.terminate()
 		self.cancel()
 		self.wait()
 

--- a/pym/portage/tests/util/eventloop/test_call_soon_fifo.py
+++ b/pym/portage/tests/util/eventloop/test_call_soon_fifo.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import functools
+import random
+
+from portage import os
+from portage.tests import TestCase
+from portage.util._eventloop.global_event_loop import global_event_loop
+from portage.util.futures.futures import Future
+
+class CallSoonFifoTestCase(TestCase):
+
+	def testCallSoonFifo(self):
+
+		inputs = [random.random() for index in range(10)]
+		outputs = []
+		finished = Future()
+
+		def add_output(value):
+			outputs.append(value)
+			if len(outputs) == len(inputs):
+				finished.set_result(True)
+
+		event_loop = global_event_loop()
+		for value in inputs:
+			event_loop.call_soon(functools.partial(add_output, value))
+
+		event_loop.run_until_complete(finished)
+		self.assertEqual(inputs, outputs)

--- a/pym/portage/util/_async/SchedulerInterface.py
+++ b/pym/portage/util/_async/SchedulerInterface.py
@@ -13,8 +13,9 @@ class SchedulerInterface(SlotObject):
 
 	_event_loop_attrs = ("IO_ERR", "IO_HUP", "IO_IN",
 		"IO_NVAL", "IO_OUT", "IO_PRI",
-		"child_watch_add", "idle_add", "io_add_watch",
-		"iteration", "source_remove", "timeout_add")
+		"call_soon", "call_soon_threadsafe", "child_watch_add",
+		"idle_add", "io_add_watch", "iteration", "run_until_complete",
+		"source_remove", "timeout_add")
 
 	__slots__ = _event_loop_attrs + ("_event_loop", "_is_background")
 


### PR DESCRIPTION
Since asyncio.AbstractEventLoop has no equivalent to the idle
callbacks implemented by the EventLoop.idle_add method, it is
necessary to implement the AbstractEventLoop.call_soon and
call_soon_threadsafe methods, so that idle_add usage can
eventually be eliminated.

X-Gentoo-bug: 591760
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=591760