### PR TITLE
repoman: Warn about dropped keywords only for latest in SLOT.

### DIFF
--- a/repoman/pym/repoman/modules/scan/keywords/keywords.py
+++ b/repoman/pym/repoman/modules/scan/keywords/keywords.py
@@ -26,6 +26,7 @@ class KeywordChecks(ScanBase):
 	def prepare(self, **kwargs):
 		'''Prepare the checks for the next package.'''
 		self.slot_keywords = {}
+		self.dropped_keywords = {}
 		return False
 
 	def check(self, **kwargs):
@@ -57,6 +58,15 @@ class KeywordChecks(ScanBase):
 		self.slot_keywords[pkg.slot].update(ebuild.archs)
 		return False
 
+	def check_dropped_keywords(self, **kwargs):
+		for ebuild,arches in self.dropped_keywords.values():
+			if arches:
+				self.qatracker.add_error(
+					"KEYWORDS.dropped", "%s: %s" % (
+						ebuild,
+						" ".join(sorted(arches))))
+		return False
+
 	@staticmethod
 	def _isKeywordStable(keyword):
 		return not keyword.startswith("~") and not keyword.startswith("-")
@@ -80,12 +90,9 @@ class KeywordChecks(ScanBase):
 		if previous_keywords is None:
 			self.slot_keywords[pkg.slot] = set()
 		elif ebuild_archs and "*" not in ebuild_archs and not ebuild.live_ebuild:
+			self.slot_keywords[pkg.slot].update(ebuild_archs)
 			dropped_keywords = previous_keywords.difference(ebuild_archs)
-			if dropped_keywords:
-				self.qatracker.add_error(
-					"KEYWORDS.dropped", "%s: %s" % (
-						ebuild.relative_path,
-						" ".join(sorted(dropped_keywords))))
+			self.dropped_keywords[pkg.slot] = (ebuild.relative_path, { arch for arch in dropped_keywords})
 
 	def _checkForInvalidKeywords(self, ebuild, xpkg, y_ebuild):
 		myuse = ebuild.keywords
@@ -131,3 +138,8 @@ class KeywordChecks(ScanBase):
 	def runInEbuilds(self):
 		'''Ebuild level scans'''
 		return (True, [self.check])
+
+	@property
+	def runInFinal(self):
+		'''Final package level scans'''
+		return (True, [self.check_dropped_keywords])

--- a/repoman/pym/repoman/scanner.py
+++ b/repoman/pym/repoman/scanner.py
@@ -414,7 +414,7 @@ class Scanner(object):
 		# initialize per pkg plugin final checks here
 		# need to set it up for ==> self.modules_list or some other ordered list
 		xpkg_complete = False
-		for mod in [('pkgmetadata', 'PkgMetadata')]:
+		for mod in [('pkgmetadata', 'PkgMetadata'), ('keywords', 'KeywordChecks')]:
 			if mod[0] and mod[1] not in self.modules:
 				mod_class = MODULE_CONTROLLER.get_class(mod[0])
 				logging.debug("Initializing class name: %s", mod_class.__name__)


### PR DESCRIPTION
Rationale: There is no point in rekeywording non-latest and nobody ever does that.

For example:
 $ epkginfo texlive-latex
 * dev-texlive/texlive-latex [gentoo]
Maintainer:  aballier@gentoo.org (Alexis Ballier)
Maintainer:  tex@gentoo.org (Gentoo TeX Project)
Upstream:    None specified
Homepage:    http://www.tug.org/texlive/
Location:    /mnt/dev/gentoo-x86/dev-texlive/texlive-latex
Keywords:    2012:0: s390 sh sparc
Keywords:    2013:0:
Keywords:    2014:0:
Keywords:    2015:0: hppa ppc ppc64
Keywords:    2016:0: alpha amd64 arm arm64 ia64 x86
Keywords:    2017:0: ~alpha ~amd64 ~amd64-fbsd ~amd64-linux ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc-macos ~ppc64 ~s390 ~sh ~sparc ~sparc-solaris ~x64-macos ~x64-solaris ~x86 ~x86-fbsd ~x86-linux ~x86-macos ~x86-solaris

Before:
RepoMan scours the neighborhood...
  KEYWORDS.dropped              3
   dev-texlive/texlive-latex/texlive-latex-2014.ebuild: ia64 sparc
   dev-texlive/texlive-latex/texlive-latex-2015.ebuild: ia64 sparc
   dev-texlive/texlive-latex/texlive-latex-2016.ebuild: sparc
  repo.eapi.deprecated          1
   dev-texlive/texlive-latex/texlive-latex-2012.ebuild: 4

After:
RepoMan scours the neighborhood...
  repo.eapi.deprecated          1
   dev-texlive/texlive-latex/texlive-latex-2012.ebuild: 4

Or also:
 $ epkginfo ffmpeg
 * media-video/ffmpeg [gentoo]
Maintainer:  media-video@gentoo.org
Upstream:    None specified
Homepage:    http://ffmpeg.org/
Location:    /mnt/dev/gentoo-x86/media-video/ffmpeg
Keywords:    2.8.10:0/54.56.56: alpha amd64 arm hppa ia64 ppc ppc64 sparc x86
Keywords:    2.8.11:0/54.56.56: ~alpha ~amd64 ~amd64-fbsd ~amd64-linux ~arm ~arm-linux ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-linux
Keywords:    3.2.4:0/55.57.57: alpha amd64 arm hppa ia64 ppc ppc64 x86
Keywords:    3.2.5:0/55.57.57:
Keywords:    3.2.6:0/55.57.57: ~alpha ~ia64
Keywords:    3.3.2:0/55.57.57: ~amd64 ~amd64-fbsd ~amd64-linux ~arm ~arm-linux ~arm64 ~hppa ~mips ~ppc ~ppc-macos ~ppc64 ~x64-macos ~x64-solaris ~x86 ~x86-fbsd ~x86-linux ~x86-macos ~x86-solaris
Keywords:    9999:0/55.57.57:

Before:
RepoMan scours the neighborhood...
  DESCRIPTION.toolong           7
   media-video/ffmpeg/ffmpeg-2.8.10.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-2.8.11.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.2.4.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.2.5.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.2.6.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.3.2.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-9999.ebuild: DESCRIPTION is 84 characters (max 80)
  KEYWORDS.dropped              4
   media-video/ffmpeg/ffmpeg-3.2.4.ebuild: sparc
   media-video/ffmpeg/ffmpeg-3.2.5.ebuild: sparc
   media-video/ffmpeg/ffmpeg-3.2.6.ebuild: sparc
   media-video/ffmpeg/ffmpeg-3.3.2.ebuild: alpha ia64 sparc

After:
RepoMan scours the neighborhood...
  DESCRIPTION.toolong           7
   media-video/ffmpeg/ffmpeg-2.8.10.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-2.8.11.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.2.4.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.2.5.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.2.6.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-3.3.2.ebuild: DESCRIPTION is 84 characters (max 80)
   media-video/ffmpeg/ffmpeg-9999.ebuild: DESCRIPTION is 84 characters (max 80)
  KEYWORDS.dropped              1
   media-video/ffmpeg/ffmpeg-3.3.2.ebuild: alpha ia64 sparc

X-Gentoo-Bug: 256189
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=256189