### PR TITLE
man/portage.5: document -* in profile "packages" files (bug 610670)

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -369,7 +369,8 @@ hurt \fBemerge\fR's ability to parallelize.
 .I Note:
 In a cascading profile setup, you can remove packages in children
 profiles which were added by parent profiles by prefixing the atom with
-a '\-'.
+a '\-'. The '\-*' wildcard discards all @system and @profile packages
+added by parent profiles.
 
 .I Example:
 .nf


### PR DESCRIPTION
The -* wildcard has been supported since portage-2.3.4, but it was
not explicitly documented.

X-Gentoo-Bug: 610670
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=610670