### PR TITLE
install-qa-check.d/60pngfix: parallel support (bug 630292)

### DIFF
--- a/bin/install-qa-check.d/60pngfix
+++ b/bin/install-qa-check.d/60pngfix
@@ -1,7 +1,17 @@
 # Check for issues with PNG files
 
+source "${PORTAGE_BIN_PATH}/helper-functions.sh" || exit 1
+
 pngfix_check() {
-	local pngfix=$(type -P pngfix)
+	local chunksize=1 jobs pngfix=$(type -P pngfix) xargs=(${XARGS})
+
+	if "${xargs[@]}" --help | grep -q -- --max-procs=; then
+		jobs=$(makeopts_jobs)
+		if [[ ${jobs} -gt 1 ]]; then
+			xargs+=("--max-procs=${jobs}" -L "${chunksize}")
+		fi
+	fi
+
 	if [[ -n ${pngfix} ]] ; then
 		local pngout=()
 		local next
@@ -25,7 +35,7 @@ pngfix_check() {
 				fi
 				eqawarn "   ${pngout[@]:7}: ${error}"
 			fi
-		done < <(find "${ED}" -type f -name '*.png' -exec "${pngfix}" {} +)
+		done < <(find "${ED}" -type f -name '*.png' -print0 | "${xargs[@]}" -0 "${pngfix}")
 	fi
 }
 


### PR DESCRIPTION
If xargs supports the --max-procs option then use the makeopts_jobs
function from helper-functions.sh to generate a --max-procs argument.
Use xargs `-L 1` to limit the number of png files per pngfix process,
in order to ensure that enough processes are spawned, since otherwise
xargs minimizes the number of processes spawned. A benchmark with
flightgear-data-2018.2.1 shows that larger values of -L only decrease
performance.

Bug: https://bugs.gentoo.org/630292
Reviewed-by: Lars Wendler <polynomial-c@gentoo.org>
Reviewed-by: Mike Gilbert <floppym@gentoo.org>