### PR TITLE
EbuildBuild: fix event loop recursion in _fetchonly_exit (bug 614116)

### DIFF
--- a/pym/_emerge/EbuildBuild.py
+++ b/pym/_emerge/EbuildBuild.py
@@ -22,7 +22,7 @@ import portage
 from portage import _encodings, _unicode_decode, _unicode_encode, os
 from portage.package.ebuild.digestcheck import digestcheck
 from portage.package.ebuild.doebuild import _check_temp_dir
-from portage.package.ebuild._spawn_nofetch import spawn_nofetch
+from portage.package.ebuild._spawn_nofetch import SpawnNofetchWithoutBuilddir
 
 class EbuildBuild(CompositeTask):
 
@@ -165,8 +165,22 @@ class EbuildBuild(CompositeTask):
 	def _fetchonly_exit(self, fetcher):
 		self._final_exit(fetcher)
 		if self.returncode != os.EX_OK:
+			self.returncode = None
 			portdb = self.pkg.root_config.trees[self._tree].dbapi
-			spawn_nofetch(portdb, self._ebuild_path, settings=self.settings)
+			self._start_task(SpawnNofetchWithoutBuilddir(
+				background=self.background,
+				portdb=portdb,
+				ebuild_path=self._ebuild_path,
+				scheduler=self.scheduler,
+				settings=self.settings),
+				self._nofetch_without_builddir_exit)
+			return
+
+		self.wait()
+
+	def _nofetch_without_builddir_exit(self, nofetch):
+		self._final_exit(nofetch)
+		self.returncode = 1
 		self.wait()
 
 	def _pre_clean_exit(self, pre_clean_phase):

--- a/pym/_emerge/EbuildBuild.py
+++ b/pym/_emerge/EbuildBuild.py
@@ -21,7 +21,6 @@ from _emerge.TaskSequence import TaskSequence
 import portage
 from portage import _encodings, _unicode_decode, _unicode_encode, os
 from portage.package.ebuild.digestcheck import digestcheck
-from portage.package.ebuild.digestgen import digestgen
 from portage.package.ebuild.doebuild import _check_temp_dir
 from portage.package.ebuild._spawn_nofetch import spawn_nofetch
 
@@ -168,10 +167,6 @@ class EbuildBuild(CompositeTask):
 		if self.returncode != os.EX_OK:
 			portdb = self.pkg.root_config.trees[self._tree].dbapi
 			spawn_nofetch(portdb, self._ebuild_path, settings=self.settings)
-		elif 'digest' in self.settings.features:
-			if not digestgen(mysettings=self.settings,
-				myportdb=self.pkg.root_config.trees[self._tree].dbapi):
-				self.returncode = 1
 		self.wait()
 
 	def _pre_clean_exit(self, pre_clean_phase):

--- a/pym/_emerge/Scheduler.py
+++ b/pym/_emerge/Scheduler.py
@@ -616,9 +616,6 @@ class Scheduler(PollScheduler):
 		tasks are started.
 		"""
 
-		if '--fetchonly' in self.myopts:
-			return os.EX_OK
-
 		digest = '--digest' in self.myopts
 		if not digest:
 			for pkgsettings in self.pkgsettings.values():


### PR DESCRIPTION
X-Gentoo-bug: 614116
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=614116