### PR TITLE
emerge --usepkgonly: propagate implicit IUSE and USE_EXPAND (bug 640318)

### DIFF
--- a/pym/_emerge/actions.py
+++ b/pym/_emerge/actions.py
@@ -78,6 +78,7 @@ from _emerge.depgraph import backtrack_depgraph, depgraph, resume_depgraph
 from _emerge.DepPrioritySatisfiedRange import DepPrioritySatisfiedRange
 from _emerge.emergelog import emergelog
 from _emerge.is_valid_package_atom import is_valid_package_atom
+from _emerge.main import profile_check
 from _emerge.MetadataRegen import MetadataRegen
 from _emerge.Package import Package
 from _emerge.ProgressHandler import ProgressHandler
@@ -2209,9 +2210,21 @@ def action_uninstall(settings, trees, ldpath_mtimes,
 	return rval
 
 def adjust_configs(myopts, trees):
-	for myroot in trees:
+	for myroot, mytrees in trees.items():
 		mysettings =  trees[myroot]["vartree"].settings
 		mysettings.unlock()
+
+		# For --usepkgonly mode, propagate settings from the binary package
+		# database, so that it's possible to operate without dependence on
+		# a local ebuild repository and profile.
+		if ('--usepkgonly' in myopts and
+			mytrees['bintree']._propagate_config(mysettings)):
+			# Also propagate changes to the portdbapi doebuild_settings
+			# attribute which is used by Package instances for USE
+			# calculations (in support of --binpkg-respect-use).
+			mytrees['porttree'].dbapi.doebuild_settings = \
+				portage.config(clone=mysettings)
+
 		adjust_config(myopts, mysettings)
 		mysettings.lock()
 
@@ -2868,7 +2881,27 @@ def run_action(emerge_config):
 			"--usepkg", "--usepkgonly"):
 			emerge_config.opts.pop(opt, None)
 
+	# Populate the bintree with current --getbinpkg setting.
+	# This needs to happen before:
+	# * expand_set_arguments, in case any sets use the bintree
+	# * adjust_configs and profile_check, in order to propagate settings
+	#   implicit IUSE and USE_EXPAND settings from the binhost(s)
+	if (emerge_config.action in ('search', None) and
+		'--usepkg' in emerge_config.opts):
+		for mytrees in emerge_config.trees.values():
+			try:
+				mytrees['bintree'].populate(
+					getbinpkgs='--getbinpkg' in emerge_config.opts)
+			except ParseError as e:
+				writemsg('\n\n!!!%s.\nSee make.conf(5) for more info.\n'
+						 % (e,), noiselevel=-1)
+				return 1
+
 	adjust_configs(emerge_config.opts, emerge_config.trees)
+
+	if profile_check(emerge_config.trees, emerge_config.action) != os.EX_OK:
+		return 1
+
 	apply_priorities(emerge_config.target_config.settings)
 
 	if ("--autounmask-continue" in emerge_config.opts and
@@ -2918,19 +2951,6 @@ def run_action(emerge_config):
 		mydb = mytrees["porttree"].dbapi
 		# Freeze the portdbapi for performance (memoize all xmatch results).
 		mydb.freeze()
-
-		if emerge_config.action in ('search', None) and \
-			"--usepkg" in emerge_config.opts:
-			# Populate the bintree with current --getbinpkg setting.
-			# This needs to happen before expand_set_arguments(), in case
-			# any sets use the bintree.
-			try:
-				mytrees["bintree"].populate(
-					getbinpkgs="--getbinpkg" in emerge_config.opts)
-			except ParseError as e:
-				writemsg("\n\n!!!%s.\nSee make.conf(5) for more info.\n"
-						 % e, noiselevel=-1)
-				return 1
 
 	del mytrees, mydb
 

--- a/pym/_emerge/main.py
+++ b/pym/_emerge/main.py
@@ -1269,10 +1269,6 @@ def emerge_main(args=None):
 	except locale.Error as e:
 		writemsg_level("setlocale: %s\n" % e, level=logging.WARN)
 
-	rval = profile_check(emerge_config.trees, emerge_config.action)
-	if rval != os.EX_OK:
-		return rval
-
 	tmpcmdline = []
 	if "--ignore-default-opts" not in myopts:
 		tmpcmdline.extend(portage.util.shlex_split(

--- a/pym/portage/package/ebuild/config.py
+++ b/pym/portage/package/ebuild/config.py
@@ -943,8 +943,7 @@ class config(object):
 			if bsd_chflags:
 				self.features.add('chflags')
 
-			self._iuse_effective = self._calc_iuse_effective()
-			self._iuse_implicit_match = _iuse_implicit_match_cache(self)
+			self._init_iuse()
 
 			self._validate_commands()
 
@@ -960,6 +959,10 @@ class config(object):
 
 		if mycpv:
 			self.setcpv(mycpv)
+
+	def _init_iuse(self):
+		self._iuse_effective = self._calc_iuse_effective()
+		self._iuse_implicit_match = _iuse_implicit_match_cache(self)
 
 	@property
 	def mygcfg(self):

--- a/pym/portage/package/ebuild/profile_iuse.py
+++ b/pym/portage/package/ebuild/profile_iuse.py
@@ -1,0 +1,32 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+__all__ = (
+	'iter_iuse_vars',
+)
+
+
+def iter_iuse_vars(env):
+	"""
+	Iterate over (key, value) pairs of profile variables that contribute
+	to implicit IUSE for EAPI 5 and later.
+
+	@param env: Ebuild environment
+	@type env: Mapping
+	@rtype: iterator
+	@return: iterator over (key, value) pairs of profile variables
+	"""
+
+	for k in ('IUSE_IMPLICIT', 'USE_EXPAND_IMPLICIT', 'USE_EXPAND_UNPREFIXED', 'USE_EXPAND'):
+		v = env.get(k)
+		if v is not None:
+			yield (k, v)
+
+	use_expand_implicit = frozenset(env.get('USE_EXPAND_IMPLICIT', '').split())
+
+	for v in env.get('USE_EXPAND_UNPREFIXED', '').split() + env.get('USE_EXPAND', '').split():
+		if v in use_expand_implicit:
+			k = 'USE_EXPAND_VALUES_' + v
+			v = env.get(k)
+			if v is not None:
+				yield (k, v)


### PR DESCRIPTION
For emerge --usepkgonly mode, it's useful to be able to operate without
dependence on a local ebuild repository and profile. Therefore,
merge Packages header settings from the binary package database
(including binhost(s) if enabled) into the profile configuration,
in order to propagate implicit IUSE and USE_EXPAND settings for use
with binary and installed packages. Values are appended, so the result
is a union of elements.

Also use ARCH from the binary package database if it's not defined by
the profile, since ARCH is used for validation by emerge's profile_check
function, and also for KEYWORDS logic in the _getmaskingstatus function.

All changes are currently confined to --usepkgonly mode, since this is
the mode where it is needed the most, and this ensures that behavior of
source-based builds is completely unaffected.

The changes only affect dependency calculations (where implicit IUSE
plays a role) and the user interface (display of USE_EXPAND flags).
The bash execution environment for binary and installed packages is
completely unaffected, since that environment relies on variables loaded
from environment.bz2 files.

Bug: https://bugs.gentoo.org/640318