### PR TITLE
want_restart_for_use_change: backtrack only if needed (bug 632598)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -5972,11 +5972,16 @@ class depgraph(object):
 
 			new_use, changes = self._dynamic_config._needed_use_config_changes.get(pkg)
 			for ppkg, atom in parent_atoms:
-				if not atom.use or \
-					not any(x in atom.use.required for x in changes):
+				if not atom.use:
 					continue
-				else:
-					return True
+
+				# Backtrack only if changes break a USE dependency.
+				enabled = atom.use.enabled
+				disabled = atom.use.disabled
+				for k, v in changes.items():
+					want_enabled = k in enabled
+					if (want_enabled or k in disabled) and want_enabled != v:
+						return True
 
 			return False
 

--- a/pym/portage/tests/resolver/test_autounmask_use_backtrack.py
+++ b/pym/portage/tests/resolver/test_autounmask_use_backtrack.py
@@ -1,0 +1,86 @@
+# Copyright 2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+	ResolverPlayground,
+	ResolverPlaygroundTestCase,
+)
+
+class AutounmaskUseBacktrackTestCase(TestCase):
+
+	def testAutounmaskUseBacktrack(self):
+		ebuilds = {
+			'dev-libs/A-1': {
+				'EAPI': '6',
+				'RDEPEND': 'dev-libs/C',
+			},
+			'dev-libs/A-2': {
+				'EAPI': '6',
+				'RDEPEND': 'dev-libs/C[y]',
+			},
+			'dev-libs/A-3': {
+				'EAPI': '6',
+				'RDEPEND': 'dev-libs/C',
+			},
+			'dev-libs/B-1': {
+				'EAPI': '6',
+				'RDEPEND': '<dev-libs/A-3',
+			},
+			'dev-libs/C-1': {
+				'EAPI': '6',
+				'IUSE': 'x y z',
+			},
+			'dev-libs/D-1': {
+				'EAPI': '6',
+				'RDEPEND': '>=dev-libs/A-2 dev-libs/C[x]',
+			},
+		}
+
+		installed = {
+			'dev-libs/A-1': {
+				'EAPI': '6',
+				'RDEPEND': 'dev-libs/C',
+			},
+			'dev-libs/B-1': {
+				'EAPI': '6',
+				'RDEPEND': '<dev-libs/A-3',
+			},
+			'dev-libs/C-1': {
+				'EAPI': '6',
+				'IUSE': 'x y z',
+			},
+		}
+
+		world = ['dev-libs/B']
+
+		test_cases = (
+			# Test bug 632598, where autounmask USE changes triggered
+			# unnecessary backtracking. The following case should
+			# require a --backtrack setting no larger than 2.
+			ResolverPlaygroundTestCase(
+				['dev-libs/D'],
+				options={
+					'--autounmask-backtrack': 'y',
+					'--backtrack': 2,
+				},
+				success=False,
+				ambiguous_merge_order=True,
+				mergelist=[
+					('dev-libs/C-1', 'dev-libs/A-2'),
+					'dev-libs/D-1',
+				],
+				use_changes={'dev-libs/C-1': {'y': True, 'x': True}},
+			),
+		)
+
+		playground = ResolverPlayground(
+			ebuilds=ebuilds, installed=installed, world=world)
+
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True,
+					test_case.fail_msg)
+		finally:
+			playground.cleanup()


### PR DESCRIPTION
Only backtrack if changes break a USE dependency. Prior
to this fix, the included test case succeeded only with
a --backtrack setting of 3 or more, but now it succeeds
with a --backtrack setting of 2.

X-Gentoo-bug: 632598
X-Gentoo-bug-url: https://bugs.gentoo.org/632598