### PR TITLE
Add asyncio.create_subprocess_exec support for python2 (bug 662388)

### DIFF
--- a/lib/portage/tests/util/futures/asyncio/test_subprocess_exec.py
+++ b/lib/portage/tests/util/futures/asyncio/test_subprocess_exec.py
@@ -3,61 +3,16 @@
 
 import os
 import subprocess
-
-try:
-	from asyncio import create_subprocess_exec
-except ImportError:
-	create_subprocess_exec = None
+import sys
 
 from portage.process import find_binary
 from portage.tests import TestCase
 from portage.util._eventloop.global_event_loop import global_event_loop
 from portage.util.futures import asyncio
-from portage.util.futures.executor.fork import ForkExecutor
+from portage.util.futures._asyncio import create_subprocess_exec
+from portage.util.futures._asyncio.streams import _reader as reader
+from portage.util.futures.compat_coroutine import coroutine, coroutine_return
 from portage.util.futures.unix_events import DefaultEventLoopPolicy
-from _emerge.PipeReader import PipeReader
-
-
-def reader(input_file, loop=None):
-	"""
-	Asynchronously read a binary input file.
-
-	@param input_file: binary input file
-	@type input_file: file
-	@param loop: event loop
-	@type loop: EventLoop
-	@return: bytes
-	@rtype: asyncio.Future (or compatible)
-	"""
-	loop = asyncio._wrap_loop(loop)
-	future = loop.create_future()
-	_Reader(future, input_file, loop)
-	return future
-
-
-class _Reader(object):
-	def __init__(self, future, input_file, loop):
-		self._future = future
-		self._pipe_reader = PipeReader(
-			input_files={'input_file':input_file}, scheduler=loop)
-
-		self._future.add_done_callback(self._cancel_callback)
-		self._pipe_reader.addExitListener(self._eof)
-		self._pipe_reader.start()
-
-	def _cancel_callback(self, future):
-		if future.cancelled():
-			self._cancel()
-
-	def _eof(self, pipe_reader):
-		self._pipe_reader = None
-		self._future.set_result(pipe_reader.getvalue())
-
-	def _cancel(self):
-		if self._pipe_reader is not None and self._pipe_reader.poll() is None:
-			self._pipe_reader.removeExitListener(self._eof)
-			self._pipe_reader.cancel()
-			self._pipe_reader = None
 
 
 class SubprocessExecTestCase(TestCase):
@@ -76,99 +31,66 @@ class SubprocessExecTestCase(TestCase):
 				self.assertFalse(global_event_loop().is_closed())
 
 	def testEcho(self):
-		if create_subprocess_exec is None:
-			self.skipTest('create_subprocess_exec not implemented for python2')
-
 		args_tuple = (b'hello', b'world')
 		echo_binary = find_binary("echo")
 		self.assertNotEqual(echo_binary, None)
 		echo_binary = echo_binary.encode()
 
-		# Use os.pipe(), since this loop does not implement the
-		# ReadTransport necessary for subprocess.PIPE support.
-		stdout_pr, stdout_pw = os.pipe()
-		stdout_pr = os.fdopen(stdout_pr, 'rb', 0)
-		stdout_pw = os.fdopen(stdout_pw, 'wb', 0)
-		files = [stdout_pr, stdout_pw]
-
 		def test(loop):
-			output = None
-			try:
-				with open(os.devnull, 'rb', 0) as devnull:
-					proc = loop.run_until_complete(
-						create_subprocess_exec(
-						echo_binary, *args_tuple,
-						stdin=devnull, stdout=stdout_pw, stderr=stdout_pw))
+			@coroutine
+			def test_coroutine(loop=None):
 
-				# This belongs exclusively to the subprocess now.
-				stdout_pw.close()
+				proc = (yield create_subprocess_exec(echo_binary, *args_tuple,
+						stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+						loop=loop))
 
-				output = asyncio.ensure_future(
-					reader(stdout_pr, loop=loop), loop=loop)
+				out, err = (yield proc.communicate())
+				self.assertEqual(tuple(out.split()), args_tuple)
+				self.assertEqual(proc.returncode, os.EX_OK)
 
-				self.assertEqual(
-					loop.run_until_complete(proc.wait()), os.EX_OK)
-				self.assertEqual(
-					tuple(loop.run_until_complete(output).split()), args_tuple)
-			finally:
-				if output is not None and not output.done():
-					output.cancel()
-				for f in files:
-					f.close()
+				proc = (yield create_subprocess_exec(
+						'bash', '-c', 'echo foo; echo bar 1>&2;',
+						stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+						loop=loop))
+
+				out, err = (yield proc.communicate())
+				self.assertEqual(out, b'foo\n')
+				self.assertEqual(err, b'bar\n')
+				self.assertEqual(proc.returncode, os.EX_OK)
+
+				proc = (yield create_subprocess_exec(
+						'bash', '-c', 'echo foo; echo bar 1>&2;',
+						stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+						loop=loop))
+
+				out, err = (yield proc.communicate())
+				self.assertEqual(out, b'foo\nbar\n')
+				self.assertEqual(err, None)
+				self.assertEqual(proc.returncode, os.EX_OK)
+
+				coroutine_return('success')
+
+			self.assertEqual('success',
+				loop.run_until_complete(test_coroutine(loop=loop)))
 
 		self._run_test(test)
 
 	def testCat(self):
-		if create_subprocess_exec is None:
-			self.skipTest('create_subprocess_exec not implemented for python2')
-
 		stdin_data = b'hello world'
 		cat_binary = find_binary("cat")
 		self.assertNotEqual(cat_binary, None)
 		cat_binary = cat_binary.encode()
 
-		# Use os.pipe(), since this loop does not implement the
-		# ReadTransport necessary for subprocess.PIPE support.
-		stdout_pr, stdout_pw = os.pipe()
-		stdout_pr = os.fdopen(stdout_pr, 'rb', 0)
-		stdout_pw = os.fdopen(stdout_pw, 'wb', 0)
-
-		stdin_pr, stdin_pw = os.pipe()
-		stdin_pr = os.fdopen(stdin_pr, 'rb', 0)
-		stdin_pw = os.fdopen(stdin_pw, 'wb', 0)
-
-		files = [stdout_pr, stdout_pw, stdin_pr, stdin_pw]
-
 		def test(loop):
-			output = None
-			try:
-				proc = loop.run_until_complete(
-					create_subprocess_exec(
-					cat_binary,
-					stdin=stdin_pr, stdout=stdout_pw, stderr=stdout_pw))
+			proc = loop.run_until_complete(
+				create_subprocess_exec(cat_binary,
+				stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+				loop=loop))
 
-				# These belong exclusively to the subprocess now.
-				stdout_pw.close()
-				stdin_pr.close()
+			out, err = loop.run_until_complete(proc.communicate(input=stdin_data))
 
-				output = asyncio.ensure_future(
-					reader(stdout_pr, loop=loop), loop=loop)
-
-				with ForkExecutor(loop=loop) as executor:
-					writer = asyncio.ensure_future(loop.run_in_executor(
-						executor, stdin_pw.write, stdin_data), loop=loop)
-
-					# This belongs exclusively to the writer now.
-					stdin_pw.close()
-					loop.run_until_complete(writer)
-
-				self.assertEqual(loop.run_until_complete(proc.wait()), os.EX_OK)
-				self.assertEqual(loop.run_until_complete(output), stdin_data)
-			finally:
-				if output is not None and not output.done():
-					output.cancel()
-				for f in files:
-					f.close()
+			self.assertEqual(loop.run_until_complete(proc.wait()), os.EX_OK)
+			self.assertEqual(out, stdin_data)
 
 		self._run_test(test)
 
@@ -178,8 +100,8 @@ class SubprocessExecTestCase(TestCase):
 		requires an AbstractEventLoop.connect_read_pipe implementation
 		(and a ReadTransport implementation for it to return).
 		"""
-		if create_subprocess_exec is None:
-			self.skipTest('create_subprocess_exec not implemented for python2')
+		if sys.version_info.major < 3:
+			self.skipTest('ReadTransport not implemented for python2')
 
 		args_tuple = (b'hello', b'world')
 		echo_binary = find_binary("echo")
@@ -192,7 +114,8 @@ class SubprocessExecTestCase(TestCase):
 					create_subprocess_exec(
 					echo_binary, *args_tuple,
 					stdin=devnull,
-					stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+					stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+					loop=loop))
 
 			self.assertEqual(
 				tuple(loop.run_until_complete(proc.stdout.read()).split()),
@@ -207,8 +130,8 @@ class SubprocessExecTestCase(TestCase):
 		requires an AbstractEventLoop.connect_write_pipe implementation
 		(and a WriteTransport implementation for it to return).
 		"""
-		if create_subprocess_exec is None:
-			self.skipTest('create_subprocess_exec not implemented for python2')
+		if sys.version_info.major < 3:
+			self.skipTest('WriteTransport not implemented for python2')
 
 		stdin_data = b'hello world'
 		cat_binary = find_binary("cat")
@@ -220,7 +143,8 @@ class SubprocessExecTestCase(TestCase):
 				create_subprocess_exec(
 				cat_binary,
 				stdin=subprocess.PIPE,
-				stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+				stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+				loop=loop))
 
 			# This buffers data when necessary to avoid blocking.
 			proc.stdin.write(stdin_data)

--- a/lib/portage/util/futures/_asyncio/process.py
+++ b/lib/portage/util/futures/_asyncio/process.py
@@ -1,0 +1,107 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import portage
+portage.proxy.lazyimport.lazyimport(globals(),
+	'portage.util.futures:asyncio',
+)
+from portage.util.futures._asyncio.streams import _reader, _writer
+from portage.util.futures.compat_coroutine import coroutine, coroutine_return
+
+
+class _Process(object):
+	"""
+	Emulate a subset of the asyncio.subprocess.Process interface,
+	for python2.
+	"""
+	def __init__(self, proc, loop):
+		"""
+		@param proc: process instance
+		@type proc: subprocess.Popen
+		@param loop: asyncio.AbstractEventLoop (or compatible)
+		@type loop: event loop
+		"""
+		self._proc = proc
+		self._loop = loop
+		self.terminate = proc.terminate
+		self.kill = proc.kill
+		self.send_signal = proc.send_signal
+		self.pid = proc.pid
+		self._waiters = []
+		loop._asyncio_child_watcher.\
+			add_child_handler(self.pid, self._proc_exit)
+
+	@property
+	def returncode(self):
+		return self._proc.returncode
+
+	@coroutine
+	def communicate(self, input=None):
+		"""
+		Read data from stdout and stderr, until end-of-file is reached.
+		Wait for process to terminate.
+
+		@param input: stdin content to write
+		@type input: bytes
+		@return: tuple (stdout_data, stderr_data)
+		@rtype: asyncio.Future (or compatible)
+		"""
+		futures = []
+		for input_file in (self._proc.stdout, self._proc.stderr):
+			if input_file is None:
+				future = self._loop.create_future()
+				future.set_result(None)
+			else:
+				future = _reader(input_file, loop=self._loop)
+			futures.append(future)
+
+		writer = None
+		if input is not None:
+			if self._proc.stdin is None:
+				raise TypeError('communicate: expected file or int, got {}'.format(type(self._proc.stdin)))
+			writer = asyncio.ensure_future(_writer(self._proc.stdin, input), loop=self._loop)
+
+		try:
+			yield asyncio.wait(futures + [self.wait()], loop=self._loop)
+		finally:
+			if writer is not None:
+				if writer.done():
+					# Consume expected exceptions.
+					try:
+						writer.result()
+					except EnvironmentError:
+						# This is normal if the other end of the pipe was closed.
+						pass
+				else:
+					writer.cancel()
+
+		coroutine_return(tuple(future.result() for future in futures))
+
+	def wait(self):
+		"""
+		Wait for child process to terminate. Set and return returncode attribute.
+
+		@return: returncode
+		@rtype: asyncio.Future (or compatible)
+		"""
+		waiter = self._loop.create_future()
+		if self.returncode is None:
+			self._waiters.append(waiter)
+			waiter.add_done_callback(self._waiter_cancel)
+		else:
+			waiter.set_result(self.returncode)
+		return waiter
+
+	def _waiter_cancel(self, waiter):
+		if waiter.cancelled():
+			try:
+				self._waiters.remove(waiter)
+			except ValueError:
+				pass
+
+	def _proc_exit(self, pid, returncode):
+		self._proc.returncode = returncode
+		waiters = self._waiters
+		self._waiters = []
+		for waiter in waiters:
+			waiter.set_result(returncode)

--- a/lib/portage/util/futures/_asyncio/streams.py
+++ b/lib/portage/util/futures/_asyncio/streams.py
@@ -1,0 +1,96 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import errno
+import os
+
+import portage
+portage.proxy.lazyimport.lazyimport(globals(),
+	'_emerge.PipeReader:PipeReader',
+	'portage.util.futures:asyncio',
+	'portage.util.futures.unix_events:_set_nonblocking',
+)
+from portage.util.futures.compat_coroutine import coroutine
+
+
+def _reader(input_file, loop=None):
+	"""
+	Asynchronously read a binary input file, and close it when
+	it reaches EOF.
+
+	@param input_file: binary input file descriptor
+	@type input_file: file or int
+	@param loop: asyncio.AbstractEventLoop (or compatible)
+	@type loop: event loop
+	@return: bytes
+	@rtype: asyncio.Future (or compatible)
+	"""
+	loop = asyncio._wrap_loop(loop)
+	future = loop.create_future()
+	_Reader(future, input_file, loop)
+	return future
+
+
+class _Reader(object):
+	def __init__(self, future, input_file, loop):
+		self._future = future
+		self._pipe_reader = PipeReader(
+			input_files={'input_file':input_file}, scheduler=loop)
+
+		self._future.add_done_callback(self._cancel_callback)
+		self._pipe_reader.addExitListener(self._eof)
+		self._pipe_reader.start()
+
+	def _cancel_callback(self, future):
+		if future.cancelled():
+			self._cancel()
+
+	def _eof(self, pipe_reader):
+		self._pipe_reader = None
+		self._future.set_result(pipe_reader.getvalue())
+
+	def _cancel(self):
+		if self._pipe_reader is not None and self._pipe_reader.poll() is None:
+			self._pipe_reader.removeExitListener(self._eof)
+			self._pipe_reader.cancel()
+			self._pipe_reader = None
+
+
+@coroutine
+def _writer(output_file, content, loop=None):
+	"""
+	Asynchronously write bytes to output file, and close it when
+	done. If an EnvironmentError other than EAGAIN is encountered,
+	which typically indicates that the other end of the pipe has
+	close, the error is raised. This function is a coroutine.
+
+	@param output_file: output file descriptor
+	@type output_file: file or int
+	@param content: content to write
+	@type content: bytes
+	@param loop: asyncio.AbstractEventLoop (or compatible)
+	@type loop: event loop
+	"""
+	fd = output_file if isinstance(output_file, int) else output_file.fileno()
+	_set_nonblocking(fd)
+	loop = asyncio._wrap_loop(loop)
+	try:
+		while content:
+			waiter = loop.create_future()
+			loop.add_writer(fd, lambda: waiter.set_result(None))
+			try:
+				yield waiter
+				while content:
+					try:
+						content = content[os.write(fd, content):]
+					except EnvironmentError as e:
+						if e.errno == errno.EAGAIN:
+							break
+						else:
+							raise
+			finally:
+				loop.remove_writer(fd)
+	except GeneratorExit:
+		raise
+	finally:
+		os.close(output_file) if isinstance(output_file, int) else output_file.close()

--- a/lib/portage/util/futures/compat_coroutine.py
+++ b/lib/portage/util/futures/compat_coroutine.py
@@ -1,8 +1,12 @@
 # Copyright 2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-from portage.util.futures import asyncio
 import functools
+
+import portage
+portage.proxy.lazyimport.lazyimport(globals(),
+	'portage.util.futures:asyncio',
+)
 
 
 def coroutine(generator_func):


### PR DESCRIPTION
The asyncio.create_subprocess_exec function is essential for
using subprocesses in coroutines, so add support to do this
for python2. This paves the way for extensive use of coroutines
in portage, since coroutines are well-suited for many portage
tasks that involve subprocesses.

Bug: https://bugs.gentoo.org/662388