### PR TITLE
repoman: add --experimental-repository-modules=<y|n> option

### DIFF
--- a/repoman/cnf/repository/linechecks.yaml
+++ b/repoman/cnf/repository/linechecks.yaml
@@ -1,0 +1,252 @@
+---
+# linecheck.yaml
+
+# configuration file for the LineCheck plugins run via the multicheck
+# scan module
+# no random drive-by commits please
+# Please obtain authorization from the portage team
+#
+# Overlay maintainers override/add/negate checks at your discression
+# but support for third party module will be limited to the plugin API
+#
+
+# Repoman API version (do not edit)
+version: 1
+# minimum
+repoman_version: 2.3.3
+
+eclass_export_functions:
+    - ant-tasks
+    - apache-2
+    - apache-module
+    - aspell-dict
+    - autotools-utils
+    - base
+    - bsdmk
+    - cannadic
+    - clutter
+    - cmake-utils
+    - db
+    - distutils
+    - elisp
+    - embassy
+    - emboss
+    - emul-linux-x86
+    - enlightenment
+    - font-ebdftopcf
+    - font
+    - fox
+    - freebsd
+    - freedict
+    - games
+    - games-ggz
+    - games-mods
+    - gdesklets
+    - gems
+    - gkrellm-plugin
+    - gnatbuild
+    - gnat
+    - gnome2
+    - gnome-python-common
+    - gnustep-base
+    - go-mono
+    - gpe
+    - gst-plugins-bad
+    - gst-plugins-base
+    - gst-plugins-good
+    - gst-plugins-ugly
+    - gtk-sharp-module
+    - haskell-cabal
+    - horde
+    - java-ant-2
+    - java-pkg-2
+    - java-pkg-simple
+    - java-virtuals-2
+    - kde4-base
+    - kde4-meta
+    - kernel-2
+    - latex-package
+    - linux-mod
+    - mozlinguas
+    - myspell
+    - myspell-r2
+    - mysql
+    - mysql-v2
+    - mythtv-plugins
+    - oasis
+    - obs-service
+    - office-ext
+    - perl-app
+    - perl-module
+    - php-ext-base-r1
+    - php-ext-pecl-r2
+    - php-ext-source-r2
+    - php-lib-r1
+    - php-pear-lib-r1
+    - php-pear-r1
+    - python-distutils-ng
+    - python
+    - qt4-build
+    - qt4-r2
+    - rox-0install
+    - rox
+    - ruby
+    - ruby-ng
+    - scsh
+    - selinux-policy-2
+    - sgml-catalog
+    - stardict
+    - sword-module
+    - tetex-3
+    - tetex
+    - texlive-module
+    - toolchain-binutils
+    - toolchain
+    - twisted
+    - vdr-plugin-2
+    - vdr-plugin
+    - vim
+    - vim-plugin
+    - vim-spell
+    - virtuoso
+    - vmware
+    - vmware-mod
+    - waf-utils
+    - webapp
+    - xemacs-elisp
+    - xemacs-packages
+    - xfconf
+    - x-modular
+    - xorg-2
+    - zproduct
+
+eclass_info_experimental_inherit:
+    autotools:
+        funcs:
+            - eaclocal
+            - eautoconf
+            - eautoheader
+            - eautomake
+            - eautoreconf
+            - _elibtoolize
+            - eautopoint
+        comprehensive: true
+        # Exempt eclasses:
+        # git - An EGIT_BOOTSTRAP variable may be used to call one of
+        #       the autotools functions.
+        # subversion - An ESVN_BOOTSTRAP variable may be used to call one of
+        #       the autotools functions.
+        exempt_eclasses:
+            - git
+            - git-2
+            - subversion
+            - autotools-utils
+    eutils:
+        funcs:
+            - estack_push
+            - estack_pop
+            - eshopts_push
+            - eshopts_pop
+            - eumask_push
+            - eumask_pop
+            - epatch
+            - epatch_user
+            - emktemp
+            - edos2unix
+            - in_iuse
+            - use_if_iuse
+            - usex
+        comprehensive: false
+    flag-o-matic:
+        funcs:
+            - 'filter-(ld)?flags'
+            - 'strip-flags'
+            - 'strip-unsupported-flags'
+            - 'append-((ld|c(pp|xx)?))?flags'
+            - 'append-libs'
+        comprehensive: false
+    libtool:
+        funcs:
+            - elibtoolize
+        comprehensive: true
+        exempt_eclasses:
+            - autotools
+    multilib:
+        funcs:
+            - get_libdir
+        # These are "eclasses are the whole ebuild" type thing.
+        exempt_eclasses:
+            - autotools
+            - libtool
+            - multilib-minimal
+        comprehensive: false
+    multiprocessing:
+        funcs:
+            - makeopts_jobs
+        comprehensive: false
+    prefix:
+        funcs:
+            - eprefixify
+        comprehensive: true
+    toolchain-funcs:
+        funcs:
+            - gen_usr_ldscript
+        comprehensive: false
+    user:
+        funcs:
+            - enewuser
+            - enewgroup
+            - egetent
+            - egethome
+            - egetshell
+            - esethome
+        comprehensive: true
+
+# non experimental_inherit
+eclass_info:
+    autotools:
+        funcs:
+            - eaclocal
+            - eautoconf
+            - eautoheader
+            - eautomake
+            - eautoreconf
+            - _elibtoolize
+            - eautopoint
+        comprehensive: true
+        ignore_missing: true
+        # Exempt eclasses:
+        # git - An EGIT_BOOTSTRAP variable may be used to call one of
+        #       the autotools functions.
+        # subversion - An ESVN_BOOTSTRAP variable may be used to call one of
+        #       the autotools functions.
+        exempt_eclasses:
+            - git
+            - git-2
+            - subversion
+            - autotools-utils
+    prefix:
+        funcs:
+            - eprefixify
+        comprehensive: true
+
+usex_supported_eapis:
+    - "0"
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "4-python"
+    - "4-slot-abi"
+
+in_iuse_supported_eapis:
+    - "0"
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "4-python"
+    - "4-slot-abi"
+    - "5"
+    - "5-hdepend"
+    - "5-progress"

--- a/repoman/cnf/repository/qa_data.yaml
+++ b/repoman/cnf/repository/qa_data.yaml
@@ -1,0 +1,160 @@
+---
+# This yaml syntax file holds various configuration data for
+# the Quality-Assurance checks performed.
+
+# no random drive-by commits please
+# Please obtain authorization from the portage team
+#
+# Overlay maintainers override/add/negate checks at your discression
+# but support for third party module will be limited to the plugin API
+#
+
+# Repoman API version (do not edit)
+version: 1
+# minimum
+repoman_version: 2.3.3
+
+
+allowed_filename_chars: "a-zA-Z0-9._-+:"
+max_description_length: 80
+
+# missingvars check: Mandatory (non-defaulted) ebuild variables
+# list
+missingvars:
+    - KEYWORDS
+    - LICENSE
+    - DESCRIPTION
+    - HOMEPAGE
+
+# file.executable check, non executable files
+# list
+no_exec_files:
+    - Manifest
+    - ChangeLog
+    - metadata.xml
+
+# qawarnings: Non-fatal warnings,
+#             all values in here MUST have a corresponding qahelp entry
+# list
+qawarnings:
+    - changelog.missing
+    - changelog.notadded
+    - dependency.unknown
+    - dependency.badmasked
+    - dependency.badindev
+    - dependency.badmaskedindev
+    - dependency.badtilde
+    - dependency.missingslot
+    - dependency.perlcore
+    - DESCRIPTION.toolong
+    - digest.assumed
+    - digest.unused
+    - EAPI.deprecated
+    - ebuild.notadded
+    - ebuild.nesteddie
+    - ebuild.absdosym
+    - ebuild.minorsyn
+    - ebuild.badheader
+    - ebuild.patches
+    - file.empty
+    - file.size
+    - HOMEPAGE.virtual
+    - inherit.unused
+    - inherit.deprecated
+    - IUSE.rubydeprecated
+    - java.eclassesnotused
+    - KEYWORDS.dropped
+    - KEYWORDS.stupid
+    - KEYWORDS.missing
+    - LICENSE.deprecated
+    - LICENSE.virtual
+    - metadata.warning
+    - PDEPEND.suspect
+    - portage.internal
+    - RDEPEND.implicit
+    - RDEPEND.suspect
+    - repo.eapi-deprecated
+    - RESTRICT.invalid
+    - usage.obsolete
+    - upstream.workaround
+    - uri.https
+    - virtual.suspect
+    - wxwidgets.eclassnotused
+
+# ruby_deprecated: Deprecated ruby targets
+# list
+ruby_deprecated:
+    - ruby_targets_ruby18
+    - ruby_targets_ruby19
+    - ruby_targets_ruby20
+
+# suspect_rdepend: Common build only Dependencies
+#                  not usually run time dependencies
+# list
+suspect_rdepend:
+  - app-arch/cabextract
+  - app-arch/rpm2targz
+  - app-doc/doxygen
+  - dev-lang/nasm
+  - dev-lang/swig
+  - dev-lang/yasm
+  - dev-perl/extutils-pkgconfig
+  - dev-qt/linguist-tools
+  - dev-util/byacc
+  - dev-util/cmake
+  - dev-util/ftjam
+  - dev-util/gperf
+  - dev-util/gtk-doc
+  - dev-util/gtk-doc-am
+  - dev-util/intltool
+  - dev-util/jam
+  - dev-util/pkg-config-lite
+  - dev-util/pkgconf
+  - dev-util/pkgconfig
+  - dev-util/pkgconfig-openbsd
+  - dev-util/scons
+  - dev-util/unifdef
+  - dev-util/yacc
+  - media-gfx/ebdftopcf
+  - sys-apps/help2man
+  - sys-devel/autoconf
+  - sys-devel/automake
+  - sys-devel/bin86
+  - sys-devel/bison
+  - sys-devel/dev86
+  - sys-devel/flex
+  - sys-devel/m4
+  - sys-devel/pmake
+  - virtual/linux-sources
+  - virtual/linuxtv-dvb-headers
+  - virtual/os-headers
+  - virtual/pkgconfig
+  - x11-misc/bdftopcf
+  - x11-misc/imake
+
+# suspect_virtual: Dependencies that should usually be made to the virtual
+#                  Not to the final target library
+# dictionary
+suspect_virtual:
+  dev-libs/libusb: virtual/libusb
+  dev-libs/libusb-compat: virtual/libusb
+  dev-libs/libusbx: virtual/libusb
+  dev-util/pkg-config-lite: virtual/pkgconfig
+  dev-util/pkgconf: virtual/pkgconfig
+  dev-util/pkgconfig: virtual/pkgconfig
+  dev-util/pkgconfig-openbsd: virtual/pkgconfig
+
+# valid_restrict: ???
+# list
+valid_restrict:
+    - binchecks
+    - bindist
+    - fetch
+    - installsources
+    - mirror
+    - preserve-libs
+    - primaryuri
+    - splitdebug
+    - strip
+    - test
+    - userpriv

--- a/repoman/cnf/repository/repository.yaml
+++ b/repoman/cnf/repository/repository.yaml
@@ -1,0 +1,76 @@
+---
+# repository-modules.yaml
+#
+# This is the repository configuration file for repoman modules
+#
+# no random drive-by commits please
+# Please obtain authorization from the portage team
+#
+# Overlay maintainers override/add/negate checks at your discression
+# but support for third party module will be limited to the plugin API
+#
+
+# Repoman API version (do not edit)
+version: 1
+# minimum
+repoman_version: 2.3.3
+
+# NOTE: for non-gentoo repos, any custom modules added will need their
+# module names to the modules list in order for them to run.
+
+# These are the non-mandatory modules that can be disabled/enabled.
+# use -foo notation to disable, just like use flags
+# Add custom modules to enable them too
+scan_modules:
+    description
+    eapi
+    ebuild_metadata
+    fetches
+    files
+    keywords
+    live
+    manifests
+    multicheck
+    pkgmetadata
+    profile
+    restrict
+    ruby
+
+linechecks_modules:
+    assignment
+    eapi3assignment
+    implicitdepend
+    hasq
+    useq
+    preservelib
+    bindnow
+    inherit
+    dosym
+    definition
+    srcprepare
+    eapi3deprecated
+    pkgpretend
+    eapi4incompatible
+    eapi4gonevars
+    paralleldisabled
+    autodefault
+    gentooheader
+    nooffset
+    nesteddie
+    patches
+    emakeparallel
+    srccompileeconf
+    srcunpackpatches
+    portageinternal
+    portageinternalvariableassignment
+    quote
+    quoteda
+    httpsuri
+    builtwith
+    uselesscds
+    uselessdodoc
+    whitespace
+    blankline
+    addpredict
+    noasneeded
+

--- a/repoman/man/repoman.1
+++ b/repoman/man/repoman.1
@@ -100,6 +100,10 @@ can be enabled by default for a particular repository by setting
 Enable experimental inherit.missing checks which may misbehave when the
 internal eclass database becomes outdated.
 .TP
+\fB\-\-experimental\-repository\-modules=<y|n>\fR
+Enable experimental repository modules:
+\fLhttps://wiki.gentoo.org/wiki/Project:Portage/Repoman-Module-specs\fR
+.TP
 \fB\-\-if\-modified=<y|n>\fR
 Only check packages that have uncommitted modifications
 .TP

--- a/repoman/pym/repoman/argparser.py
+++ b/repoman/pym/repoman/argparser.py
@@ -106,6 +106,11 @@ def parse_args(argv, repoman_default_opts):
 			' when the internal eclass database becomes outdated'))
 
 	parser.add_argument(
+		'--experimental-repository-modules', choices=('y', 'n'), metavar="<y|n>",
+		default='n',
+		help='Enable experimental repository modules')
+
+	parser.add_argument(
 		'-f', '--force', dest='force', action='store_true',
 		default=False,
 		help='Commit with QA violations')

--- a/repoman/pym/repoman/modules/scan/module.py
+++ b/repoman/pym/repoman/modules/scan/module.py
@@ -8,8 +8,10 @@ import logging
 import os
 import yaml
 
+import portage
 from portage.module import InvalidModuleName, Modules
 from portage.util import stack_lists
+from repoman import _not_installed
 from repoman.config import ConfigError
 
 MODULES_PATH = os.path.dirname(__file__)
@@ -21,12 +23,20 @@ class ModuleConfig(object):
 	'''Holds the scan modules configuration information and
 	creates the ordered list of modulles to run'''
 
-	def __init__(self, configpaths, valid_versions=None):
+	def __init__(self, configpaths, valid_versions=None, repository_modules=False):
 		'''Module init
 
 		@param configpaths: ordered list of filepaths to load
 		'''
-		self.configpaths = [os.path.join(path, 'repository.yaml') for path in configpaths]
+		if repository_modules:
+			self.configpaths = [os.path.join(path, 'repository.yaml') for path in configpaths]
+		elif _not_installed:
+			self.configpaths = [os.path.realpath(os.path.join(os.path.dirname(
+				os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+				os.path.dirname(__file__)))))), 'repoman/cnf/repository/repository.yaml'))]
+		else:
+			self.configpaths = [os.path.join(portage.const.EPREFIX or '/',
+				'usr/share/repoman/repository/repository.yaml')]
 		logging.debug("ModuleConfig; configpaths: %s", self.configpaths)
 
 		self.controller = Modules(path=MODULES_PATH, namepath="repoman.modules.scan")

--- a/repoman/pym/repoman/qa_data.py
+++ b/repoman/pym/repoman/qa_data.py
@@ -37,6 +37,7 @@ class QAData(object):
 						 repoman_masters layout.conf variable
 		'''
 		# add our base qahelp
+		repository_modules = options.experimental_repository_modules == 'y'
 		if _not_installed:
 			cnfdir = os.path.realpath(os.path.join(os.path.dirname(
 				os.path.dirname(os.path.dirname(__file__))), 'cnf/qa_data'))
@@ -44,7 +45,15 @@ class QAData(object):
 			cnfdir = os.path.join(portage.const.EPREFIX or '/', 'usr/share/repoman/qa_data')
 		repomanpaths = [os.path.join(cnfdir, _file_) for _file_ in os.listdir(cnfdir)]
 		logging.debug("QAData: cnfdir: %s, repomanpaths: %s", cnfdir, repomanpaths)
-		repopaths = [os.path.join(path,'qa_data.yaml') for path in repopaths]
+		if repository_modules:
+			repopaths = [os.path.join(path,'qa_data.yaml') for path in repopaths]
+		elif _not_installed:
+			repopaths = [os.path.realpath(os.path.join(os.path.dirname(
+				os.path.dirname(os.path.dirname(__file__))),
+				'cnf/repository/qa_data.yaml'))]
+		else:
+			repopaths = [os.path.join(portage.const.EPREFIX or '/',
+				'usr/share/repoman/repository/qa_data.yaml')]
 		infopaths = repomanpaths + repopaths
 
 		qadata = load_config(infopaths, None, valid_versions)

--- a/repoman/pym/repoman/scanner.py
+++ b/repoman/pym/repoman/scanner.py
@@ -117,7 +117,8 @@ class Scanner(object):
 		# Initialize the ModuleConfig class here
 		# TODO Add layout.conf masters repository.yml config to the list to load/stack
 		self.moduleconfig = ModuleConfig(self.repo_settings.masters_list,
-										self.repo_settings.repoman_settings.valid_versions)
+										self.repo_settings.repoman_settings.valid_versions,
+										repository_modules=self.options.experimental_repository_modules == 'y')
 
 		checks = {}
 		# The --echangelog option causes automatic ChangeLog generation,

--- a/repoman/setup.py
+++ b/repoman/setup.py
@@ -481,6 +481,10 @@ setup(
 		['$docdir', ['NEWS', 'RELEASE-NOTES']],
 		['share/repoman/qa_data', ['cnf/qa_data/qa_data.yaml']],
 		['share/repoman/linechecks', ['cnf/linechecks/linechecks.yaml']],
+		['share/repoman/repository', [
+			'cnf/repository/linechecks.yaml',
+			'cnf/repository/qa_data.yaml',
+			'cnf/repository/repository.yaml']],
 	],
 
 	cmdclass = {


### PR DESCRIPTION
This disables the new repository modules feature by default,
and it can be enabled in REPOMAN_DEFAULT_OPTS if desired.