### PR TITLE
emerge: add --changed-slot [ y | n ] option (bug 631358)

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -471,6 +471,13 @@ changed since the installed instance was built. Behavior with respect to
 changed build\-time dependencies is controlled by the
 \fB\-\-with\-bdeps\fR option.
 .TP
+.BR "\-\-changed\-slot [ y | n ]"
+Tells emerge to replace installed packages for which the corresponding
+ebuild SLOT metadata has changed since the packages were built. This
+option also implies the \fB\-\-selective\fR option. This may also result
+in rebuilds for any installed packages that have slot/sub\-slot :=
+operator dependencies that are sensitive to the relevant SLOT metadata.
+.TP
 .BR \-\-changed\-use ", " \-U
 Tells emerge to include installed packages where USE flags have
 changed since installation. This option also implies the

--- a/pym/_emerge/create_depgraph_params.py
+++ b/pym/_emerge/create_depgraph_params.py
@@ -30,6 +30,7 @@ def create_depgraph_params(myopts, myaction):
 	# with_test_deps: pull in test deps for packages matched by arguments
 	# changed_deps: rebuild installed packages with outdated deps
 	# changed_deps_report: report installed packages with outdated deps
+	# changed_slot: rebuild installed packages with outdated SLOT metadata
 	# binpkg_changed_deps: reject binary packages with outdated deps
 	myparams = {"recurse" : True}
 
@@ -64,12 +65,17 @@ def create_depgraph_params(myopts, myaction):
 	if rebuild_if_new_slot is not None:
 		myparams['rebuild_if_new_slot'] = rebuild_if_new_slot
 
+	changed_slot = myopts.get('--changed-slot') is True
+	if changed_slot:
+		myparams["changed_slot"] = True
+
 	if "--update" in myopts or \
 		"--newrepo" in myopts or \
 		"--newuse" in myopts or \
 		"--reinstall" in myopts or \
 		"--noreplace" in myopts or \
 		myopts.get("--changed-deps", "n") != "n" or \
+		changed_slot or \
 		myopts.get("--selective", "n") != "n":
 		myparams["selective"] = True
 

--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -2667,6 +2667,10 @@ class depgraph(object):
 
 		return changed
 
+	def _changed_slot(self, pkg):
+		ebuild = self._equiv_ebuild(pkg)
+		return ebuild is not None and (ebuild.slot, ebuild.sub_slot) != (pkg.slot, pkg.sub_slot)
+
 	def _create_graph(self, allow_unsatisfied=False):
 		dep_stack = self._dynamic_config._dep_stack
 		dep_disjunctive_stack = self._dynamic_config._dep_disjunctive_stack
@@ -6474,6 +6478,13 @@ class depgraph(object):
 						modified_use=self._pkg_use_enabled(pkg))):
 						if myeb and "--newrepo" in self._frozen_config.myopts and myeb.repo != pkg.repo:
 							break
+						elif self._dynamic_config.myparams.get("changed_slot") and self._changed_slot(pkg):
+							if installed:
+								break
+							else:
+								# Continue searching for a binary package
+								# with the desired SLOT metadata.
+								continue
 						elif reinstall_use or (not installed and respect_use):
 							iuses = pkg.iuse.all
 							old_use = self._pkg_use_enabled(pkg)

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -136,6 +136,7 @@ def insert_optional_args(args):
 		'--binpkg-changed-deps'  : y_or_n,
 		'--buildpkg'             : y_or_n,
 		'--changed-deps'         : y_or_n,
+		'--changed-slot'         : y_or_n,
 		'--changed-deps-report'  : y_or_n,
 		'--complete-graph'       : y_or_n,
 		'--deep'       : valid_integers,
@@ -413,6 +414,12 @@ def parse_opts(tmpcmdline, silent=False):
 		"--changed-deps-report": {
 			"help"    : ("report installed packages with "
 				"outdated dependencies"),
+			"choices" : true_y_or_n
+		},
+
+		"--changed-slot": {
+			"help"    : ("replace installed packages with "
+				"outdated SLOT metadata"),
 			"choices" : true_y_or_n
 		},
 
@@ -851,6 +858,12 @@ def parse_opts(tmpcmdline, silent=False):
 			myoptions.changed_deps_report = 'y'
 		else:
 			myoptions.changed_deps_report = 'n'
+
+	if myoptions.changed_slot is not None:
+		if myoptions.changed_slot in true_y:
+			myoptions.changed_slot = True
+		else:
+			myoptions.changed_slot = None
 
 	if myoptions.changed_use is not False:
 		myoptions.reinstall = "changed-use"

--- a/pym/portage/tests/resolver/test_slot_change_without_revbump.py
+++ b/pym/portage/tests/resolver/test_slot_change_without_revbump.py
@@ -57,6 +57,25 @@ class SlotChangeWithoutRevBumpTestCase(TestCase):
 				success = True,
 				mergelist = ['app-arch/libarchive-3.1.1', "kde-base/ark-4.10.0"]),
 
+			ResolverPlaygroundTestCase(
+				["app-arch/libarchive"],
+				options = {"--noreplace": True, "--usepkg": True},
+				success = True,
+				mergelist = []),
+
+			ResolverPlaygroundTestCase(
+				["app-arch/libarchive"],
+				options = {"--usepkg": True},
+				success = True,
+				mergelist = ["[binary]app-arch/libarchive-3.1.1"]),
+
+			# Test --changed-slot
+			ResolverPlaygroundTestCase(
+				["app-arch/libarchive"],
+				options = {"--changed-slot": True, "--usepkg": True},
+				success = True,
+				mergelist = ["app-arch/libarchive-3.1.1", "kde-base/ark-4.10.0"]),
+
 		)
 
 		playground = ResolverPlayground(ebuilds=ebuilds, binpkgs=binpkgs,


### PR DESCRIPTION
This is similar to --changed-deps, but for SLOT metadata.

Bug: https://bugs.gentoo.org/631358