### PR TITLE
profile_check: detect missing ARCH variable (bug 586214)

### DIFF
--- a/pym/_emerge/Scheduler.py
+++ b/pym/_emerge/Scheduler.py
@@ -656,38 +656,6 @@ class Scheduler(PollScheduler):
 
 		return os.EX_OK
 
-	def _env_sanity_check(self):
-		"""
-		Verify a sane environment before trying to build anything from source.
-		"""
-		have_src_pkg = False
-		for x in self._mergelist:
-			if isinstance(x, Package) and not x.built:
-				have_src_pkg = True
-				break
-
-		if not have_src_pkg:
-			return os.EX_OK
-
-		for settings in self.pkgsettings.values():
-			for var in ("ARCH", ):
-				value = settings.get(var)
-				if value and value.strip():
-					continue
-				msg = _("%(var)s is not set... "
-					"Are you missing the '%(configroot)s%(profile_path)s' symlink? "
-					"Is the symlink correct? "
-					"Is your portage tree complete?") % \
-					{"var": var, "configroot": settings["PORTAGE_CONFIGROOT"],
-					"profile_path": portage.const.PROFILE_PATH}
-
-				out = portage.output.EOutput()
-				for line in textwrap.wrap(msg, 70):
-					out.eerror(line)
-				return FAILURE
-
-		return os.EX_OK
-
 	def _check_manifests(self):
 		# Verify all the manifests now so that the user is notified of failure
 		# as soon as possible.
@@ -999,10 +967,6 @@ class Scheduler(PollScheduler):
 		failed_pkgs = self._failed_pkgs
 
 		rval = self._generate_digests()
-		if rval != os.EX_OK:
-			return rval
-
-		rval = self._env_sanity_check()
 		if rval != os.EX_OK:
 			return rval
 

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -1123,7 +1123,8 @@ def profile_check(trees, myaction):
 	if myaction in ("help", "info", "search", "sync", "version"):
 		return os.EX_OK
 	for root_trees in trees.values():
-		if root_trees["root_config"].settings.profiles:
+		if (root_trees["root_config"].settings.profiles and
+			'ARCH' in root_trees["root_config"].settings):
 			continue
 		# generate some profile related warning messages
 		validate_ebuild_environment(trees)

--- a/pym/portage/package/ebuild/config.py
+++ b/pym/portage/package/ebuild/config.py
@@ -1098,7 +1098,9 @@ class config(object):
 
 		profile_broken = False
 
-		if not self.profile_path:
+		# getmaskingstatus requires ARCH for ACCEPT_KEYWORDS support
+		arch = self.get('ARCH')
+		if not self.profile_path or not arch:
 			profile_broken = True
 		else:
 			# If any one of these files exists, then


### PR DESCRIPTION
The Scheduler._env_sanity_check method executed too late
to prevent a KeyError for ARCH in getmaskingstatus, so
use profile_check to detect missing ARCH and exit earlier.

Bug: https://bugs.gentoo.org/586214