### PR TITLE
rsync: default to sync-rsync-verify-jobs = 1 (bug 650696)

### DIFF
--- a/cnf/repos.conf
+++ b/cnf/repos.conf
@@ -6,6 +6,7 @@ location = /usr/portage
 sync-type = rsync
 sync-uri = rsync://rsync.gentoo.org/gentoo-portage
 auto-sync = yes
+sync-rsync-verify-jobs = 1
 sync-rsync-verify-metamanifest = yes
 sync-rsync-verify-max-age = 24
 sync-openpgp-key-path = /var/lib/gentoo/gkeys/keyrings/gentoo/release/pubring.gpg

--- a/man/portage.5
+++ b/man/portage.5
@@ -1105,9 +1105,11 @@ Ignore vcs directories that may be present in the repository. It is the
 user's responsibility to set sync-rsync-extra-opts to protect vcs
 directories if appropriate.
 .TP
-.B sync\-rsync\-verify\-jobs
-Number of parallel jobs to use when verifying nested Manifests. Defaults
-to the apparent number of processors.
+.B sync\-rsync\-verify\-jobs = 1
+Number of parallel jobs to use when verifying nested Manifests. When
+set to 0, this will use the apparent number of processors if parallel
+verification is supported by the installed version of app-portage/gemato.
+Defaults to 1.
 .TP
 .B sync\-rsync\-verify\-max\-age
 Warn if repository is older than the specified number of days. Disabled

--- a/pym/portage/sync/modules/rsync/rsync.py
+++ b/pym/portage/sync/modules/rsync/rsync.py
@@ -107,12 +107,17 @@ class RsyncSync(NewBase):
 		if self.verify_jobs is not None:
 			try:
 				self.verify_jobs = int(self.verify_jobs)
-				if self.verify_jobs <= 0:
+				if self.verify_jobs < 0:
 					raise ValueError(self.verify_jobs)
 			except ValueError:
 				writemsg_level("!!! sync-rsync-verify-jobs not a positive integer: %s\n" % (self.verify_jobs,),
 					level=logging.WARNING, noiselevel=-1)
 				self.verify_jobs = None
+			else:
+				if self.verify_jobs == 0:
+					# Use the apparent number of processors if gemato
+					# supports it.
+					self.verify_jobs = None
 		# Support overriding max age.
 		self.max_age = self.repo.module_specific_options.get(
 				'sync-rsync-verify-max-age', '')


### PR DESCRIPTION
Some users have reported that using all processors to verify
manifests results in overloading, therefore default to using
a single processor. On modern hardware, verification of the
gentoo repository completes in less than 20 seconds, so using
multiple processors is not really necessary. Also, gemato-13.0
disables parallel verification due to the unresolved deadlock
issue reported in bug 647964, so this brings the default
portage configuration into alignment with current gemato
behavior.

Bug: https://bugs.gentoo.org/650696
Bug: https://bugs.gentoo.org/647964