### PR TITLE
depgraph: account for binpkg-multi-instance in unused warning (bug 619620)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -876,6 +876,15 @@ class depgraph(object):
 					self._dynamic_config.ignored_binaries.pop(pkg)
 					break
 
+				# NOTE: The Package.__ge__ implementation accounts for
+				# differences in build_time, so the warning about "ignored"
+				# packages will be triggered if both packages are the same
+				# version and selected_pkg is not the most recent build.
+				if (selected_pkg.type_name == "binary" and
+					selected_pkg >= pkg):
+					self._dynamic_config.ignored_binaries.pop(pkg)
+					break
+
 				if selected_pkg.installed and \
 					selected_pkg.cpv == pkg.cpv and \
 					selected_pkg.build_time == pkg.build_time:


### PR DESCRIPTION
With FEATURES=binpkg-multi-instance, it is normal to have some
unused binary packages, so don't warn if the selected package
is the latest version and the most recent build.

X-Gentoo-bug: 619620
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=619620