### PR TITLE
quickpkg: revert premature return from quickpkg_atom (bug 628060)

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -66,6 +66,7 @@ def quickpkg_atom(options, infos, arg, eout):
 
 	matches = vardb.match(atom)
 	pkgs_for_arg = 0
+	retval = 0
 	for cpv in matches:
 		excluded_config_files = []
 		dblnk = vardb._dblink(cpv)
@@ -177,20 +178,19 @@ def quickpkg_atom(options, infos, arg, eout):
 			eout.eerror(str(e))
 			del e
 			eout.eerror("Failed to create package: '%s'" % binpkg_path)
-			return 1
+			retval |= 1
 		else:
 			eout.eend(0)
 			infos["successes"].append((cpv, s.st_size))
 			infos["config_files_excluded"] += len(excluded_config_files)
 			for filename in excluded_config_files:
 				eout.ewarn("Excluded config: '%s'" % filename)
-			return os.EX_OK
 	if not pkgs_for_arg:
 		eout.eerror("Could not find anything " + \
 			"to match '%s'; skipping" % arg)
 		infos["missing"].append(arg)
-		return 1
-	return os.EX_OK
+		retval |= 1
+	return retval
 
 def quickpkg_set(options, infos, arg, eout):
 	eroot = portage.settings['EROOT']

--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -163,7 +163,16 @@ def quickpkg_atom(options, infos, arg, eout):
 				with tarfile.open(mode="w|",format=tarfile.PAX_FORMAT if xattrs else tarfile.DEFAULT_FORMAT, fileobj=proc.stdin) as tar:
 					tar_contents(contents, root, tar, protect=protect, xattrs=xattrs)
 				proc.stdin.close()
-				proc.wait()
+				if proc.wait() != os.EX_OK:
+					eout.eend(1)
+					eout.eerror("Compressor failed for package %s" % cpv)
+					retval |= 1
+					try:
+						os.unlink(binpkg_tmpfile)
+					except OSError as e:
+						if e.errno not in (errno.ENOENT, errno.ESTALE):
+							raise
+					continue
 			xpak.tbz2(binpkg_tmpfile).recompose_mem(xpdata)
 		finally:
 			if have_lock:


### PR DESCRIPTION
Revert premature return from the quickpkg_atom function for atoms
that match multiple slots. This fixes it to create packages for
all matched slots, rather than just the lowest version.

Fixes: cff2c0149142 ("Support different compressors for binary packages")
X-Gentoo-bug: 628060
X-Gentoo-bug-url: https://bugs.gentoo.org/628060