### PR TITLE
do not try to install files when there are none

### DIFF
--- a/bin/Makefile.in
+++ b/bin/Makefile.in
@@ -41,6 +41,7 @@ install:
 	$(INSTALL) -d -m 755 -o "$(portageuser)" -g "$(portagegroup)" $(DESTDIR)$(PORTAGE_BIN)
 	( cd "$(srcdir)" && find . -type d ) | while read f ; do \
 		files=( ) ; \
+		shopt -s nullglob ; \
 		for t in "$(srcdir)/$${f}"/* ; do \
 			[[ -d $${t} ]] && continue ; \
 			[[ $${t} == */Makefile* ]] && continue ; \
@@ -49,6 +50,7 @@ install:
 		$(INSTALL) -d -m 755 \
 			-o "$(portageuser)" -g "$(portagegroup)" \
 			"$(DESTDIR)$(PORTAGE_BIN)/$${f}" && \
+		[[ $${files[0]} ]] || continue ; \
 		$(INSTALL_subst) -m 755 \
 			-o "$(portageuser)" -g "$(portagegroup)" \
 			-t "$(DESTDIR)$(PORTAGE_BIN)/$${f}" \

--- a/pym/Makefile.in
+++ b/pym/Makefile.in
@@ -22,6 +22,7 @@ install:
 	$(INSTALL) -d -m 755 -o "$(portageuser)" -g "$(portagegroup)" $(DESTDIR)$(PORTAGE_PYM)
 	( cd "$(srcdir)" && find * -type d ) | while read f ; do \
 		files=( ) ; \
+		shopt -s nullglob ; \
 		for t in "$(srcdir)/$${f}"/* ; do \
 			[[ -d $${t} ]] && continue ; \
 			[[ $${t} == */Makefile* ]] && continue ; \
@@ -30,6 +31,7 @@ install:
 		$(INSTALL) -d -m 755 \
 			-o "$(portageuser)" -g "$(portagegroup)" \
 			"$(DESTDIR)$(PORTAGE_PYM)/$${f}" && \
+		[[ $${files[0]} ]] || continue ; \
 		$(INSTALL_subst) \
 			-o "$(portageuser)" -g "$(portagegroup)" \
 			-t "$(DESTDIR)$(PORTAGE_PYM)/$${f}" \


### PR DESCRIPTION
The error message shown is:
<pre>
/usr/bin/install -c -m 644 -o wie -g None -t /tools/gentoo/buildslave/ow04-f_pfx-15/build/gentoo-prefix/tmp/usr/lib/portage/pym/portage/__pycache__ ./portage/__pycache__/*
/usr/bin/install: cannot stat './portage/__pycache__/*': No such file or directory
make[1]: *** [Makefile:23: install] Error 1
make[1]: Leaving directory '/tools/gentoo/buildslave/ow04-f_pfx-15/build/gentoo-prefix/var/tmp/portage-2.3.40.1/prefix-portage-2.3.40.1/pym'
make: *** [Makefile:385: install-recursive] Error 1

I tried running
  bootstrap_stage1_log
but that failed :(  I have no clue, really.  Please find friendly folks
in #gentoo-prefix on irc.gentoo.org, gentoo-alt@lists.gentoo.org mailing list,
or file a bug at bugs.gentoo.org under Gentoo/Alt, Prefix Support.
Sorry that I have failed you master.  I shall now return to my humble cave.
You can find a log of what happened in /tools/gentoo/buildslave/ow04-f_pfx-15/build/gentoo-prefix/stage1.log
</pre>