### PR TITLE
repoman: Update metadata.dtd URI to allow https://

### DIFF
--- a/pym/portage/tests/resolver/ResolverPlayground.py
+++ b/pym/portage/tests/resolver/ResolverPlayground.py
@@ -45,7 +45,7 @@ class ResolverPlayground(object):
 		"unpack_dependencies", "use.aliases", "use.force", "use.mask", "layout.conf"))
 
 	metadata_xml_template = """<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <maintainer type="person">
 <email>maintainer-needed@gentoo.org</email>

--- a/repoman/pym/repoman/metadata.py
+++ b/repoman/pym/repoman/metadata.py
@@ -29,7 +29,7 @@ if sys.hexversion >= 0x3000000:
 
 # Note: This URI is hardcoded in all metadata.xml files.  We can't
 # change it without updating all the xml files in the tree.
-metadata_dtd_uri = 'http://www.gentoo.org/dtd/metadata.dtd'
+metadata_dtd_uri = 'https://www.gentoo.org/dtd/metadata.dtd'
 metadata_xsd_uri = 'https://www.gentoo.org/xml-schema/metadata.xsd'
 # force refetch if the local copy creation time is older than this
 metadata_xsd_ctime_interval = 60 * 60 * 24 * 7  # 7 days

--- a/repoman/pym/repoman/modules/scan/metadata/pkgmetadata.py
+++ b/repoman/pym/repoman/modules/scan/metadata/pkgmetadata.py
@@ -120,7 +120,7 @@ class PkgMetadata(ScanBase, USEFlagChecks):
 				"%s/metadata.xml: %s" % (xpkg, "DOCTYPE is missing"))
 		else:
 			doctype_system = _metadata_xml.docinfo.system_url
-			if doctype_system != metadata_dtd_uri:
+			if doctype_system.replace('http://', 'https://') != metadata_dtd_uri:
 				if doctype_system is None:
 					system_problem = "but it is undefined"
 				else:


### PR DESCRIPTION
Update the default metadata.dtd URI used in repoman and Portage tests
to use https://. However, allow also http:// form for the migration
period.

The http:// compat can be removed once the Gentoo repository is updated
to use https:// everywhere.

Bug: https://bugs.gentoo.org/552720

https://archives.gentoo.org/gentoo-portage-dev/message/b0b43d71c8d48f155e161e2066d68186