### PR TITLE
bin/doins.py: avoid timestamp precision loss with python2 (bug 642632)

### DIFF
--- a/bin/doins.py
+++ b/bin/doins.py
@@ -110,6 +110,10 @@ def _parse_install_options(
 	parser.add_argument('-p', '--preserve-timestamps', action='store_true')
 	split_options = shlex.split(options)
 	namespace, remaining = parser.parse_known_args(split_options)
+	if namespace.preserve_timestamps and sys.version_info < (3, 3):
+		# -p is not supported in this case, since timestamps cannot
+		# be preserved with full precision
+		remaining.append('-p')
 	# Because parsing '--mode' option is partially supported. If unknown
 	# arg for --mode is passed, namespace.mode is set to None.
 	if remaining or namespace.mode is None:


### PR DESCRIPTION
Since conversion to/from float results in timestamp precision loss
with less than Python 3.3, do not use the python implementation
in this case.

Bug: https://bugs.gentoo.org/642632
Fixes: d459f05ff71f ("bin/doins.py: implement install -p option (bug 642632)")