### PR TITLE
dep_zapdeps: sort by new_slot_count for DNF only (bug 645002)

### DIFF
--- a/pym/portage/tests/dep/test_overlap_dnf.py
+++ b/pym/portage/tests/dep/test_overlap_dnf.py
@@ -12,7 +12,7 @@ class OverlapDNFTestCase(TestCase):
 		test_cases = (
 			(
 				'|| ( cat/A cat/B ) cat/E || ( cat/C cat/D )',
-				['cat/E', ['||', 'cat/A', 'cat/B'], ['||', 'cat/C', 'cat/D']],
+				[['||', 'cat/A', 'cat/B'], 'cat/E', ['||', 'cat/C', 'cat/D']],
 			),
 			(
 				'|| ( cat/A cat/B ) cat/D || ( cat/B cat/C )',

--- a/pym/portage/tests/resolver/test_virtual_minimize_children.py
+++ b/pym/portage/tests/resolver/test_virtual_minimize_children.py
@@ -168,17 +168,15 @@ class VirtualMinimizeChildrenTestCase(TestCase):
 		}
 
 		test_cases = (
-			# Test bug 645002, where we want to prefer choices
-			# based on the number of new slots rather than the total
-			# number of slots. This is necessary so that perl-cleaner's
-			# deps are satisfied by the ( portage portage-utils )
-			# choice which has a larger total number of slots than the
-			# paludis choice.
+			# Test bug 645002, where paludis was selected to satisfy a
+			# perl-cleaner dependency because that choice contained fewer
+			# packages than the ( portage portage-utils ) choice which
+			# should have been preferred according to the order of
+			# choices specified in the ebuild.
 			ResolverPlaygroundTestCase(
 				[
 					'app-admin/perl-cleaner',
 					'virtual/package-manager',
-					'app-portage/portage-utils',
 				],
 				all_permutations=True,
 				success=True,


### PR DESCRIPTION
Sorting of choices by new_slot_count causes the order of
choices specified in the ebuild to be discarded, and
new_slot_count may have variance related to the order that
packages are added to the graph. This variance can
contribute to outcomes that appear to be random, like when
catalyst stage1 builds sometimes pull in paludis to
satisfy perl-cleaner dependencies.

Meanwhile, the order specified in the ebuild has no
variance, and the preferences that it specifies can serve
as a crucial sources of guidance. Therefore, take advantage
of the order specified in the ebuild whenever possible, and
use new_slot_count only when it is needed to select optimal
choices from DNF (as in bug 632026).

This fixes random outcomes in the unit test for bug 645002.
Previously, the unit test pulled in paludis randomly unless
portage-utils was added to the arguments. With this patch,
the portage-utils argument is no longer needed for the unit
test to succeed consistently. The perl-cleaner dependencies
do not have any overlapping || deps, so the DNF conversion
and new_slot_count sorting do not apply, and the first
choice is preferred regardless of the number of slots that
it pulls in:
```
|| (
  ( sys-apps/portage app-portage/portage-utils )
  sys-apps/pkgcore
  sys-apps/paludis
)
```
The _overlap_dnf function now returns the argument object
when there is no overlap, so OverlapDNFTestCase has to be
adjusted to account for this.

Bug: https://bugs.gentoo.org/645002
Fixes: 9fdaf9bdbdf5 ("dep_check: use DNF to optimize overlapping virtual || deps (bug 632026)")