### PR TITLE
Implement AbstractEventLoopPolicy.get_child_watcher() (bug 649588)

### DIFF
--- a/pym/portage/tests/util/futures/asyncio/test_child_watcher.py
+++ b/pym/portage/tests/util/futures/asyncio/test_child_watcher.py
@@ -1,0 +1,45 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+
+from portage.process import find_binary, spawn
+from portage.tests import TestCase
+from portage.util.futures import asyncio
+from portage.util.futures.unix_events import DefaultEventLoopPolicy
+
+
+class ChildWatcherTestCase(TestCase):
+	def testChildWatcher(self):
+		true_binary = find_binary("true")
+		self.assertNotEqual(true_binary, None)
+
+		initial_policy = asyncio.get_event_loop_policy()
+		if not isinstance(initial_policy, DefaultEventLoopPolicy):
+			asyncio.set_event_loop_policy(DefaultEventLoopPolicy())
+
+		try:
+			try:
+				asyncio.set_child_watcher(None)
+			except NotImplementedError:
+				pass
+			else:
+				self.assertTrue(False)
+
+			args_tuple = ('hello', 'world')
+
+			loop = asyncio.get_event_loop()
+			future = loop.create_future()
+
+			def callback(pid, returncode, *args):
+				future.set_result((pid, returncode, args))
+
+			with asyncio.get_child_watcher() as watcher:
+				pids = spawn([true_binary], returnpid=True)
+				watcher.add_child_handler(pids[0], callback, *args_tuple)
+
+				self.assertEqual(
+					loop.run_until_complete(future),
+					(pids[0], os.EX_OK, args_tuple))
+		finally:
+			asyncio.set_event_loop_policy(initial_policy)

--- a/pym/portage/util/futures/_asyncio.py
+++ b/pym/portage/util/futures/_asyncio.py
@@ -3,7 +3,9 @@
 
 __all__ = (
 	'ensure_future',
+	'get_child_watcher',
 	'get_event_loop',
+	'set_child_watcher',
 	'get_event_loop_policy',
 	'set_event_loop_policy',
 	'sleep',
@@ -60,6 +62,17 @@ def get_event_loop():
 	@return: the event loop for the current context
 	"""
 	return get_event_loop_policy().get_event_loop()
+
+
+def get_child_watcher():
+    """Equivalent to calling get_event_loop_policy().get_child_watcher()."""
+    return get_event_loop_policy().get_child_watcher()
+
+
+def set_child_watcher(watcher):
+    """Equivalent to calling
+    get_event_loop_policy().set_child_watcher(watcher)."""
+    return get_event_loop_policy().set_child_watcher(watcher)
 
 
 class Task(Future):


### PR DESCRIPTION
Use a _PortageChildWatcher class to wrap portage's internal event loop
and implement asyncio's AbstractChildWatcher interface.

Bug: https://bugs.gentoo.org/649588