### PR TITLE
Replace implicit {FEATURES->USE}=test forcing with USE default

### DIFF
--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -107,7 +107,7 @@ CONFIG_PROTECT="/etc"
 CONFIG_PROTECT_MASK="/etc/env.d"
 
 # Disable auto-use
-USE_ORDER="env:pkg:conf:defaults:pkginternal:repo:env.d"
+USE_ORDER="env:pkg:conf:defaults:pkginternal:features:repo:env.d"
 
 # Mode bits for ${WORKDIR} (see ebuild.5).
 PORTAGE_WORKDIR_MODE="0700"

--- a/lib/portage/eapi.py
+++ b/lib/portage/eapi.py
@@ -170,7 +170,7 @@ def _get_eapi_attrs(eapi):
 		exports_EBUILD_PHASE_FUNC = (eapi is None or eapi_exports_EBUILD_PHASE_FUNC(eapi)),
 		exports_PORTDIR = (eapi is None or eapi_exports_PORTDIR(eapi)),
 		exports_ECLASSDIR = (eapi is not None and eapi_exports_ECLASSDIR(eapi)),
-		feature_flag_test = True,
+		feature_flag_test = False,
 		feature_flag_targetroot = (eapi is not None and eapi_has_targetroot(eapi)),
 		hdepend = (eapi is not None and eapi_has_hdepend(eapi)),
 		iuse_defaults = (eapi is None or eapi_has_iuse_defaults(eapi)),

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1138,7 +1138,7 @@ This variable contains options that control the build behavior of several
 packages.  More information in \fBebuild\fR(5).  Possible USE values
 can be found in \fI/usr/portage/profiles/use.desc\fR.
 .TP
-\fBUSE_ORDER\fR = \fI"env:pkg:conf:defaults:pkginternal:repo:env.d"\fR
+\fBUSE_ORDER\fR = \fI"env:pkg:conf:defaults:pkginternal:features:repo:env.d"\fR
 Determines the precedence of layers in the incremental stacking of the USE
 variable. Precedence decreases from left to right such that env overrides
 pkg, pkg overrides conf, and so forth.
@@ -1166,6 +1166,10 @@ USE from make.defaults and package.use in the profile
 .TP
 .B pkginternal
 USE from \fBebuild\fR(5) IUSE defaults
+.TP
+.B features
+Flags implied by FEATURES.  Currently includes USE=\fBtest\fR
+for FEATURES=\fBtest\fR.
 .TP
 .B repo
 USE from make.defaults and package.use in the repo's profiles/ top dir


### PR DESCRIPTION
Use an explicit USE_ORDER entry to control mapping FEATURES=test into
default-enabled USE=test, rather than forcing/masking it depending
on the state of FEATURES.

This makes it possible for users to enable (or disable) USE=test
independently of FEATURES.  An example use case is installing test
dependencies and building test cases without actually running tests
at a particular moment which is something I've been doing quite
frequently with LLVM.