### PR TITLE
emerge: Add head commit per repo to --info

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -1644,8 +1644,18 @@ def action_info(settings, trees, myopts, myfiles):
 
 	for repo in repos:
 		last_sync = portage.grabfile(os.path.join(repo.location, "metadata", "timestamp.chk"))
+		head_commit = None
 		if last_sync:
 			append("Timestamp of repository %s: %s" % (repo.name, last_sync[0]))
+		if repo.sync_type:
+			sync = portage.sync.module_controller.get_class(repo.sync_type)()
+			options = { 'repo': repo }
+			try:
+				head_commit = sync.retrieve_head(options=options)
+			except NotImplementedError:
+				head_commit = (1, False)
+		if head_commit and head_commit[0] == os.EX_OK:
+			append("Head commit of repository %s: %s" % (repo.name, head_commit[1]))
 
 	# Searching contents for the /bin/sh provider is somewhat
 	# slow. Therefore, use the basename of the symlink target

--- a/pym/portage/sync/modules/git/__init__.py
+++ b/pym/portage/sync/modules/git/__init__.py
@@ -43,12 +43,13 @@ module_spec = {
 			'sourcefile': "git",
 			'class': "GitSync",
 			'description': doc,
-			'functions': ['sync', 'new', 'exists'],
+			'functions': ['sync', 'new', 'exists', 'retrieve_head'],
 			'func_desc': {
 				'sync': 'Performs a git pull on the repository',
 				'new': 'Creates the new repository at the specified location',
 				'exists': 'Returns a boolean of whether the specified dir ' +
 					'exists and is a valid Git repository',
+				'retrieve_head': 'Returns the head commit hash',
 			},
 			'validate_config': CheckGitConfig,
 			'module_specific_options': (

--- a/pym/portage/sync/modules/git/git.py
+++ b/pym/portage/sync/modules/git/git.py
@@ -130,3 +130,15 @@ class GitSync(NewBase):
 			cwd=portage._unicode_encode(self.repo.location))
 
 		return (os.EX_OK, current_rev != previous_rev)
+
+	def retrieve_head(self, **kwargs):
+		'''Get information about the head commit'''
+		if kwargs:
+			self._kwargs(kwargs)
+		rev_cmd = [self.bin_command, "rev-list", "--max-count=1", "HEAD"]
+		try:
+			ret = (os.EX_OK, subprocess.check_output(rev_cmd,
+				cwd=portage._unicode_encode(self.repo.location)))
+		except CalledProcessError:
+			ret = (1, False)
+		return ret

--- a/pym/portage/sync/modules/rsync/__init__.py
+++ b/pym/portage/sync/modules/rsync/__init__.py
@@ -17,11 +17,12 @@ module_spec = {
 			'sourcefile': "rsync",
 			'class': "RsyncSync",
 			'description': doc,
-			'functions': ['sync', 'new', 'exists'],
+			'functions': ['sync', 'new', 'exists', 'retrieve_head'],
 			'func_desc': {
 				'sync': 'Performs rsync transfers on the repository',
 				'new': 'Creates the new repository at the specified location',
 				'exists': 'Returns a boolean if the specified directory exists',
+				'retrieve_head': 'Returns the head commit based on metadata/timestamp.commit',
 				},
 			'validate_config': CheckSyncConfig,
 			'module_specific_options': (

--- a/pym/portage/sync/modules/rsync/rsync.py
+++ b/pym/portage/sync/modules/rsync/rsync.py
@@ -303,6 +303,18 @@ class RsyncSync(NewBase):
 			return (1, False)
 		return self.update()
 
+	def retrieve_head(self, **kwargs):
+		'''Get information about the head commit'''
+		if kwargs:
+			self._kwargs(kwargs)
+		last_sync = portage.grabfile(os.path.join(self.repo.location, "metadata", "timestamp.commit"))
+		ret = (1, False)
+		if last_sync:
+			try:
+				ret = (os.EX_OK, last_sync[0].split()[0])
+			except IndexError:
+				pass
+		return ret
 
 	def _set_rsync_defaults(self):
 		portage.writemsg("PORTAGE_RSYNC_OPTS empty or unset, using hardcoded defaults\n")

--- a/pym/portage/sync/syncbase.py
+++ b/pym/portage/sync/syncbase.py
@@ -129,8 +129,11 @@ class NewBase(SyncBase):
 		'''Do the initial download and install of the repository'''
 		raise NotImplementedError
 
-
 	def update(self):
 		'''Update existing repository
 		'''
+		raise NotImplementedError
+
+	def retrieve_head(self, **kwargs):
+		'''Get information about the head commit'''
 		raise NotImplementedError


### PR DESCRIPTION
This adds more information to emerge --info output if timestamp.commit exists.
``` Head commit of repository gentoo: 0518b330edac963f54f98df33391b8e7b9eaee4c ```