### PR TITLE
emerge: add --autounmask-keep-keywords option (bug 622480)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -395,6 +395,13 @@ using the \'=\' operator will be written. With this
 option, \'>=\' operators will be used whenever possible.
 USE and license changes always use the latter behavior.
 .TP
+.BR "\-\-autounmask\-keep\-keywords [ y | n ]"
+If \-\-autounmask is enabled, no package.accept_keywords changes will
+be created. This leads to unsatisfied dependencies if any keyword
+changes are required. This option does not imply \-\-autounmask\-keep\-masks,
+so \-\-autounmask is still allowed to create package.unmask changes unless
+the \-\-autounmask\-keep\-masks is also specified.
+.TP
 .BR "\-\-autounmask\-keep\-masks [ y | n ]"
 If \-\-autounmask is enabled, no package.unmask or ** keyword changes
 will be created. This leads to unsatisfied dependencies if

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -5707,6 +5707,7 @@ class depgraph(object):
 		if self._dynamic_config._autounmask is not True:
 			return
 
+		autounmask_keep_keywords = self._frozen_config.myopts.get("--autounmask-keep-keywords", "n") != "n"
 		autounmask_keep_masks = self._frozen_config.myopts.get("--autounmask-keep-masks", "n") != "n"
 		autounmask_level = self._AutounmaskLevel()
 
@@ -5716,14 +5717,16 @@ class depgraph(object):
 		autounmask_level.allow_license_changes = True
 		yield autounmask_level
 
-		autounmask_level.allow_unstable_keywords = True
-		yield autounmask_level
+		if not autounmask_keep_keywords:
+			autounmask_level.allow_unstable_keywords = True
+			yield autounmask_level
 
-		if not autounmask_keep_masks:
-
+		if not (autounmask_keep_keywords or autounmask_keep_masks):
+			autounmask_level.allow_unstable_keywords = True
 			autounmask_level.allow_missing_keywords = True
 			yield autounmask_level
 
+		if not autounmask_keep_masks:
 			# 4. USE + license + masks
 			# Try to respect keywords while discarding
 			# package.mask (see bug #463394).
@@ -5732,6 +5735,7 @@ class depgraph(object):
 			autounmask_level.allow_unmasks = True
 			yield autounmask_level
 
+		if not (autounmask_keep_keywords or autounmask_keep_masks):
 			autounmask_level.allow_unstable_keywords = True
 
 			for missing_keyword, unmask in ((False, True), (True, True)):

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -129,6 +129,7 @@ def insert_optional_args(args):
 		'--autounmask'           : y_or_n,
 		'--autounmask-continue'  : y_or_n,
 		'--autounmask-only'      : y_or_n,
+		'--autounmask-keep-keywords' : y_or_n,
 		'--autounmask-keep-masks': y_or_n,
 		'--autounmask-unrestricted-atoms' : y_or_n,
 		'--autounmask-write'     : y_or_n,
@@ -345,6 +346,11 @@ def parse_opts(tmpcmdline, silent=False):
 
 		"--autounmask-unrestricted-atoms": {
 			"help"    : "write autounmask changes with >= atoms if possible",
+			"choices" : true_y_or_n
+		},
+
+		"--autounmask-keep-keywords": {
+			"help"    : "don't add package.accept_keywords entries",
 			"choices" : true_y_or_n
 		},
 
@@ -796,6 +802,9 @@ def parse_opts(tmpcmdline, silent=False):
 
 	if myoptions.autounmask_unrestricted_atoms in true_y:
 		myoptions.autounmask_unrestricted_atoms = True
+
+	if myoptions.autounmask_keep_keywords in true_y:
+		myoptions.autounmask_keep_keywords = True
 
 	if myoptions.autounmask_keep_masks in true_y:
 		myoptions.autounmask_keep_masks = True

--- a/pym/portage/tests/resolver/test_autounmask_keep_keywords.py
+++ b/pym/portage/tests/resolver/test_autounmask_keep_keywords.py
@@ -1,0 +1,72 @@
+# Copyright 2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+	ResolverPlayground,
+	ResolverPlaygroundTestCase,
+)
+
+class AutounmaskKeepKeywordsTestCase(TestCase):
+
+	def testAutounmaskKeepKeywordsTestCase(self):
+		ebuilds = {
+			'app-misc/A-2': {
+				'EAPI': '6',
+				'RDEPEND': 'app-misc/B',
+			},
+			'app-misc/A-1': {
+				'EAPI': '6',
+				'RDEPEND': 'app-misc/C[foo]',
+			},
+			'app-misc/B-1': {
+				'EAPI': '6',
+				'KEYWORDS': '~x86',
+			},
+			'app-misc/C-1': {
+				'EAPI': '6',
+				'IUSE': 'foo',
+			},
+		}
+		installed = {
+		}
+
+		test_cases = (
+			ResolverPlaygroundTestCase(
+				['app-misc/A'],
+				success = False,
+				options = {
+					'--autounmask-keep-keywords': 'n',
+				},
+				mergelist = [
+				    'app-misc/B-1',
+				    'app-misc/A-2',
+				],
+				unstable_keywords={'app-misc/B-1'},
+			),
+			# --autounmask-keep-keywords prefers app-misc/A-1 because
+			# it can be installed without accepting unstable
+			# keywords
+			ResolverPlaygroundTestCase(
+				['app-misc/A'],
+				success = False,
+				options = {
+					'--autounmask-keep-keywords': 'y',
+				},
+				mergelist = [
+				    'app-misc/C-1',
+				    'app-misc/A-1',
+				],
+				use_changes = {'app-misc/C-1': {'foo': True}},
+			),
+		)
+
+		playground = ResolverPlayground(ebuilds=ebuilds, debug=False)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success,
+					True, test_case.fail_msg)
+		finally:
+			playground.debug = False
+			playground.cleanup()


### PR DESCRIPTION
The option prevents --autounmask from making changes to
package.accept_keywords. This option does not imply
--autounmask-keep-masks, so --autounmask is still allowed
to create package.unmask changes unless the
--autounmask-keep-masks is also specified.

X-Gentoo-bug: 622480
X-Gentoo-bug-url: https://bugs.gentoo.org/622480