### PR TITLE
localization: Replace deprecated locale.format() with format_string()

### DIFF
--- a/pym/portage/localization.py
+++ b/pym/portage/localization.py
@@ -39,7 +39,7 @@ def localized_size(num_bytes):
 	# always round up, so that small files don't end up as '0 KiB'
 	num_kib = math.ceil(num_bytes / 1024)
 	try:
-		formatted_num = locale.format('%d', num_kib, grouping=True)
+		formatted_num = locale.format_string('%d', num_kib, grouping=True)
 	except UnicodeDecodeError:
 		# failure to decode locale data
 		formatted_num = str(num_kib)


### PR DESCRIPTION
Silences deprecation warnings in test

```
testConfigProtect (portage.tests.emerge.test_config_protect.ConfigProtectTestCase) ... /home/travis/build/gentoo/portage/build/lib.linux-x86_64-3.7/portage/localization.py:42: DeprecationWarning: This method will be removed in a future version of Python. Use 'locale.format_string()' instead.

  formatted_num = locale.format('%d', num_kib, grouping=True)

/home/travis/build/gentoo/portage/build/lib.linux-x86_64-3.7/portage/localization.py:42: DeprecationWarning: This method will be removed in a future version of Python. Use 'locale.format_string()' instead.

  formatted_num = locale.format('%d', num_kib, grouping=True)

/home/travis/build/gentoo/portage/build/lib.linux-x86_64-3.7/portage/localization.py:42: DeprecationWarning: This method will be removed in a future version of Python. Use 'locale.format_string()' instead.

  formatted_num = locale.format('%d', num_kib, grouping=True)

/home/travis/build/gentoo/portage/build/lib.linux-x86_64-3.7/portage/localization.py:42: DeprecationWarning: This method will be removed in a future version of Python. Use 'locale.format_string()' instead.

  formatted_num = locale.format('%d', num_kib, grouping=True)

/home/travis/build/gentoo/portage/build/lib.linux-x86_64-3.7/portage/localization.py:42: DeprecationWarning: This method will be removed in a future version of Python. Use 'locale.format_string()' instead.

  formatted_num = locale.format('%d', num_kib, grouping=True)

/home/travis/build/gentoo/portage/build/lib.linux-x86_64-3.7/portage/localization.py:42: DeprecationWarning: This method will be removed in a future version of Python. Use 'locale.format_string()' instead.

  formatted_num = locale.format('%d', num_kib, grouping=True)
```