### PR TITLE
Fix a misprint for a SANDBOX_ON variable condition check

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -944,7 +944,7 @@ __ebuild_main() {
 		# so we ensure that there can't be a stale log to
 		# interfere with our logic.
 		local x=
-		if [[ -n SANDBOX_ON ]] ; then
+		if [[ -n $SANDBOX_ON ]] ; then
 			x=$SANDBOX_ON
 			export SANDBOX_ON=0
 		fi


### PR DESCRIPTION
While studying the portage source code I accidentally found a typo in a condition that checks the SANDBOX_ON variable state and currently has no sense as it always returns the true.
Also checked the code for similar misprints with the following command:
```grep -HPrn '\[ +-[nz] (\\"|")?[^$`\\][^$`]' .``` but there are no more ones :smiley_cat: