### PR TITLE
Stop crippling metadata for virtual/*

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -662,23 +662,19 @@ __dyn_install() {
 	local f x
 	IFS=$' \t\n\r'
 	for f in CATEGORY DEFINED_PHASES FEATURES INHERITED IUSE \
-		PF PKGUSE SLOT KEYWORDS HOMEPAGE DESCRIPTION ; do
+		PF PKGUSE SLOT KEYWORDS HOMEPAGE DESCRIPTION \
+		ASFLAGS CBUILD CC CFLAGS CHOST CTARGET CXX \
+		CXXFLAGS EXTRA_ECONF EXTRA_EINSTALL EXTRA_MAKE \
+		LDFLAGS LIBCFLAGS LIBCXXFLAGS QA_CONFIGURE_OPTIONS \
+		QA_DESKTOP_FILE QA_PREBUILT PROVIDES_EXCLUDE REQUIRES_EXCLUDE ; do
+
 		x=$(echo -n ${!f})
 		[[ -n $x ]] && echo "$x" > $f
 	done
-	if [[ $CATEGORY != virtual ]] ; then
-		for f in ASFLAGS CBUILD CC CFLAGS CHOST CTARGET CXX \
-			CXXFLAGS EXTRA_ECONF EXTRA_EINSTALL EXTRA_MAKE \
-			LDFLAGS LIBCFLAGS LIBCXXFLAGS QA_CONFIGURE_OPTIONS \
-			QA_DESKTOP_FILE QA_PREBUILT PROVIDES_EXCLUDE REQUIRES_EXCLUDE ; do
-			x=$(echo -n ${!f})
-			[[ -n $x ]] && echo "$x" > $f
-		done
-		# whitespace preserved
-		for f in QA_AM_MAINTAINER_MODE ; do
-			[[ -n ${!f} ]] && echo "${!f}" > $f
-		done
-	fi
+	# whitespace preserved
+	for f in QA_AM_MAINTAINER_MODE ; do
+		[[ -n ${!f} ]] && echo "${!f}" > $f
+	done
 	echo "${USE}"       > USE
 	echo "${EAPI:-0}"   > EAPI
 

--- a/pym/portage/package/ebuild/doebuild.py
+++ b/pym/portage/package/ebuild/doebuild.py
@@ -1930,13 +1930,10 @@ def _post_src_install_write_metadata(settings):
 		if v is not None:
 			write_atomic(os.path.join(build_info_dir, k), v + '\n')
 
-	# The following variables are irrelevant for virtual packages.
-	if settings.get('CATEGORY') != 'virtual':
-
-		for k in ('CHOST',):
-			v = settings.get(k)
-			if v is not None:
-				write_atomic(os.path.join(build_info_dir, k), v + '\n')
+	for k in ('CHOST',):
+		v = settings.get(k)
+		if v is not None:
+			write_atomic(os.path.join(build_info_dir, k), v + '\n')
 
 	with io.open(_unicode_encode(os.path.join(build_info_dir,
 		'BUILD_TIME'), encoding=_encodings['fs'], errors='strict'),


### PR DESCRIPTION
There is no technical requirement that virtual/* packages will reliably
contain no executable code. Therefore, stop crippling the metadata
stored in vdb for them.