### PR TITLE
FileNotFoundError is not defined in python2.7

### DIFF
--- a/repoman/pym/repoman/config.py
+++ b/repoman/pym/repoman/config.py
@@ -8,6 +8,11 @@ import stat
 
 import yaml
 
+try:
+	FileNotFoundError
+except NameError:
+	FileNotFoundError = IOError
+
 
 class ConfigError(Exception):
 	"""Raised when a config file fails to load"""


### PR DESCRIPTION
As reported by aballier

```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python2.7/repoman", line 44, in <module>
    repoman_main(sys.argv[1:])
  File "/usr/lib64/python2.7/site-packages/repoman/main.py", line 122, in repoman_main
    scanner.scan_pkgs(can_force)
  File "/usr/lib64/python2.7/site-packages/repoman/scanner.py", line 357, in scan_pkgs
    self._scan_ebuilds(ebuildlist, dynamic_data)
  File "/usr/lib64/python2.7/site-packages/repoman/scanner.py", line 375, in _scan_ebuilds
    self.modules[mod_class.__name__] = mod_class(**self.set_kwargs(mod))
  File "/usr/lib64/python2.7/site-packages/repoman/modules/scan/ebuild/multicheck.py", line 27, in __init__
    kwargs.get('linechecks')
  File "/usr/lib64/python2.7/site-packages/repoman/modules/linechecks/controller.py", line 31, in __init__
    self.config = LineChecksConfig(repo_settings)
  File "/usr/lib64/python2.7/site-packages/repoman/modules/linechecks/config.py", line 62, in __init__
    self.load_checks_info()
  File "/usr/lib64/python2.7/site-packages/repoman/modules/linechecks/config.py", line 87, in load_checks_info
    configs = load_config(self.infopaths, 'yaml', self.repo_settings.repoman_settings.valid_versions)
  File "/usr/lib64/python2.7/site-packages/repoman/config.py", line 119, in load_config
    for filename in iter_files(conf_dirs):
  File "/usr/lib64/python2.7/site-packages/repoman/config.py", line 97, in iter_files
    except FileNotFoundError:
NameError: global name 'FileNotFoundError' is not defined
```