### PR TITLE
AsynchronousLock: allow missing dummy_threading for Python 3.7

### DIFF
--- a/pym/_emerge/AsynchronousLock.py
+++ b/pym/_emerge/AsynchronousLock.py
@@ -1,11 +1,15 @@
 # Copyright 2010-2013 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-import dummy_threading
 import fcntl
 import errno
 import logging
 import sys
+
+try:
+	import dummy_threading
+except ImportError:
+	dummy_threading = None
 
 try:
 	import threading

--- a/pym/portage/tests/locks/test_asynchronous_lock.py
+++ b/pym/portage/tests/locks/test_asynchronous_lock.py
@@ -5,6 +5,11 @@ import itertools
 import signal
 import tempfile
 
+try:
+	import dummy_threading
+except ImportError:
+	dummy_threading = None
+
 from portage import os
 from portage import shutil
 from portage.tests import TestCase
@@ -20,7 +25,8 @@ class AsynchronousLockTestCase(TestCase):
 			path = os.path.join(tempdir, 'lock_me')
 			for force_async, async_unlock in itertools.product(
 				(True, False), repeat=2):
-				for force_dummy in (True, False):
+				for force_dummy in ((False,) if dummy_threading is None
+					else (True, False)):
 					async_lock = AsynchronousLock(path=path,
 						scheduler=scheduler, _force_async=force_async,
 						_force_thread=True,


### PR DESCRIPTION
Python 3.7 does not support thread-less builds.

Reported-by: Arfrever Frehtes Taifersar Arahesis <Arfrever@Apache.Org>
See: https://bugs.python.org/issue31370
X-Gentoo-bug: 630730
X-Gentoo-bug-url: https://bugs.gentoo.org/630730