### PR TITLE
emerge: add --onlydeps-with-rdeps=<y|n> option (bug 294719)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -724,6 +724,11 @@ it possible for \fB\-\-deep\fR to be disabled by default.
 Only merge (or pretend to merge) the dependencies of the packages
 specified, not the packages themselves.
 .TP
+.BR "\-\-onlydeps\-with\-rdeps < y | n >"
+Include run time dependencies when \fB\-\-onlydeps\fR is specified.
+When this is disabled only build time dependencies are included. This
+option is enabled by default.
+.TP
 .BR "\-\-package\-moves [ y | n ]"
 Perform package moves when necessary. This option is enabled
 by default. Package moves are typically applied immediately

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -3066,6 +3066,11 @@ class depgraph(object):
 			edepend["RDEPEND"] = ""
 			edepend["PDEPEND"] = ""
 
+		if pkg.onlydeps and \
+			self._frozen_config.myopts.get("--onlydeps-with-rdeps") == 'n':
+			edepend["RDEPEND"] = ""
+			edepend["PDEPEND"] = ""
+
 		ignore_build_time_deps = False
 		if pkg.built and not removal_action:
 			if self._dynamic_config.myparams.get("bdeps") in ("y", "auto"):

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -147,6 +147,7 @@ def insert_optional_args(args):
 		'--jobs'       : valid_integers,
 		'--keep-going'           : y_or_n,
 		'--load-average'         : valid_floats,
+		'--onlydeps-with-rdeps'  : y_or_n,
 		'--package-moves'        : y_or_n,
 		'--quiet'                : y_or_n,
 		'--quiet-build'          : y_or_n,
@@ -563,6 +564,11 @@ def parse_opts(tmpcmdline, silent=False):
 				"Emerge will ignore matching binary packages. ",
 
 			"action" : "append",
+		},
+
+		"--onlydeps-with-rdeps": {
+			"help"    : "modify interpretation of depedencies",
+			"choices" : true_y_or_n
 		},
 
 		"--rebuild-exclude": {

--- a/pym/portage/tests/resolver/test_onlydeps_minimal.py
+++ b/pym/portage/tests/resolver/test_onlydeps_minimal.py
@@ -1,0 +1,47 @@
+# Copyright 2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground, ResolverPlaygroundTestCase
+
+class OnlydepsMinimalTestCase(TestCase):
+
+	def testOnlydepsMinimal(self):
+		ebuilds = {
+			"dev-libs/A-1": { "DEPEND": "dev-libs/B",
+			                  "RDEPEND": "dev-libs/C",
+			                  "PDEPEND": "dev-libs/D" },
+			"dev-libs/B-1": { },
+			"dev-libs/C-1": { },
+			"dev-libs/D-1": { },
+			}
+		installed = {
+		}
+
+		test_cases = (
+			ResolverPlaygroundTestCase(
+				["dev-libs/A"],
+				all_permutations = True,
+				success = True,
+				options = { "--onlydeps": True,
+				            "--onlydeps-with-rdeps": "y" },
+				mergelist = ["dev-libs/B-1",
+				             "dev-libs/C-1",
+				             "dev-libs/D-1"]),
+			ResolverPlaygroundTestCase(
+				["dev-libs/A"],
+				all_permutations = True,
+				success = True,
+				options = { "--onlydeps": True,
+				            "--onlydeps-with-rdeps": "n" },
+				mergelist = ["dev-libs/B-1"]),
+			)
+
+		playground = ResolverPlayground(ebuilds=ebuilds,
+			installed=installed, debug=False)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+		finally:
+			playground.cleanup()


### PR DESCRIPTION
Add --onlydeps-with-rdeps=n option in order to omit pure
run-time dependencies with --onlydeps. The dependencies
that get pulled in are those that are necessary for the
equivalent --buildpkgonly command to succeed. The default
--onlydeps behavior remains unchanged.

X-Gentoo-bug: 294719
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=294719