### PR TITLE
repoman: Make all shebangs prefix friendly

### DIFF
--- a/repoman/bin/repoman
+++ b/repoman/bin/repoman
@@ -1,5 +1,5 @@
-#!/usr/bin/python -bO
-# Copyright 1999-2014 Gentoo Foundation
+#!/usr/bin/env python
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 """Ebuild and tree health checks and maintenance utilities.

--- a/repoman/pym/repoman/main.py
+++ b/repoman/pym/repoman/main.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python -bO
+#!/usr/bin/env python
 # -*- coding:utf-8 -*-
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function, unicode_literals

--- a/repoman/pym/repoman/tests/runTests.py
+++ b/repoman/pym/repoman/tests/runTests.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python -bWd
+#!/usr/bin/env python
 # runTests.py -- Portage Unit Test Functionality
-# Copyright 2006-2014 Gentoo Foundation
+# Copyright 2006-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import os, sys

--- a/repoman/runtests
+++ b/repoman/runtests
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-# Copyright 2010-2015 Gentoo Foundation
+#!/usr/bin/env python
+# Copyright 2010-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 #
 # Note: We don't want to import portage modules directly because we do things


### PR DESCRIPTION
* Simplifies the repoman ebuild, as the
  prefixifying can be made redundant.
* See also:
  https://blogs.gentoo.org/mgorny/2016/02/08/a-quick-note-on-portable-shebangs/