### PR TITLE
scanelf: fix %p format string for EAPI 7 (bug 659228)

### DIFF
--- a/bin/install-qa-check.d/10executable-issues
+++ b/bin/install-qa-check.d/10executable-issues
@@ -66,7 +66,7 @@ elf_check() {
 	[[ -n ${!qa_var} ]] && QA_TEXTRELS=${!qa_var}
 	[[ -n ${QA_STRICT_TEXTRELS} ]] && QA_TEXTRELS=""
 	export QA_TEXTRELS="${QA_TEXTRELS} lib*/modules/*.ko"
-	f=$(scanelf -qyRF '%t %p' "${ED}" | grep -v 'usr/lib/debug/')
+	f=$(scanelf -qyRF '%t %p' "${ED%/}/" | grep -v 'usr/lib/debug/')
 	if [[ -n ${f} ]] ; then
 		scanelf -qyRAF '%T %p' "${PORTAGE_BUILDDIR}"/ &> "${T}"/scanelf-textrel.log
 		__vecho -ne '\n'
@@ -109,7 +109,7 @@ elf_check() {
 				[[ -n ${QA_STRICT_WX_LOAD} ]] && QA_WX_LOAD=""
 				export QA_EXECSTACK="${QA_EXECSTACK} lib*/modules/*.ko"
 				export QA_WX_LOAD="${QA_WX_LOAD} lib*/modules/*.ko"
-				f=$(scanelf -qyRAF '%e %p' "${ED}" | grep -v 'usr/lib/debug/')
+				f=$(scanelf -qyRAF '%e %p' "${ED%/}/" | grep -v 'usr/lib/debug/')
 				;;
 		esac
 		;;

--- a/bin/install-qa-check.d/10ignored-flags
+++ b/bin/install-qa-check.d/10ignored-flags
@@ -26,7 +26,7 @@ ignored_flag_check() {
 	[[ "${FFLAGS}" == *-frecord-gcc-switches* ]] && \
 	[[ "${FCFLAGS}" == *-frecord-gcc-switches* ]] ; then
 		rm -f "${T}"/scanelf-ignored-CFLAGS.log
-		for x in $(scanelf -qyRF '#k%p' -k '!.GCC.command.line' "${ED}") ; do
+		for x in $(scanelf -qyRF '#k%p' -k '!.GCC.command.line' "${ED%/}/") ; do
 			# Separate out file types that are known to support
 			# .GCC.command.line sections, using the `file` command
 			# similar to how prepstrip uses it.
@@ -66,8 +66,8 @@ ignored_flag_check() {
 	# Check for files built without respecting LDFLAGS
 	if [[ "${LDFLAGS}" == *,--defsym=__gentoo_check_ldflags__* ]] && \
 		! has binchecks ${RESTRICT} ; then
-		f=$(LC_ALL=C comm -3 <(scanelf -qyRF '#k%p' -k .dynsym "${ED}" | LC_ALL=C sort) \
-			<(scanelf -qyRF '#s%p' -s __gentoo_check_ldflags__ "${ED}" | LC_ALL=C sort))
+		f=$(LC_ALL=C comm -3 <(scanelf -qyRF '#k%p' -k .dynsym "${ED%/}/" | LC_ALL=C sort) \
+			<(scanelf -qyRF '#s%p' -s __gentoo_check_ldflags__ "${ED%/}/" | LC_ALL=C sort))
 		if [[ -n ${f} ]] ; then
 			echo "${f}" > "${T}"/scanelf-ignored-LDFLAGS.log
 			if [ "${QA_STRICT_FLAGS_IGNORED-unset}" = unset ] ; then

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -237,7 +237,7 @@ install_qa_check() {
 	if type -P scanelf > /dev/null ; then
 		# Save NEEDED information after removing self-contained providers
 		rm -f "$PORTAGE_BUILDDIR"/build-info/NEEDED{,.ELF.2}
-		scanelf -qyRF '%a;%p;%S;%r;%n' "${D}" | { while IFS= read -r l; do
+		scanelf -qyRF '%a;%p;%S;%r;%n' "${D%/}/" | { while IFS= read -r l; do
 			arch=${l%%;*}; l=${l#*;}
 			obj="/${l%%;*}"; l=${l#*;}
 			soname=${l%%;*}; l=${l#*;}


### PR DESCRIPTION
For all scanelf path arguments that are used in processing of
the `%p` format string, normalize the argument to have a trailing
slash, so that the leading slash is consistently stripped in
the expansion of the `%p` format string.

Bug: https://bugs.gentoo.org/659228