### PR TITLE
EbuildFetcher._get_uri_map(): fix event loop recursion (bug 653810)

### DIFF
--- a/pym/_emerge/EbuildBuild.py
+++ b/pym/_emerge/EbuildBuild.py
@@ -216,8 +216,14 @@ class EbuildBuild(CompositeTask):
 			logfile=self.settings.get('PORTAGE_LOG_FILE'),
 			pkg=self.pkg, scheduler=self.scheduler)
 
+		self._start_task(AsyncTaskFuture(
+			future=fetcher.async_already_fetched(self.settings)),
+			functools.partial(self._start_fetch, fetcher))
+
+	def _start_fetch(self, fetcher, already_fetched_task):
+		self._assert_current(already_fetched_task)
 		try:
-			already_fetched = fetcher.already_fetched(self.settings)
+			already_fetched = already_fetched_task.future.result()
 		except portage.exception.InvalidDependString as e:
 			msg_lines = []
 			msg = "Fetch failed for '%s' due to invalid SRC_URI: %s" % \


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/653810

Zac Medico (5):
  portdbapi: add async_fetch_map method (bug 653810)
  EbuildFetcher: inherit CompositeTask (bug 653810)
  EbuildFetcher: add _async_uri_map method (bug 653810)
  EbuildFetcher: use _async_uri_map in _start (bug 653810)
  EbuildFetcher: add async_already_fetched method (bug 653810)

 pym/_emerge/EbuildBuild.py    |   8 +++-
 pym/_emerge/EbuildFetcher.py  | 105 ++++++++++++++++++++++++++++++++----------
 pym/portage/dbapi/porttree.py |  75 +++++++++++++++++++++++-------
 3 files changed, 146 insertions(+), 42 deletions(-)