### PR TITLE
emerge: add --changed-deps-report option (bug 645780)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -465,6 +465,17 @@ option also implies the \fB\-\-selective\fR option. Behavior with
 respect to changed build\-time dependencies is controlled by the
 \fB\-\-with\-bdeps\fR option.
 .TP
+.BR "\-\-changed\-deps\-report [ y | n ]"
+Tells emerge to report ebuilds for which the ebuild dependencies have
+changed since the installed instance was built. Behavior with respect to
+changed build\-time dependencies is controlled by the
+\fB\-\-with\-bdeps\fR option. If the \fB\-\-update\fR and \fB\-\-deep\fR
+options are enabled then this option is enabled automatically for a
+dependency calculation if the cost of report generation is relatively
+insignificant (any calculation exclusively involving binary packages is
+exempt). The \fIEMERGE_DEFAULT_OPTS\fR variable may be used to disable
+this by default.
+.TP
 .BR \-\-changed\-use ", " \-U
 Tells emerge to include installed packages where USE flags have
 changed since installation. This option also implies the

--- a/pym/_emerge/create_depgraph_params.py
+++ b/pym/_emerge/create_depgraph_params.py
@@ -28,6 +28,7 @@ def create_depgraph_params(myopts, myaction):
 	#   failures, or cause packages to be rebuilt or replaced.
 	# with_test_deps: pull in test deps for packages matched by arguments
 	# changed_deps: rebuild installed packages with outdated deps
+	# changed_deps_report: report installed packages with outdated deps
 	# binpkg_changed_deps: reject binary packages with outdated deps
 	myparams = {"recurse" : True}
 
@@ -125,6 +126,12 @@ def create_depgraph_params(myopts, myaction):
 	changed_deps = myopts.get('--changed-deps')
 	if changed_deps is not None:
 		myparams['changed_deps'] = changed_deps
+
+	changed_deps_report = myopts.get('--changed-deps-report')
+	if (changed_deps_report != 'n' and
+		not (myaction == 'remove' or '--usepkgonly' in myopts) and
+		deep is True and '--update' in myopts):
+		myparams['changed_deps_report'] = True
 
 	if myopts.get("--selective") == "n":
 		# --selective=n can be used to remove selective

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -136,6 +136,7 @@ def insert_optional_args(args):
 		'--binpkg-changed-deps'  : y_or_n,
 		'--buildpkg'             : y_or_n,
 		'--changed-deps'         : y_or_n,
+		'--changed-deps-report'  : y_or_n,
 		'--complete-graph'       : y_or_n,
 		'--deep'       : valid_integers,
 		'--depclean-lib-check'   : y_or_n,
@@ -404,6 +405,12 @@ def parse_opts(tmpcmdline, silent=False):
 
 		"--changed-deps": {
 			"help"    : ("replace installed packages with "
+				"outdated dependencies"),
+			"choices" : true_y_or_n
+		},
+
+		"--changed-deps-report": {
+			"help"    : ("report installed packages with "
 				"outdated dependencies"),
 			"choices" : true_y_or_n
 		},
@@ -832,6 +839,12 @@ def parse_opts(tmpcmdline, silent=False):
 			myoptions.changed_deps = 'y'
 		else:
 			myoptions.changed_deps = 'n'
+
+	if myoptions.changed_deps_report is not None:
+		if myoptions.changed_deps_report in true_y:
+			myoptions.changed_deps_report = 'y'
+		else:
+			myoptions.changed_deps_report = 'n'
 
 	if myoptions.changed_use is not False:
 		myoptions.reinstall = "changed-use"


### PR DESCRIPTION
The --dynamic-deps=n default causes confusion for users that are
accustomed to dynamic deps, therefore add a --changed-deps-report
option that is enabled by default for deep updates (if --usepkgonly
is not enabled).

The report is entirely suppressed in the following cases in which
the packages with changed dependencies are entirely harmless to the
user:

  * --changed-deps or --dynamic-deps is enabled
  * none of the packages with changed deps are in the graph

These cases suppress noise for the unaffected user, even though some
of the changed dependencies might be worthy of revision bumps.

The --quiet option suppresses the NOTE section of the report, but
the HINT section is still displayed since it might help users
resolve problems that are solved by --changed-deps.

Example output is as follows:
```
!!! Detected ebuild dependency change(s) without revision bump:

    net-misc/openssh-7.5_p1-r3::gentoo
    sys-fs/udisks-2.7.5::gentoo

NOTE: Refer to the following page for more information about dependency
      change(s) without revision bump:

          https://wiki.gentoo.org/wiki/Project:Portage/Changed_Deps

      In order to suppress reports about dependency changes, add
      --changed-deps-report=n to the EMERGE_DEFAULT_OPTS variable in
      '/etc/portage/make.conf'.

HINT: In order to avoid problems involving changed dependencies, use the
      --changed-deps option to automatically trigger rebuilds when changed
      dependencies are detected. Refer to the emerge man page for more
      information about this option.
```
Bug: https://bugs.gentoo.org/645780