### PR TITLE
_solve_..slot_conflicts: make "forced" set recursive (bug 632210)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -1457,6 +1457,19 @@ class depgraph(object):
 
 		# Remove 'non_conflict_node' and or_tuples from 'forced'.
 		forced = set(pkg for pkg in forced if isinstance(pkg, Package))
+
+		# Add dependendencies of forced packages.
+		stack = list(forced)
+		traversed = set()
+		while stack:
+			pkg = stack.pop()
+			traversed.add(pkg)
+			for child in conflict_graph.child_nodes(pkg):
+				if (isinstance(child, Package) and
+					child not in traversed):
+					forced.add(child)
+					stack.append(child)
+
 		non_forced = set(pkg for pkg in conflict_pkgs if pkg not in forced)
 
 		if debug:

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -1337,7 +1337,8 @@ class depgraph(object):
 					self._dynamic_config._parent_atoms.get(pkg, []))
 
 			for parent, atom in all_parent_atoms:
-				is_arg_parent = isinstance(parent, AtomArg)
+				is_arg_parent = (inst_pkg is not None and
+					not self._want_installed_pkg(inst_pkg))
 				is_non_conflict_parent = parent not in conflict_pkgs and \
 					parent not in indirect_conflict_pkgs
 

--- a/pym/portage/tests/resolver/test_slot_conflict_update.py
+++ b/pym/portage/tests/resolver/test_slot_conflict_update.py
@@ -80,7 +80,7 @@ class SlotConflictUpdateTestCase(TestCase):
 			# this behavior makes SlotConflictMaskUpdateTestCase
 			# fail.
 			ResolverPlaygroundTestCase(
-				world,
+				['@world'],
 				all_permutations = True,
 				options = {"--update": True, "--deep": True},
 				success = True,


### PR DESCRIPTION
When the slot conflict solver decides that it is "forced"
to choose a particular package, recursively force the
dependencies as well. Prior to this fix, substitution of
`@world` in the arguments for SlotConflictMaskUpdateTestCase
caused the test to fail because the solver removed
boost-build-1.53.0 from the graph event though it had
added the parent boost-1.53.0 package to the "forced"
set.

X-Gentoo-bug: 632210
X-Gentoo-bug-url: https://bugs.gentoo.org/632210