### PR TITLE
rsync: add key refresh retry (bug 649276)

### DIFF
--- a/cnf/repos.conf
+++ b/cnf/repos.conf
@@ -9,6 +9,11 @@ auto-sync = yes
 sync-rsync-verify-metamanifest = yes
 sync-rsync-verify-max-age = 24
 sync-openpgp-key-path = /var/lib/gentoo/gkeys/keyrings/gentoo/release/pubring.gpg
+sync-openpgp-key-refresh-retry-count = 40
+sync-openpgp-key-refresh-retry-overall-timeout = 1200
+sync-openpgp-key-refresh-retry-delay-exp-base = 2
+sync-openpgp-key-refresh-retry-delay-max = 60
+sync-openpgp-key-refresh-retry-delay-mult = 4
 
 # for daily squashfs snapshots
 #sync-type = squashdelta

--- a/man/portage.5
+++ b/man/portage.5
@@ -1,4 +1,4 @@
-.TH "PORTAGE" "31" "May 2017" "Portage VERSION" "Portage"
+.TH "PORTAGE" "31" "Apr 2018" "Portage VERSION" "Portage"
 .SH NAME
 portage \- the heart of Gentoo
 .SH "DESCRIPTION"
@@ -1080,6 +1080,25 @@ Path to the OpenPGP key(ring) used to verify received repository. Used
 only for protocols supporting cryptographic verification, provided
 that the respective verification option is enabled. If unset, the user's
 keyring is used.
+.TP
+.B sync\-openpgp\-key\-refresh\-retry\-count = 40
+Maximum number of times to retry key refresh if it fails. Between each
+key refresh attempt, there is an exponential delay with a constant
+multiplier and a uniform random multiplier between 0 and 1.
+.TP
+.B sync\-openpgp\-key\-refresh\-retry\-delay\-exp\-base = 2
+The base of the exponential expression. The exponent is the number of
+previous refresh attempts.
+.TP
+.B sync\-openpgp\-key\-refresh\-retry\-delay\-max = 60
+Maximum delay between each retry attempt, in units of seconds. This
+places a limit on the length of the exponential delay.
+.TP
+.B sync\-openpgp\-key\-refresh\-retry\-delay\-mult = 4
+Multiplier for the exponential delay.
+.TP
+.B sync\-openpgp\-key\-refresh\-retry\-overall\-timeout = 1200
+Combined time limit for all refresh attempts, in units of seconds.
 .TP
 .B sync-rsync-vcs-ignore = true|false
 Ignore vcs directories that may be present in the repository. It is the

--- a/pym/portage/repository/config.py
+++ b/pym/portage/repository/config.py
@@ -87,6 +87,11 @@ class RepoConfig(object):
 		'update_changelog', '_eapis_banned', '_eapis_deprecated',
 		'_masters_orig', 'module_specific_options', 'manifest_required_hashes',
 		'sync_openpgp_key_path',
+		'sync_openpgp_key_refresh_retry_count',
+		'sync_openpgp_key_refresh_retry_delay_max',
+		'sync_openpgp_key_refresh_retry_delay_exp_base',
+		'sync_openpgp_key_refresh_retry_delay_mult',
+		'sync_openpgp_key_refresh_retry_overall_timeout',
 		)
 
 	def __init__(self, name, repo_opts, local_config=True):
@@ -185,6 +190,13 @@ class RepoConfig(object):
 
 		self.sync_openpgp_key_path = repo_opts.get(
 			'sync-openpgp-key-path', None)
+
+		for k in ('sync_openpgp_key_refresh_retry_count',
+			'sync_openpgp_key_refresh_retry_delay_max',
+			'sync_openpgp_key_refresh_retry_delay_exp_base',
+			'sync_openpgp_key_refresh_retry_delay_mult',
+			'sync_openpgp_key_refresh_retry_overall_timeout'):
+			setattr(self, k, repo_opts.get(k.replace('_', '-'), None))
 
 		self.module_specific_options = {}
 
@@ -523,6 +535,11 @@ class RepoConfigLoader(object):
 							'force', 'masters', 'priority', 'strict_misc_digests',
 							'sync_depth', 'sync_hooks_only_on_change',
 							'sync_openpgp_key_path',
+							'sync_openpgp_key_refresh_retry_count',
+							'sync_openpgp_key_refresh_retry_delay_max',
+							'sync_openpgp_key_refresh_retry_delay_exp_base',
+							'sync_openpgp_key_refresh_retry_delay_mult',
+							'sync_openpgp_key_refresh_retry_overall_timeout',
 							'sync_type', 'sync_umask', 'sync_uri', 'sync_user',
 							'module_specific_options'):
 							v = getattr(repos_conf_opts, k, None)
@@ -946,6 +963,11 @@ class RepoConfigLoader(object):
 		bool_keys = ("strict_misc_digests",)
 		str_or_int_keys = ("auto_sync", "clone_depth", "format", "location",
 			"main_repo", "priority", "sync_depth", "sync_openpgp_key_path",
+			"sync_openpgp_key_refresh_retry_count",
+			"sync_openpgp_key_refresh_retry_delay_max",
+			"sync_openpgp_key_refresh_retry_delay_exp_base",
+			"sync_openpgp_key_refresh_retry_delay_mult",
+			"sync_openpgp_key_refresh_retry_overall_timeout",
 			"sync_type", "sync_umask", "sync_uri", 'sync_user')
 		str_tuple_keys = ("aliases", "eclass_overrides", "force")
 		repo_config_tuple_keys = ("masters",)

--- a/pym/portage/tests/util/futures/test_retry.py
+++ b/pym/portage/tests/util/futures/test_retry.py
@@ -1,0 +1,147 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import functools
+
+try:
+	import threading
+except ImportError:
+	import dummy_threading as threading
+
+from portage.tests import TestCase
+from portage.util._eventloop.global_event_loop import global_event_loop
+from portage.util.backoff import RandomExponentialBackoff
+from portage.util.futures.futures import TimeoutError
+from portage.util.futures.retry import retry
+from portage.util.futures.wait import wait
+from portage.util.monotonic import monotonic
+
+
+class SucceedLaterException(Exception):
+	pass
+
+
+class SucceedLater(object):
+	"""
+	A callable object that succeeds some duration of time has passed.
+	"""
+	def __init__(self, duration):
+		self._succeed_time = monotonic() + duration
+
+	def __call__(self):
+		remaining = self._succeed_time - monotonic()
+		if remaining > 0:
+			raise SucceedLaterException('time until success: {} seconds'.format(remaining))
+		return 'success'
+
+
+class SucceedNeverException(Exception):
+	pass
+
+
+class SucceedNever(object):
+	"""
+	A callable object that never succeeds.
+	"""
+	def __call__(self):
+		raise SucceedNeverException('expected failure')
+
+
+class HangForever(object):
+	"""
+	A callable object that sleeps forever.
+	"""
+	def __call__(self):
+		threading.Event().wait()
+
+
+class RetryTestCase(TestCase):
+	def testSucceedLater(self):
+		loop = global_event_loop()
+		func = SucceedLater(1)
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(try_max=9999,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		result = loop.run_until_complete(decorated_func())
+		self.assertEqual(result, 'success')
+
+	def testSucceedNever(self):
+		loop = global_event_loop()
+		func = SucceedNever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(try_max=4, try_timeout=None,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		done, pending = loop.run_until_complete(wait([decorated_func()]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(isinstance(done[0].exception().__cause__, SucceedNeverException))
+
+	def testSucceedNeverReraise(self):
+		loop = global_event_loop()
+		func = SucceedNever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(reraise=True, try_max=4, try_timeout=None,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		done, pending = loop.run_until_complete(wait([decorated_func()]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(isinstance(done[0].exception(), SucceedNeverException))
+
+	def testHangForever(self):
+		loop = global_event_loop()
+		func = HangForever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(try_max=2, try_timeout=0.1,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		done, pending = loop.run_until_complete(wait([decorated_func()]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(isinstance(done[0].exception().__cause__, TimeoutError))
+
+	def testHangForeverReraise(self):
+		loop = global_event_loop()
+		func = HangForever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(reraise=True, try_max=2, try_timeout=0.1,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		done, pending = loop.run_until_complete(wait([decorated_func()]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(isinstance(done[0].exception(), TimeoutError))
+
+	def testCancelRetry(self):
+		loop = global_event_loop()
+		func = SucceedNever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(try_timeout=0.1,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		future = decorated_func()
+		loop.call_later(0.3, future.cancel)
+		done, pending = loop.run_until_complete(wait([future]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(done[0].cancelled())
+
+	def testOverallTimeoutWithException(self):
+		loop = global_event_loop()
+		func = SucceedNever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(try_timeout=0.1, overall_timeout=0.3,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		done, pending = loop.run_until_complete(wait([decorated_func()]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(isinstance(done[0].exception().__cause__, SucceedNeverException))
+
+	def testOverallTimeoutWithTimeoutError(self):
+		loop = global_event_loop()
+		# results in TimeoutError because it hangs forever
+		func = HangForever()
+		func_coroutine = functools.partial(loop.run_in_executor, None, func)
+		decorator = retry(try_timeout=0.1, overall_timeout=0.3,
+			delay_func=RandomExponentialBackoff(multiplier=0.1, base=2))
+		decorated_func = decorator(func_coroutine)
+		done, pending = loop.run_until_complete(wait([decorated_func()]))
+		self.assertEqual(len(done), 1)
+		self.assertTrue(isinstance(done[0].exception().__cause__, TimeoutError))

--- a/pym/portage/util/backoff.py
+++ b/pym/portage/util/backoff.py
@@ -1,0 +1,53 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+__all__ = (
+	'ExponentialBackoff',
+	'RandomExponentialBackoff',
+)
+
+import random
+import sys
+
+
+class ExponentialBackoff(object):
+	"""
+	An object that when called with number of previous tries, calculates
+	an exponential delay for the next try.
+	"""
+	def __init__(self, multiplier=1, base=2, limit=sys.maxsize):
+		"""
+		@param multiplier: constant multiplier
+		@type multiplier: int or float
+		@param base: maximum number of tries
+		@type base: int or float
+		@param limit: maximum number of seconds to delay
+		@type limit: int or float
+		"""
+		self._multiplier = multiplier
+		self._base = base
+		self._limit = limit
+
+	def __call__(self, tries):
+		"""
+		Given a number of previous tries, calculate the amount of time
+		to delay the next try.
+
+		@param tries: number of previous tries
+		@type tries: int
+		@return: amount of time to delay the next try
+		@rtype: int
+		"""
+		try:
+			return min(self._limit, self._multiplier * (self._base ** tries))
+		except OverflowError:
+			return self._limit
+
+
+class RandomExponentialBackoff(ExponentialBackoff):
+	"""
+	Equivalent to ExponentialBackoff, with an extra multiplier that uses
+	a random distribution between 0 and 1.
+	"""
+	def __call__(self, tries):
+		return random.random() * super(RandomExponentialBackoff, self).__call__(tries)

--- a/pym/portage/util/futures/executor/fork.py
+++ b/pym/portage/util/futures/executor/fork.py
@@ -1,0 +1,134 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+__all__ = (
+	'ForkExecutor',
+)
+
+import collections
+import functools
+import multiprocessing
+import os
+import sys
+import traceback
+
+from portage.util._async.AsyncFunction import AsyncFunction
+from portage.util._eventloop.global_event_loop import global_event_loop
+
+
+class ForkExecutor(object):
+	"""
+	An implementation of concurrent.futures.Executor that forks a
+	new process for each task, with support for cancellation of tasks.
+
+	This is entirely driven by an event loop.
+	"""
+	def __init__(self, max_workers=None, loop=None):
+		self._max_workers = max_workers or multiprocessing.cpu_count()
+		self._loop = loop or global_event_loop()
+		self._submit_queue = collections.deque()
+		self._running_tasks = {}
+		self._shutdown = False
+		self._shutdown_future = self._loop.create_future()
+
+	def submit(self, fn, *args, **kwargs):
+		"""Submits a callable to be executed with the given arguments.
+
+		Schedules the callable to be executed as fn(*args, **kwargs) and returns
+		a Future instance representing the execution of the callable.
+
+		Returns:
+			A Future representing the given call.
+		"""
+		future = self._loop.create_future()
+		proc = AsyncFunction(target=functools.partial(
+			self._guarded_fn_call, fn, args, kwargs))
+		self._submit_queue.append((future, proc))
+		self._schedule()
+		return future
+
+	def _schedule(self):
+		while (not self._shutdown and self._submit_queue and
+			len(self._running_tasks) < self._max_workers):
+			future, proc = self._submit_queue.popleft()
+			future.add_done_callback(functools.partial(self._cancel_cb, proc))
+			proc.addExitListener(functools.partial(self._proc_exit, future))
+			proc.scheduler = self._loop
+			proc.start()
+			self._running_tasks[id(proc)] = proc
+
+	def _cancel_cb(self, proc, future):
+		if future.cancelled():
+			# async, handle the rest in _proc_exit
+			proc.cancel()
+
+	@staticmethod
+	def _guarded_fn_call(fn, args, kwargs):
+		try:
+			result = fn(*args, **kwargs)
+			exception = None
+		except Exception as e:
+			result = None
+			exception = _ExceptionWithTraceback(e)
+
+		return result, exception
+
+	def _proc_exit(self, future, proc):
+		if not future.cancelled():
+			if proc.returncode == os.EX_OK:
+				result, exception = proc.result
+				if exception is not None:
+					future.set_exception(exception)
+				else:
+					future.set_result(result)
+			else:
+				# TODO: add special exception class for this, maybe
+				# distinguish between kill and crash
+				future.set_exception(
+					Exception('pid {} crashed or killed, exitcode {}'.\
+						format(proc.pid, proc.returncode)))
+
+		del self._running_tasks[id(proc)]
+		self._schedule()
+		if self._shutdown and not self._running_tasks:
+			self._shutdown_future.set_result(None)
+
+	def shutdown(self, wait=True):
+		self._shutdown = True
+		if wait:
+			self._loop.run_until_complete(self._shutdown_future)
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		self.shutdown(wait=True)
+		return False
+
+
+class _ExceptionWithTraceback:
+	def __init__(self, exc):
+		tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+		tb = ''.join(tb)
+		self.exc = exc
+		self.tb = '\n"""\n%s"""' % tb
+	def __reduce__(self):
+		return _rebuild_exc, (self.exc, self.tb)
+
+
+class _RemoteTraceback(Exception):
+	def __init__(self, tb):
+		self.tb = tb
+	def __str__(self):
+		return self.tb
+
+
+def _rebuild_exc(exc, tb):
+	exc.__cause__ = _RemoteTraceback(tb)
+	return exc
+
+
+if sys.version_info < (3,):
+	# Python 2 does not support exception chaining, so
+	# don't bother to preserve the traceback.
+	_ExceptionWithTraceback = lambda exc: exc

--- a/pym/portage/util/futures/futures.py
+++ b/pym/portage/util/futures/futures.py
@@ -11,6 +11,7 @@ __all__ = (
 	'CancelledError',
 	'Future',
 	'InvalidStateError',
+	'TimeoutError',
 )
 
 try:
@@ -18,6 +19,7 @@ try:
 		CancelledError,
 		Future,
 		InvalidStateError,
+		TimeoutError,
 	)
 except ImportError:
 
@@ -29,6 +31,10 @@ except ImportError:
 	class CancelledError(Error):
 		def __init__(self):
 			Error.__init__(self, "cancelled")
+
+	class TimeoutError(Error):
+		def __init__(self):
+			Error.__init__(self, "timed out")
 
 	class InvalidStateError(Error):
 		pass

--- a/pym/portage/util/futures/retry.py
+++ b/pym/portage/util/futures/retry.py
@@ -1,0 +1,183 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+__all__ = (
+	'RetryError',
+	'retry',
+)
+
+import functools
+
+from portage.exception import PortageException
+from portage.util._eventloop.global_event_loop import global_event_loop
+from portage.util.futures.futures import TimeoutError
+
+
+class RetryError(PortageException):
+	"""Raised when retry fails."""
+	def __init__(self):
+		PortageException.__init__(self, "retry error")
+
+
+def retry(try_max=None, try_timeout=None, overall_timeout=None,
+	delay_func=None, reraise=False, loop=None):
+	"""
+	Create and return a retry decorator. The decorator is intended to
+	operate only on a coroutine function.
+
+	@param try_max: maximum number of tries
+	@type try_max: int or None
+	@param try_timeout: number of seconds to wait for a try to succeed
+		before cancelling it, which is only effective if func returns
+		tasks that support cancellation
+	@type try_timeout: float or None
+	@param overall_timeout: number of seconds to wait for retires to
+		succeed before aborting, which is only effective if func returns
+		tasks that support cancellation
+	@type overall_timeout: float or None
+	@param delay_func: function that takes an int argument corresponding
+		to the number of previous tries and returns a number of seconds
+		to wait before the next try
+	@type delay_func: callable
+	@param reraise: Reraise the last exception, instead of RetryError
+	@type reraise: bool
+	@param loop: event loop
+	@type loop: EventLoop
+	@return: func decorated with retry support
+	@rtype: callable
+	"""
+	return functools.partial(_retry_wrapper, loop, try_max, try_timeout,
+		overall_timeout, delay_func, reraise)
+
+
+def _retry_wrapper(loop, try_max, try_timeout, overall_timeout, delay_func,
+	reraise, func):
+	"""
+	Create and return a decorated function.
+	"""
+	return functools.partial(_retry, loop, try_max, try_timeout,
+		overall_timeout, delay_func, reraise, func)
+
+
+def _retry(loop, try_max, try_timeout, overall_timeout, delay_func,
+	reraise, func, *args, **kwargs):
+	"""
+	Retry coroutine, used to implement retry decorator.
+
+	@return: func return value
+	@rtype: asyncio.Future (or compatible)
+	"""
+	loop = loop or global_event_loop()
+	future = loop.create_future()
+	_Retry(future, loop, try_max, try_timeout, overall_timeout, delay_func,
+		reraise, functools.partial(func, *args, **kwargs))
+	return future
+
+
+class _Retry(object):
+	def __init__(self, future, loop, try_max, try_timeout, overall_timeout,
+		delay_func, reraise, func):
+		self._future = future
+		self._loop = loop
+		self._try_max = try_max
+		self._try_timeout = try_timeout
+		self._delay_func = delay_func
+		self._reraise = reraise
+		self._func = func
+
+		self._try_timeout_handle = None
+		self._overall_timeout_handle = None
+		self._overall_timeout_expired = None
+		self._tries = 0
+		self._current_task = None
+		self._previous_result = None
+
+		future.add_done_callback(self._cancel_callback)
+		if overall_timeout is not None:
+			self._overall_timeout_handle = loop.call_later(
+				overall_timeout, self._overall_timeout_callback)
+		self._begin_try()
+
+	def _cancel_callback(self, future):
+		if future.cancelled() and self._current_task is not None:
+			self._current_task.cancel()
+
+	def _try_timeout_callback(self):
+		self._try_timeout_handle = None
+		self._current_task.cancel()
+
+	def _overall_timeout_callback(self):
+		self._overall_timeout_handle = None
+		self._overall_timeout_expired = True
+		self._current_task.cancel()
+		self._retry_error()
+
+	def _begin_try(self):
+		self._tries += 1
+		self._current_task = self._func()
+		self._current_task.add_done_callback(self._try_done)
+		if self._try_timeout is not None:
+			self._try_timeout_handle = self._loop.call_later(
+				self._try_timeout, self._try_timeout_callback)
+
+	def _try_done(self, future):
+		self._current_task = None
+
+		if self._try_timeout_handle is not None:
+			self._try_timeout_handle.cancel()
+			self._try_timeout_handle = None
+
+		if not future.cancelled():
+			# consume exception, so that the event loop
+			# exception handler does not report it
+			future.exception()
+
+		if self._overall_timeout_expired:
+			return
+
+		try:
+			if self._future.cancelled():
+				return
+
+			self._previous_result = future
+			if not (future.cancelled() or future.exception() is not None):
+				# success
+				self._future.set_result(future.result())
+				return
+		finally:
+			if self._future.done() and self._overall_timeout_handle is not None:
+				self._overall_timeout_handle.cancel()
+				self._overall_timeout_handle = None
+
+		if self._try_max is not None and self._tries >= self._try_max:
+			self._retry_error()
+			return
+
+		if self._delay_func is not None:
+			delay = self._delay_func(self._tries)
+			self._current_task = self._loop.call_later(delay, self._delay_done)
+			return
+
+		self._begin_try()
+
+	def _delay_done(self):
+		self._current_task = None
+
+		if self._future.cancelled() or self._overall_timeout_expired:
+			return
+
+		self._begin_try()
+
+	def _retry_error(self):
+		if self._previous_result is None or self._previous_result.cancelled():
+			cause = TimeoutError()
+		else:
+			cause = self._previous_result.exception()
+
+		if self._reraise:
+			e = cause
+		else:
+			e = RetryError()
+			e.__cause__ = cause
+
+		self._future.set_exception(e)


### PR DESCRIPTION
Since key refresh is prone to failure, retry using exponential
backoff with random jitter. This adds the following sync-openpgp-*
configuration settings:

sync-openpgp-key-refresh-retry-count = 40

  Maximum number of times to retry key refresh if it fails.  Between
  each  key  refresh attempt, there is an exponential delay with a
  constant multiplier and a uniform random multiplier between 0 and 1.

sync-openpgp-key-refresh-retry-delay-exp-base = 2

  The base of the exponential expression. The exponent is the number
  of previous refresh attempts.

sync-openpgp-key-refresh-retry-delay-max = 60

  Maximum  delay between each retry attempt, in units of seconds. This
  places a limit on the length of the exponential delay.

sync-openpgp-key-refresh-retry-delay-mult = 4

  Multiplier for the exponential delay.

sync-openpgp-key-refresh-retry-overall-timeout = 1200

  Combined time limit for all refresh attempts, in units of seconds.

Bug: https://bugs.gentoo.org/649276

Zac Medico (4):
  Add ForkExecutor (bug 649588)
  Add ExponentialBackoff and RandomExponentialBackoff
  Add retry decorator (API inspired by tenacity)
  rsync: add key refresh retry (bug 649276)

 cnf/repos.conf                                |   5 +
 man/portage.5                                 |  19 +++
 pym/portage/repository/config.py              |  22 ++++
 pym/portage/sync/modules/rsync/rsync.py       |  16 ++-
 pym/portage/sync/syncbase.py                  |  85 +++++++++++-
 pym/portage/tests/util/futures/test_retry.py  | 147 +++++++++++++++++++++
 pym/portage/util/_eventloop/EventLoop.py      |  45 ++++++-
 pym/portage/util/backoff.py                   |  48 +++++++
 pym/portage/util/futures/executor/__init__.py |   0
 pym/portage/util/futures/executor/fork.py     | 130 +++++++++++++++++++
 pym/portage/util/futures/futures.py           |   6 +
 pym/portage/util/futures/retry.py             | 178 ++++++++++++++++++++++++++
 12 files changed, 697 insertions(+), 4 deletions(-)
 create mode 100644 pym/portage/tests/util/futures/test_retry.py
 create mode 100644 pym/portage/util/backoff.py
 create mode 100644 pym/portage/util/futures/executor/__init__.py
 create mode 100644 pym/portage/util/futures/executor/fork.py
 create mode 100644 pym/portage/util/futures/retry.py