### PR TITLE
config/env_blacklist: add DOCS (bug 627106)

### DIFF
--- a/pym/portage/package/ebuild/_config/special_env_vars.py
+++ b/pym/portage/package/ebuild/_config/special_env_vars.py
@@ -14,7 +14,7 @@ import re
 # to enter the config instance from the external environment or
 # configuration files.
 env_blacklist = frozenset((
-	"A", "AA", "CATEGORY", "DEPEND", "DESCRIPTION", "EAPI",
+	"A", "AA", "CATEGORY", "DEPEND", "DESCRIPTION", "DOCS", "EAPI",
 	"EBUILD_FORCE_TEST", "EBUILD_PHASE",
 	"EBUILD_PHASE_FUNC", "EBUILD_SKIP_MANIFEST",
 	"ED", "EMERGE_FROM", "EPREFIX", "EROOT",


### PR DESCRIPTION
DOCS is used by default_src_install.

X-Gentoo-bug: 627106
X-Gentoo-bug-url: https://bugs.gentoo.org/627106