### PR TITLE
file_copy: replace loff_t with off_t for portability (bug 617778)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -676,7 +676,10 @@ setup(
 		['$sysconfdir/portage/repo.postsync.d', ['cnf/repo.postsync.d/example']],
 	],
 
-	ext_modules = [Extension(name=n, sources=m) for n, m in x_c_helpers.items()],
+	ext_modules = [Extension(name=n, sources=m,
+		extra_compile_args=['-D_FILE_OFFSET_BITS=64',
+		'-D_LARGEFILE_SOURCE', '-D_LARGEFILE64_SOURCE'])
+		for n, m in x_c_helpers.items()],
 
 	cmdclass = {
 		'build': x_build,

--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -66,7 +66,7 @@ initreflink_linux(void)
  * (errno is set appropriately).
  */
 static ssize_t
-cfr_wrapper(int fd_out, int fd_in, loff_t *off_out, size_t len)
+cfr_wrapper(int fd_out, int fd_in, off_t *off_out, size_t len)
 {
 #ifdef __NR_copy_file_range
     return syscall(__NR_copy_file_range, fd_in, NULL, fd_out,
@@ -96,7 +96,7 @@ cfr_wrapper(int fd_out, int fd_in, loff_t *off_out, size_t len)
  * reaches EOF.
  */
 static off_t
-do_lseek_data(int fd_out, int fd_in, loff_t *off_out) {
+do_lseek_data(int fd_out, int fd_in, off_t *off_out) {
 #ifdef SEEK_DATA
     /* Use lseek SEEK_DATA/SEEK_HOLE for sparse file support,
      * as suggested in the copy_file_range man page.
@@ -189,7 +189,7 @@ _reflink_linux_file_copy(PyObject *self, PyObject *args)
     ssize_t buf_bytes, buf_offset, copyfunc_ret;
     struct stat stat_in, stat_out;
     char* buf;
-    ssize_t (*copyfunc)(int, int, loff_t *, size_t);
+    ssize_t (*copyfunc)(int, int, off_t *, size_t);
 
     if (!PyArg_ParseTuple(args, "ii", &fd_in, &fd_out))
         return NULL;


### PR DESCRIPTION
The loff_t type is a GNU extension, so use the portable off_t
type instead. Also, enable Large File Support macros in setup.py,
for 64-bit offsets.

Reported-by: Patrick Steinhardt <ps@pks.im>
X-Gentoo-bug: 617778
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=617778

I'm thinking this is going to be more portable that the -D_GNU_SOURCE approach from https://github.com/gentoo/portage/pull/159.

@pks-t @blueness