### PR TITLE
repoman/setup.py: create pym -> lib symlink for unit tests (bug 637460)

### DIFF
--- a/repoman/pym/repoman/tests/simple/test_simple.py
+++ b/repoman/pym/repoman/tests/simple/test_simple.py
@@ -8,7 +8,6 @@ import time
 from repoman._portage import portage
 from portage import os
 from portage import _unicode_decode
-from portage.const import PORTAGE_BASE_PATH, PORTAGE_PYM_PATH
 from portage.process import find_binary
 from portage.tests.resolver.ResolverPlayground import ResolverPlayground
 from portage.util import ensure_dirs
@@ -204,19 +203,6 @@ class SimpleRepomanTestCase(TestCase):
 			("dev-libs/A", repoman_cmd + ("commit", "-m", "bump to version 4")),
 		)
 
-		pythonpath =  os.environ.get("PYTHONPATH")
-		if pythonpath is not None and not pythonpath.strip():
-			pythonpath = None
-		if pythonpath is not None and \
-			pythonpath.split(":")[0] == PORTAGE_PYM_PATH:
-			pass
-		else:
-			if pythonpath is None:
-				pythonpath = ""
-			else:
-				pythonpath = ":" + pythonpath
-			pythonpath = PORTAGE_PYM_PATH + pythonpath
-
 		env = {
 			"PORTAGE_OVERRIDE_EPREFIX" : eprefix,
 			"DISTDIR" : distdir,
@@ -228,7 +214,6 @@ class SimpleRepomanTestCase(TestCase):
 			"PORTAGE_USERNAME" : os.environ["PORTAGE_USERNAME"],
 			"PORTAGE_REPOSITORIES" : settings.repositories.config_string(),
 			"PYTHONDONTWRITEBYTECODE" : os.environ.get("PYTHONDONTWRITEBYTECODE", ""),
-			"PYTHONPATH" : pythonpath,
 		}
 
 		if os.environ.get("SANDBOX_ON") == "1":

--- a/repoman/setup.py
+++ b/repoman/setup.py
@@ -147,6 +147,11 @@ class x_clean(clean):
 			print('removing %s symlink' % repr(conf_dir))
 			os.unlink(conf_dir)
 
+		pym_dir = os.path.join(top_dir, 'pym')
+		if os.path.islink(pym_dir):
+			print('removing %s sylink' % repr(pym_dir))
+			os.unlink(pym_dir)
+
 		pni_file = os.path.join(top_dir, '.repoman_not_installed')
 		if os.path.exists(pni_file):
 			print('removing %s' % repr(pni_file))
@@ -392,6 +397,17 @@ class build_tests(x_build_scripts_custom):
 		conf_src = os.path.relpath('cnf', self.top_dir)
 		print('Symlinking %s -> %s' % (conf_dir, conf_src))
 		os.symlink(conf_src, conf_dir)
+
+		# symlink 'pym' directory
+		pym_dir = os.path.join(self.top_dir, 'pym')
+		if os.path.exists(pym_dir):
+			if not os.path.islink(pym_dir):
+				raise SystemError('%s exists and is not a symlink (collision)'
+					% repr(pym_dir))
+			os.unlink(pym_dir)
+		pym_src = 'lib'
+		print('Symlinking %s -> %s' % (pym_dir, pym_src))
+		os.symlink(pym_src, pym_dir)
 
 		# create $build_lib/../.repoman_not_installed
 		# to enable proper paths in tests


### PR DESCRIPTION
Various code involving the .repoman_not_installed file assumes
that the 'pym' directory should be added to sys.path, therefore
create a pym -> lib symlink during unit tests.

Bug: https://bugs.gentoo.org/637460