### PR TITLE
GitSync: support sync-depth (bug 552814)

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -985,7 +985,8 @@ overlay filesystems.
 Specifies CVS repository.
 .TP
 .B sync\-depth
-This is a deprecated alias for the \fBclone\-depth\fR option.
+Specifies sync depth to use for DVCS repositories. If set to 0, the
+depth is unlimited. Defaults to 0.
 .TP
 .B sync\-git\-clone\-env
 Set environment variables for git when cloning repository (git clone).

--- a/pym/portage/repository/config.py
+++ b/pym/portage/repository/config.py
@@ -179,10 +179,6 @@ class RepoConfig(object):
 		self.clone_depth = repo_opts.get('clone-depth')
 		self.sync_depth = repo_opts.get('sync-depth')
 
-		if self.sync_depth is not None:
-			warnings.warn(_("repos.conf: sync-depth is deprecated,"
-				" use clone-depth instead"))
-
 		self.sync_hooks_only_on_change = repo_opts.get(
 			'sync-hooks-only-on-change', 'false').lower() == 'true'
 


### PR DESCRIPTION
Support sync-depth for shallow sync, using git reset --merge just
like in the earlier implementation that was reverted in commit
ab840ac982d3c8b676b89f6bedd14e85dd06870f. Also, use git gc --auto
in order to trigger periodic housekeeping and hopefully avoid
errors from automatic git gc calls as reported in bug 599008.

The default sync-depth is unlimited, which means that default
behavior remains unchanged (unlike the previous implementation that
was reverted).

Bug: https://bugs.gentoo.org/552814
Bug: https://bugs.gentoo.org/599008