### PR TITLE
dbapi: fix repoman implicit IUSE (bug 660982)

### DIFF
--- a/pym/_emerge/Package.py
+++ b/pym/_emerge/Package.py
@@ -93,7 +93,10 @@ class Package(Task):
 		# sync metadata with validated repo (may be UNKNOWN_REPO)
 		self._metadata['repository'] = self.cpv.repo
 
-		implicit_match = db._iuse_implicit_cnstr(self.cpv, self._metadata)
+		if self.root_config.settings.local_config:
+			implicit_match = db._iuse_implicit_cnstr(self.cpv, self._metadata)
+		else:
+			implicit_match = db._repoman_iuse_implicit_cnstr(self.cpv, self._metadata)
 		usealiases = self.root_config.settings._use_manager.getUseAliases(self)
 		self.iuse = self._iuse(self, self._metadata["IUSE"].split(),
 			implicit_match, usealiases, self.eapi)

--- a/pym/portage/dbapi/__init__.py
+++ b/pym/portage/dbapi/__init__.py
@@ -216,6 +216,22 @@ class dbapi(object):
 
 			yield cpv
 
+	def _repoman_iuse_implicit_cnstr(self, pkg, metadata):
+		"""
+		In repoman's version of _iuse_implicit_cnstr, account for modifications
+		of the self.settings reference between calls, and treat all flags as
+		valid for the empty profile because it does not have any implicit IUSE
+		settings. See bug 660982.
+		"""
+		eapi_attrs = _get_eapi_attrs(metadata["EAPI"])
+		if eapi_attrs.iuse_effective:
+			iuse_implicit_match = lambda flag: (True if not self.settings.profile_path
+				else self.settings._iuse_effective_match(flag))
+		else:
+			iuse_implicit_match = lambda flag: (True if not self.settings.profile_path
+				else self.settings._iuse_implicit_match(flag))
+		return iuse_implicit_match
+
 	def _iuse_implicit_cnstr(self, pkg, metadata):
 		"""
 		Construct a callable that checks if a given USE flag should


### PR DESCRIPTION
Account for repoman modifications of the portdbapi self.settings
reference, and treat all flags as valid for the empty profile
because it does not have any implicit IUSE settings.

Bug: https://bugs.gentoo.org/660982