### PR TITLE
Disable dynamic-deps by default

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -547,7 +547,7 @@ In dependency calculations, substitute the dependencies of installed
 packages with the dependencies of corresponding unbuilt ebuilds from
 source repositories. This causes the effective dependencies of
 installed packages to vary dynamically when source ebuild dependencies
-are modified. This option is enabled by default.
+are modified. This option is disabled by default.
 
 \fBWARNING:\fR
 If you want to disable \-\-dynamic\-deps, then it may be necessary to

--- a/pym/_emerge/FakeVartree.py
+++ b/pym/_emerge/FakeVartree.py
@@ -54,7 +54,7 @@ class FakeVartree(vartree):
 	is not a matching ebuild in the tree). Instances of this class are not
 	populated until the sync() method is called."""
 	def __init__(self, root_config, pkg_cache=None, pkg_root_config=None,
-		dynamic_deps=True, ignore_built_slot_operator_deps=False,
+		dynamic_deps=False, ignore_built_slot_operator_deps=False,
 		soname_deps=False):
 		self._root_config = root_config
 		self._dynamic_deps = dynamic_deps

--- a/pym/_emerge/Scheduler.py
+++ b/pym/_emerge/Scheduler.py
@@ -352,7 +352,7 @@ class Scheduler(PollScheduler):
 		"""
 		self._set_graph_config(graph_config)
 		self._blocker_db = {}
-		dynamic_deps = self.myopts.get("--dynamic-deps", "y") != "n"
+		dynamic_deps = self.myopts.get("--dynamic-deps", "n") != "n"
 		ignore_built_slot_operator_deps = self.myopts.get(
 			"--ignore-built-slot-operator-deps", "n") == "y"
 		for root in self.trees:

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -137,7 +137,7 @@ class _frozen_depgraph_config(object):
 		self.soname_deps_enabled = (
 			("--usepkgonly" in myopts or "remove" in params) and
 			params.get("ignore_soname_deps") != "y")
-		dynamic_deps = myopts.get("--dynamic-deps", "y") != "n"
+		dynamic_deps = myopts.get("--dynamic-deps", "n") != "n"
 		ignore_built_slot_operator_deps = myopts.get(
 			"--ignore-built-slot-operator-deps", "n") == "y"
 		for myroot in trees:
@@ -627,7 +627,7 @@ class depgraph(object):
 		for myroot in self._frozen_config.trees:
 
 			dynamic_deps = self._dynamic_config.myparams.get(
-				"dynamic_deps", "y") != "n"
+				"dynamic_deps", "n") != "n"
 			preload_installed_pkgs = \
 				"--nodeps" not in self._frozen_config.myopts
 

--- a/pym/portage/tests/resolver/test_changed_deps.py
+++ b/pym/portage/tests/resolver/test_changed_deps.py
@@ -52,6 +52,7 @@ class ChangedDepsTestCase(TestCase):
 				options = {
 					"--update": True,
 					"--deep": True,
+					"--dynamic-deps": "y",
 					"--usepkg": True,
 				},
 				mergelist = ["app-misc/B-0"]

--- a/pym/portage/tests/resolver/test_virtual_slot.py
+++ b/pym/portage/tests/resolver/test_virtual_slot.py
@@ -142,7 +142,7 @@ class VirtualSlotResolverTestCase(TestCase):
 			# bug 526160 - test for missed pypy sub-slot update
 			ResolverPlaygroundTestCase(
 				["@world"],
-				options = {"--update": True, "--deep": True},
+				options = {"--update": True, "--deep": True, "--dynamic-deps": "y"},
 				success=True,
 				mergelist = ['dev-python/pypy-2.4.0',
 					'virtual/pypy-2.4.0',


### PR DESCRIPTION
We have prepared for this for quite a while and it's time to pull
the plug. Disable dynamic-deps by default and restore the standard
PMS behavior. This will cause some one-time pain but eventually will
result in improvement of ebuild quality, especially when developers
start experiencing the need for revbumps first hand.