### PR TITLE
gnome2-utils postinst: fix false positive for gtk-update-icon-cache (bug 649464)

### DIFF
--- a/bin/postinst-qa-check.d/50gnome2-utils
+++ b/bin/postinst-qa-check.d/50gnome2-utils
@@ -39,6 +39,9 @@ gnome2_icon_cache_check() {
 	# parallel-install makes it impossible to blame a specific package
 	has parallel-install ${FEATURES} && return
 
+	# avoid false-positives on first install (bug 649464)
+	[[ ${PN} == gtk-update-icon-cache ]] && return
+
 	# The eqatag call is prohibitively expensive if the cache is
 	# missing and there are a large number of files.
 	if [[ -z ${missing} && ${all_files[@]} ]]; then


### PR DESCRIPTION
For the first install of gtk-update-icon-cache, there's no
way to initialize state during preinst, so we have to ignore
this package in order to avoid false positives.

Bug: https://bugs.gentoo.org/649464