### PR TITLE
testDoInsOption: fix timestamp comparison to work in travis

### DIFF
--- a/pym/portage/tests/bin/test_doins.py
+++ b/pym/portage/tests/bin/test_doins.py
@@ -45,8 +45,9 @@ class DoIns(setup_env.BinTestCase):
 			st = os.lstat(env['D'] + '/test')
 			if stat.S_IMODE(st.st_mode) != 0o644:
 				raise tests.TestCase.failureException
-			if os.stat(os.path.join(env['S'], 'test')).st_mtime != st.st_mtime:
-				raise tests.TestCase.failureException
+			self.assertEqual(
+				os.stat(os.path.join(env['S'], 'test'))[stat.ST_MTIME],
+				st[stat.ST_MTIME])
 		finally:
 			self.cleanup()
 


### PR DESCRIPTION
Use integer comparison in order to avoid failures like the
following:

AssertionError: 1515530127.479328 != 1515530127.479327  