### PR TITLE
emerge: terminate backtracking early for autounmask changes (bug 615680)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -412,7 +412,7 @@ precedence over existing changes. This option is automatically enabled with
 .BR \-\-backtrack=COUNT
 Specifies an integer number of times to backtrack if
 dependency calculation fails due to a conflict or an
-unsatisfied dependency (default: \'3\').
+unsatisfied dependency (default: \'10\').
 .TP
 .BR "\-\-binpkg\-changed\-deps [ y | n ]"
 Tells emerge to ignore binary packages for which the corresponding

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -363,12 +363,20 @@ the specified configuration file(s), or enable the
 \fBEMERGE_DEFAULT_OPTS\fR variable may be used to
 disable this option by default in \fBmake.conf\fR(5).
 .TP
+.BR "\-\-autounmask\-backtrack < y | n >"
+Allow backtracking after autounmask has detected that
+configuration changes are necessary. This option is not
+recommended, since it can cause a large amount of time to
+be wasted by backtracking calculations, even though there
+is no guarantee that it will produce a solution. This
+option is disabled by default.
+.TP
 .BR "\-\-autounmask\-continue [ y | n ]"
 Automatically apply autounmask changes to configuration
 files, and continue to execute the specified command. If
 the dependency calculation is not entirely successful, then
 emerge will simply abort without modifying any configuration
-files.
+files. This option implies \fB\-\-autounmask\-backtrack=y\fR.
 \fBWARNING:\fR
 This option is intended to be used only with great caution,
 since it is possible for it to make nonsensical configuration

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -9460,7 +9460,7 @@ def _backtrack_depgraph(settings, trees, myopts, myparams, myaction, myfiles, sp
 
 	debug = "--debug" in myopts
 	mydepgraph = None
-	max_retries = myopts.get('--backtrack', 3)
+	max_retries = myopts.get('--backtrack', 10)
 	max_depth = max(1, (max_retries + 1) // 2)
 	allow_backtracking = max_retries > 0
 	backtracker = Backtracker(max_depth)

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -326,6 +326,12 @@ def parse_opts(tmpcmdline, silent=False):
 			"choices" : true_y_or_n
 		},
 
+		"--autounmask-backtrack": {
+			"help": ("continue backtracking when there are autounmask "
+				"configuration changes"),
+			"choices":("y", "n")
+		},
+
 		"--autounmask-continue": {
 			"help"    : "write autounmask changes and continue",
 			"choices" : true_y_or_n

--- a/pym/portage/tests/resolver/test_autounmask_use_breakage.py
+++ b/pym/portage/tests/resolver/test_autounmask_use_breakage.py
@@ -46,12 +46,52 @@ class AutounmaskUseBreakageTestCase(TestCase):
 			# due to autounmask USE breakage.
 			ResolverPlaygroundTestCase(
 				["app-misc/C", "app-misc/B", "app-misc/A"],
+				options={"--autounmask-backtrack": "y"},
 				all_permutations = True,
 				success = False,
 				ambiguous_slot_collision_solutions = True,
 				slot_collision_solutions = [None, []]
 			),
 
+			# With --autounmask-backtrack=y:
+			#emerge: there are no ebuilds built with USE flags to satisfy "app-misc/D[foo]".
+			#!!! One of the following packages is required to complete your request:
+			#- app-misc/D-0::test_repo (Change USE: +foo)
+			#(dependency required by "app-misc/B-0::test_repo" [ebuild])
+			#(dependency required by "app-misc/B" [argument])
+
+			# Without --autounmask-backtrack=y:
+			#[ebuild  N     ] app-misc/D-0  USE="foo"
+			#[ebuild  N     ] app-misc/D-1  USE="-bar"
+			#[ebuild  N     ] app-misc/C-0
+			#[ebuild  N     ] app-misc/B-0
+			#[ebuild  N     ] app-misc/A-0
+			#
+			#!!! Multiple package instances within a single package slot have been pulled
+			#!!! into the dependency graph, resulting in a slot conflict:
+			#
+			#app-misc/D:0
+			#
+			#  (app-misc/D-0:0/0::test_repo, ebuild scheduled for merge) pulled in by
+			#    app-misc/D[-foo] required by (app-misc/A-0:0/0::test_repo, ebuild scheduled for merge)
+			#               ^^^^
+			#    app-misc/D[foo] required by (app-misc/B-0:0/0::test_repo, ebuild scheduled for merge)
+			#               ^^^
+			#
+			#  (app-misc/D-1:0/0::test_repo, ebuild scheduled for merge) pulled in by
+			#    >=app-misc/D-1 required by (app-misc/C-0:0/0::test_repo, ebuild scheduled for merge)
+			#    ^^           ^
+			#
+			#The following USE changes are necessary to proceed:
+			# (see "package.use" in the portage(5) man page for more details)
+			## required by app-misc/B-0::test_repo
+			## required by app-misc/B (argument)
+			#=app-misc/D-0 foo
+
+			# NOTE: The --autounmask-backtrack=n output is preferable here,
+			# because it highlights the unsolvable dependency conflict.
+			# It would be better if it eliminated the autounmask suggestion,
+			# since that suggestion won't solve the conflict.
 		)
 
 		playground = ResolverPlayground(ebuilds=ebuilds, debug=False)


### PR DESCRIPTION

    emerge: terminate backtracking early for autounmask changes (bug 615680)
    
    Since autounmask changes are a strong indicator that backtracking
    will ultimately fail to produce a solution, terminate early for
    autounmask changes, and add a --autounmask-backtrack=<y|n> option
    to modify this behavior. The --autounmask-continue option implies
    --autounmask-backtrack=y behavior, for backward compatibility.
    
    When backtracking terminates early, the following warning message
    is displayed after the autounmask change(s):
    
     * In order to avoid wasting time, backtracking has terminated early
     * due to the above autounmask change(s). The --autounmask-backtrack=y
     * option can be used to force further backtracking, but there is no
     * guarantee that it will produce a solution.
    
    With this change, five of the existing cases fail unless
    --autounmask-backtrack=y is added to the options. For each of
    these cases, comments below the test case document how it behaves
    with and without --autounmask-backtrack=y enabled.
    
    X-Gentoo-bug: 615680
    X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=615680