### PR TITLE
AsynchronousTask: disable event loop recursion (bug 653856)

### DIFF
--- a/pym/_emerge/AbstractEbuildProcess.py
+++ b/pym/_emerge/AbstractEbuildProcess.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -18,6 +18,7 @@ from portage.localization import _
 from portage.package.ebuild._ipc.ExitCommand import ExitCommand
 from portage.package.ebuild._ipc.QueryCommand import QueryCommand
 from portage import shutil, os
+from portage.util.futures import asyncio
 from portage.util._pty import _create_pty_or_pipe
 from portage.util import apply_secpass_permissions
 
@@ -420,6 +421,8 @@ class AbstractEbuildProcess(SpawnProcess):
 		if self._build_dir is None:
 			SpawnProcess._async_wait(self)
 		elif self._build_dir_unlock is None:
+			if self.returncode is None:
+				raise asyncio.InvalidStateError('Result is not ready.')
 			self._async_unlock_builddir(returncode=self.returncode)
 
 	def _async_unlock_builddir(self, returncode=None):

--- a/pym/_emerge/AbstractPollTask.py
+++ b/pym/_emerge/AbstractPollTask.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import array
@@ -135,12 +135,6 @@ class AbstractPollTask(AsynchronousTask):
 				self._unregister()
 				self.returncode = self.returncode or os.EX_OK
 				self._async_wait()
-
-	def _wait(self):
-		if self.returncode is not None:
-			return self.returncode
-		self._wait_loop()
-		return self.returncode
 
 	def _wait_loop(self, timeout=None):
 		loop = getattr(self.scheduler, '_asyncio_wrapper', self.scheduler)

--- a/pym/_emerge/AsynchronousLock.py
+++ b/pym/_emerge/AsynchronousLock.py
@@ -82,15 +82,6 @@ class AsynchronousLock(AsynchronousTask):
 			self._imp.poll()
 		return self.returncode
 
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		if self.returncode is not None:
-			return self.returncode
-		self.returncode = self._imp.wait()
-		return self.returncode
-
 	def async_unlock(self):
 		"""
 		Release the lock asynchronously. Release notification is available

--- a/pym/_emerge/AsynchronousTask.py
+++ b/pym/_emerge/AsynchronousTask.py
@@ -84,12 +84,6 @@ class AsynchronousTask(SlotObject):
 		self._wait_hook()
 		return self.returncode
 
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		return self.returncode
-
 	def _async_wait(self):
 		"""
 		For cases where _start exits synchronously, this method is a

--- a/pym/_emerge/FifoIpcDaemon.py
+++ b/pym/_emerge/FifoIpcDaemon.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2013 Gentoo Foundation
+# Copyright 2010-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -80,17 +80,6 @@ class FifoIpcDaemon(AbstractPollTask):
 		self._unregister()
 		# notify exit listeners
 		self._async_wait()
-
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		if self.returncode is not None:
-			return self.returncode
-		self._wait_loop()
-		if self.returncode is None:
-			self.returncode = os.EX_OK
-		return self.returncode
 
 	def _input_handler(self, fd, event):
 		raise NotImplementedError(self)

--- a/pym/_emerge/PipeReader.py
+++ b/pym/_emerge/PipeReader.py
@@ -52,13 +52,6 @@ class PipeReader(AbstractPollTask):
 		if self.returncode is None:
 			self.returncode = self._cancelled_returncode
 
-	def _wait(self):
-		if self.returncode is not None:
-			return self.returncode
-		self._wait_loop()
-		self.returncode = os.EX_OK
-		return self.returncode
-
 	def getvalue(self):
 		"""Retrieve the entire contents"""
 		return b''.join(self._read_data)

--- a/pym/_emerge/SpawnProcess.py
+++ b/pym/_emerge/SpawnProcess.py
@@ -1,4 +1,4 @@
-# Copyright 2008-2013 Gentoo Foundation
+# Copyright 2008-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 try:
@@ -171,16 +171,6 @@ class SpawnProcess(SubProcess):
 	def _pipe_logger_exit(self, pipe_logger):
 		self._pipe_logger = None
 		self._async_waitpid()
-
-	def _waitpid_loop(self):
-		SubProcess._waitpid_loop(self)
-
-		pipe_logger = self._pipe_logger
-		if pipe_logger is not None:
-			self._pipe_logger = None
-			pipe_logger.removeExitListener(self._pipe_logger_exit)
-			pipe_logger.cancel()
-			pipe_logger.wait()
 
 	def _set_returncode(self, wait_retval):
 		SubProcess._set_returncode(self, wait_retval)

--- a/pym/portage/_emirrordist/MirrorDistTask.py
+++ b/pym/portage/_emirrordist/MirrorDistTask.py
@@ -241,13 +241,6 @@ class MirrorDistTask(CompositeTask):
 		else:
 			self._async_wait()
 
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		CompositeTask._wait(self)
-		self._cleanup()
-
 	def _async_wait(self):
 		"""
 		Override _async_wait to call self._cleanup().

--- a/pym/portage/util/_async/AsyncScheduler.py
+++ b/pym/portage/util/_async/AsyncScheduler.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2013 Gentoo Foundation
+# Copyright 2012-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 from portage import os
@@ -96,26 +96,3 @@ class AsyncScheduler(AsynchronousTask, PollScheduler):
 		"""
 		self._cleanup()
 		super(AsyncScheduler, self)._async_wait()
-
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		# Loop while there are jobs to be scheduled.
-		while self._keep_scheduling():
-			self._event_loop.iteration()
-
-		# Clean shutdown of previously scheduled jobs. In the
-		# case of termination, this allows for basic cleanup
-		# such as flushing of buffered output to logs.
-		while self._is_work_scheduled():
-			self._event_loop.iteration()
-
-		self._cleanup()
-
-		if self._error_count > 0:
-			self.returncode = 1
-		else:
-			self.returncode = os.EX_OK 
-
-		return self.returncode

--- a/pym/portage/util/_async/AsyncTaskFuture.py
+++ b/pym/portage/util/_async/AsyncTaskFuture.py
@@ -29,11 +29,3 @@ class AsyncTaskFuture(AsynchronousTask):
 		else:
 			self.returncode = 1
 		self._async_wait()
-
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		if self.returncode is None:
-			self.scheduler.run_until_complete(self.future)
-		return self.returncode

--- a/pym/portage/util/_async/PipeLogger.py
+++ b/pym/portage/util/_async/PipeLogger.py
@@ -66,13 +66,6 @@ class PipeLogger(AbstractPollTask):
 		if self.returncode is None:
 			self.returncode = self._cancelled_returncode
 
-	def _wait(self):
-		if self.returncode is not None:
-			return self.returncode
-		self._wait_loop()
-		self.returncode = os.EX_OK
-		return self.returncode
-
 	def _output_handler(self, fd, event):
 
 		background = self.background

--- a/pym/portage/util/_async/PipeReaderBlockingIO.py
+++ b/pym/portage/util/_async/PipeReaderBlockingIO.py
@@ -72,16 +72,6 @@ class PipeReaderBlockingIO(AbstractPollTask):
 			self.returncode = self._cancelled_returncode
 		self._async_wait()
 
-	def _wait(self):
-		"""
-		Deprecated. Use _async_wait() instead.
-		"""
-		if self.returncode is not None:
-			return self.returncode
-		self._wait_loop()
-		self.returncode = os.EX_OK
-		return self.returncode
-
 	def getvalue(self):
 		"""Retrieve the entire contents"""
 		with self._thread_rlock:

--- a/pym/portage/util/_async/SchedulerInterface.py
+++ b/pym/portage/util/_async/SchedulerInterface.py
@@ -15,7 +15,6 @@ class SchedulerInterface(SlotObject):
 		"IO_NVAL", "IO_OUT", "IO_PRI",
 		"child_watch_add",
 		"io_add_watch",
-		"iteration",
 		"source_remove",
 		"timeout_add",
 


### PR DESCRIPTION
Make the wait() and _async_wait() methods raise InvalidStateError
when the event loop is running and the returncode is not available,
since these cases would trigger event loop recursion. There are no
known remaining cases that cause event loop recursion via wait()
and _async_wait(), and this patch protects against changes that would
accidentally re-introduce event loop recursion.

Since the wait() method now raises InvalidStateError in cases where
it previously would have called the _wait() method, this patch makes
it possible to remove the _wait() method implementations from all
subclasses of AsynchronousTask. Subclasses that used the _wait()
method to perform cleanup now use the _async_wait() method instead.

Bug: https://bugs.gentoo.org/653856