### PR TITLE
emerge: add --ignore-world [ y | n ] option (bug 608564)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1,4 +1,4 @@
-.TH "EMERGE" "1" "Jul 2016" "Portage VERSION" "Portage"
+.TH "EMERGE" "1" "Mar 2018" "Portage VERSION" "Portage"
 .SH "NAME"
 emerge \- Command\-line interface to the Portage system
 .SH "SYNOPSIS"
@@ -629,6 +629,23 @@ to determine whether an unresolved soname dependency can be satisfied.
 Therefore, \fB\-\-usepkgonly\fR (or \fB\-\-getbinpkgonly\fR) must be
 used in order to enable soname depedency resolution when installing
 packages.
+.TP
+.BR "\-\-ignore\-world [ y | n ]"
+Ignore the @world package set and its dependencies. This may be useful
+if there is a desire to perform an action even though it might break
+the dependencies of some installed packages (it might also remove
+installed packages in order to solve blockers). This also alters the
+behavior of \fB\-\-complete\-graph\fR options so that only deep
+dependencies of packages given as arguments are included in the
+dependency graph. This option may be useful as an alternative to
+\fB\-\-nodeps\fR in cases where it is desirable to account for
+dependencies of packages given as arguments.
+
+\fBWARNING:\fR
+This option is intended to be used only with great caution, since it is
+possible for it to make nonsensical changes which may lead to system
+breakage. Therefore, it is advisable to use \fB\-\-ask\fR together with
+this option.
 .TP
 .BR \-j\ [JOBS] ", "  \-\-jobs[=JOBS]
 Specifies the number of packages to build simultaneously. If this option is

--- a/pym/_emerge/create_depgraph_params.py
+++ b/pym/_emerge/create_depgraph_params.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
@@ -26,6 +26,7 @@ def create_depgraph_params(myopts, myaction):
 	# ignore_soname_deps: ignore the soname dependencies of built
 	#   packages, so that they do not trigger dependency resolution
 	#   failures, or cause packages to be rebuilt or replaced.
+	# ignore_world: ignore the @world package set and its dependencies
 	# with_test_deps: pull in test deps for packages matched by arguments
 	# changed_deps: rebuild installed packages with outdated deps
 	# changed_deps_report: report installed packages with outdated deps
@@ -55,6 +56,9 @@ def create_depgraph_params(myopts, myaction):
 		myparams["complete"] = True
 		myparams["selective"] = True
 		return myparams
+
+	if myopts.get('--ignore-world') is True:
+		myparams['ignore_world'] = True
 
 	rebuild_if_new_slot = myopts.get('--rebuild-if-new-slot')
 	if rebuild_if_new_slot is not None:

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -163,7 +163,10 @@ class _frozen_depgraph_config(object):
 				self.trees[myroot]["bintree"] = DummyTree(
 					DbapiProvidesIndex(trees[myroot]["bintree"].dbapi))
 
-		self._required_set_names = set(["world"])
+		if params.get("ignore_world", False):
+			self._required_set_names = set()
+		else:
+			self._required_set_names = set(["world"])
 
 		atoms = ' '.join(myopts.get("--exclude", [])).split()
 		self.excluded_pkgs = _wildcard_set(atoms)
@@ -7554,6 +7557,7 @@ class depgraph(object):
 		ignored_uninstall_tasks = set()
 		have_uninstall_task = False
 		complete = "complete" in self._dynamic_config.myparams
+		ignore_world = self._dynamic_config.myparams.get("ignore_world", False)
 		asap_nodes = []
 
 		def get_nodes(**kwargs):
@@ -7971,7 +7975,7 @@ class depgraph(object):
 					# detected as early as possible, which makes it possible
 					# to avoid calling self._complete_graph() when it is
 					# unnecessary due to blockers triggering an abortion.
-					if not complete:
+					if not (complete or ignore_world):
 						# For packages in the world set, go ahead an uninstall
 						# when necessary, as long as the atom will be satisfied
 						# in the final state.

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function
@@ -146,6 +146,7 @@ def insert_optional_args(args):
 		'--fuzzy-search'         : y_or_n,
 		'--getbinpkg'            : y_or_n,
 		'--getbinpkgonly'        : y_or_n,
+		'--ignore-world'         : y_or_n,
 		'--jobs'       : valid_integers,
 		'--keep-going'           : y_or_n,
 		'--load-average'         : valid_floats,
@@ -501,6 +502,11 @@ def parse_opts(tmpcmdline, silent=False):
 				"exist for binary and installed packages built with "
 				"older versions of portage.",
 			"choices": y_or_n
+		},
+
+		"--ignore-world": {
+			"help"    : "ignore the @world package set and its dependencies",
+			"choices" : true_y_or_n
 		},
 
 		"--jobs": {
@@ -918,6 +924,9 @@ def parse_opts(tmpcmdline, silent=False):
 		myoptions.getbinpkgonly = True
 	else:
 		myoptions.getbinpkgonly = None
+
+	if myoptions.ignore_world in true_y:
+		myoptions.ignore_world = True
 
 	if myoptions.keep_going in true_y:
 		myoptions.keep_going = True

--- a/pym/portage/tests/resolver/test_complete_graph.py
+++ b/pym/portage/tests/resolver/test_complete_graph.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2012 Gentoo Foundation
+# Copyright 2011-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -59,6 +59,12 @@ class CompleteGraphTestCase(TestCase):
 				success = True,
 			),
 
+			ResolverPlaygroundTestCase(
+				["dev-libs/libxml2"],
+				options = {"--ignore-world" : True},
+				mergelist = ["dev-libs/libxml2-2.8.0"],
+				success = True,
+			),
 		)
 
 		playground = ResolverPlayground(ebuilds=ebuilds,
@@ -99,6 +105,12 @@ class CompleteGraphTestCase(TestCase):
 			),
 			ResolverPlaygroundTestCase(
 				[">=sys-libs/x-2"],
+				options = {"--ignore-world" : True},
+				mergelist = ["sys-libs/x-2"],
+				success = True,
+			),
+			ResolverPlaygroundTestCase(
+				[">=sys-libs/x-2"],
 				options = {"--complete-graph-if-new-ver" : "y"},
 				mergelist = ["sys-libs/x-2"],
 				slot_collision_solutions = [],
@@ -107,6 +119,12 @@ class CompleteGraphTestCase(TestCase):
 			ResolverPlaygroundTestCase(
 				["<sys-libs/x-1"],
 				options = {"--complete-graph-if-new-ver" : "n", "--rebuild-if-new-slot": "n"},
+				mergelist = ["sys-libs/x-0.1"],
+				success = True,
+			),
+			ResolverPlaygroundTestCase(
+				["<sys-libs/x-1"],
+				options = {"--ignore-world" : True},
 				mergelist = ["sys-libs/x-0.1"],
 				success = True,
 			),


### PR DESCRIPTION
Ignore the @world package set and its dependencies. This may be useful
if there is a desire to perform an action even though it might break
the dependencies of some installed packages (it might also remove
installed packages in order to solve blockers). This also alters the
behavior of --complete-graph options so that only deep dependencies
of packages given as arguments are included in the dependency graph.
This option may be useful as an alternative to --nodeps in cases where
it is desirable to account for dependencies of packages given as
arguments.

Bug: https://bugs.gentoo.org/608564