### PR TITLE
emerge --search: use slash to auto-detect category (bug 647940)

### DIFF
--- a/pym/_emerge/search.py
+++ b/pym/_emerge/search.py
@@ -256,6 +256,10 @@ class search(object):
 		if self.searchkey.startswith('@'):
 			match_category = 1
 			self.searchkey = self.searchkey[1:]
+		# Auto-detect category match mode (@ symbol can be deprecated
+		# after this is available in a stable version of portage).
+		if '/' in self.searchkey:
+			match_category = 1
 		fuzzy = False
 		if regexsearch:
 			self.searchre=re.compile(self.searchkey,re.I)


### PR DESCRIPTION
Since search strings containing a slash do no work unless category
match mode is enabled, use slash to auto-detect category match mode,
so that users do not have to prefix the search string with the special
@ symbol.

Bug: https://bugs.gentoo.org/647940