### PR TITLE
Fix emerge --info when using webrsync (bug 630538)

### DIFF
--- a/pym/portage/sync/syncbase.py
+++ b/pym/portage/sync/syncbase.py
@@ -102,6 +102,10 @@ class SyncBase(object):
 				paths.extend(_SUBMODULE_PATH_MAP[name])
 		return tuple(paths)
 
+	def retrieve_head(self, **kwargs):
+		'''Get information about the head commit'''
+		raise NotImplementedError
+
 
 class NewBase(SyncBase):
 	'''Subclasses Syncbase adding a new() and runs it
@@ -132,8 +136,4 @@ class NewBase(SyncBase):
 	def update(self):
 		'''Update existing repository
 		'''
-		raise NotImplementedError
-
-	def retrieve_head(self, **kwargs):
-		'''Get information about the head commit'''
 		raise NotImplementedError


### PR DESCRIPTION
When calling retrieve_head from a SyncBase object, it is expected to
raise a NotImplementedError. However, all classes that do not inherit
from NewBase will raise an AttributeError which is not caught.