### PR TITLE
repoman: Mark ruby-2.0 as deprecated

### DIFF
--- a/repoman/pym/repoman/qa_data.py
+++ b/repoman/pym/repoman/qa_data.py
@@ -358,6 +358,7 @@ ruby_deprecated = frozenset([
 	"ruby_targets_ree18",
 	"ruby_targets_ruby18",
 	"ruby_targets_ruby19",
+	"ruby_targets_ruby20",
 ])
 
 


### PR DESCRIPTION
Ruby 2.0 was removed from ::gentoo a while ago. Add it to the repoman check.