### PR TITLE
dep_zapdeps: exclude virtuals from new_slot_count (bug 645190)

### DIFF
--- a/pym/portage/dep/dep_check.py
+++ b/pym/portage/dep/dep_check.py
@@ -499,7 +499,8 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None):
 				cp_map[avail_pkg.cp] = avail_pkg
 
 		new_slot_count = (len(slot_map) if graph_db is None else
-			sum(not graph_db.match_pkgs(slot_atom) for slot_atom in slot_map))
+			sum(not graph_db.match_pkgs(slot_atom) for slot_atom in slot_map
+			if not slot_atom.cp.startswith("virtual/")))
 
 		this_choice = _dep_choice(atoms=atoms, slot_map=slot_map,
 			cp_map=cp_map, all_available=all_available,


### PR DESCRIPTION
Fix new_slot_count to exclude virtual packages, since they are considered
to have zero-cost. This solves an issue where the catalyst stage1 build
would unexpectedly pull in static-dev to satisfy virtual/dev-manager,
but eudev is the preferred choice.

Bug: https://bugs.gentoo.org/645190
Fixes: 9fdaf9bdbdf5 ("dep_check: use DNF to optimize overlapping virtual || deps (bug 632026)")
Reported-by: Ben Kohler <bkohler@gmail.com>