### PR TITLE
Remaining EAPI 7 cross-compile bits boilerplate v2

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -30,6 +30,10 @@ ___eapi_has_prefix_variables() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ || " ${FEATURES} " == *" force-prefix "* ]]
 }
 
+___eapi_has_SYSROOT() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress|6)$ ]]
+}
+
 ___eapi_has_HDEPEND() {
 	[[ ${1-${EAPI-0}} =~ ^(5-hdepend)$ ]]
 }

--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -155,7 +155,11 @@ ___eapi_has_package_manager_build_group() {
 # HELPERS BEHAVIOR
 
 ___eapi_best_version_and_has_version_support_--host-root() {
-	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+	[[ ${1-${EAPI-0}} =~ ^(5|5-progress|6)$ ]]
+}
+
+___eapi_best_version_and_has_version_support_-b_-d_-r() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
 }
 
 ___eapi_unpack_supports_xz() {

--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -178,6 +178,10 @@ ___eapi_econf_passes_--docdir_and_--htmldir() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
 }
 
+___eapi_econf_passes_--with-sysroot() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
+}
+
 ___eapi_use_enable_and_use_with_support_empty_third_argument() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
 }

--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -30,6 +30,10 @@ ___eapi_has_prefix_variables() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ || " ${FEATURES} " == *" force-prefix "* ]]
 }
 
+___eapi_has_BROOT() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress|6)$ ]]
+}
+
 ___eapi_has_SYSROOT() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress|6)$ ]]
 }

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -769,6 +769,9 @@ else
 	if ___eapi_has_prefix_variables; then
 		declare -r ED EPREFIX EROOT
 	fi
+	if ___eapi_has_BROOT; then
+		declare -r BROOT
+	fi
 
 	# If ${EBUILD_FORCE_TEST} == 1 and USE came from ${T}/environment
 	# then it might not have USE=test like it's supposed to here.

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -100,10 +100,16 @@ __filter_readonly_variables() {
 	filtered_vars="$readonly_bash_vars $bash_misc_vars
 		$PORTAGE_READONLY_VARS $misc_garbage_vars"
 
+	if ___eapi_has_SYSROOT; then
+		filtered_vars+=" SYSROOT"
+	fi
 	# Don't filter/interfere with prefix variables unless they are
 	# supported by the current EAPI.
 	if ___eapi_has_prefix_variables; then
 		filtered_vars+=" ED EPREFIX EROOT"
+		if ___eapi_has_SYSROOT; then
+			filtered_vars+=" ESYSROOT"
+		fi
 	fi
 	if ___eapi_has_PORTDIR_ECLASSDIR; then
 		filtered_vars+=" PORTDIR ECLASSDIR"

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -100,6 +100,9 @@ __filter_readonly_variables() {
 	filtered_vars="$readonly_bash_vars $bash_misc_vars
 		$PORTAGE_READONLY_VARS $misc_garbage_vars"
 
+	if ___eapi_has_BROOT; then
+		filtered_vars+=" BROOT"
+	fi
 	if ___eapi_has_SYSROOT; then
 		filtered_vars+=" SYSROOT"
 	fi

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -878,46 +878,55 @@ __eapi6_src_install() {
 	einstalldocs
 }
 
-# @FUNCTION: has_version
-# @USAGE: [--host-root] <DEPEND ATOM>
-# @DESCRIPTION:
-# Return true if given package is installed. Otherwise return false.
-# Callers may override the ROOT variable in order to match packages from an
-# alternative ROOT.
-has_version() {
-
-	local atom eroot host_root=false root=${ROOT}
-	if [[ $1 == --host-root ]] ; then
-		host_root=true
-		shift
-	fi
+___best_version_and_has_version_common() {
+	local atom root root_arg
+	case $1 in
+		--host-root|-r|-d|-b)
+			root_arg=$1
+			shift ;;
+	esac
 	atom=$1
 	shift
-	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
+	[ $# -gt 0 ] && die "${FUNCNAME[1]}: unused argument(s): $*"
 
-	if ${host_root} ; then
-		if ! ___eapi_best_version_and_has_version_support_--host-root; then
-			die "${FUNCNAME[0]}: option --host-root is not supported with EAPI ${EAPI}"
-		fi
-		root=/
-	fi
+	case ${root_arg} in
+		"") if ___eapi_has_prefix_variables; then
+				root=${EROOT}
+			else
+				root=${ROOT}
+			fi ;;
+		--host-root)
+			if ! ___eapi_best_version_and_has_version_support_--host-root; then
+				die "${FUNCNAME[1]}: option ${root_arg} is not supported with EAPI ${EAPI}"
+			fi
+			if ___eapi_has_prefix_variables; then
+				root=/${PORTAGE_OVERRIDE_EPREFIX#/}
+			else
+				root=/
+			fi ;;
+		-r|-d|-b)
+			if ! ___eapi_best_version_and_has_version_support_-b_-d_-r; then
+				die "${FUNCNAME[1]}: option ${root_arg} is not supported with EAPI ${EAPI}"
+			fi
+			if ___eapi_has_prefix_variables; then
+				case ${root_arg} in
+					-r) root=${EROOT} ;;
+					-d) root=${ESYSROOT} ;;
+					-b) root=${BROOT:-/} ;;
+				esac
+			else
+				case ${root_arg} in
+					-r) root=${ROOT} ;;
+					-d) root=${SYSROOT} ;;
+					-b) root=/ ;;
+				esac
+			fi ;;
+	esac
 
-	if ___eapi_has_prefix_variables; then
-		# [[ ${root} == / ]] would be ambiguous here,
-		# since both prefixes can share root=/ while
-		# having different EPREFIX offsets.
-		if ${host_root} ; then
-			eroot=${root%/}${PORTAGE_OVERRIDE_EPREFIX}/
-		else
-			eroot=${root%/}${EPREFIX}/
-		fi
-	else
-		eroot=${root}
-	fi
 	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
-		"$PORTAGE_BIN_PATH"/ebuild-ipc has_version "${eroot}" "${atom}"
+		"${PORTAGE_BIN_PATH}"/ebuild-ipc "${FUNCNAME[1]}" "${root}" "${atom}"
 	else
-		"${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" has_version "${eroot}" "${atom}"
+		"${PORTAGE_BIN_PATH}"/ebuild-helpers/portageq "${FUNCNAME[1]}" "${root}" "${atom}"
 	fi
 	local retval=$?
 	case "${retval}" in
@@ -925,75 +934,36 @@ has_version() {
 			return ${retval}
 			;;
 		2)
-			die "${FUNCNAME[0]}: invalid atom: ${atom}"
+			die "${FUNCNAME[1]}: invalid atom: ${atom}"
 			;;
 		*)
 			if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
-				die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				die "${FUNCNAME[1]}: unexpected ebuild-ipc exit code: ${retval}"
 			else
-				die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				die "${FUNCNAME[1]}: unexpected portageq exit code: ${retval}"
 			fi
 			;;
 	esac
 }
 
+# @FUNCTION: has_version
+# @USAGE: [--host-root|-r|-d|-b] <DEPEND ATOM>
+# @DESCRIPTION:
+# Return true if given package is installed. Otherwise return false.
+# Callers may override the ROOT variable in order to match packages from an
+# alternative ROOT.
+has_version() {
+	___best_version_and_has_version_common "$@"
+}
+
 # @FUNCTION: best_version
-# @USAGE: [--host-root] <DEPEND ATOM>
+# @USAGE: [--host-root|-r|-d|-b] <DEPEND ATOM>
 # @DESCRIPTION:
 # Returns highest installed matching category/package-version (without .ebuild).
 # Callers may override the ROOT variable in order to match packages from an
 # alternative ROOT.
 best_version() {
-
-	local atom eroot host_root=false root=${ROOT}
-	if [[ $1 == --host-root ]] ; then
-		host_root=true
-		shift
-	fi
-	atom=$1
-	shift
-	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
-
-	if ${host_root} ; then
-		if ! ___eapi_best_version_and_has_version_support_--host-root; then
-			die "${FUNCNAME[0]}: option --host-root is not supported with EAPI ${EAPI}"
-		fi
-		root=/
-	fi
-
-	if ___eapi_has_prefix_variables; then
-		# [[ ${root} == / ]] would be ambiguous here,
-		# since both prefixes can share root=/ while
-		# having different EPREFIX offsets.
-		if ${host_root} ; then
-			eroot=${root%/}${PORTAGE_OVERRIDE_EPREFIX}/
-		else
-			eroot=${root%/}${EPREFIX}/
-		fi
-	else
-		eroot=${root}
-	fi
-	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
-		"$PORTAGE_BIN_PATH"/ebuild-ipc best_version "${eroot}" "${atom}"
-	else
-		"${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" best_version "${eroot}" "${atom}"
-	fi
-	local retval=$?
-	case "${retval}" in
-		0|1)
-			return ${retval}
-			;;
-		2)
-			die "${FUNCNAME[0]}: invalid atom: ${atom}"
-			;;
-		*)
-			if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
-				die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
-			else
-				die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
-			fi
-			;;
-	esac
+	___best_version_and_has_version_common "$@"
 }
 
 if ___eapi_has_get_libdir; then

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -640,7 +640,7 @@ econf() {
 		fi
 
 		local conf_args=()
-		if ___eapi_econf_passes_--disable-dependency-tracking || ___eapi_econf_passes_--disable-silent-rules || ___eapi_econf_passes_--docdir_and_--htmldir; then
+		if ___eapi_econf_passes_--disable-dependency-tracking || ___eapi_econf_passes_--disable-silent-rules || ___eapi_econf_passes_--docdir_and_--htmldir || ___eapi_econf_passes_--with-sysroot; then
 			local conf_help=$("${ECONF_SOURCE}/configure" --help 2>/dev/null)
 
 			if ___eapi_econf_passes_--disable-dependency-tracking; then
@@ -662,6 +662,12 @@ econf() {
 
 				if [[ ${conf_help} == *--htmldir* ]]; then
 					conf_args+=( --htmldir="${EPREFIX}"/usr/share/doc/${PF}/html )
+				fi
+			fi
+
+			if ___eapi_econf_passes_--with-sysroot; then
+				if [[ ${conf_help} == *--with-sysroot* ]]; then
+					conf_args+=( --with-sysroot="${ESYSROOT:-/}" )
 				fi
 			fi
 		fi

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -527,6 +527,12 @@ Beginning with \fBEAPI 3\fR, contains
 "${ROOT%/}${EPREFIX}/" for convenience
 purposes. Do not modify this variable.
 .TP
+.B BROOT\fR = \fI"${EPREFIX}"
+Beginning with \fBEAPI 7\fR, the absolute path to the root directory
+containing build dependencies satisfied by BDEPEND, typically
+executable build tools. This includes any applicable offset prefix. Do
+not modify this variable.
+.TP
 .B DESCRIPTION\fR = \fI"A happy little package"
 Should contain a short description of the package.
 .TP

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -911,6 +911,9 @@ necessary.
 .BR \-\-root=DIR
 Set the \fBROOT\fR environment variable.
 .TP
+.BR \-\-sysroot=DIR
+Set the \fBSYSROOT\fR environment variable.
+.TP
 .BR \-\-root\-deps[=rdeps]
 If no argument is given then build\-time dependencies of packages for
 \fBROOT\fR are installed to \fBROOT\fR instead of /.
@@ -919,12 +922,16 @@ of packages for \fBROOT\fR.
 This option is only meaningful when used together with \fBROOT\fR and it should
 not be enabled under normal circumstances!
 
-Does not affect EAPIs that support \fBHDEPEND\fR.
-Experimental \fBEAPI 5-hdepend\fR provides \fBHDEPEND\fR as a new
-means to adjust installation into "\fI/\fR" and \fBROOT\fR.
-If ebuilds using EAPIs which \fIdo not\fR support \fBHDEPEND\fR are built in
-the same \fBemerge\fR run as those using EAPIs which \fIdo\fR support
-\fBHDEPEND\fR, this option affects only the former.
+Does not affect EAPIs that support \fBBDEPEND\fR or \fBHDEPEND\fR.
+\fBEAPI 7\fR introduces \fBBDEPEND\fR and experimental
+\fBEAPI 5-hdepend\fR features \fBHDEPEND\fR as a means to adjust
+installation into / and \fBROOT\fR.  Use the \fBSYSROOT\fR environment
+variable to control where \fBDEPEND\fR is installed to under
+\fBEAPI 7\fR.
+
+When ebuilds with different EAPIs feature in the same emerge run, the
+appropriate behaviour for each EAPI is applied independently to each
+ebuild.
 .TP
 .BR "\-\-search\-index < y | n >"
 Enable or disable indexed search for search actions. This option is
@@ -1090,8 +1097,19 @@ Defaults to the prefix where portage is currently installed.
 .TP
 \fBROOT\fR = \fI[path]\fR
 Use \fBROOT\fR to specify the target root filesystem to be used for
-merging packages or ebuilds. This variable can be set via the \fB\-\-root\fR
-option or in \fBmake.conf\fR(5) (the command line overrides other settings).
+merging the requested packages or ebuilds and their runtime
+dependencies.  This variable can be set via the \fB\-\-root\fR option
+or in \fBmake.conf\fR(5) (the command line overrides other settings).
+.br
+Defaults to /.
+.TP
+\fBSYSROOT\fR = \fI[path]\fR
+Use \fBSYSROOT\fR to specify the target root filesystem to be used for
+merging the build dependencies satisfied by \fBDEPEND\fR.  This
+variable can be set via the \fB\-\-sysroot\fR option or in
+\fBmake.conf\fR(5) (the command line overrides other settings).  The
+value must either be / or equal to \fBROOT\fR.  When cross-compiling,
+only the latter is valid.
 .br
 Defaults to /.
 .TP
@@ -1099,7 +1117,9 @@ Defaults to /.
 Use \fBPORTAGE_CONFIGROOT\fR to specify the location for various portage
 configuration files
 (see \fBFILES\fR for a detailed list of configuration files).  This variable
-can be set via the \fB\-\-config\-root\fR option.
+can be set via the \fB\-\-config\-root\fR option.  However, it is now
+superseded by the \fBSYSROOT\fR variable and can only be given if its
+value matches \fBSYSROOT\fR or if \fBROOT=/\fR.
 .br
 Defaults to /.
 .SH "OUTPUT"

--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -2438,7 +2438,7 @@ def load_emerge_config(emerge_config=None, env=None, **kargs):
 	env = os.environ if env is None else env
 	kwargs = {'env': env}
 	for k, envvar in (("config_root", "PORTAGE_CONFIGROOT"), ("target_root", "ROOT"),
-			("eprefix", "EPREFIX")):
+			("sysroot", "SYSROOT"), ("eprefix", "EPREFIX")):
 		v = env.get(envvar)
 		if v and v.strip():
 			kwargs[k] = v

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -3322,8 +3322,10 @@ class depgraph(object):
 		if removal_action:
 			depend_root = myroot
 		else:
-			if eapi_attrs.bdepend or eapi_attrs.hdepend:
+			if eapi_attrs.hdepend:
 				depend_root = myroot
+			elif eapi_attrs.bdepend:
+				depend_root = pkg.root_config.settings["ESYSROOT"]
 			else:
 				depend_root = self._frozen_config._running_root.root
 				root_deps = self._frozen_config.myopts.get("--root-deps")

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -732,6 +732,11 @@ def parse_opts(tmpcmdline, silent=False):
 			"action" : "append",
 		},
 
+		"--sysroot": {
+			"help":"specify the location for build dependencies specified in DEPEND",
+			"action":"store"
+		},
+
 		"--use-ebuild-visibility": {
 			"help"     : "use unbuilt ebuild metadata for visibility checks on built packages",
 			"choices"  : true_y_or_n
@@ -1201,6 +1206,8 @@ def emerge_main(args=None):
 		os.environ["PORTAGE_DEBUG"] = "1"
 	if "--config-root" in myopts:
 		os.environ["PORTAGE_CONFIGROOT"] = myopts["--config-root"]
+	if "--sysroot" in myopts:
+		os.environ["SYSROOT"] = myopts["--sysroot"]
 	if "--root" in myopts:
 		os.environ["ROOT"] = myopts["--root"]
 	if "--prefix" in myopts:

--- a/pym/portage/__init__.py
+++ b/pym/portage/__init__.py
@@ -525,7 +525,7 @@ class _trees_dict(dict):
 		self._target_eroot = None
 
 def create_trees(config_root=None, target_root=None, trees=None, env=None,
-	eprefix=None):
+	sysroot=None, eprefix=None):
 
 	if trees is None:
 		trees = _trees_dict()
@@ -538,7 +538,7 @@ def create_trees(config_root=None, target_root=None, trees=None, env=None,
 		env = os.environ
 
 	settings = config(config_root=config_root, target_root=target_root,
-		env=env, eprefix=eprefix)
+		env=env, sysroot=sysroot, eprefix=eprefix)
 	settings.lock()
 
 	depcachedir = settings.get('PORTAGE_DEPCACHEDIR')
@@ -562,7 +562,7 @@ def create_trees(config_root=None, target_root=None, trees=None, env=None,
 		if depcachedir is not None:
 			clean_env['PORTAGE_DEPCACHEDIR'] = depcachedir
 		settings = config(config_root=None, target_root="/",
-			env=clean_env, eprefix=None)
+			env=clean_env, sysroot="/", eprefix=None)
 		settings.lock()
 		trees._running_eroot = settings['EROOT']
 		myroots.append((settings['EROOT'], settings))

--- a/pym/portage/_legacy_globals.py
+++ b/pym/portage/_legacy_globals.py
@@ -28,7 +28,8 @@ def _get_legacy_global(name):
 
 	kwargs = {}
 	for k, envvar in (("config_root", "PORTAGE_CONFIGROOT"),
-			("target_root", "ROOT"), ("eprefix", "EPREFIX")):
+			("target_root", "ROOT"), ("sysroot", "SYSROOT"),
+			("eprefix", "EPREFIX")):
 		kwargs[k] = os.environ.get(envvar)
 
 	portage._initializing_globals = True

--- a/pym/portage/eapi.py
+++ b/pym/portage/eapi.py
@@ -123,13 +123,17 @@ def eapi_path_variables_end_with_trailing_slash(eapi):
 	return eapi in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
 			"5", "5-progress", "6")
 
+def eapi_has_broot(eapi):
+	return eapi not in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
+			"5", "5-progress", "5-hdepend", "6")
+
 def eapi_has_sysroot(eapi):
 	return eapi not in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
 			"5", "5-progress", "5-hdepend", "6")
 
 _eapi_attrs = collections.namedtuple('_eapi_attrs',
 	'allows_package_provided '
-	'bdepend dots_in_PN dots_in_use_flags exports_EBUILD_PHASE_FUNC '
+	'bdepend broot dots_in_PN dots_in_use_flags exports_EBUILD_PHASE_FUNC '
 	'exports_PORTDIR exports_ECLASSDIR '
 	'feature_flag_test feature_flag_targetroot '
 	'hdepend iuse_defaults iuse_effective posixish_locale '
@@ -159,6 +163,7 @@ def _get_eapi_attrs(eapi):
 	eapi_attrs = _eapi_attrs(
 		allows_package_provided=(eapi is None or eapi_allows_package_provided(eapi)),
 		bdepend = (eapi is not None and eapi_has_bdepend(eapi)),
+		broot = (eapi is None or eapi_has_broot(eapi)),
 		dots_in_PN = (eapi is None or eapi_allows_dots_in_PN(eapi)),
 		dots_in_use_flags = (eapi is None or eapi_allows_dots_in_use_flags(eapi)),
 		empty_groups_always_true = (eapi is not None and eapi_empty_groups_always_true(eapi)),

--- a/pym/portage/eapi.py
+++ b/pym/portage/eapi.py
@@ -123,6 +123,10 @@ def eapi_path_variables_end_with_trailing_slash(eapi):
 	return eapi in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
 			"5", "5-progress", "6")
 
+def eapi_has_sysroot(eapi):
+	return eapi not in ("0", "1", "2", "3", "4", "4-python", "4-slot-abi",
+			"5", "5-progress", "5-hdepend", "6")
+
 _eapi_attrs = collections.namedtuple('_eapi_attrs',
 	'allows_package_provided '
 	'bdepend dots_in_PN dots_in_use_flags exports_EBUILD_PHASE_FUNC '
@@ -132,7 +136,7 @@ _eapi_attrs = collections.namedtuple('_eapi_attrs',
 	'path_variables_end_with_trailing_slash '
 	'repo_deps required_use required_use_at_most_one_of slot_operator slot_deps '
 	'src_uri_arrows strong_blocks use_deps use_dep_defaults '
-	'empty_groups_always_true')
+	'empty_groups_always_true sysroot')
 
 _eapi_attrs_cache = {}
 
@@ -176,6 +180,7 @@ def _get_eapi_attrs(eapi):
 		slot_operator = (eapi is None or eapi_has_slot_operator(eapi)),
 		src_uri_arrows = (eapi is None or eapi_has_src_uri_arrows(eapi)),
 		strong_blocks = (eapi is None or eapi_has_strong_blocks(eapi)),
+		sysroot = (eapi is None or eapi_has_sysroot(eapi)),
 		use_deps = (eapi is None or eapi_has_use_deps(eapi)),
 		use_dep_defaults = (eapi is None or eapi_has_use_dep_defaults(eapi))
 	)

--- a/pym/portage/package/ebuild/_config/LocationsManager.py
+++ b/pym/portage/package/ebuild/_config/LocationsManager.py
@@ -16,7 +16,7 @@ from portage import os, eapi_is_supported, _encodings, _unicode_encode
 from portage.const import CUSTOM_PROFILE_PATH, GLOBAL_CONFIG_PATH, \
 	PROFILE_PATH, USER_CONFIG_PATH
 from portage.eapi import eapi_allows_directories_on_profile_level_and_repository_level
-from portage.exception import DirectoryNotFound, ParseError
+from portage.exception import DirectoryNotFound, InvalidLocation, ParseError
 from portage.localization import _
 from portage.util import ensure_dirs, grabfile, \
 	normalize_path, read_corresponding_eapi_file, shlex_split, writemsg
@@ -40,12 +40,13 @@ _allow_parent_colon = frozenset(
 class LocationsManager(object):
 
 	def __init__(self, config_root=None, eprefix=None, config_profile_path=None, local_config=True, \
-		target_root=None):
+		target_root=None, sysroot=None):
 		self.user_profile_dir = None
 		self._local_repo_conf_path = None
 		self.eprefix = eprefix
 		self.config_root = config_root
 		self.target_root = target_root
+		self.sysroot = sysroot
 		self._user_config = local_config
 
 		if self.eprefix is None:
@@ -64,6 +65,13 @@ class LocationsManager(object):
 		self._check_var_directory("PORTAGE_CONFIGROOT", self.config_root)
 		self.abs_user_config = os.path.join(self.config_root, USER_CONFIG_PATH)
 		self.config_profile_path = config_profile_path
+
+		if self.sysroot is None:
+			self.sysroot = "/"
+		else:
+			self.sysroot = normalize_path(os.path.abspath(self.sysroot)).rstrip(os.sep) + os.sep
+
+		self.esysroot = self.sysroot.rstrip(os.sep) + self.eprefix + os.sep
 
 	def load_profiles(self, repositories, known_repository_paths):
 		known_repository_paths = set(os.path.realpath(x)
@@ -297,6 +305,13 @@ class LocationsManager(object):
 
 		self.target_root = normalize_path(os.path.abspath(
 			self.target_root)).rstrip(os.path.sep) + os.path.sep
+
+		if self.sysroot != "/" and self.sysroot != self.target_root:
+			writemsg(_("!!! Error: SYSROOT (currently %s) must "
+				"equal / or ROOT (currently %s).\n") %
+				(self.sysroot, self.target_root),
+				noiselevel=-1)
+			raise InvalidLocation(self.sysroot)
 
 		ensure_dirs(self.target_root)
 		self._check_var_directory("ROOT", self.target_root)

--- a/pym/portage/package/ebuild/_config/LocationsManager.py
+++ b/pym/portage/package/ebuild/_config/LocationsManager.py
@@ -73,6 +73,10 @@ class LocationsManager(object):
 
 		self.esysroot = self.sysroot.rstrip(os.sep) + self.eprefix + os.sep
 
+		# TODO: Set this via the constructor using
+		# PORTAGE_OVERRIDE_EPREFIX.
+		self.broot = portage.const.EPREFIX
+
 	def load_profiles(self, repositories, known_repository_paths):
 		known_repository_paths = set(os.path.realpath(x)
 			for x in known_repository_paths)

--- a/pym/portage/package/ebuild/_config/special_env_vars.py
+++ b/pym/portage/package/ebuild/_config/special_env_vars.py
@@ -14,7 +14,7 @@ import re
 # to enter the config instance from the external environment or
 # configuration files.
 env_blacklist = frozenset((
-	"A", "AA", "BDEPEND", "CATEGORY", "DEPEND", "DESCRIPTION",
+	"A", "AA", "BDEPEND", "BROOT", "CATEGORY", "DEPEND", "DESCRIPTION",
 	"DOCS", "EAPI",
 	"EBUILD_FORCE_TEST", "EBUILD_PHASE",
 	"EBUILD_PHASE_FUNC", "EBUILD_SKIP_MANIFEST",
@@ -42,7 +42,7 @@ environ_whitelist = []
 # environment in order to prevent sandbox from sourcing /etc/profile
 # in it's bashrc (causing major leakage).
 environ_whitelist += [
-	"ACCEPT_LICENSE", "BASH_ENV", "BUILD_PREFIX", "COLUMNS", "D",
+	"ACCEPT_LICENSE", "BASH_ENV", "BROOT", "BUILD_PREFIX", "COLUMNS", "D",
 	"DISTDIR", "DOC_SYMLINKS_DIR", "EAPI", "EBUILD",
 	"EBUILD_FORCE_TEST",
 	"EBUILD_PHASE", "EBUILD_PHASE_FUNC", "ECLASSDIR", "ECLASS_DEPTH", "ED",

--- a/pym/portage/package/ebuild/config.py
+++ b/pym/portage/package/ebuild/config.py
@@ -346,6 +346,7 @@ class config(object):
 			config_root = locations_manager.config_root
 			sysroot = locations_manager.sysroot
 			esysroot = locations_manager.esysroot
+			broot = locations_manager.broot
 			abs_user_config = locations_manager.abs_user_config
 			make_conf_paths = [
 				os.path.join(config_root, 'etc', 'make.conf'),
@@ -509,6 +510,7 @@ class config(object):
 			self["EPREFIX"] = eprefix
 			self["EROOT"] = eroot
 			self["ESYSROOT"] = esysroot
+			self["BROOT"] = broot
 			known_repos = []
 			portdir = ""
 			portdir_overlay = ""
@@ -680,6 +682,8 @@ class config(object):
 			self.backup_changes("EROOT")
 			self["ESYSROOT"] = esysroot
 			self.backup_changes("ESYSROOT")
+			self["BROOT"] = broot
+			self.backup_changes("BROOT")
 
 			# The prefix of the running portage instance is used in the
 			# ebuild environment to implement the --host-root option for
@@ -2758,6 +2762,9 @@ class config(object):
 		if not (src_phase and eapi_attrs.sysroot):
 			mydict.pop("ESYSROOT", None)
 
+		if not (src_phase and eapi_attrs.broot):
+			mydict.pop("BROOT", None)
+
 		# Prefix variables are supported beginning with EAPI 3, or when
 		# force-prefix is in FEATURES, since older EAPIs would otherwise be
 		# useless with prefix configurations. This brings compatibility with
@@ -2806,7 +2813,8 @@ class config(object):
 			mydict.pop("ECLASSDIR", None)
 
 		if not eapi_attrs.path_variables_end_with_trailing_slash:
-			for v in ("D", "ED", "ROOT", "EROOT", "SYSROOT", "ESYSROOT"):
+			for v in ("D", "ED", "ROOT", "EROOT", "SYSROOT", "ESYSROOT",
+					"BROOT"):
 				if v in mydict:
 					mydict[v] = mydict[v].rstrip(os.path.sep)
 

--- a/repoman/cnf/qa_data/qa_data.yaml
+++ b/repoman/cnf/qa_data/qa_data.yaml
@@ -128,7 +128,7 @@ qahelp:
     variable:
         invalidchar: "A variable contains an invalid character that is not part of the ASCII character set"
         readonly: "Assigning a readonly variable"
-        usedwithhelpers: "Ebuild uses D, ROOT, ED, EROOT or EPREFIX with helpers"
+        usedwithhelpers: "Ebuild uses D, ROOT, BROOT, ED, EROOT or EPREFIX with helpers"
     virtual:
         suspect: "Ebuild contains a package that usually should be pulled via virtual/, not directly."
     wxwidgets:

--- a/repoman/man/repoman.1
+++ b/repoman/man/repoman.1
@@ -432,7 +432,7 @@ character set.
 Assigning a readonly variable
 .TP
 .B variable.usedwithhelpers
-Ebuild uses D, ROOT, ED, EROOT or EPREFIX with helpers
+Ebuild uses D, ROOT, BROOT, ED, EROOT or EPREFIX with helpers
 .TP
 .B virtual.suspect
 Ebuild contains a package that usually should be pulled via virtual/,

--- a/repoman/pym/repoman/modules/linechecks/assignment/assignment.py
+++ b/repoman/pym/repoman/modules/linechecks/assignment/assignment.py
@@ -1,7 +1,7 @@
 
 import re
 
-from portage.eapi import eapi_supports_prefix
+from portage.eapi import eapi_supports_prefix, eapi_has_broot
 from repoman.modules.linechecks.base import LineCheck
 
 
@@ -29,3 +29,10 @@ class Eapi3EbuildAssignment(EbuildAssignment):
 	def check_eapi(self, eapi):
 		return eapi_supports_prefix(eapi)
 
+class Eapi7EbuildAssignment(EbuildAssignment):
+	"""Ensure ebuilds don't assign to readonly EAPI 7-introduced variables."""
+
+	readonly_assignment = re.compile(r'\s*(export\s+)?BROOT=')
+
+	def check_eapi(self, eapi):
+		return eapi_has_broot(eapi)

--- a/repoman/pym/repoman/modules/linechecks/quotes/quotes.py
+++ b/repoman/pym/repoman/modules/linechecks/quotes/quotes.py
@@ -17,7 +17,8 @@ class EbuildQuote(LineCheck):
 		r'(^$)|(^\s*#.*)|(^\s*\w+=.*)' +
 		r'|(^\s*(' + "|".join(_ignored_commands) + r')\s+)')
 	ignore_comment = False
-	var_names = ["D", "DISTDIR", "FILESDIR", "S", "T", "ROOT", "WORKDIR"]
+	var_names = [
+                "D", "DISTDIR", "FILESDIR", "S", "T", "ROOT", "BROOT", "WORKDIR"]
 
 	# EAPI=3/Prefix vars
 	var_names += ["ED", "EPREFIX", "EROOT"]


### PR DESCRIPTION
This is my version of #275. You may want to diff the two to see what's really changed. Admittedly it's barely tested because it's late and I'm tired. I tried to do `BROOT` in the way that was requested with `PORTAGE_OVERRIDE_EPREFIX` while keeping a `broot` variable in `LocationsManager`, currently defined with `portage.const.EPREFIX` until that can be fixed properly. @zmedico, I hope that's what you wanted.