### PR TITLE
SpawnProcess: fix event loop recursion in _pipe_logger_exit (bug 613990)

### DIFF
--- a/pym/_emerge/SpawnProcess.py
+++ b/pym/_emerge/SpawnProcess.py
@@ -170,8 +170,7 @@ class SpawnProcess(SubProcess):
 
 	def _pipe_logger_exit(self, pipe_logger):
 		self._pipe_logger = None
-		self._unregister()
-		self.wait()
+		self._async_waitpid()
 
 	def _waitpid_loop(self):
 		SubProcess._waitpid_loop(self)


### PR DESCRIPTION
Fix SpawnProcess._pipe_logger_exit to wait for process exit status
asynchronously, in order to avoid event loop recursion. This is
required for asyncio compatibility, and also protects emerge from
exceeding the maximum recursion depth limit like in bug 402335.

X-Gentoo-bug: 613990
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=613990