### PR TITLE
portage.process.spawn: default close_fds=False (bug 648432)

### DIFF
--- a/bin/ebuild
+++ b/bin/ebuild
@@ -58,6 +58,8 @@ import portage.util
 from _emerge.Package import Package
 from _emerge.RootConfig import RootConfig
 
+portage.process.sanitize_fds()
+
 description = "See the ebuild(1) man page for more info"
 usage = "Usage: ebuild <ebuild file> <command> [command] ..."
 parser = argparse.ArgumentParser(description=description, usage=usage)

--- a/bin/emerge
+++ b/bin/emerge
@@ -46,6 +46,7 @@ try:
 	if __name__ == "__main__":
 		from portage.exception import IsADirectory, ParseError, \
 				PermissionDenied
+		portage.process.sanitize_fds()
 		try:
 			retval = emerge_main()
 		except PermissionDenied as e:

--- a/pym/portage/process.py
+++ b/pym/portage/process.py
@@ -196,7 +196,8 @@ def cleanup():
 
 def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
           uid=None, gid=None, groups=None, umask=None, logfile=None,
-          path_lookup=True, pre_exec=None, close_fds=True, unshare_net=False,
+          path_lookup=True, pre_exec=None,
+          close_fds=(sys.version_info < (3, 4)), unshare_net=False,
           unshare_ipc=False, cgroup=None):
 	"""
 	Spawns a given command.
@@ -228,7 +229,8 @@ def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
 	@param pre_exec: A function to be called with no arguments just prior to the exec call.
 	@type pre_exec: callable
 	@param close_fds: If True, then close all file descriptors except those
-		referenced by fd_pipes (default is True).
+		referenced by fd_pipes (default is True for python3.3 and earlier, and False for
+		python3.4 and later due to non-inheritable file descriptor behavior from PEP 446).
 	@type close_fds: Boolean
 	@param unshare_net: If True, networking will be unshared from the spawned process
 	@type unshare_net: Boolean


### PR DESCRIPTION
For python3.4 and later, default to close_fds=False, since file
descriptors are non-inheritable by default due to PEP 446. This solves
a performance problem on systems like FreeBSD, where our get_open_fds
function returns all possible file descriptor values (including those
that are not open).

Bug: https://bugs.gentoo.org/648432
See: https://www.python.org/dev/peps/pep-0446/