### PR TITLE
multilib-strict: disable recursion into subdirectories (bug 424423)

### DIFF
--- a/bin/install-qa-check.d/80multilib-strict
+++ b/bin/install-qa-check.d/80multilib-strict
@@ -6,14 +6,13 @@ multilib_strict_check() {
 	then
 		rm -f "${T}/multilib-strict.log"
 		local abort=no dir file
-		MULTILIB_STRICT_EXEMPT=$(echo ${MULTILIB_STRICT_EXEMPT} | sed -e 's:\([(|)]\):\\\1:g')
 		for dir in ${MULTILIB_STRICT_DIRS} ; do
 			[[ -d ${ED}/${dir} ]] || continue
-			for file in $(find ${ED}/${dir} -type f | grep -v "^${ED}/${dir}/${MULTILIB_STRICT_EXEMPT}"); do
-				if file ${file} | egrep -q "${MULTILIB_STRICT_DENY}" ; then
+			while read -r -d '' file; do
+				if file "${file}" | grep -Eq "${MULTILIB_STRICT_DENY}" ; then
 					echo "${file#${ED}//}" >> "${T}/multilib-strict.log"
 				fi
-			done
+			done < <(find "${ED}/${dir}" -maxdepth 1 -type f -print0)
 		done
 
 		if [[ -s ${T}/multilib-strict.log ]] ; then


### PR DESCRIPTION
Disable recursion into subdirectories, in order to avoid false-positives.
The MULTILIB_STRICT_EXEMPT variable only served to filter false-positives
that were triggered by recursion, so it will no longer be needed.

X-Gentoo-bug: 424423
X-Gentoo-bug-url: https://bugs.gentoo.org/show_bug.cgi?id=424423