### PR TITLE
emerge --autounmask: prevent unmask due to unsatisfied REQUIRED_USE (bug 622462)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -358,6 +358,13 @@ class _rebuild_config(object):
 		return need_restart
 
 
+class _use_changes(tuple):
+	def __new__(cls, new_use, new_changes, required_use_satisfied=True):
+		obj = tuple.__new__(cls, [new_use, new_changes])
+		obj.required_use_satisfied = required_use_satisfied
+		return obj
+
+
 class _dynamic_depgraph_config(object):
 
 	"""
@@ -6133,22 +6140,25 @@ class depgraph(object):
 
 		if new_changes != old_changes:
 			#Don't do the change if it violates REQUIRED_USE.
+			required_use_satisfied = True
 			required_use = pkg._metadata.get("REQUIRED_USE")
 			if required_use and check_required_use(required_use, old_use,
 				pkg.iuse.is_valid_flag, eapi=pkg.eapi) and \
 				not check_required_use(required_use, new_use,
 				pkg.iuse.is_valid_flag, eapi=pkg.eapi):
-				return old_use
+				required_use_satisfied = False
 
 			if any(x in pkg.use.mask for x in new_changes) or \
 				any(x in pkg.use.force for x in new_changes):
 				return old_use
 
-			self._dynamic_config._needed_use_config_changes[pkg] = (new_use, new_changes)
+			changes = _use_changes(new_use, new_changes,
+				required_use_satisfied=required_use_satisfied)
+			self._dynamic_config._needed_use_config_changes[pkg] = changes
 			backtrack_infos = self._dynamic_config._backtrack_infos
 			backtrack_infos.setdefault("config", {})
 			backtrack_infos["config"].setdefault("needed_use_config_changes", [])
-			backtrack_infos["config"]["needed_use_config_changes"].append((pkg, (new_use, new_changes)))
+			backtrack_infos["config"]["needed_use_config_changes"].append((pkg, changes))
 			if want_restart_for_use_change(pkg, new_use):
 				self._dynamic_config._need_restart = True
 		return new_use
@@ -9388,6 +9398,10 @@ class depgraph(object):
 		return self._dynamic_config._need_config_reload
 
 	def autounmask_breakage_detected(self):
+		# Check for REQUIRED_USE violations.
+		for changes in self._dynamic_config._needed_use_config_changes.values():
+			if getattr(changes, 'required_use_satisfied', None) is False:
+				return True
 		try:
 			for pargs, kwargs in self._dynamic_config._unsatisfied_deps_for_display:
 				self._show_unsatisfied_dep(

--- a/pym/portage/tests/resolver/test_autounmask.py
+++ b/pym/portage/tests/resolver/test_autounmask.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2012 Gentoo Foundation
+# Copyright 2010-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -61,6 +61,21 @@ class AutounmaskTestCase(TestCase):
 
 			"app-portage/B-1": { "IUSE": "foo +bar", "REQUIRED_USE": "^^ ( foo bar )", "EAPI": "4" },
 			"app-portage/C-1": { "IUSE": "+foo +bar", "REQUIRED_USE": "^^ ( foo bar )", "EAPI": "4" },
+
+			"sci-mathematics/octave-4.2.2": {
+				"EAPI": 6,
+				"RDEPEND": ">=x11-libs/qscintilla-2.9.3-r2:=[qt5(+)]",
+			},
+			"x11-libs/qscintilla-2.9.4": {
+				"EAPI": 6,
+				"IUSE": "+qt4 qt5",
+				"REQUIRED_USE": "^^ ( qt4 qt5 )",
+			},
+			"x11-libs/qscintilla-2.10": {
+				"EAPI": 6,
+				"KEYWORDS": "~x86",
+				"IUSE": "qt4 +qt5",
+			},
 			}
 
 		test_cases = (
@@ -249,6 +264,14 @@ class AutounmaskTestCase(TestCase):
 				ResolverPlaygroundTestCase(
 					["=app-portage/C-1"],
 					options={ "--autounmask": True },
+					use_changes=None,
+					success=False),
+
+				# Test bug 622462, where it inappropriately unmasked a newer
+				# version rather than report unsatisfied REQUIRED_USE.
+				ResolverPlaygroundTestCase(
+					["sci-mathematics/octave"],
+					options={"--autounmask": True},
 					use_changes=None,
 					success=False),
 


### PR DESCRIPTION
Fix autounmask to generate USE changes that violate REQUIRED_USE, in
order to prevent it from trying to create inappropriate keywords or
package.unmask. This solves the problem reported in bug 622462, where
it inappropriately unmasked a newer version of qscintilla. With this
fix, it will generate USE changes that violate REQUIRED_USE, and then
report the issue as follows:
```
emerge: there are no ebuilds built with USE flags to satisfy ">=x11-libs/qscintilla-2.9.3-r2:=[qt5(+)]".
!!! One of the following packages is required to complete your request:
- x11-libs/qscintilla-2.9.4::test_repo (Change USE: +qt5, this change violates use flag constraints defined by x11-libs/qscintilla-2.9.4: 'exactly-one-of ( qt4 qt5 )')
```
Note that it may be possible for autounmask to try harder to solve
REQUIRED_USE in cases like this, but that it beyond the scope of this
bug fix. The only goal of this patch is to correctly handle the case
where satisfaction of REQUIRED_USE has failed.

Bug: https://bugs.gentoo.org/622462