### PR TITLE
AsynchronousTask: add async_wait() method (bug 653856)

### DIFF
--- a/pym/_emerge/AbstractPollTask.py
+++ b/pym/_emerge/AbstractPollTask.py
@@ -11,8 +11,7 @@ from _emerge.AsynchronousTask import AsynchronousTask
 
 class AbstractPollTask(AsynchronousTask):
 
-	__slots__ = ("scheduler",) + \
-		("_registered",)
+	__slots__ = ("_registered",)
 
 	_bufsize = 4096
 

--- a/pym/_emerge/AsynchronousLock.py
+++ b/pym/_emerge/AsynchronousLock.py
@@ -37,7 +37,7 @@ class AsynchronousLock(AsynchronousTask):
 	signals to the main thread).
 	"""
 
-	__slots__ = ('path', 'scheduler',) + \
+	__slots__ = ('path',) + \
 		('_imp', '_force_async', '_force_dummy', '_force_process', \
 		'_force_thread', '_unlock_future')
 

--- a/pym/_emerge/AsynchronousTask.py
+++ b/pym/_emerge/AsynchronousTask.py
@@ -16,7 +16,7 @@ class AsynchronousTask(SlotObject):
 	the task is complete and self.returncode has been set.
 	"""
 
-	__slots__ = ("background", "cancelled", "returncode") + \
+	__slots__ = ("background", "cancelled", "returncode", "scheduler") + \
 		("_exit_listeners", "_exit_listener_stack", "_start_listeners",
 		"_waiting")
 

--- a/pym/_emerge/CompositeTask.py
+++ b/pym/_emerge/CompositeTask.py
@@ -6,7 +6,7 @@ from portage import os
 
 class CompositeTask(AsynchronousTask):
 
-	__slots__ = ("scheduler",) + ("_current_task",)
+	__slots__ = ("_current_task",)
 
 	_TASK_QUEUED = -1
 

--- a/pym/portage/tests/ebuild/test_ipc_daemon.py
+++ b/pym/portage/tests/ebuild/test_ipc_daemon.py
@@ -157,6 +157,6 @@ class IpcDaemonTestCase(TestCase):
 		try:
 			task_scheduler.start()
 			event_loop.run_until_complete(self._run_done)
-			task_scheduler.wait()
+			event_loop.run_until_complete(task_scheduler.async_wait())
 		finally:
 			timeout_handle.cancel()

--- a/pym/portage/util/SlotObject.py
+++ b/pym/portage/util/SlotObject.py
@@ -20,7 +20,14 @@ class SlotObject(object):
 					raise AssertionError(
 						"class '%s' duplicates '%s' value in __slots__ of base class '%s'" %
 						(self.__class__.__name__, myattr, c.__name__))
-				setattr(self, myattr, myvalue)
+				try:
+					setattr(self, myattr, myvalue)
+				except AttributeError:
+					# Allow a property to override a __slots__ value, but raise an
+					# error if the intended value is something other than None.
+					if not (myvalue is None and
+						isinstance(getattr(type(self), myattr, None), property)):
+						raise
 
 		if kwargs:
 			raise TypeError(

--- a/pym/portage/util/_async/AsyncScheduler.py
+++ b/pym/portage/util/_async/AsyncScheduler.py
@@ -20,6 +20,13 @@ class AsyncScheduler(AsynchronousTask, PollScheduler):
 		self._remaining_tasks = True
 		self._loadavg_check_id = None
 
+	@property
+	def scheduler(self):
+		"""
+		Provides compatibility with the AsynchronousTask.scheduler attribute.
+		"""
+		return self._event_loop
+
 	def _poll(self):
 		if not (self._is_work_scheduled() or self._keep_scheduling()):
 			self.wait()

--- a/pym/portage/util/_async/AsyncTaskFuture.py
+++ b/pym/portage/util/_async/AsyncTaskFuture.py
@@ -12,7 +12,7 @@ class AsyncTaskFuture(AsynchronousTask):
 	Wraps a Future in an AsynchronousTask, which is useful for
 	scheduling with TaskScheduler.
 	"""
-	__slots__ = ('future', 'scheduler')
+	__slots__ = ('future',)
 	def _start(self):
 		self.future.add_done_callback(self._done_callback)
 


### PR DESCRIPTION
Since the AsynchronousTask.wait() method is prone to event loop
recursion, deprecate it, and add an async_wait() method method to
replace it. Instead of using task.wait() in order to implicitly run
the event loop, now loop.run_until_complete(task.async_wait()) will
be used to explicitly run the event loop. This explicit approach will
make it more obvious when code will trigger event loop recursion
which would not be compatible with asyncio's default event loop.

Bug: https://bugs.gentoo.org/653856

Zac Medico (2):
  AsynchronousTask: add scheduler attribute (bug 653856)
  AsynchronousTask: add async_wait() method (bug 653856)

 pym/_emerge/AbstractPollTask.py             |  3 +--
 pym/_emerge/AsynchronousLock.py             |  2 +-
 pym/_emerge/AsynchronousTask.py             | 25 ++++++++++++++++++++++++-
 pym/_emerge/CompositeTask.py                |  2 +-
 pym/portage/tests/ebuild/test_ipc_daemon.py |  2 +-
 pym/portage/util/SlotObject.py              |  9 ++++++++-
 pym/portage/util/_async/AsyncScheduler.py   |  7 +++++++
 pym/portage/util/_async/AsyncTaskFuture.py  |  2 +-
 8 files changed, 44 insertions(+), 8 deletions(-)