### PR TITLE
repoman: Obey to GLEP66

### DIFF
--- a/repoman/pym/repoman/actions.py
+++ b/repoman/pym/repoman/actions.py
@@ -628,8 +628,8 @@ the whole commit message to abort.
 			problems.append('summary line must start with a logical unit name, e.g. "cat/pkg:"')
 		if '\n' in summary.strip():
 			problems.append('commit message must start with a *single* line of summary, followed by empty line')
-		# accept 69 overall or unit+50, in case of very long package names
-		elif len(summary.strip()) > 69 and len(summary.split(':', 1)[-1]) > 50:
+		# accept 69 characters overall
+		elif len(summary.strip()) > 69:
 			problems.append('summary line is too long (max 69 characters)')
 
 		multiple_footers = False

--- a/repoman/pym/repoman/tests/commit/test_commitmsg.py
+++ b/repoman/pym/repoman/tests/commit/test_commitmsg.py
@@ -76,8 +76,9 @@ in a single line that should trigger an explicit error',
 				r'summary.*too long')
 
 	def test_summary_with_very_long_package_name(self):
-		self.assertGood('dev-foo/foo-bar-bar-baz-bar-bar-foo-bar-bar-\
-baz-foo-baz-baz-foo: We do not fail because pkgname was long')
+		self.assertBad('dev-foo/foo-bar-bar-baz-bar-bar-foo-bar-bar-\
+baz-foo-baz-baz-foo: We do fail because GLEP66 says 69 chars maximum',
+				r'summary.*too long')
 
 	def test_multiple_footers(self):
 		self.assertBad('''dev-foo/bar: Good summary


### PR DESCRIPTION
As of https://www.gentoo.org/glep/glep-0066.html
"The summary line must not exceed 69 characters, and must not be
wrapped."