### PR TITLE
postinst-qa-check.d: fix [[ ${files[@]} ]] logic in for loops

### DIFF
--- a/bin/postinst-qa-check.d/50gnome2-utils
+++ b/bin/postinst-qa-check.d/50gnome2-utils
@@ -1,12 +1,12 @@
 # check for missing calls to gnome2-utils regen functions
 
 gnome2_icon_cache_check() {
-	local d f files=() find_args
+	local d f all_files=() find_args
 	for d in usr/share/icons/*/; do
 		# gnome2_icon_cache_update updates only themes with an index
 		[[ -f ${d}/index.theme ]] || continue
 
-		find_args=(
+		local files=() find_args=(
 			# gtk-update-icon-cache supports only specific file
 			# suffixes; match that to avoid false positives
 			'(' -name '*.png' -o -name '*.svg'
@@ -27,15 +27,16 @@ gnome2_icon_cache_check() {
 		# (note: yes, it will eagerly repeat the update for next dirs
 		# but that's a minor issue)
 		if [[ ${files[@]} ]]; then
+			all_files+=("${files[@]}")
 			addwrite "${d}"
 			gtk-update-icon-cache -qf "${d}"
 		fi
 	done
 
-	if [[ ${files[@]} ]]; then
+	if [[ ${all_files[@]} ]]; then
 		eqawarn "QA Notice: new icons were found installed but GTK+ icon cache"
 		eqawarn "has not been updated:"
-		eqatag -v gnome2-utils.icon-cache "${files[@]/#//}"
+		eqatag -v gnome2-utils.icon-cache "${all_files[@]/#//}"
 		eqawarn "Please make sure to call gnome2_icon_cache_update()"
 		eqawarn "in pkg_postinst() and pkg_postrm() phases of appropriate pkgs."
 	fi

--- a/bin/postinst-qa-check.d/50gnome2-utils
+++ b/bin/postinst-qa-check.d/50gnome2-utils
@@ -1,7 +1,7 @@
 # check for missing calls to gnome2-utils regen functions
 
 gnome2_icon_cache_check() {
-	local d f all_files=() find_args
+	local d f all_files=() find_args missing
 	for d in usr/share/icons/*/; do
 		# gnome2_icon_cache_update updates only themes with an index
 		[[ -f ${d}/index.theme ]] || continue
@@ -15,7 +15,7 @@ gnome2_icon_cache_check() {
 		# if the cache does not exist at all, we complain for any file
 		# otherwise, we look for files newer than the cache
 		[[ -f ${d}/icon-theme.cache ]] &&
-			find_args+=( -newercm "${d}"/icon-theme.cache )
+			find_args+=( -newercm "${d}"/icon-theme.cache ) || missing=1
 
 		# (use -mindepth 2 to easily skip the cache files)
 		while read -r -d $'\0' f; do
@@ -33,7 +33,9 @@ gnome2_icon_cache_check() {
 		fi
 	done
 
-	if [[ ${all_files[@]} ]]; then
+	# The eqatag call is prohibitively expensive if the cache is
+	# missing and there are a large number of files.
+	if [[ -z missing && ${all_files[@]} ]]; then
 		eqawarn "QA Notice: new icons were found installed but GTK+ icon cache"
 		eqawarn "has not been updated:"
 		eqatag -v gnome2-utils.icon-cache "${all_files[@]/#//}"

--- a/bin/postinst-qa-check.d/50xdg-utils
+++ b/bin/postinst-qa-check.d/50xdg-utils
@@ -5,7 +5,7 @@ xdg_desktop_database_check() {
 	for d in usr/share/applications; do
 		[[ -d ${d} ]] || continue
 
-		find_args=()
+		local files=() find_args=()
 		# if the cache does not exist at all, we complain for any file
 		# otherwise, we look for files newer than the cache
 		[[ -f ${d}/mimeinfo.cache ]] &&
@@ -23,15 +23,16 @@ xdg_desktop_database_check() {
 		# (note: yes, it will eagerly repeat the update for next dirs
 		# but it's a minor issue and we have only one dir anyway)
 		if [[ ${files[@]} ]]; then
+			all_files+=("${files[@]}")
 			addwrite "${d}"
 			update-desktop-database "${d}"
 		fi
 	done
 
-	if [[ ${files[@]} ]]; then
+	if [[ ${all_files[@]} ]]; then
 		eqawarn "QA Notice: .desktop files with MimeType= were found installed"
 		eqawarn "but desktop mimeinfo cache has not been updated:"
-		eqatag -v xdg-utils.desktop "${files[@]/#//}"
+		eqatag -v xdg-utils.desktop "${all_files[@]/#//}"
 		eqawarn "Please make sure to call xdg_desktop_database_update()"
 		eqawarn "in pkg_postinst() and pkg_postrm() phases of appropriate pkgs."
 	fi
@@ -42,7 +43,7 @@ xdg_mimeinfo_database_check() {
 	for d in usr/share/mime; do
 		[[ -d ${d} ]] || continue
 
-		find_args=()
+		local files=() find_args=()
 		# if the cache does not exist at all, we complain for any file
 		# otherwise, we look for files newer than the cache
 		[[ -f ${d}/mime.cache ]] &&
@@ -57,15 +58,16 @@ xdg_mimeinfo_database_check() {
 		# (note: yes, it will eagerly repeat the update for next dirs
 		# but it's a minor issue and we have only one dir anyway)
 		if [[ ${files[@]} ]]; then
+			all_files+=("${files[@]}")
 			addwrite "${d}"
 			update-mime-database "${d}"
 		fi
 	done
 
-	if [[ ${files[@]} ]]; then
+	if [[ ${all_files[@]} ]]; then
 		eqawarn "QA Notice: mime-info files were found installed but mime-info"
 		eqawarn "cache has not been updated:"
-		eqatag -v xdg-utils.mime-info "${files[@]/#//}"
+		eqatag -v xdg-utils.mime-info "${all_files[@]/#//}"
 		eqawarn "Please make sure to call xdg_mimeinfo_database_update()"
 		eqawarn "in pkg_postinst() and pkg_postrm() phases of appropriate pkgs."
 	fi

--- a/bin/postinst-qa-check.d/50xdg-utils
+++ b/bin/postinst-qa-check.d/50xdg-utils
@@ -1,7 +1,7 @@
 # check for missing calls to xdg-utils regen functions
 
 xdg_desktop_database_check() {
-	local d f files=()
+	local d f files=() missing
 	for d in usr/share/applications; do
 		[[ -d ${d} ]] || continue
 
@@ -9,7 +9,7 @@ xdg_desktop_database_check() {
 		# if the cache does not exist at all, we complain for any file
 		# otherwise, we look for files newer than the cache
 		[[ -f ${d}/mimeinfo.cache ]] &&
-			find_args+=( -newercm "${d}"/mimeinfo.cache )
+			find_args+=( -newercm "${d}"/mimeinfo.cache ) || missing=1
 
 		# look for any .desktop files that are newer than the cache
 		# and that have any mime types defined
@@ -29,7 +29,9 @@ xdg_desktop_database_check() {
 		fi
 	done
 
-	if [[ ${all_files[@]} ]]; then
+	# The eqatag call is prohibitively expensive if the cache is
+	# missing and there are a large number of files.
+	if [[ -z ${missing} && ${all_files[@]} ]]; then
 		eqawarn "QA Notice: .desktop files with MimeType= were found installed"
 		eqawarn "but desktop mimeinfo cache has not been updated:"
 		eqatag -v xdg-utils.desktop "${all_files[@]/#//}"
@@ -39,7 +41,7 @@ xdg_desktop_database_check() {
 }
 
 xdg_mimeinfo_database_check() {
-	local d f files=()
+	local d f files=() missing
 	for d in usr/share/mime; do
 		[[ -d ${d} ]] || continue
 
@@ -47,7 +49,7 @@ xdg_mimeinfo_database_check() {
 		# if the cache does not exist at all, we complain for any file
 		# otherwise, we look for files newer than the cache
 		[[ -f ${d}/mime.cache ]] &&
-			find_args+=( -newercm "${d}"/mime.cache )
+			find_args+=( -newercm "${d}"/mime.cache ) || missing=1
 
 		while read -r -d $'\0' f; do
 			files+=( "${f}" )
@@ -64,7 +66,9 @@ xdg_mimeinfo_database_check() {
 		fi
 	done
 
-	if [[ ${all_files[@]} ]]; then
+	# The eqatag call is prohibitively expensive if the cache is
+	# missing and there are a large number of files.
+	if [[ -z ${missing} && ${all_files[@]} ]]; then
 		eqawarn "QA Notice: mime-info files were found installed but mime-info"
 		eqawarn "cache has not been updated:"
 		eqatag -v xdg-utils.mime-info "${all_files[@]/#//}"


### PR DESCRIPTION
Use a separate all_files array to accumulate the results
from all loops, so that [[ ${files[@]} ]] only checks for
files found during the current loop.