### PR TITLE
portdbapi.cp_list: cache repo associations (bug 650814)

### DIFF
--- a/pym/_emerge/depgraph.py
+++ b/pym/_emerge/depgraph.py
@@ -5613,10 +5613,6 @@ class depgraph(object):
 		if cp_list:
 			atom_set = InternalPackageSet(initial_atoms=(atom,),
 				allow_repo=True)
-			if atom.repo is None and hasattr(db, "getRepositories"):
-				repo_list = db.getRepositories(catpkg=atom_exp.cp)
-			else:
-				repo_list = [atom.repo]
 
 			# descending order
 			cp_list.reverse()
@@ -5624,13 +5620,11 @@ class depgraph(object):
 				# Call match_from_list on one cpv at a time, in order
 				# to avoid unnecessary match_from_list comparisons on
 				# versions that are never yielded from this method.
-				if not match_from_list(atom_exp, [cpv]):
-					continue
-				for repo in repo_list:
-
+				if match_from_list(atom_exp, [cpv]):
 					try:
 						pkg = self._pkg(cpv, pkg_type, root_config,
-							installed=installed, onlydeps=onlydeps, myrepo=repo)
+							installed=installed, onlydeps=onlydeps,
+							myrepo=getattr(cpv, 'repo', None))
 					except portage.exception.PackageNotFound:
 						pass
 					else:


### PR DESCRIPTION
Make portdbapi.cp_list return _pkg_str instances that have a 'repo'
attribute (bindbapi.cp_list already does this), with results
in ascending order by (pkg.version, repo.priority). Optimize
portdbapi.findname2 to use the 'repo' attribute to enable cached
results for files previously found by the portdbapi.cp_list
method, avoiding filesystem access when possible. Optimize the
depgraph._iter_match_pkgs_atom method by elimination of the repo
loop, since portdbapi.cp_list now returns separate items when the
same package version is found in multiple repos.

Bug: https://bugs.gentoo.org/650814