### PR TITLE
copyfile: fix compiling against musl libc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -676,7 +676,8 @@ setup(
 		['$sysconfdir/portage/repo.postsync.d', ['cnf/repo.postsync.d/example']],
 	],
 
-	ext_modules = [Extension(name=n, sources=m) for n, m in x_c_helpers.items()],
+	ext_modules = [Extension(name=n, sources=m,extra_compile_args=['-D_GNU_SOURCE'])
+            for n, m in x_c_helpers.items()],
 
 	cmdclass = {
 		'build': x_build,

--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -4,6 +4,7 @@
 
 #include <Python.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/sendfile.h>


### PR DESCRIPTION
The native C module for copying files directly in-kernel is using the
`loff_t` data type, which is defined in fcntl.h. While the file seems to
be indirectly included when building with glibc, it breaks compiling
with musl libc.

Fix the issue by directly including fcntl.h. Define GNU_SOURCE as the
typedef is guarded by this preprocessor macro.