### PR TITLE
Remaining EAPI 7 cross-compile bits boilerplate

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -151,7 +151,11 @@ ___eapi_has_package_manager_build_group() {
 # HELPERS BEHAVIOR
 
 ___eapi_best_version_and_has_version_support_--host-root() {
-	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+	[[ ${1-${EAPI-0}} =~ ^(5|5-progress|6)$ ]]
+}
+
+___eapi_best_version_and_has_version_support_-b_-d_-r() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
 }
 
 ___eapi_unpack_supports_xz() {

--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -30,6 +30,10 @@ ___eapi_has_prefix_variables() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ || " ${FEATURES} " == *" force-prefix "* ]]
 }
 
+___eapi_has_SYSROOT() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress|6)$ ]]
+}
+
 ___eapi_has_HDEPEND() {
 	[[ ${1-${EAPI-0}} =~ ^(5-hdepend)$ ]]
 }

--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -174,6 +174,10 @@ ___eapi_econf_passes_--docdir_and_--htmldir() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
 }
 
+___eapi_econf_passes_--with-sysroot() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
+}
+
 ___eapi_use_enable_and_use_with_support_empty_third_argument() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
 }

--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -30,6 +30,10 @@ ___eapi_has_prefix_variables() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ || " ${FEATURES} " == *" force-prefix "* ]]
 }
 
+___eapi_has_BROOT() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress|6)$ ]]
+}
+
 ___eapi_has_SYSROOT() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress|6)$ ]]
 }

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -100,10 +100,16 @@ __filter_readonly_variables() {
 	filtered_vars="$readonly_bash_vars $bash_misc_vars
 		$PORTAGE_READONLY_VARS $misc_garbage_vars"
 
+	if ___eapi_has_SYSROOT; then
+		filtered_vars+=" SYSROOT"
+	fi
 	# Don't filter/interfere with prefix variables unless they are
 	# supported by the current EAPI.
 	if ___eapi_has_prefix_variables; then
 		filtered_vars+=" ED EPREFIX EROOT"
+		if ___eapi_has_SYSROOT; then
+			filtered_vars+=" ESYSROOT"
+		fi
 	fi
 	if ___eapi_has_PORTDIR_ECLASSDIR; then
 		filtered_vars+=" PORTDIR ECLASSDIR"

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -100,6 +100,9 @@ __filter_readonly_variables() {
 	filtered_vars="$readonly_bash_vars $bash_misc_vars
 		$PORTAGE_READONLY_VARS $misc_garbage_vars"
 
+	if ___eapi_has_BROOT; then
+		filtered_vars+=" BROOT"
+	fi
 	if ___eapi_has_SYSROOT; then
 		filtered_vars+=" SYSROOT"
 	fi

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -849,46 +849,55 @@ __eapi6_src_install() {
 	einstalldocs
 }
 
-# @FUNCTION: has_version
-# @USAGE: [--host-root] <DEPEND ATOM>
-# @DESCRIPTION:
-# Return true if given package is installed. Otherwise return false.
-# Callers may override the ROOT variable in order to match packages from an
-# alternative ROOT.
-has_version() {
-
-	local atom eroot host_root=false root=${ROOT}
-	if [[ $1 == --host-root ]] ; then
-		host_root=true
-		shift
-	fi
+__best_version_and_has_version_common() {
+	local atom root root_arg
+	case $1 in
+		--host-root|-r|-d|-b)
+			root_arg=$1
+			shift ;;
+	esac
 	atom=$1
 	shift
-	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
+	[ $# -gt 0 ] && die "${FUNCNAME[1]}: unused argument(s): $*"
 
-	if ${host_root} ; then
-		if ! ___eapi_best_version_and_has_version_support_--host-root; then
-			die "${FUNCNAME[0]}: option --host-root is not supported with EAPI ${EAPI}"
-		fi
-		root=/
-	fi
+	case ${root_arg} in
+		"") if ___eapi_has_prefix_variables; then
+				root=${EROOT}
+			else
+				root=${ROOT}
+			fi ;;
+		--host-root)
+			if ! ___eapi_best_version_and_has_version_support_--host-root; then
+				die "${FUNCNAME[1]}: option ${root_arg} is not supported with EAPI ${EAPI}"
+			fi
+			if ___eapi_has_prefix_variables; then
+				root=/${PORTAGE_OVERRIDE_EPREFIX#/}
+			else
+				root=/
+			fi ;;
+		-r|-d|-b)
+			if ! ___eapi_best_version_and_has_version_support_-b_-d_-r; then
+				die "${FUNCNAME[1]}: option ${root_arg} is not supported with EAPI ${EAPI}"
+			fi
+			if ___eapi_has_prefix_variables; then
+				case ${root_arg} in
+					-r) root=${EROOT} ;;
+					-d) root=${ESYSROOT} ;;
+					-b) root=${BROOT} ;;
+				esac
+			else
+				case ${root_arg} in
+					-r) root=${ROOT} ;;
+					-d) root=${SYSROOT} ;;
+					-b) root=/ ;;
+				esac
+			fi ;;
+	esac
 
-	if ___eapi_has_prefix_variables; then
-		# [[ ${root} == / ]] would be ambiguous here,
-		# since both prefixes can share root=/ while
-		# having different EPREFIX offsets.
-		if ${host_root} ; then
-			eroot=${root%/}${PORTAGE_OVERRIDE_EPREFIX}/
-		else
-			eroot=${root%/}${EPREFIX}/
-		fi
-	else
-		eroot=${root}
-	fi
 	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
-		"$PORTAGE_BIN_PATH"/ebuild-ipc has_version "${eroot}" "${atom}"
+		"${PORTAGE_BIN_PATH}"/ebuild-ipc "${FUNCNAME[1]}" "${root}" "${atom}"
 	else
-		"${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" has_version "${eroot}" "${atom}"
+		"${PORTAGE_BIN_PATH}"/ebuild-helpers/portageq "${FUNCNAME[1]}" "${root}" "${atom}"
 	fi
 	local retval=$?
 	case "${retval}" in
@@ -896,75 +905,36 @@ has_version() {
 			return ${retval}
 			;;
 		2)
-			die "${FUNCNAME[0]}: invalid atom: ${atom}"
+			die "${FUNCNAME[1]}: invalid atom: ${atom}"
 			;;
 		*)
 			if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
-				die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				die "${FUNCNAME[1]}: unexpected ebuild-ipc exit code: ${retval}"
 			else
-				die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				die "${FUNCNAME[1]}: unexpected portageq exit code: ${retval}"
 			fi
 			;;
 	esac
 }
 
+# @FUNCTION: has_version
+# @USAGE: [--host-root|-r|-d|-b] <DEPEND ATOM>
+# @DESCRIPTION:
+# Return true if given package is installed. Otherwise return false.
+# Callers may override the ROOT variable in order to match packages from an
+# alternative ROOT.
+has_version() {
+	__best_version_and_has_version_common "$@"
+}
+
 # @FUNCTION: best_version
-# @USAGE: [--host-root] <DEPEND ATOM>
+# @USAGE: [--host-root|-r|-d|-b] <DEPEND ATOM>
 # @DESCRIPTION:
 # Returns highest installed matching category/package-version (without .ebuild).
 # Callers may override the ROOT variable in order to match packages from an
 # alternative ROOT.
 best_version() {
-
-	local atom eroot host_root=false root=${ROOT}
-	if [[ $1 == --host-root ]] ; then
-		host_root=true
-		shift
-	fi
-	atom=$1
-	shift
-	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
-
-	if ${host_root} ; then
-		if ! ___eapi_best_version_and_has_version_support_--host-root; then
-			die "${FUNCNAME[0]}: option --host-root is not supported with EAPI ${EAPI}"
-		fi
-		root=/
-	fi
-
-	if ___eapi_has_prefix_variables; then
-		# [[ ${root} == / ]] would be ambiguous here,
-		# since both prefixes can share root=/ while
-		# having different EPREFIX offsets.
-		if ${host_root} ; then
-			eroot=${root%/}${PORTAGE_OVERRIDE_EPREFIX}/
-		else
-			eroot=${root%/}${EPREFIX}/
-		fi
-	else
-		eroot=${root}
-	fi
-	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
-		"$PORTAGE_BIN_PATH"/ebuild-ipc best_version "${eroot}" "${atom}"
-	else
-		"${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" best_version "${eroot}" "${atom}"
-	fi
-	local retval=$?
-	case "${retval}" in
-		0|1)
-			return ${retval}
-			;;
-		2)
-			die "${FUNCNAME[0]}: invalid atom: ${atom}"
-			;;
-		*)
-			if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
-				die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
-			else
-				die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
-			fi
-			;;
-	esac
+	__best_version_and_has_version_common "$@"
 }
 
 if ___eapi_has_get_libdir; then

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -611,7 +611,7 @@ econf() {
 		fi
 
 		local conf_args=()
-		if ___eapi_econf_passes_--disable-dependency-tracking || ___eapi_econf_passes_--disable-silent-rules || ___eapi_econf_passes_--docdir_and_--htmldir; then
+		if ___eapi_econf_passes_--disable-dependency-tracking || ___eapi_econf_passes_--disable-silent-rules || ___eapi_econf_passes_--docdir_and_--htmldir || ___eapi_econf_passes_--with-sysroot; then
 			local conf_help=$("${ECONF_SOURCE}/configure" --help 2>/dev/null)
 
 			if ___eapi_econf_passes_--disable-dependency-tracking; then
@@ -633,6 +633,12 @@ econf() {
 
 				if [[ ${conf_help} == *--htmldir* ]]; then
 					conf_args+=( --htmldir="${EPREFIX}"/usr/share/doc/${PF}/html )
+				fi
+			fi
+
+			if ___eapi_econf_passes_--with-sysroot; then
+				if [[ ${conf_help} == *--with-sysroot* ]]; then
+					conf_args+=( --with-sysroot="${ESYSROOT:-/}" )
 				fi
 			fi
 		fi

--- a/pym/portage/eapi.py
+++ b/pym/portage/eapi.py
@@ -119,12 +119,16 @@ def eapi_path_variables_end_with_trailing_slash(eapi):
 	return eapi in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
 			"5", "5-progress", "6")
 
+def eapi_has_broot(eapi):
+	return eapi not in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
+			"5", "5-progress", "6")
+
 def eapi_has_sysroot(eapi):
 	return eapi not in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
 			"5", "5-progress", "6")
 
 _eapi_attrs = collections.namedtuple('_eapi_attrs',
-	'bdepend dots_in_PN dots_in_use_flags exports_EBUILD_PHASE_FUNC '
+	'bdepend broot dots_in_PN dots_in_use_flags exports_EBUILD_PHASE_FUNC '
 	'exports_PORTDIR exports_ECLASSDIR '
 	'feature_flag_test feature_flag_targetroot '
 	'hdepend iuse_defaults iuse_effective posixish_locale '
@@ -153,6 +157,7 @@ def _get_eapi_attrs(eapi):
 
 	eapi_attrs = _eapi_attrs(
 		bdepend = (eapi is not None and eapi_has_bdepend(eapi)),
+		broot = (eapi is None or eapi_has_broot(eapi)),
 		dots_in_PN = (eapi is None or eapi_allows_dots_in_PN(eapi)),
 		dots_in_use_flags = (eapi is None or eapi_allows_dots_in_use_flags(eapi)),
 		empty_groups_always_true = (eapi is not None and eapi_empty_groups_always_true(eapi)),

--- a/pym/portage/eapi.py
+++ b/pym/portage/eapi.py
@@ -119,6 +119,10 @@ def eapi_path_variables_end_with_trailing_slash(eapi):
 	return eapi in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
 			"5", "5-progress", "6")
 
+def eapi_has_sysroot(eapi):
+	return eapi not in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
+			"5", "5-progress", "6")
+
 _eapi_attrs = collections.namedtuple('_eapi_attrs',
 	'bdepend dots_in_PN dots_in_use_flags exports_EBUILD_PHASE_FUNC '
 	'exports_PORTDIR exports_ECLASSDIR '
@@ -127,7 +131,7 @@ _eapi_attrs = collections.namedtuple('_eapi_attrs',
 	'path_variables_end_with_trailing_slash '
 	'repo_deps required_use required_use_at_most_one_of slot_operator slot_deps '
 	'src_uri_arrows strong_blocks use_deps use_dep_defaults '
-	'empty_groups_always_true')
+	'empty_groups_always_true sysroot')
 
 _eapi_attrs_cache = {}
 
@@ -170,6 +174,7 @@ def _get_eapi_attrs(eapi):
 		slot_operator = (eapi is None or eapi_has_slot_operator(eapi)),
 		src_uri_arrows = (eapi is None or eapi_has_src_uri_arrows(eapi)),
 		strong_blocks = (eapi is None or eapi_has_strong_blocks(eapi)),
+		sysroot = (eapi is None or eapi_has_sysroot(eapi)),
 		use_deps = (eapi is None or eapi_has_use_deps(eapi)),
 		use_dep_defaults = (eapi is None or eapi_has_use_dep_defaults(eapi))
 	)

--- a/pym/portage/package/ebuild/config.py
+++ b/pym/portage/package/ebuild/config.py
@@ -2736,6 +2736,8 @@ class config(object):
 			mydict["ESYSROOT"] = (
 					mydict["SYSROOT"].rstrip(os.path.sep) + self.get("EPREFIX", "")
 					+ os.path.sep)
+		if eapi_attrs.broot and _phase_func_map.get(phase, '').startswith('src_'):
+			mydict["BROOT"] = self.get("EPREFIX", "") + os.path.sep
 
 		# Prefix variables are supported beginning with EAPI 3, or when
 		# force-prefix is in FEATURES, since older EAPIs would otherwise be
@@ -2785,7 +2787,8 @@ class config(object):
 			mydict.pop("ECLASSDIR", None)
 
 		if not eapi_attrs.path_variables_end_with_trailing_slash:
-			for v in ("D", "ED", "ROOT", "EROOT", "SYSROOT", "ESYSROOT"):
+			for v in ("D", "ED", "ROOT", "EROOT", "SYSROOT", "ESYSROOT",
+					"BROOT"):
 				if v in mydict:
 					mydict[v] = mydict[v].rstrip(os.path.sep)
 

--- a/pym/portage/package/ebuild/config.py
+++ b/pym/portage/package/ebuild/config.py
@@ -2729,6 +2729,14 @@ class config(object):
 		if not eapi_exports_merge_type(eapi):
 			mydict.pop("MERGE_TYPE", None)
 
+		if eapi_attrs.sysroot and _phase_func_map.get(phase, '').startswith('src_'):
+			# TODO: implement Portage-wide support for custom SYSROOT
+			mydict["SYSROOT"] = (
+					self.get('SYSROOT', '').rstrip(os.path.sep) + os.path.sep)
+			mydict["ESYSROOT"] = (
+					mydict["SYSROOT"].rstrip(os.path.sep) + self.get("EPREFIX", "")
+					+ os.path.sep)
+
 		# Prefix variables are supported beginning with EAPI 3, or when
 		# force-prefix is in FEATURES, since older EAPIs would otherwise be
 		# useless with prefix configurations. This brings compatibility with
@@ -2740,6 +2748,7 @@ class config(object):
 			mydict.pop("ED", None)
 			mydict.pop("EPREFIX", None)
 			mydict.pop("EROOT", None)
+			mydict.pop("ESYSROOT", None)
 
 		if phase not in ("pretend", "setup", "preinst", "postinst") or \
 			not eapi_exports_replace_vars(eapi):
@@ -2776,7 +2785,7 @@ class config(object):
 			mydict.pop("ECLASSDIR", None)
 
 		if not eapi_attrs.path_variables_end_with_trailing_slash:
-			for v in ("D", "ED", "ROOT", "EROOT"):
+			for v in ("D", "ED", "ROOT", "EROOT", "SYSROOT", "ESYSROOT"):
 				if v in mydict:
 					mydict[v] = mydict[v].rstrip(os.path.sep)
 


### PR DESCRIPTION
This is just a boilerplate that satisfies EAPI 7 without actually changing much from the existing code. Cross people will probably want to work on it further later on, e.g. to bring full SYSROOT support in Portage.