### PR TITLE
RepoConfig: fix make.conf PORTDIR override (bug 661276)

### DIFF
--- a/pym/portage/repository/config.py
+++ b/pym/portage/repository/config.py
@@ -524,7 +524,8 @@ class RepoConfigLoader(object):
 					(base_priority == 0 and ov is portdir):
 					repo_opts = default_repo_opts.copy()
 					repo_opts['location'] = ov
-					repo = RepoConfig(None, repo_opts, local_config=local_config)
+					name = prepos['DEFAULT'].main_repo if ov is portdir else None
+					repo = RepoConfig(name, repo_opts, local_config=local_config)
 					# repos_conf_opts contains options from repos.conf
 					repos_conf_opts = repos_conf.get(repo.name)
 					if repos_conf_opts is not None:


### PR DESCRIPTION
Pass the main-repo name from repos.conf as the repository name
for the PORTDIR RepoConfig constructor, so that it can override
the main repo location even if the profiles/repo_name file does
not exist yet (like in a stage3 tarball).

Bug: https://bugs.gentoo.org/661276
Reported-by: Jorge Manuel B. S. Vicetto <jmbsvicetto@gentoo.org>