### PR TITLE
depgraph._in_blocker_conflict: call _validate_blockers if needed (bug 615982)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -2176,9 +2176,9 @@ class depgraph(object):
 		only works after the _validate_blockers method has been called.
 		"""
 
-		if self._dynamic_config._blocked_pkgs is None:
-			raise AssertionError(
-				'_in_blocker_conflict called before _validate_blockers')
+		if (self._dynamic_config._blocked_pkgs is None
+			and not self._validate_blockers()):
+			raise self._unknown_internal_error()
 
 		if pkg in self._dynamic_config._blocked_pkgs:
 			return True
@@ -6728,7 +6728,14 @@ class depgraph(object):
 		packages within the graph.  If necessary, create hard deps to ensure
 		correct merge order such that mutually blocking packages are never
 		installed simultaneously. Also add runtime blockers from all installed
-		packages if any of them haven't been added already (bug 128809)."""
+		packages if any of them haven't been added already (bug 128809).
+
+		Normally, this method is called only after the graph is complete, and
+		after _solve_non_slot_operator_slot_conflicts has had an opportunity
+		to solve slot conflicts (possibly removing some blockers). It can also
+		be called earlier, in order to get a preview of the blocker data, but
+		then it needs to be called again after the graph is complete.
+		"""
 
 		# The _in_blocker_conflict method needs to assert that this method
 		# has been called before it, by checking that it is not None.

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -6901,6 +6901,12 @@ class depgraph(object):
 			self._dynamic_config._blocker_uninstalls = digraph()
 			self._dynamic_config.digraph.difference_update(previous_uninstall_tasks)
 
+		# Revert state from previous calls.
+		self._dynamic_config._blocker_parents.update(
+			self._dynamic_config._irrelevant_blockers)
+		self._dynamic_config._irrelevant_blockers.clear()
+		self._dynamic_config._unsolvable_blockers.clear()
+
 		for blocker in self._dynamic_config._blocker_parents.leaf_nodes():
 			self._spinner_update()
 			root_config = self._frozen_config.roots[blocker.root]

--- a/pym/portage/tests/util/test_digraph.py
+++ b/pym/portage/tests/util/test_digraph.py
@@ -88,7 +88,9 @@ class DigraphTest(TestCase):
 		g.add("D", "A", 2)
 
 		f = g.clone()
-		for x in g, f:
+		h = digraph()
+		h.update(f)
+		for x in g, f, h:
 			self.assertEqual(bool(x), True)
 			self.assertEqual(x.contains("A"), True)
 			self.assertEqual(x.firstzero(), None)

--- a/pym/portage/util/digraph.py
+++ b/pym/portage/util/digraph.py
@@ -44,8 +44,10 @@ class digraph(object):
 			priorities = []
 			self.nodes[node][1][parent] = priorities
 			self.nodes[parent][0][node] = priorities
-		priorities.append(priority)
-		priorities.sort()
+
+		if not priorities or priorities[-1] is not priority:
+			priorities.append(priority)
+			priorities.sort()
 
 	def discard(self, node):
 		"""
@@ -72,6 +74,26 @@ class digraph(object):
 
 		del self.nodes[node]
 		self.order.remove(node)
+
+	def update(self, other):
+		"""
+		Add all nodes and edges from another digraph instance.
+		"""
+		for node in other.order:
+			children, parents, node = other.nodes[node]
+			if parents:
+				for parent, priorities in parents.items():
+					for priority in priorities:
+						self.add(node, parent, priority=priority)
+			else:
+				self.add(node, None)
+
+	def clear(self):
+		"""
+		Remove all nodes and edges.
+		"""
+		self.nodes.clear()
+		del self.order[:]
 
 	def difference_update(self, t):
 		"""


### PR DESCRIPTION
Sometimes _complete_graph calls _slot_operator_update_probe, which
sometimes calls _in_blocker_conflict. This case occurs infrequently,
so call _validate_blockers only if needed.

Fixes: a83bb83909c5 ("depgraph: trigger slot operator rebuilds via _complete_graph (bug 614390)")
X-Gentoo-bug: 615982
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=615982