### PR TITLE
preinst_selinux_labels: disable LD_PRELOAD sandbox (bug 655996)

### DIFF
--- a/pym/_emerge/MiscFunctionsProcess.py
+++ b/pym/_emerge/MiscFunctionsProcess.py
@@ -13,7 +13,7 @@ class MiscFunctionsProcess(AbstractEbuildProcess):
 	Spawns misc-functions.sh with an existing ebuild environment.
 	"""
 
-	__slots__ = ('commands',)
+	__slots__ = ('commands', 'ld_preload_sandbox')
 
 	def _start(self):
 		settings = self.settings
@@ -29,6 +29,10 @@ class MiscFunctionsProcess(AbstractEbuildProcess):
 		AbstractEbuildProcess._start(self)
 
 	def _spawn(self, args, **kwargs):
+		# If self.ld_preload_sandbox is None, default to free=False,
+		# in alignment with the spawn(free=False) default.
+		kwargs.setdefault('free', False if self.ld_preload_sandbox is None
+			else not self.ld_preload_sandbox)
 
 		if self._dummy_pipe_fd is not None:
 			self.settings["PORTAGE_PIPE_FD"] = str(self._dummy_pipe_fd)

--- a/pym/portage/package/ebuild/doebuild.py
+++ b/pym/portage/package/ebuild/doebuild.py
@@ -1722,13 +1722,27 @@ _post_phase_cmds = {
 		"install_symlink_html_docs",
 		"install_hooks"],
 
-	"preinst" : [
-		"preinst_sfperms",
-		"preinst_selinux_labels",
-		"preinst_suid_scan",
-		"preinst_qa_check",
-		],
-
+	"preinst" : (
+		(
+			# Since SELinux does not allow LD_PRELOAD across domain transitions,
+			# disable the LD_PRELOAD sandbox for preinst_selinux_labels.
+			{
+				"ld_preload_sandbox": False,
+				"selinux_only": True,
+			},
+			[
+				"preinst_selinux_labels",
+			],
+		),
+		(
+			{},
+			[
+				"preinst_sfperms",
+				"preinst_suid_scan",
+				"preinst_qa_check",
+			],
+		),
+	),
 	"postinst" : [
 		"postinst_qa_check"],
 }


### PR DESCRIPTION
Since SELinux does not allow LD_PRELOAD across domain transitions,
disable the LD_PRELOAD sandbox for preinst_selinux_labels.

Bug: https://bugs.gentoo.org/655996

@perfinion