### PR TITLE
emerge: warn for --autounmask-continue with --autounmask=n (bug 619612)

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -2862,6 +2862,12 @@ def run_action(emerge_config):
 	adjust_configs(emerge_config.opts, emerge_config.trees)
 	apply_priorities(emerge_config.target_config.settings)
 
+	if ("--autounmask-continue" in emerge_config.opts and
+		emerge_config.opts.get("--autounmask") == "n"):
+		writemsg_level(
+			" %s --autounmask-continue has been disabled by --autounmask=n\n" %
+			warn("*"), level=logging.WARNING, noiselevel=-1)
+
 	for fmt in emerge_config.target_config.settings.get("PORTAGE_BINPKG_FORMAT", "").split():
 		if not fmt in portage.const.SUPPORTED_BINPKG_FORMATS:
 			if "--pkg-format" in emerge_config.opts:

--- a/pym/portage/tests/emerge/test_simple.py
+++ b/pym/portage/tests/emerge/test_simple.py
@@ -311,7 +311,10 @@ pkg_preinst() {
 			emerge_cmd + ("--unmerge", "--quiet", "dev-libs/A"),
 			emerge_cmd + ("-C", "--quiet", "dev-libs/B"),
 
-			emerge_cmd + ("--autounmask-continue", "dev-libs/C",),
+			# If EMERGE_DEFAULT_OPTS contains --autounmask=n, then --autounmask
+			# must be specified with --autounmask-continue.
+			({"EMERGE_DEFAULT_OPTS" : "--autounmask=n"},) + \
+				emerge_cmd + ("--autounmask", "--autounmask-continue", "dev-libs/C",),
 			# Verify that the above --autounmask-continue command caused
 			# USE=flag to be applied correctly to dev-libs/D.
 			portageq_cmd + ("match", eroot, "dev-libs/D[flag]"),


### PR DESCRIPTION
In order to avoid possible confusion when the user has specified
--autounmask-continue and EMERGE_DEFAULT_OPTS contains
--autounmask=n, display a warning message as follows:
```
 * --autounmask-continue has been disabled by --autounmask=n
```
X-Gentoo-bug: 619612
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=619612