### PR TITLE
enable allow_build_id=True for user config keywords and use

### DIFF
--- a/pym/portage/package/ebuild/_config/KeywordsManager.py
+++ b/pym/portage/package/ebuild/_config/KeywordsManager.py
@@ -57,12 +57,12 @@ class KeywordsManager(object):
 			pkgdict = grabdict_package(
 				os.path.join(abs_user_config, "package.keywords"),
 				recursive=1, allow_wildcard=True, allow_repo=True,
-				verify_eapi=False)
+				verify_eapi=False, allow_build_id=True)
 
 			for k, v in grabdict_package(
 				os.path.join(abs_user_config, "package.accept_keywords"),
 				recursive=1, allow_wildcard=True, allow_repo=True,
-				verify_eapi=False).items():
+				verify_eapi=False, allow_build_id=True).items():
 				pkgdict.setdefault(k, []).extend(v)
 
 			accept_keywords_defaults = global_accept_keywords.split()

--- a/pym/portage/package/ebuild/_config/UseManager.py
+++ b/pym/portage/package/ebuild/_config/UseManager.py
@@ -239,7 +239,8 @@ class UseManager(object):
 		ret = ExtendedAtomDict(dict)
 		if user_config:
 			pusedict = grabdict_package(
-				os.path.join(location, file_name), recursive=1, newlines=1, allow_wildcard=True, allow_repo=True, verify_eapi=False)
+				os.path.join(location, file_name), recursive=1, newlines=1, allow_wildcard=True, allow_repo=True,
+				verify_eapi=False, allow_build_id=True)
 			for k, v in pusedict.items():
 				l = []
 				use_expand_prefix = ''


### PR DESCRIPTION
Hello,

I need use build-id feature in /etc/portage/{package.keywords, package.use}. And I think the long ago patches http://comments.gmane.org/gmane.linux.gentoo.portage.devel/5239 missing this.