### PR TITLE
ebuild.sh: Fail on command-not-found in global scope

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -79,6 +79,10 @@ else
 		eval "${x}() { die \"\${FUNCNAME}() calls are not allowed in global scope\"; }"
 	done
 	unset funcs x
+
+	command_not_found_handle() {
+		die "Command not found while sourcing ebuild: ${*}"
+	}
 fi
 
 # Don't use sandbox's BASH_ENV for new shells because it does


### PR DESCRIPTION
The PMS specifies that ebuilds must not call external commands in global
scope. We can not prevent that from happening at the moment since a few
ebuilds in Gentoo are still doing that.

Instead, start increasing strictness by explicitly failing if ebuilds
call external commands that are not found. This is not going to really
break any ebuilds that are not broken already (since command-not-found
usually indicates something is going wrong), and it will help noticing
typos and reliance on non-common external commands.

A similar change has been tested in pkgcore, and confirmed not to cause
any failures with the current state of the Gentoo repository.