### PR TITLE
ebuild.sh: Explicitly ban get_libdir in global scope

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -66,6 +66,7 @@ else
 		use useq usev use_with use_enable"
 	___eapi_has_usex && funcs+=" usex"
 	___eapi_has_in_iuse && funcs+=" in_iuse"
+	___eapi_has_get_libdir && funcs+=" get_libdir"
 	# These functions die because calls to them during the "depend" phase
 	# are considered to be severe QA violations.
 	funcs+=" best_version has_version portageq"


### PR DESCRIPTION
The value of get_libdir depends on the profile, and so it is not useful
for dependency calculations. Furthermore, it seems that Portage does
not handle defining it in global scope well due to EAPI checking magic.
Ban it completely where it is defined as EAPI function to let developers
catch their mistakes early rather than see them as 'command not found'
errors during dependency calculation / cache updates.

Bug: https://bugs.gentoo.org/629010