### PR TITLE
Implement _PortageEventLoop.subprocess_exec (bug 649588)

### DIFF
--- a/pym/portage/tests/util/futures/asyncio/test_subprocess_exec.py
+++ b/pym/portage/tests/util/futures/asyncio/test_subprocess_exec.py
@@ -1,0 +1,163 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+
+from portage.process import find_binary
+from portage.tests import TestCase
+from portage.util.futures import asyncio
+from portage.util.futures.executor.fork import ForkExecutor
+from portage.util.futures.unix_events import DefaultEventLoopPolicy
+from _emerge.PipeReader import PipeReader
+
+
+def reader(input_file, loop=None):
+	"""
+	Asynchronously read a binary input file.
+
+	@param input_file: binary input file
+	@type input_file: file
+	@param loop: event loop
+	@type loop: EventLoop
+	@return: bytes
+	@rtype: asyncio.Future (or compatible)
+	"""
+	loop = loop or asyncio.get_event_loop()
+	loop = getattr(loop, '_asyncio_wrapper', loop)
+	future = loop.create_future()
+	_Reader(future, input_file, loop)
+	return future
+
+
+class _Reader(object):
+	def __init__(self, future, input_file, loop):
+		self._future = future
+		self._pipe_reader = PipeReader(
+			input_files={'input_file':input_file}, scheduler=loop._loop)
+
+		self._future.add_done_callback(self._cancel_callback)
+		self._pipe_reader.addExitListener(self._eof)
+		self._pipe_reader.start()
+
+	def _cancel_callback(self, future):
+		if future.cancelled():
+			self._cancel()
+
+	def _eof(self, pipe_reader):
+		self._pipe_reader = None
+		self._future.set_result(pipe_reader.getvalue())
+
+	def _cancel(self):
+		if self._pipe_reader is not None and self._pipe_reader.poll() is None:
+			self._pipe_reader.removeExitListener(self._eof)
+			self._pipe_reader.cancel()
+			self._pipe_reader = None
+
+
+class SubprocessExecTestCase(TestCase):
+	def _run_test(self, test):
+		initial_policy = asyncio.get_event_loop_policy()
+		if not isinstance(initial_policy, DefaultEventLoopPolicy):
+			asyncio.set_event_loop_policy(DefaultEventLoopPolicy())
+
+		try:
+			test(asyncio.get_event_loop())
+		finally:
+			asyncio.set_event_loop_policy(initial_policy)
+
+	def testEcho(self):
+		if not hasattr(asyncio, 'create_subprocess_exec'):
+			self.skipTest('create_subprocess_exec not implemented for python2')
+
+		args_tuple = (b'hello', b'world')
+		echo_binary = find_binary("echo")
+		self.assertNotEqual(echo_binary, None)
+		echo_binary = echo_binary.encode()
+
+		# Use os.pipe(), since this loop does not implement the
+		# ReadTransport necessary for subprocess.PIPE support.
+		stdout_pr, stdout_pw = os.pipe()
+		stdout_pr = os.fdopen(stdout_pr, 'rb', 0)
+		stdout_pw = os.fdopen(stdout_pw, 'wb', 0)
+		files = [stdout_pr, stdout_pw]
+
+		def test(loop):
+			output = None
+			try:
+				with open(os.devnull, 'rb', 0) as devnull:
+					proc = loop.run_until_complete(
+						asyncio.create_subprocess_exec(
+						echo_binary, *args_tuple,
+						stdin=devnull, stdout=stdout_pw, stderr=stdout_pw))
+
+				# This belongs exclusively to the subprocess now.
+				stdout_pw.close()
+
+				output = asyncio.ensure_future(
+					reader(stdout_pr, loop=loop), loop=loop)
+
+				self.assertEqual(
+					loop.run_until_complete(proc.wait()), os.EX_OK)
+				self.assertEqual(
+					tuple(loop.run_until_complete(output).split()), args_tuple)
+			finally:
+				if output is not None and not output.done():
+					output.cancel()
+				for f in files:
+					f.close()
+
+		self._run_test(test)
+
+	def testCat(self):
+		if not hasattr(asyncio, 'create_subprocess_exec'):
+			self.skipTest('create_subprocess_exec not implemented for python2')
+
+		stdin_data = b'hello world'
+		cat_binary = find_binary("cat")
+		self.assertNotEqual(cat_binary, None)
+		cat_binary = cat_binary.encode()
+
+		# Use os.pipe(), since this loop does not implement the
+		# ReadTransport necessary for subprocess.PIPE support.
+		stdout_pr, stdout_pw = os.pipe()
+		stdout_pr = os.fdopen(stdout_pr, 'rb', 0)
+		stdout_pw = os.fdopen(stdout_pw, 'wb', 0)
+
+		stdin_pr, stdin_pw = os.pipe()
+		stdin_pr = os.fdopen(stdin_pr, 'rb', 0)
+		stdin_pw = os.fdopen(stdin_pw, 'wb', 0)
+
+		files = [stdout_pr, stdout_pw, stdin_pr, stdin_pw]
+
+		def test(loop):
+			output = None
+			try:
+				proc = loop.run_until_complete(
+					asyncio.create_subprocess_exec(
+					cat_binary,
+					stdin=stdin_pr, stdout=stdout_pw, stderr=stdout_pw))
+
+				# These belong exclusively to the subprocess now.
+				stdout_pw.close()
+				stdin_pr.close()
+
+				output = asyncio.ensure_future(
+					reader(stdout_pr, loop=loop), loop=loop)
+
+				with ForkExecutor(loop=loop) as executor:
+					writer = asyncio.ensure_future(loop.run_in_executor(
+						executor, stdin_pw.write, stdin_data), loop=loop)
+
+					# This belongs exclusively to the writer now.
+					stdin_pw.close()
+					loop.run_until_complete(writer)
+
+				self.assertEqual(loop.run_until_complete(proc.wait()), os.EX_OK)
+				self.assertEqual(loop.run_until_complete(output), stdin_data)
+			finally:
+				if output is not None and not output.done():
+					output.cancel()
+				for f in files:
+					f.close()
+
+		self._run_test(test)


### PR DESCRIPTION
In python versions that support asyncio, this allows API consumers
to use the asyncio.create_subprocess_exec() function with portage's
internal event loop. Currently, subprocess.PIPE is not implemented
because that would require an implementation of asyncio's private
asyncio.unix_events._UnixReadPipeTransport class. However, it's
possible to use pipes created with os.pipe() for stdin, stdout,
and stderr, as demonstrated in the included unit tests.

Bug: https://bugs.gentoo.org/649588