### PR TITLE
GitSync: Add support for setting the environment

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -1,4 +1,4 @@
-.TH "PORTAGE" "5" "Jan 2017" "Portage VERSION" "Portage"
+.TH "PORTAGE" "31" "May 2017" "Portage VERSION" "Portage"
 .SH NAME
 portage \- the heart of Gentoo
 .SH "DESCRIPTION"
@@ -979,8 +979,30 @@ Specifies CVS repository.
 .B sync\-depth
 This is a deprecated alias for the \fBclone\-depth\fR option.
 .TP
+.B sync\-git\-clone\-env
+Set environment variables for git when cloning repository (git clone).
+This will override settings from sync-git-env.
+.RS
+.TP
+.I Example:
+sync-git-clone-env="VAR1=word1 word2" VAR2=word3 "VAR3=$word 5 6"
+.br
+Gives three variables "VAR1", "VAR2", "VAR3" with the values "word1 word2",
+"word3", "$word 5 6".
+.RE
+.TP
 .B sync\-git\-clone\-extra\-opts
 Extra options to give to git when cloning repository (git clone).
+.TP
+.B sync\-git\-env
+Set environment variables for git when cloning or pulling the repository.
+These will be overridden by setting them again in sync-git-clone-env and sync-git-pull-env.
+See also example for sync-git-clone-env.
+.TP
+.B sync\-git\-pull\-env
+Set environment variables for git when updating repository (git pull).
+This will override settings from sync-git-env.
+See also example for sync-git-clone-env.
 .TP
 .B sync\-git\-pull\-extra\-opts
 Extra options to give to git when updating repository (git pull).

--- a/pym/portage/sync/modules/git/__init__.py
+++ b/pym/portage/sync/modules/git/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Gentoo Foundation
+# Copyright 2014-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 doc = """Git plug-in module for portage.
@@ -52,7 +52,10 @@ module_spec = {
 			},
 			'validate_config': CheckGitConfig,
 			'module_specific_options': (
+				'sync-git-clone-env',
 				'sync-git-clone-extra-opts',
+				'sync-git-env',
+				'sync-git-pull-env',
 				'sync-git-pull-extra-opts',
 				),
 		}

--- a/pym/portage/sync/modules/git/git.py
+++ b/pym/portage/sync/modules/git/git.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2015 Gentoo Foundation
+# Copyright 2005-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
@@ -6,7 +6,7 @@ import subprocess
 
 import portage
 from portage import os
-from portage.util import writemsg_level
+from portage.util import writemsg_level, shlex_split
 from portage.output import create_color_func
 good = create_color_func("GOOD")
 bad = create_color_func("BAD")
@@ -50,6 +50,16 @@ class GitSync(NewBase):
 			sync_uri = sync_uri[6:]
 
 		git_cmd_opts = ""
+		if self.repo.module_specific_options.get('sync-git-env'):
+			shlexed_env = shlex_split(self.repo.module_specific_options['sync-git-env'])
+			env = dict((k, v) for k, _, v in (assignment.partition('=') for assignment in shlexed_env) if k)
+			self.spawn_kwargs['env'].update(env)
+
+		if self.repo.module_specific_options.get('sync-git-clone-env'):
+			shlexed_env = shlex_split(self.repo.module_specific_options['sync-git-clone-env'])
+			clone_env = dict((k, v) for k, _, v in (assignment.partition('=') for assignment in shlexed_env) if k)
+			self.spawn_kwargs['env'].update(clone_env)
+
 		if self.settings.get("PORTAGE_QUIET") == "1":
 			git_cmd_opts += " --quiet"
 		if self.repo.clone_depth is not None:
@@ -86,6 +96,16 @@ class GitSync(NewBase):
 		'''
 
 		git_cmd_opts = ""
+		if self.repo.module_specific_options.get('sync-git-env'):
+			shlexed_env = shlex_split(self.repo.module_specific_options['sync-git-env'])
+			env = dict((k, v) for k, _, v in (assignment.partition('=') for assignment in shlexed_env) if k)
+			self.spawn_kwargs['env'].update(env)
+
+		if self.repo.module_specific_options.get('sync-git-pull-env'):
+			shlexed_env = shlex_split(self.repo.module_specific_options['sync-git-pull-env'])
+			pull_env = dict((k, v) for k, _, v in (assignment.partition('=') for assignment in shlexed_env) if k)
+			self.spawn_kwargs['env'].update(pull_env)
+
 		if self.settings.get("PORTAGE_QUIET") == "1":
 			git_cmd_opts += " --quiet"
 		if self.repo.module_specific_options.get('sync-git-pull-extra-opts'):


### PR DESCRIPTION
This can be used to provide private SSH keys to portage in order to
clone repositories from a non-public repository.

An exemplary usage would be:
sync-git-pull-env = GIT_SSH_COMMAND=ssh -i /etc/portage/.ssh/id_rsa -o UserKnownHostsFile=/etc/portage/.ssh/known_hosts
sync-git-clone-env = GIT_SSH_COMMAND=ssh -i /etc/portage/.ssh/id_rsa -o UserKnownHostsFile=/etc/portage/.ssh/known_hosts