### PR TITLE
postinst_qa_check: initialize preinst state (bug 635474)

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -256,8 +256,12 @@ install_qa_check() {
 	rm -f "${ED}"/usr/share/info/dir{,.gz,.bz2} || die "rm failed!"
 }
 
+preinst_qa_check() {
+	postinst_qa_check preinst
+}
+
 postinst_qa_check() {
-	local d f paths qa_checks=()
+	local d f paths qa_checks=() PORTAGE_QA_PHASE=${1:-postinst}
 	if ! ___eapi_has_prefix_variables; then
 		local EPREFIX= EROOT=${ROOT}
 	fi
@@ -267,23 +271,23 @@ postinst_qa_check() {
 	# Collect the paths for QA checks, highest prio first.
 	paths=(
 		# sysadmin overrides
-		"${PORTAGE_OVERRIDE_EPREFIX}"/usr/local/lib/postinst-qa-check.d
+		"${PORTAGE_OVERRIDE_EPREFIX}"/usr/local/lib/${PORTAGE_QA_PHASE}-qa-check.d
 		# system-wide package installs
-		"${PORTAGE_OVERRIDE_EPREFIX}"/usr/lib/postinst-qa-check.d
+		"${PORTAGE_OVERRIDE_EPREFIX}"/usr/lib/${PORTAGE_QA_PHASE}-qa-check.d
 	)
 
 	# Now repo-specific checks.
 	# (yes, PORTAGE_ECLASS_LOCATIONS contains repo paths...)
 	for d in "${PORTAGE_ECLASS_LOCATIONS[@]}"; do
 		paths+=(
-			"${d}"/metadata/postinst-qa-check.d
+			"${d}"/metadata/${PORTAGE_QA_PHASE}-qa-check.d
 		)
 	done
 
 	paths+=(
 		# Portage built-in checks
-		"${PORTAGE_OVERRIDE_EPREFIX}"/usr/lib/portage/postinst-qa-check.d
-		"${PORTAGE_BIN_PATH}"/postinst-qa-check.d
+		"${PORTAGE_OVERRIDE_EPREFIX}"/usr/lib/portage/${PORTAGE_QA_PHASE}-qa-check.d
+		"${PORTAGE_BIN_PATH}"/${PORTAGE_QA_PHASE}-qa-check.d
 	)
 
 	# Collect file names of QA checks. We need them early to support
@@ -308,7 +312,7 @@ postinst_qa_check() {
 			# Allow inheriting eclasses.
 			# XXX: we want this only in repository-wide checks.
 			_IN_INSTALL_QA_CHECK=1
-			source "${d}/${f}" || eerror "Post-postinst QA check ${f} failed to run"
+			source "${d}/${f}" || eerror "Post-${PORTAGE_QA_PHASE} QA check ${f} failed to run"
 		)
 	done < <(printf "%s\0" "${qa_checks[@]}" | LC_ALL=C sort -u -z)
 }

--- a/bin/postinst-qa-check.d/50gnome2-utils
+++ b/bin/postinst-qa-check.d/50gnome2-utils
@@ -33,6 +33,9 @@ gnome2_icon_cache_check() {
 		fi
 	done
 
+	# preinst initializes the baseline state for the posinst check
+	[[ ${PORTAGE_QA_PHASE} == preinst ]] && return
+
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.
 	if [[ -z ${missing} && ${all_files[@]} ]]; then

--- a/bin/postinst-qa-check.d/50gnome2-utils
+++ b/bin/postinst-qa-check.d/50gnome2-utils
@@ -36,6 +36,9 @@ gnome2_icon_cache_check() {
 	# preinst initializes the baseline state for the posinst check
 	[[ ${PORTAGE_QA_PHASE} == preinst ]] && return
 
+	# parallel-install makes it impossible to blame a specific package
+	has parallel-install ${FEATURES} && return
+
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.
 	if [[ -z ${missing} && ${all_files[@]} ]]; then

--- a/bin/postinst-qa-check.d/50xdg-utils
+++ b/bin/postinst-qa-check.d/50xdg-utils
@@ -32,6 +32,9 @@ xdg_desktop_database_check() {
 	# preinst initializes the baseline state for the posinst check
 	[[ ${PORTAGE_QA_PHASE} == preinst ]] && return
 
+	# parallel-install makes it impossible to blame a specific package
+	has parallel-install ${FEATURES} && return
+
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.
 	if [[ -z ${missing} && ${all_files[@]} ]]; then
@@ -71,6 +74,9 @@ xdg_mimeinfo_database_check() {
 
 	# preinst initializes the baseline state for the posinst check
 	[[ ${PORTAGE_QA_PHASE} == preinst ]] && return
+
+	# parallel-install makes it impossible to blame a specific package
+	has parallel-install ${FEATURES} && return
 
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.

--- a/bin/postinst-qa-check.d/50xdg-utils
+++ b/bin/postinst-qa-check.d/50xdg-utils
@@ -29,6 +29,9 @@ xdg_desktop_database_check() {
 		fi
 	done
 
+	# preinst initializes the baseline state for the posinst check
+	[[ ${PORTAGE_QA_PHASE} == preinst ]] && return
+
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.
 	if [[ -z ${missing} && ${all_files[@]} ]]; then
@@ -65,6 +68,9 @@ xdg_mimeinfo_database_check() {
 			update-mime-database "${d}"
 		fi
 	done
+
+	# preinst initializes the baseline state for the posinst check
+	[[ ${PORTAGE_QA_PHASE} == preinst ]] && return
 
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.

--- a/bin/preinst-qa-check.d/50gnome2-utils
+++ b/bin/preinst-qa-check.d/50gnome2-utils
@@ -1,0 +1,1 @@
+../postinst-qa-check.d/50gnome2-utils

--- a/bin/preinst-qa-check.d/50xdg-utils
+++ b/bin/preinst-qa-check.d/50xdg-utils
@@ -1,0 +1,1 @@
+../postinst-qa-check.d/50xdg-utils

--- a/pym/portage/package/ebuild/doebuild.py
+++ b/pym/portage/package/ebuild/doebuild.py
@@ -1738,6 +1738,7 @@ _post_phase_cmds = {
 		"preinst_sfperms",
 		"preinst_selinux_labels",
 		"preinst_suid_scan",
+		"preinst_qa_check",
 		],
 
 	"postinst" : [


### PR DESCRIPTION
In order to prevent false-positives during postinst_qa_check,
use a preinst_qa_check function to initialize a baseline state
for the postinst checks.

Bug: https://bugs.gentoo.org/635474