### PR TITLE
emerge: disable --changed-deps-report by default (bug 645780)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -469,12 +469,7 @@ respect to changed build\-time dependencies is controlled by the
 Tells emerge to report ebuilds for which the ebuild dependencies have
 changed since the installed instance was built. Behavior with respect to
 changed build\-time dependencies is controlled by the
-\fB\-\-with\-bdeps\fR option. If the \fB\-\-update\fR and \fB\-\-deep\fR
-options are enabled then this option is enabled automatically for a
-dependency calculation if the cost of report generation is relatively
-insignificant (any calculation exclusively involving binary packages is
-exempt). The \fIEMERGE_DEFAULT_OPTS\fR variable may be used to disable
-this by default.
+\fB\-\-with\-bdeps\fR option.
 .TP
 .BR \-\-changed\-use ", " \-U
 Tells emerge to include installed packages where USE flags have

--- a/pym/_emerge/create_depgraph_params.py
+++ b/pym/_emerge/create_depgraph_params.py
@@ -127,10 +127,8 @@ def create_depgraph_params(myopts, myaction):
 	if changed_deps is not None:
 		myparams['changed_deps'] = changed_deps
 
-	changed_deps_report = myopts.get('--changed-deps-report')
-	if (changed_deps_report != 'n' and
-		not (myaction == 'remove' or '--usepkgonly' in myopts) and
-		deep is True and '--update' in myopts):
+	changed_deps_report = myopts.get('--changed-deps-report', 'n') == 'y'
+	if changed_deps_report:
 		myparams['changed_deps_report'] = True
 
 	if myopts.get("--selective") == "n":


### PR DESCRIPTION
This option is too noisy to enable by default, since it reports
hundreds of packages for most users.

Suggested-by: Michał Górny <mgorny@gentoo.org>