### PR TITLE
dep_zapdeps: fix virtual/rust handling (bug 645416)

### DIFF
--- a/pym/portage/dep/dep_check.py
+++ b/pym/portage/dep/dep_check.py
@@ -463,11 +463,15 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None):
 						avail_pkg = avail_pkg_use
 					avail_slot = Atom("%s:%s" % (atom.cp, avail_pkg.slot))
 
-			if downgrade_probe is not None:
+			if downgrade_probe is not None and graph is not None:
 				highest_in_slot = mydbapi_match_pkgs(avail_slot)
+				highest_in_slot = (highest_in_slot[-1]
+					if highest_in_slot else None)
 				if (avail_pkg and highest_in_slot and
-					avail_pkg < highest_in_slot[-1] and
-					not downgrade_probe(avail_pkg)):
+					avail_pkg < highest_in_slot and
+					not downgrade_probe(avail_pkg) and
+					(highest_in_slot.installed or
+					highest_in_slot in graph)):
 					installed_downgrade = True
 
 			slot_map[avail_slot] = avail_pkg


### PR DESCRIPTION
Fix the code from bug 643974 to set the installed_downgrade flag only
if the selected newer package is either installed or in the graph. This
is currently needed for appropriate handling of virtual/rust-1.19.0,
since there's an upgrade to dev-lang/rust-1.23.0 available which may
not be desired since it would mean that dev-lang/rust-bin-1.19.0 has
to be installed in order to satisfy virtual/rust-1.19.0:

 || ( =dev-lang/rust-1.19.0* =dev-lang/rust-bin-1.19.0* )

So, the rust-bin choice is desirable only if the rust-1.23.0 package is
already installed or in the graph.

Fixes: 86ba22da7a2f ("dep_zapdeps: install new package, allow upgrade (bug 643974)")
Bug: https://bugs.gentoo.org/645416