### PR TITLE
repoman: populate implicit IUSE for empty profile (bug 660982)

### DIFF
--- a/pym/portage/dbapi/__init__.py
+++ b/pym/portage/dbapi/__init__.py
@@ -219,17 +219,13 @@ class dbapi(object):
 	def _repoman_iuse_implicit_cnstr(self, pkg, metadata):
 		"""
 		In repoman's version of _iuse_implicit_cnstr, account for modifications
-		of the self.settings reference between calls, and treat all flags as
-		valid for the empty profile because it does not have any implicit IUSE
-		settings. See bug 660982.
+		of the self.settings reference between calls.
 		"""
 		eapi_attrs = _get_eapi_attrs(metadata["EAPI"])
 		if eapi_attrs.iuse_effective:
-			iuse_implicit_match = lambda flag: (True if not self.settings.profile_path
-				else self.settings._iuse_effective_match(flag))
+			iuse_implicit_match = lambda flag: self.settings._iuse_effective_match(flag)
 		else:
-			iuse_implicit_match = lambda flag: (True if not self.settings.profile_path
-				else self.settings._iuse_implicit_match(flag))
+			iuse_implicit_match = lambda flag: self.settings._iuse_implicit_match(flag)
 		return iuse_implicit_match
 
 	def _iuse_implicit_cnstr(self, pkg, metadata):


### PR DESCRIPTION
For the empty profile that's used to check dependencies of
ebuilds that have empty KEYWORDS, populate implicit IUSE
from all of the make.defaults files found in the relevant
repositories (this should take less than 1 second on most
hardware). Since the IUSE.missing check cannot be performed
without implicit IUSE settings, this makes the IUSE.missing
check work for ebuilds with empty KEYWORDS.

Bug: https://bugs.gentoo.org/660982