### PR TITLE
webrsync: support sync-openpgp-key-path (bug 661838)

### DIFF
--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -191,6 +191,13 @@ check_file_signature() {
 					fi
 				done <<< "${gnupg_status}"
 			fi
+			if [[ ${r} -ne 0 ]]; then
+				# Exit early since it's typically inappropriate to
+				# try other mirrors in this case (it may indicate
+				# a keyring problem).
+				eecho "signature verification failed"
+				exit 1
+			fi
 		else
 			eecho "cannot check signature: gpg binary not found"
 			exit 1

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -10,7 +10,14 @@
 #  - all output should prob be converted to e* funcs
 #  - add support for ROOT
 
+# repos.conf configuration for use with emerge --sync and emaint sync
+# using keyring from app-crypt/openpgp-keys-gentoo-release:
+# [gentoo]
+# sync-type = webrsync
+# sync-webrsync-verify-signature = true
+# sync-openpgp-key-path = /usr/share/openpgp-keys/gentoo-release.asc
 #
+# Alternative (legacy) PORTAGE_GPG_DIR configuration:
 # gpg key import
 # KEY_ID=0x96D8BF6D
 # gpg --homedir /etc/portage/gnupg --keyserver subkeys.pgp.net --recv-keys $KEY_ID
@@ -67,7 +74,14 @@ do_verbose=0
 do_debug=0
 keep=false
 
-if has webrsync-gpg ${FEATURES} ; then
+if has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature | \
+	LC_ALL=C tr '[:upper:]' '[:lower:]') true yes; then
+	if [[ ! -d ${PORTAGE_GPG_DIR} ]]; then
+		eecho "Do not call ${argv0##*/} directly, instead call emerge --sync or emaint sync."
+		exit 1
+	fi
+	WEBSYNC_VERIFY_SIGNATURE=1
+elif has webrsync-gpg ${FEATURES}; then
 	WEBSYNC_VERIFY_SIGNATURE=1
 else
 	WEBSYNC_VERIFY_SIGNATURE=0

--- a/lib/portage/sync/modules/webrsync/__init__.py
+++ b/lib/portage/sync/modules/webrsync/__init__.py
@@ -45,7 +45,9 @@ module_spec = {
 					'exists and is a valid repository',
 			},
 			'validate_config': CheckSyncConfig,
-			'module_specific_options': (),
+			'module_specific_options': (
+				'sync-webrsync-verify-signature',
+			),
 		},
 	}
 }

--- a/lib/portage/sync/modules/webrsync/__init__.py
+++ b/lib/portage/sync/modules/webrsync/__init__.py
@@ -46,6 +46,7 @@ module_spec = {
 			},
 			'validate_config': CheckSyncConfig,
 			'module_specific_options': (
+				'sync-webrsync-keep-snapshots',
 				'sync-webrsync-verify-signature',
 			),
 		},

--- a/lib/portage/sync/modules/webrsync/__init__.py
+++ b/lib/portage/sync/modules/webrsync/__init__.py
@@ -46,6 +46,7 @@ module_spec = {
 			},
 			'validate_config': CheckSyncConfig,
 			'module_specific_options': (
+				'sync-webrsync-delta',
 				'sync-webrsync-keep-snapshots',
 				'sync-webrsync-verify-signature',
 			),

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -34,6 +34,16 @@ class WebRsync(SyncBase):
 	def __init__(self):
 		SyncBase.__init__(self, 'emerge-webrsync', '>=sys-apps/portage-2.3')
 
+	@property
+	def has_bin(self):
+		if (self._bin_command != 'emerge-delta-webrsync' and
+			self.repo.module_specific_options.get(
+			'sync-webrsync-delta', 'false').lower() in ('true', 'yes')):
+			self._bin_command = 'emerge-delta-webrsync'
+			self.bin_command = portage.process.find_binary(self._bin_command)
+			self.bin_pkg = '>=app-portage/emerge-delta-webrsync-3.7.5'
+
+		return super(WebRsync, self).has_bin
 
 	def sync(self, **kwargs):
 		'''Sync the repository'''

--- a/man/portage.5
+++ b/man/portage.5
@@ -1128,6 +1128,9 @@ when 0. Defaults to disabled.
 Require the repository to contain a signed MetaManifest and verify
 it using \fBapp\-portage/gemato\fR. Defaults to no.
 .TP
+.B sync\-webrsync\-keep\-snapshots = true|false
+Keep snapshots in \fBDISTDIR\fR (do not delete). Defaults to false.
+.TP
 .B sync\-webrsync\-verify\-signature = true|false
 Require the detached tarball signature to contain a good OpenPGP
 signature. This uses the OpenPGP key(ring) specified by the

--- a/man/portage.5
+++ b/man/portage.5
@@ -1128,6 +1128,10 @@ when 0. Defaults to disabled.
 Require the repository to contain a signed MetaManifest and verify
 it using \fBapp\-portage/gemato\fR. Defaults to no.
 .TP
+.B sync\-webrsync\-delta = true|false
+Use \fBapp\-portage/emerge\-delta\-webrsync\fR to minimize bandwidth.
+Defaults to false.
+.TP
 .B sync\-webrsync\-keep\-snapshots = true|false
 Keep snapshots in \fBDISTDIR\fR (do not delete). Defaults to false.
 .TP

--- a/man/portage.5
+++ b/man/portage.5
@@ -1127,6 +1127,11 @@ when 0. Defaults to disabled.
 .B sync\-rsync\-verify\-metamanifest = yes|no
 Require the repository to contain a signed MetaManifest and verify
 it using \fBapp\-portage/gemato\fR. Defaults to no.
+.TP
+.B sync\-webrsync\-verify\-signature = true|false
+Require the detached tarball signature to contain a good OpenPGP
+signature. This uses the OpenPGP key(ring) specified by the
+sync\-openpgp\-key\-path setting. Defaults to false.
 
 .RE
 

--- a/misc/emerge-delta-webrsync
+++ b/misc/emerge-delta-webrsync
@@ -283,6 +283,13 @@ check_file_signature() {
 					fi
 				done <<< "${gnupg_status}"
 			fi
+			if [[ ${r} -ne 0 ]]; then
+				# Exit early since it's typically inappropriate to
+				# try other mirrors in this case (it may indicate
+				# a keyring problem).
+				eecho "signature verification failed"
+				exit 1
+			fi
 		else
 			eecho "cannot check signature: gpg binary not found"
 			exit 1

--- a/misc/emerge-delta-webrsync
+++ b/misc/emerge-delta-webrsync
@@ -4,7 +4,15 @@
 # Author: Brian Harring <ferringb@gentoo.org>, karltk@gentoo.org originally.
 # Rewritten from the old, Perl-based emerge-webrsync script
 
+# repos.conf configuration for use with emerge --sync and emaint sync
+# using keyring from app-crypt/openpgp-keys-gentoo-release:
+# [gentoo]
+# sync-type = webrsync
+# sync-webrsync-delta = true
+# sync-webrsync-verify-signature = true
+# sync-openpgp-key-path = /usr/share/openpgp-keys/gentoo-release.asc
 #
+# Alternative (legacy) PORTAGE_GPG_DIR configuration:
 # gpg key import
 # KEY_ID=0x96D8BF6D
 # gpg --homedir /etc/portage/gnupg --keyserver subkeys.pgp.net --recv-keys $KEY_ID
@@ -106,7 +114,14 @@ if [[ ! -d $STATE_DIR ]]; then
 	exit -2
 fi
 
-if has webrsync-gpg ${FEATURES} ; then
+if has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature | \
+	LC_ALL=C tr '[:upper:]' '[:lower:]') true yes; then
+	if [[ ! -d ${PORTAGE_GPG_DIR} ]]; then
+		eecho "Do not call ${argv0##*/} directly, instead call emerge --sync or emaint sync."
+		exit 1
+	fi
+	WEBSYNC_VERIFY_SIGNATURE=1
+elif has webrsync-gpg ${FEATURES}; then
 	WEBSYNC_VERIFY_SIGNATURE=1
 else
 	WEBSYNC_VERIFY_SIGNATURE=0


### PR DESCRIPTION
Add repos.conf settings that enable sync-openpgp-key-path support for
both emerge-webrsync and emerge-delta-webrsync:
```
sync-webrsync-delta = true|false
	Use app-portage/emerge-delta-webrsync to minimize
	bandwidth. Defaults to false.

sync-webrsync-keep-snapshots = true|false
	Keep snapshots in DISTDIR (do not delete). Defaults to false.

sync-webrsync-verify-signature = true|false
	Require the detached tarball signature to contain a good OpenPGP
	signature. This  uses the OpenPGP key(ring) specified by the
	sync-openpgp-key-path setting. Defaults to false.
```
Bug: https://bugs.gentoo.org/661838