### PR TITLE
Prevent crash if os.nice() fails

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -2553,7 +2553,7 @@ def nice(settings):
 	except (OSError, ValueError) as e:
 		out = portage.output.EOutput()
 		out.eerror("Failed to change nice value to '%s'" % \
-			settings["PORTAGE_NICENESS"])
+			settings.get("PORTAGE_NICENESS", "0"))
 		out.eerror("%s\n" % str(e))
 
 def ionice(settings):


### PR DESCRIPTION
If settings["PORTAGE_NICENESS"] is undefined, portage crashes with a
KeyError when trying to print the error.

Signed-off-by: Peter Foley <pefoley2@pefoley.com>
X-Gentoo-bug: 615328
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=615328