### PR TITLE
Apply shellcheck recommendations

### DIFF
--- a/bin/bashrc-functions.sh
+++ b/bin/bashrc-functions.sh
@@ -4,16 +4,16 @@
 
 register_die_hook() {
 	local x
-	for x in $* ; do
-		has $x $EBUILD_DEATH_HOOKS || \
+	for x in "$@" ; do
+		has "$x" "$EBUILD_DEATH_HOOKS" || \
 			export EBUILD_DEATH_HOOKS="$EBUILD_DEATH_HOOKS $x"
 	done
 }
 
 register_success_hook() {
 	local x
-	for x in $* ; do
-		has $x $EBUILD_SUCCESS_HOOKS || \
+	for x in "$@" ; do
+		has "$x" "$EBUILD_SUCCESS_HOOKS" || \
 			export EBUILD_SUCCESS_HOOKS="$EBUILD_SUCCESS_HOOKS $x"
 	done
 }
@@ -31,14 +31,16 @@ __strip_duplicate_slashes() {
 KV_major() {
 	[[ -z $1 ]] && return 1
 
-	local KV=$@
+	local KV
+	KV=$*
 	echo "${KV%%.*}"
 }
 
 KV_minor() {
 	[[ -z $1 ]] && return 1
 
-	local KV=$@
+	local KV
+	KV=$*
 	KV=${KV#*.}
 	echo "${KV%%.*}"
 }
@@ -46,7 +48,8 @@ KV_minor() {
 KV_micro() {
 	[[ -z $1 ]] && return 1
 
-	local KV=$@
+	local KV
+	KV=$*
 	KV=${KV#*.*.}
 	echo "${KV%%[^[:digit:]]*}"
 }
@@ -54,10 +57,11 @@ KV_micro() {
 KV_to_int() {
 	[[ -z $1 ]] && return 1
 
-	local KV_MAJOR=$(KV_major "$1")
-	local KV_MINOR=$(KV_minor "$1")
-	local KV_MICRO=$(KV_micro "$1")
-	local KV_int=$(( KV_MAJOR * 65536 + KV_MINOR * 256 + KV_MICRO ))
+	local KV_MAJOR KV_MINOR KV_MICRO KV_int
+	KV_MAJOR=$(KV_major "$1")
+	KV_MINOR=$(KV_minor "$1")
+	KV_MICRO=$(KV_micro "$1")
+	KV_int=$(( KV_MAJOR * 65536 + KV_MINOR * 256 + KV_MICRO ))
 
 	# We make version 2.2.0 the minimum version we will handle as
 	# a sanity check ... if its less, we fail ...
@@ -74,7 +78,7 @@ get_KV() {
 	[[ -z ${_RC_GET_KV_CACHE} ]] \
 		&& _RC_GET_KV_CACHE=$(uname -r)
 
-	echo $(KV_to_int "${_RC_GET_KV_CACHE}")
+	KV_to_int "${_RC_GET_KV_CACHE}"
 
 	return $?
 }


### PR DESCRIPTION
WIP, let's see if stuff breaks.
```
shellcheck bashrc-functions.sh 

In bashrc-functions.sh line 7:
        for x in $* ; do
                 ^-- SC2048: Use "$@" (with quotes) to prevent whitespace problems.


In bashrc-functions.sh line 8:
                has $x $EBUILD_DEATH_HOOKS || \
                    ^-- SC2086: Double quote to prevent globbing and word splitting.
                       ^-- SC2086: Double quote to prevent globbing and word splitting.


In bashrc-functions.sh line 15:
        for x in $* ; do
                 ^-- SC2048: Use "$@" (with quotes) to prevent whitespace problems.


In bashrc-functions.sh line 16:
                has $x $EBUILD_SUCCESS_HOOKS || \
                    ^-- SC2086: Double quote to prevent globbing and word splitting.
                       ^-- SC2086: Double quote to prevent globbing and word splitting.


In bashrc-functions.sh line 34:
        local KV=$@
                 ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In bashrc-functions.sh line 41:
        local KV=$@
                 ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In bashrc-functions.sh line 49:
        local KV=$@
                 ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In bashrc-functions.sh line 57:
        local KV_MAJOR=$(KV_major "$1")
              ^-- SC2155: Declare and assign separately to avoid masking return values.


In bashrc-functions.sh line 58:
        local KV_MINOR=$(KV_minor "$1")
              ^-- SC2155: Declare and assign separately to avoid masking return values.


In bashrc-functions.sh line 59:
        local KV_MICRO=$(KV_micro "$1")
              ^-- SC2155: Declare and assign separately to avoid masking return values.


In bashrc-functions.sh line 77:
        echo $(KV_to_int "${_RC_GET_KV_CACHE}")
             ^-- SC2046: Quote this to prevent word splitting.
             ^-- SC2005: Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
```