### PR TITLE
emerge: enable --dynamic-deps=y by default once again (bug 646458)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -558,7 +558,7 @@ In dependency calculations, substitute the dependencies of installed
 packages with the dependencies of corresponding unbuilt ebuilds from
 source repositories. This causes the effective dependencies of
 installed packages to vary dynamically when source ebuild dependencies
-are modified. This option is disabled by default.
+are modified. This option is enabled by default.
 
 \fBWARNING:\fR
 If you want to disable \-\-dynamic\-deps, then it may be necessary to

--- a/pym/_emerge/Scheduler.py
+++ b/pym/_emerge/Scheduler.py
@@ -352,7 +352,8 @@ class Scheduler(PollScheduler):
 		"""
 		self._set_graph_config(graph_config)
 		self._blocker_db = {}
-		dynamic_deps = self.myopts.get("--dynamic-deps", "n") != "n"
+		depgraph_params = create_depgraph_params(self.myopts, None)
+		dynamic_deps = "dynamic_deps" in depgraph_params
 		ignore_built_slot_operator_deps = self.myopts.get(
 			"--ignore-built-slot-operator-deps", "n") == "y"
 		for root in self.trees:

--- a/pym/_emerge/create_depgraph_params.py
+++ b/pym/_emerge/create_depgraph_params.py
@@ -46,9 +46,9 @@ def create_depgraph_params(myopts, myaction):
 	myparams["ignore_soname_deps"] = myopts.get(
 		"--ignore-soname-deps", "y")
 
-	dynamic_deps = myopts.get("--dynamic-deps")
-	if dynamic_deps is not None:
-		myparams["dynamic_deps"] = dynamic_deps
+	dynamic_deps = myopts.get("--dynamic-deps", "y") != "n"
+	if dynamic_deps:
+		myparams["dynamic_deps"] = True
 
 	if myaction == "remove":
 		myparams["remove"] = True

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -137,7 +137,7 @@ class _frozen_depgraph_config(object):
 		self.soname_deps_enabled = (
 			("--usepkgonly" in myopts or "remove" in params) and
 			params.get("ignore_soname_deps") != "y")
-		dynamic_deps = myopts.get("--dynamic-deps", "n") != "n"
+		dynamic_deps = "dynamic_deps" in params
 		ignore_built_slot_operator_deps = myopts.get(
 			"--ignore-built-slot-operator-deps", "n") == "y"
 		for myroot in trees:
@@ -627,8 +627,7 @@ class depgraph(object):
 
 		for myroot in self._frozen_config.trees:
 
-			dynamic_deps = self._dynamic_config.myparams.get(
-				"dynamic_deps", "n") != "n"
+			dynamic_deps = "dynamic_deps" in self._dynamic_config.myparams
 			preload_installed_pkgs = \
 				"--nodeps" not in self._frozen_config.myopts
 
@@ -985,7 +984,7 @@ class depgraph(object):
 		  * none of the packages with changed deps are in the graph
 		"""
 		if (self._dynamic_config.myparams.get("changed_deps", "n") == "y" or
-			self._dynamic_config.myparams.get("dynamic_deps", "n") == "y"):
+			"dynamic_deps" in self._dynamic_config.myparams):
 			return
 
 		report_pkgs = []


### PR DESCRIPTION
There's been a lot of pushback involving the --dynamic-deps=n default.
What we really need is a tool to apply dependency changes in-place,
without the need for a rebuild.

Reverts: 2905e1c2c28d ("Disable dynamic-deps by default")
Bug: https://bugs.gentoo.org/646458