### PR TITLE
_spawn_actionmap: simplify nosandbox logic

### DIFF
--- a/pym/portage/package/ebuild/doebuild.py
+++ b/pym/portage/package/ebuild/doebuild.py
@@ -1354,11 +1354,6 @@ def _spawn_actionmap(settings):
 		("usersandbox" not in features) and \
 		"userpriv" not in restrict and \
 		"nouserpriv" not in restrict)
-	if nosandbox and ("userpriv" not in features or \
-		"userpriv" in restrict or \
-		"nouserpriv" in restrict):
-		nosandbox = ("sandbox" not in features and \
-			"usersandbox" not in features)
 
 	if not portage.process.sandbox_capable:
 		nosandbox = True


### PR DESCRIPTION
Remove a nosandbox assignment that never executes, since the condition for
the 'if' statement always evaluates to False:
```python
nosandbox = ( "userpriv" in features and
              "usersandbox" not in features and
              "userpriv" not in restrict and
              "nouserpriv" not in restrict )
```
If nosandbox is True, it implies that the following expression is False:
```python
            ( "userpriv" not in features or
              "userpriv" in restrict or
              "nouserpriv" in restrict )
```
Therefore, the condition for the 'if' statement always evaluates to False.

Reported-by: Douglas Freed <dwfreed@mtu.edu>