### PR TITLE
ebuild.sh: Completely ban external commands in global scope

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -80,8 +80,12 @@ else
 	done
 	unset funcs x
 
+	# prevent the shell from finding external executables
+	# note: we can't use empty because it implies current directory
+	_PORTAGE_ORIG_PATH=${PATH}
+	export PATH=/dev/null
 	command_not_found_handle() {
-		die "Command not found while sourcing ebuild: ${*}"
+		die "External commands disallowed while sourcing ebuild: ${*}"
 	}
 fi
 

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -121,6 +121,10 @@ __helpers_die() {
 }
 
 die() {
+	# restore PATH since die calls basename & sed
+	# TODO: make it pure bash
+	[[ -n ${_PORTAGE_ORIG_PATH} ]] && PATH=${_PORTAGE_ORIG_PATH}
+
 	set +x # tracing only produces useless noise here
 	local IFS=$' \t\n'
 


### PR DESCRIPTION
Set PATH to /dev/null when sourcing the ebuild for dependency resolution
in order to prevent shell from finding external commands via PATH
lookup. While this does not prevent executing programs via full path, it
should catch the majority of accidental uses.

// Note: this can't be merged right now since we still have ebuilds
// calling external commands; see:
// https://bugs.gentoo.org/show_bug.cgi?id=629222