### PR TITLE
multilib_category.py: add ALTERA_NIOS2 ELF type

### DIFF
--- a/pym/portage/dep/soname/multilib_category.py
+++ b/pym/portage/dep/soname/multilib_category.py
@@ -35,7 +35,8 @@ from __future__ import unicode_literals
 
 from portage.util.elf.constants import (
 	EF_MIPS_ABI, EF_MIPS_ABI2, ELFCLASS32, ELFCLASS64,
-	EM_386, EM_68K, EM_AARCH64, EM_ALPHA, EM_ARM, EM_IA_64, EM_MIPS,
+	EM_386, EM_68K, EM_AARCH64, EM_ALPHA, EM_ARM, EM_ALTERA_NIOS2,
+	EM_IA_64, EM_MIPS,
 	EM_PARISC, EM_PPC, EM_PPC64, EM_S390, EM_SH, EM_SPARC,
 	EM_SPARC32PLUS, EM_SPARCV9, EM_X86_64, E_MIPS_ABI_EABI32,
 	E_MIPS_ABI_EABI64, E_MIPS_ABI_O32, E_MIPS_ABI_O64)
@@ -45,6 +46,7 @@ _machine_prefix_map = {
 	EM_68K:             "m68k",
 	EM_AARCH64:         "arm",
 	EM_ALPHA:           "alpha",
+	EM_ALTERA_NIOS2:    "nios2",
 	EM_ARM:             "arm",
 	EM_IA_64:           "ia64",
 	EM_MIPS:            "mips",

--- a/pym/portage/util/elf/constants.py
+++ b/pym/portage/util/elf/constants.py
@@ -33,6 +33,7 @@ EM_SH              = 42
 EM_SPARCV9         = 43
 EM_IA_64           = 50
 EM_X86_64          = 62
+EM_ALTERA_NIOS2    = 113
 EM_AARCH64         = 183
 EM_ALPHA           = 0x9026
 


### PR DESCRIPTION
Discovered as missing ELF as:

 * QA Notice: Unrecognized ELF file(s):
 *      ALTERA_NIOS2;/lib/libz.so.1.2.11;libz.so.1;;libc.so.6;

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>