### PR TITLE
EbuildBuildDir: add async_lock method (bug 614112)

### DIFF
--- a/pym/_emerge/EbuildBuild.py
+++ b/pym/_emerge/EbuildBuild.py
@@ -150,8 +150,13 @@ class EbuildBuild(CompositeTask):
 
 		self._build_dir = EbuildBuildDir(
 			scheduler=self.scheduler, settings=settings)
-		self._build_dir.lock()
+		self._start_task(
+			AsyncTaskFuture(future=self._build_dir.async_lock()),
+			self._start_pre_clean)
 
+	def _start_pre_clean(self, lock_task):
+		self._assert_current(lock_task)
+		lock_task.future.result()
 		# Cleaning needs to happen before fetch, since the build dir
 		# is used for log handling.
 		msg = " === (%s of %s) Cleaning (%s::%s)" % \

--- a/pym/_emerge/EbuildBuildDir.py
+++ b/pym/_emerge/EbuildBuildDir.py
@@ -19,53 +19,6 @@ class EbuildBuildDir(SlotObject):
 		SlotObject.__init__(self, **kwargs)
 		self.locked = False
 
-	def lock(self):
-		"""
-		This raises an AlreadyLocked exception if lock() is called
-		while a lock is already held. In order to avoid this, call
-		unlock() or check whether the "locked" attribute is True
-		or False before calling lock().
-		"""
-		if self._lock_obj is not None:
-			raise self.AlreadyLocked((self._lock_obj,))
-
-		dir_path = self.settings.get('PORTAGE_BUILDDIR')
-		if not dir_path:
-			raise AssertionError('PORTAGE_BUILDDIR is unset')
-		catdir = os.path.dirname(dir_path)
-		self._catdir = catdir
-
-		try:
-			portage.util.ensure_dirs(os.path.dirname(catdir),
-				gid=portage.portage_gid,
-				mode=0o70, mask=0)
-		except PortageException:
-			if not os.path.isdir(os.path.dirname(catdir)):
-				raise
-		catdir_lock = AsynchronousLock(path=catdir, scheduler=self.scheduler)
-		catdir_lock.start()
-		catdir_lock.wait()
-		self._assert_lock(catdir_lock)
-
-		try:
-			try:
-				portage.util.ensure_dirs(catdir,
-					gid=portage.portage_gid,
-					mode=0o70, mask=0)
-			except PortageException:
-				if not os.path.isdir(catdir):
-					raise
-			builddir_lock = AsynchronousLock(path=dir_path,
-				scheduler=self.scheduler)
-			builddir_lock.start()
-			builddir_lock.wait()
-			self._assert_lock(builddir_lock)
-			self._lock_obj = builddir_lock
-			self.settings['PORTAGE_BUILDDIR_LOCKED'] = '1'
-		finally:
-			self.locked = self._lock_obj is not None
-			catdir_lock.unlock()
-
 	def _assert_lock(self, async_lock):
 		if async_lock.returncode != os.EX_OK:
 			# TODO: create a better way to propagate this error to the caller

--- a/pym/_emerge/Scheduler.py
+++ b/pym/_emerge/Scheduler.py
@@ -799,7 +799,7 @@ class Scheduler(PollScheduler):
 			settings["PORTAGE_BUILDDIR"] = build_dir_path
 			build_dir = EbuildBuildDir(scheduler=sched_iface,
 				settings=settings)
-			build_dir.lock()
+			sched_iface.run_until_complete(build_dir.async_lock())
 			current_task = None
 
 			try:

--- a/pym/portage/dbapi/vartree.py
+++ b/pym/portage/dbapi/vartree.py
@@ -2081,7 +2081,7 @@ class dblink(object):
 				builddir_lock = EbuildBuildDir(
 					scheduler=scheduler,
 					settings=self.settings)
-				builddir_lock.lock()
+				scheduler.run_until_complete(builddir_lock.async_lock())
 				prepare_build_dirs(settings=self.settings, cleanup=True)
 				log_path = self.settings.get("PORTAGE_LOG_FILE")
 

--- a/pym/portage/package/ebuild/doebuild.py
+++ b/pym/portage/package/ebuild/doebuild.py
@@ -813,7 +813,8 @@ def doebuild(myebuild, mydo, _unused=DeprecationWarning, settings=None, debug=0,
 					scheduler=(portage._internal_caller and
 						global_event_loop() or EventLoop(main=False)),
 					settings=mysettings)
-				builddir_lock.lock()
+				builddir_lock.scheduler.run_until_complete(
+					builddir_lock.async_lock())
 			try:
 				return _spawn_phase(mydo, mysettings,
 					fd_pipes=fd_pipes, returnpid=returnpid)
@@ -939,7 +940,8 @@ def doebuild(myebuild, mydo, _unused=DeprecationWarning, settings=None, debug=0,
 							scheduler=(portage._internal_caller and
 								global_event_loop() or EventLoop(main=False)),
 							settings=mysettings)
-						builddir_lock.lock()
+						builddir_lock.scheduler.run_until_complete(
+							builddir_lock.async_lock())
 					try:
 						_spawn_phase("clean", mysettings)
 					finally:
@@ -963,7 +965,8 @@ def doebuild(myebuild, mydo, _unused=DeprecationWarning, settings=None, debug=0,
 					scheduler=(portage._internal_caller and
 						global_event_loop() or EventLoop(main=False)),
 					settings=mysettings)
-				builddir_lock.lock()
+				builddir_lock.scheduler.run_until_complete(
+					builddir_lock.async_lock())
 			mystatus = prepare_build_dirs(myroot, mysettings, cleanup)
 			if mystatus:
 				return mystatus

--- a/pym/portage/tests/ebuild/test_ipc_daemon.py
+++ b/pym/portage/tests/ebuild/test_ipc_daemon.py
@@ -60,7 +60,7 @@ class IpcDaemonTestCase(TestCase):
 			build_dir = EbuildBuildDir(
 				scheduler=event_loop,
 				settings=env)
-			build_dir.lock()
+			event_loop.run_until_complete(build_dir.async_lock())
 			ensure_dirs(env['PORTAGE_BUILDDIR'])
 
 			input_fifo = os.path.join(env['PORTAGE_BUILDDIR'], '.ipc_in')


### PR DESCRIPTION
Asynchronoulsy handle locking of both the category directory and
build directory.

Bug: https://bugs.gentoo.org/614112