### PR TITLE
Closes bug #616262

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -50,7 +50,7 @@ so this syntax shouldn't be used.
 .BR tbz2file
 A \fItbz2file\fR must be a valid .tbz2 created with \fBebuild
 <package>\-<version>.ebuild package\fR or \fBemerge \-\-buildpkg
-[category/]<package>\fR or \fBquickpkg /var/db/pkg/<category>/<package>\fR.
+[category/]<package>\fR or \fBquickpkg [category/]<package>\fR.
 .TP
 .BR file
 A \fIfile\fR must be a file or directory that has been installed by one or


### PR DESCRIPTION
Per bug [616262](https://bugs.gentoo.org/show_bug.cgi?id=616262) quickpkg now takes atom input, not `/var/db/pkg/<category>/<package>`. I only reported that bug before filing this pull request because someone has neglected to fix this line from the [Project:Portage](https://wiki.gentoo.org/index.php?title=Project:Portage&oldid=553258) Gentoo Wiki:

> We also have a GitHub mirror, but note that this is just a mirror, so do not file bugs nor pull requests there.

Please someone fix it. 