### PR TITLE
Add sync-rcu support for rsync (bug 662070)

### DIFF
--- a/lib/portage/repository/storage/__init__.py
+++ b/lib/portage/repository/storage/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2

--- a/lib/portage/repository/storage/hardlink_quarantine.py
+++ b/lib/portage/repository/storage/hardlink_quarantine.py
@@ -1,0 +1,95 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage import os
+from portage.repository.storage.interface import (
+	RepoStorageException,
+	RepoStorageInterface,
+)
+from portage.util.futures import asyncio
+from portage.util.futures.compat_coroutine import (
+	coroutine,
+	coroutine_return,
+)
+
+from _emerge.SpawnProcess import SpawnProcess
+
+
+class HardlinkQuarantineRepoStorage(RepoStorageInterface):
+	"""
+	This is the default storage module, since its quite compatible with
+	most configurations.
+
+	It's desirable to be able to create shared hardlinks between the
+	download directory and the normal repository, and this is facilitated
+	by making the download directory be a subdirectory of the normal
+	repository location (ensuring that no mountpoints are crossed).
+	Shared hardlinks are created by using the rsync --link-dest option.
+
+	Since the download is initially unverified, it is safest to save
+	it in a quarantine directory. The quarantine directory is also
+	useful for making the repository update more atomic, so that it
+	less likely that normal repository location will be observed in
+	a partially synced state.
+	"""
+	def __init__(self, repo, spawn_kwargs):
+		self._user_location = repo.location
+		self._update_location = None
+		self._spawn_kwargs = spawn_kwargs
+		self._current_update = None
+
+	@coroutine
+	def _check_call(self, cmd):
+		"""
+		Run cmd and raise RepoStorageException on failure.
+
+		@param cmd: command to executre
+		@type cmd: list
+		"""
+		p = SpawnProcess(args=cmd, scheduler=asyncio._wrap_loop(), **self._spawn_kwargs)
+		p.start()
+		if (yield p.async_wait()) != os.EX_OK:
+			raise RepoStorageException('command exited with status {}: {}'.\
+				format(p.returncode, ' '.join(cmd)))
+
+	@coroutine
+	def init_update(self):
+		update_location = os.path.join(self._user_location, '.tmp-unverified-download-quarantine')
+		yield self._check_call(['rm', '-rf', update_location])
+
+		# Use  rsync --link-dest to hardlink a files into self._update_location,
+		# since cp -l is not portable.
+		yield self._check_call(['rsync', '-a', '--link-dest', self._user_location,
+			'--exclude', '/{}'.format(os.path.basename(update_location)),
+			self._user_location + '/', update_location + '/'])
+
+		self._update_location = update_location
+
+		coroutine_return(self._update_location)
+
+	@property
+	def current_update(self):
+		if self._update_location is None:
+			raise RepoStorageException('current update does not exist')
+		return self._update_location
+
+	@coroutine
+	def commit_update(self):
+		update_location = self.current_update
+		self._update_location = None
+		yield self._check_call(['rsync', '-a', '--delete',
+			'--exclude', '/{}'.format(os.path.basename(update_location)),
+			update_location + '/', self._user_location + '/'])
+
+		yield self._check_call(['rm', '-rf', update_location])
+
+	@coroutine
+	def abort_update(self):
+		if self._update_location is not None:
+			update_location = self._update_location
+			self._update_location = None
+			yield self._check_call(['rm', '-rf', update_location])
+
+	@coroutine
+	def garbage_collection(self):
+		yield self.abort_update()

--- a/lib/portage/repository/storage/hardlink_rcu.py
+++ b/lib/portage/repository/storage/hardlink_rcu.py
@@ -1,0 +1,251 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import datetime
+
+import portage
+from portage import os
+from portage.repository.storage.interface import (
+	RepoStorageException,
+	RepoStorageInterface,
+)
+from portage.util.futures import asyncio
+from portage.util.futures.compat_coroutine import (
+	coroutine,
+	coroutine_return,
+)
+
+from _emerge.SpawnProcess import SpawnProcess
+
+
+class HardlinkRcuRepoStorage(RepoStorageInterface):
+	"""
+	Enable read-copy-update (RCU) behavior for sync operations. The
+	current latest immutable version of a repository will be
+	reference by a symlink found where the repository would normally
+	be located.  Repository consumers should resolve the cannonical
+	path of this symlink before attempt to access the repository,
+	and all operations should be read-only, since the repository
+	is considered immutable. Updates occur by atomic replacement
+	of the symlink, which causes new consumers to use the new
+	immutable version, while any earlier consumers continue to use
+	the cannonical path that was resolved earlier.
+
+	Performance is better than HardlinkQuarantineRepoStorage,
+	since commit involves atomic replacement of a symlink. Since
+	the symlink usage would require special handling for scenarios
+	involving bind mounts and chroots, this module is not enabled
+	by default.
+
+	repos.conf parameters:
+
+		sync-rcu-store-dir
+
+			Directory path reserved for sync-rcu storage. This
+			directory must have a unique value for each repository
+			(do not set it in the DEFAULT section).  This directory
+			must not contain any other files or directories aside
+			from those that are created automatically when sync-rcu
+			is enabled.
+
+		sync-rcu-spare-snapshots = 1
+
+			Number of spare snapshots for sync-rcu to retain with
+			expired ttl. This protects the previous latest snapshot
+			from being removed immediately after a new version
+			becomes available, since it might still be used by
+			running processes.
+
+		sync-rcu-ttl-days = 7
+
+			Number of days for sync-rcu to retain previous immutable
+			snapshots of a repository. After the ttl of a particular
+			snapshot has expired, it will be remove automatically (the
+			latest snapshot is exempt, and sync-rcu-spare-snapshots
+			configures the number of previous snapshots that are
+			exempt). If the ttl is set too low, then a snapshot could
+			expire while it is in use by a running process.
+
+	"""
+	def __init__(self, repo, spawn_kwargs):
+		# Note that repo.location cannot substitute for repo.user_location here,
+		# since we manage a symlink that resides at repo.user_location, and
+		# repo.location is the irreversible result of realpath(repo.user_location).
+		self._user_location = repo.user_location
+		self._spawn_kwargs = spawn_kwargs
+
+		if not repo.sync_allow_hardlinks:
+			raise RepoStorageException("repos.conf sync-rcu setting"
+				" for repo '%s' requires that sync-allow-hardlinks be enabled" % repo.name)
+
+		# Raise an exception if repo.sync_rcu_store_dir is unset, since the
+		# user needs to be aware of this location for bind mount and chroot
+		# scenarios
+		if not repo.sync_rcu_store_dir:
+			raise RepoStorageException("repos.conf sync-rcu setting"
+				" for repo '%s' requires that sync-rcu-store-dir be set" % repo.name)
+
+		self._storage_location = repo.sync_rcu_store_dir
+		if repo.sync_rcu_spare_snapshots is None or repo.sync_rcu_spare_snapshots < 0:
+			self._spare_snapshots = 1
+		else:
+			self._spare_snapshots = repo.sync_rcu_spare_snapshots
+		if self._spare_snapshots < 0:
+			self._spare_snapshots = 0
+		if repo.sync_rcu_ttl_days is None or repo.sync_rcu_ttl_days < 0:
+			self._ttl_days = 1
+		else:
+			self._ttl_days = repo.sync_rcu_ttl_days
+		self._update_location = None
+		self._latest_symlink = os.path.join(self._storage_location, 'latest')
+		self._latest_canonical = os.path.realpath(self._latest_symlink)
+		if not os.path.exists(self._latest_canonical) or os.path.islink(self._latest_canonical):
+			# It doesn't exist, or it's a broken symlink.
+			self._latest_canonical = None
+		self._snapshots_dir = os.path.join(self._storage_location, 'snapshots')
+
+	@coroutine
+	def _check_call(self, cmd, privileged=False):
+		"""
+		Run cmd and raise RepoStorageException on failure.
+
+		@param cmd: command to executre
+		@type cmd: list
+		@param privileged: run with maximum privileges
+		@type privileged: bool
+		"""
+		if privileged:
+			kwargs = dict(fd_pipes=self._spawn_kwargs.get('fd_pipes'))
+		else:
+			kwargs = self._spawn_kwargs
+		p = SpawnProcess(args=cmd, scheduler=asyncio._wrap_loop(), **kwargs)
+		p.start()
+		if (yield p.async_wait()) != os.EX_OK:
+			raise RepoStorageException('command exited with status {}: {}'.\
+				format(p.returncode, ' '.join(cmd)))
+
+	@coroutine
+	def init_update(self):
+		update_location = os.path.join(self._storage_location, 'update')
+		yield self._check_call(['rm', '-rf', update_location])
+
+		# This assumes normal umask permissions if it doesn't exist yet.
+		portage.util.ensure_dirs(self._storage_location)
+
+		if self._latest_canonical is not None:
+			portage.util.ensure_dirs(update_location)
+			portage.util.apply_stat_permissions(update_location,
+				os.stat(self._user_location))
+			# Use  rsync --link-dest to hardlink a files into update_location,
+			# since cp -l is not portable.
+			yield self._check_call(['rsync', '-a', '--link-dest', self._latest_canonical,
+				self._latest_canonical + '/', update_location + '/'])
+
+		elif not os.path.islink(self._user_location):
+			yield self._migrate(update_location)
+			update_location = (yield self.init_update())
+
+		self._update_location = update_location
+
+		coroutine_return(self._update_location)
+
+	@coroutine
+	def _migrate(self, update_location):
+		"""
+		When repo.user_location is a normal directory, migrate it to
+		storage so that it can be replaced with a symlink. After migration,
+		commit the content as the latest snapshot.
+		"""
+		try:
+			os.rename(self._user_location, update_location)
+		except OSError:
+			portage.util.ensure_dirs(update_location)
+			portage.util.apply_stat_permissions(update_location,
+				os.stat(self._user_location))
+			# It's probably on a different device, so copy it.
+			yield self._check_call(['rsync', '-a',
+				self._user_location + '/', update_location + '/'])
+
+			# Remove the old copy so that symlink can be created. Run with
+			# maximum privileges, since removal requires write access to
+			# the parent directory.
+			yield self._check_call(['rm', '-rf', user_location], privileged=True)
+
+		self._update_location = update_location
+
+		# Make this copy the latest snapshot
+		yield self.commit_update()
+
+	@property
+	def current_update(self):
+		if self._update_location is None:
+			raise RepoStorageException('current update does not exist')
+		return self._update_location
+
+	@coroutine
+	def commit_update(self):
+		update_location = self.current_update
+		self._update_location = None
+		try:
+			snapshots = [int(name) for name in os.listdir(self._snapshots_dir)]
+		except OSError:
+			snapshots = []
+			portage.util.ensure_dirs(self._snapshots_dir)
+			portage.util.apply_stat_permissions(self._snapshots_dir,
+				os.stat(self._storage_location))
+		if snapshots:
+			new_id = max(snapshots) + 1
+		else:
+			new_id = 1
+		os.rename(update_location, os.path.join(self._snapshots_dir, str(new_id)))
+		new_symlink = self._latest_symlink + '.new'
+		try:
+			os.unlink(new_symlink)
+		except OSError:
+			pass
+		os.symlink('snapshots/{}'.format(new_id), new_symlink)
+		os.rename(new_symlink, self._latest_symlink)
+
+		try:
+			user_location_correct = os.path.samefile(self._user_location, self._latest_symlink)
+		except OSError:
+			user_location_correct = False
+
+		if not user_location_correct:
+			new_symlink = self._user_location + '.new'
+			try:
+				os.unlink(new_symlink)
+			except OSError:
+				pass
+			os.symlink(self._latest_symlink, new_symlink)
+			os.rename(new_symlink, self._user_location)
+
+		coroutine_return()
+		yield None
+
+	@coroutine
+	def abort_update(self):
+		if self._update_location is not None:
+			update_location = self._update_location
+			self._update_location = None
+			yield self._check_call(['rm', '-rf', update_location])
+
+	@coroutine
+	def garbage_collection(self):
+		snap_ttl = datetime.timedelta(days=self._ttl_days)
+		snapshots = sorted(int(name) for name in os.listdir(self._snapshots_dir))
+		# always preserve the latest snapshot
+		protect_count = self._spare_snapshots + 1
+		while snapshots and protect_count:
+			protect_count -= 1
+			snapshots.pop()
+		for snap_id in snapshots:
+			snap_path = os.path.join(self._snapshots_dir, str(snap_id))
+			try:
+				st = os.stat(snap_path)
+			except OSError:
+				continue
+			snap_timestamp = datetime.datetime.utcfromtimestamp(st.st_mtime)
+			if (datetime.datetime.utcnow() - snap_timestamp) < snap_ttl:
+				continue
+			yield self._check_call(['rm', '-rf', snap_path])

--- a/lib/portage/repository/storage/inplace.py
+++ b/lib/portage/repository/storage/inplace.py
@@ -1,0 +1,49 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.repository.storage.interface import (
+	RepoStorageException,
+	RepoStorageInterface,
+)
+from portage.util.futures.compat_coroutine import coroutine, coroutine_return
+
+
+class InplaceRepoStorage(RepoStorageInterface):
+	"""
+	Legacy repo storage behavior, where updates are applied in-place.
+	This module is not recommended, since the repository is left in an
+	unspecified (possibly malicious) state if the update fails.
+	"""
+	def __init__(self, repo, spawn_kwargs):
+		self._user_location = repo.location
+		self._update_location = None
+
+	@coroutine
+	def init_update(self):
+		self._update_location = self._user_location
+		coroutine_return(self._update_location)
+		yield None
+
+	@property
+	def current_update(self):
+		if self._update_location is None:
+			raise RepoStorageException('current update does not exist')
+		return self._update_location
+
+	@coroutine
+	def commit_update(self):
+		self.current_update
+		self._update_location = None
+		coroutine_return()
+		yield None
+
+	@coroutine
+	def abort_update(self):
+		self._update_location = None
+		coroutine_return()
+		yield None
+
+	@coroutine
+	def garbage_collection(self):
+		coroutine_return()
+		yield None

--- a/lib/portage/repository/storage/interface.py
+++ b/lib/portage/repository/storage/interface.py
@@ -1,0 +1,87 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.exception import PortageException
+from portage.util.futures.compat_coroutine import coroutine
+
+
+class RepoStorageException(PortageException):
+	"""
+	Base class for exceptions raise by RepoStorageInterface.
+	"""
+
+
+class RepoStorageInterface(object):
+	"""
+	Abstract repository storage interface.
+
+	Implementations can assume that the repo.location directory already
+	exists with appropriate permissions (SyncManager handles this).
+
+	TODO: Add a method to check of a previous uncommitted update, which
+	typically indicates a verification failure:
+	    https://bugs.gentoo.org/662386
+	"""
+	def __init__(self, repo, spawn_kwargs):
+		"""
+		@param repo: repository configuration
+		@type repo: portage.repository.config.RepoConfig
+		@param spawn_kwargs: keyword arguments supported by the
+			portage.process.spawn function
+		@type spawn_kwargs: dict
+		"""
+		raise NotImplementedError
+
+	@coroutine
+	def init_update(self):
+		"""
+		Create an update directory as a destination to sync updates to.
+		The directory will be populated with files from the previous
+		immutable snapshot, if available. Note that this directory
+		may contain hardlinks that reference files in the previous
+		immutable snapshot, so these files should not be modified
+		(tools like rsync and git normally break hardlinks when
+		files need to be modified).
+
+		@rtype: str
+		@return: path of directory to update, populated with files from
+			the previous snapshot if available
+		"""
+		raise NotImplementedError
+
+	@property
+	def current_update(self):
+		"""
+		Get the current update directory which would have been returned
+		from the most recent call to the init_update method. This raises
+		RepoStorageException if the init_update method has not been
+		called.
+
+		@rtype: str
+		@return: path of directory to update
+		"""
+		raise NotImplementedError
+
+	@coroutine
+	def commit_update(self):
+		"""
+		Commit the current update directory, so that is becomes the
+		latest immutable snapshot.
+		"""
+		raise NotImplementedError
+
+	@coroutine
+	def abort_update(self):
+		"""
+		Delete the current update directory. If there was not an update
+		in progress, or it has already been committed, then this has
+		no effect.
+		"""
+		raise NotImplementedError
+
+	@coroutine
+	def garbage_collection(self):
+		"""
+		Remove expired snapshots.
+		"""
+		raise NotImplementedError

--- a/lib/portage/sync/controller.py
+++ b/lib/portage/sync/controller.py
@@ -327,6 +327,7 @@ class SyncManager(object):
 		# override the defaults when sync_umask is set
 		if repo.sync_umask is not None:
 			spawn_kwargs["umask"] = int(repo.sync_umask, 8)
+		spawn_kwargs.setdefault("umask", 0o022)
 		self.spawn_kwargs = spawn_kwargs
 
 		if self.usersync_uid is not None:

--- a/lib/portage/sync/syncbase.py
+++ b/lib/portage/sync/syncbase.py
@@ -93,7 +93,9 @@ class SyncBase(object):
 		@rtype: str
 		@return: name of the selected repo storage constructor
 		'''
-		if self.repo.sync_allow_hardlinks:
+		if self.repo.sync_rcu:
+			mod_name = 'portage.repository.storage.hardlink_rcu.HardlinkRcuRepoStorage'
+		elif self.repo.sync_allow_hardlinks:
 			mod_name = 'portage.repository.storage.hardlink_quarantine.HardlinkQuarantineRepoStorage'
 		else:
 			mod_name = 'portage.repository.storage.inplace.InplaceRepoStorage'

--- a/lib/portage/sync/syncbase.py
+++ b/lib/portage/sync/syncbase.py
@@ -12,9 +12,11 @@ import logging
 import os
 
 import portage
+from portage.repository.storage.interface import RepoStorageException
 from portage.util import writemsg_level
 from portage.util._eventloop.global_event_loop import global_event_loop
 from portage.util.backoff import RandomExponentialBackoff
+from portage.util.futures._sync_decorator import _sync_methods
 from portage.util.futures.retry import retry
 from portage.util.futures.executor.fork import ForkExecutor
 from . import _SUBMODULE_PATH_MAP
@@ -40,6 +42,8 @@ class SyncBase(object):
 		self.repo = None
 		self.xterm_titles = None
 		self.spawn_kwargs = None
+		self._repo_storage = None
+		self._download_dir = None
 		self.bin_command = None
 		self._bin_command = bin_command
 		self.bin_pkg = bin_pkg
@@ -49,7 +53,8 @@ class SyncBase(object):
 
 	@property
 	def has_bin(self):
-		'''Checks for existance of the external binary.
+		'''Checks for existance of the external binary, and also
+		checks for storage driver configuration problems.
 
 		MUST only be called after _kwargs() has set the logger
 		'''
@@ -61,8 +66,15 @@ class SyncBase(object):
 				writemsg_level("!!! %s\n" % l,
 					level=logging.ERROR, noiselevel=-1)
 			return False
-		return True
 
+		try:
+			self.repo_storage
+		except RepoStorageException as e:
+			writemsg_level("!!! %s\n" % (e,),
+				level=logging.ERROR, noiselevel=-1)
+			return False
+
+		return True
 
 	def _kwargs(self, kwargs):
 		'''Sets internal variables from kwargs'''
@@ -73,6 +85,43 @@ class SyncBase(object):
 		self.xterm_titles = self.options.get('xterm_titles', False)
 		self.spawn_kwargs = self.options.get('spawn_kwargs', None)
 
+	def _select_storage_module(self):
+		'''
+		Select an appropriate implementation of RepoStorageInterface, based
+		on repos.conf settings.
+
+		@rtype: str
+		@return: name of the selected repo storage constructor
+		'''
+		if self.repo.sync_allow_hardlinks:
+			mod_name = 'portage.repository.storage.hardlink_quarantine.HardlinkQuarantineRepoStorage'
+		else:
+			mod_name = 'portage.repository.storage.inplace.InplaceRepoStorage'
+		return mod_name
+
+	@property
+	def repo_storage(self):
+		"""
+		Get the repo storage driver instance. Raise RepoStorageException
+		if there is a configuration problem
+		"""
+		if self._repo_storage is None:
+			storage_cls = portage.load_mod(self._select_storage_module())
+			self._repo_storage = _sync_methods(storage_cls(self.repo, self.spawn_kwargs))
+		return self._repo_storage
+
+	@property
+	def download_dir(self):
+		"""
+		Get the path of the download directory, where the repository
+		update is staged. The directory is initialized lazily, since
+		the repository might already be at the latest revision, and
+		there may be some cost associated with the directory
+		initialization.
+		"""
+		if self._download_dir is None:
+			self._download_dir = self.repo_storage.init_update()
+		return self._download_dir
 
 	def exists(self, **kwargs):
 		'''Tests whether the repo actually exists'''

--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -36,6 +36,7 @@ except ImportError:
 import portage
 portage.proxy.lazyimport.lazyimport(globals(),
 	'portage.util.futures.unix_events:_PortageEventLoopPolicy',
+	'portage.util.futures:compat_coroutine@_compat_coroutine',
 )
 from portage.util._eventloop.asyncio_event_loop import AsyncioEventLoop as _AsyncioEventLoop
 from portage.util._eventloop.global_event_loop import (
@@ -150,6 +151,19 @@ def create_subprocess_exec(*args, **kwargs):
 		stderr=kwargs.pop('stderr', None), **kwargs), loop))
 
 	return result
+
+
+def iscoroutinefunction(func):
+	"""
+	Return True if func is a decorated coroutine function,
+	supporting both asyncio.coroutine and compat_coroutine since
+	their behavior is identical for all practical purposes.
+	"""
+	if _compat_coroutine._iscoroutinefunction(func):
+		return True
+	elif _real_asyncio is not None and _real_asyncio.iscoroutinefunction(func):
+		return True
+	return False
 
 
 class Task(Future):

--- a/lib/portage/util/futures/_sync_decorator.py
+++ b/lib/portage/util/futures/_sync_decorator.py
@@ -1,0 +1,54 @@
+# Copyright 2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import functools
+
+import portage
+portage.proxy.lazyimport.lazyimport(globals(),
+	'portage.util.futures:asyncio',
+)
+
+
+def _sync_decorator(func, loop=None):
+	"""
+	Decorate an asynchronous function (either a corouting function or a
+	function that returns a Future) with a wrapper that runs the function
+	synchronously.
+	"""
+	loop = asyncio._wrap_loop(loop)
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		return loop.run_until_complete(func(*args, **kwargs))
+	return wrapper
+
+
+def _sync_methods(obj, loop=None):
+	"""
+	For use with synchronous code that needs to interact with an object
+	that has coroutine methods, this function generates a proxy which
+	conveniently converts coroutine methods into synchronous methods.
+	This allows coroutines to smoothly blend with synchronous
+	code, eliminating clutter that might otherwise discourage the
+	proliferation of coroutine usage for I/O bound tasks.
+	"""
+	loop = asyncio._wrap_loop(loop)
+	return _ObjectAttrWrapper(obj,
+		lambda attr: _sync_decorator(attr, loop=loop)
+		if asyncio.iscoroutinefunction(attr) else attr)
+
+
+class _ObjectAttrWrapper(portage.proxy.objectproxy.ObjectProxy):
+
+	__slots__ = ('_obj', '_attr_wrapper')
+
+	def __init__(self, obj, attr_wrapper):
+		object.__setattr__(self, '_obj', obj)
+		object.__setattr__(self, '_attr_wrapper', attr_wrapper)
+
+	def __getattribute__(self, attr):
+		obj = object.__getattribute__(self, '_obj')
+		attr_wrapper = object.__getattribute__(self, '_attr_wrapper')
+		return attr_wrapper(getattr(obj, attr))
+
+	def _get_target(self):
+		return object.__getattribute__(self, '_obj')

--- a/lib/portage/util/futures/compat_coroutine.py
+++ b/lib/portage/util/futures/compat_coroutine.py
@@ -8,6 +8,17 @@ portage.proxy.lazyimport.lazyimport(globals(),
 	'portage.util.futures:asyncio',
 )
 
+# A marker for iscoroutinefunction.
+_is_coroutine = object()
+
+
+def _iscoroutinefunction(func):
+	"""
+	Return True if func is a decorated coroutine function
+	created with the coroutine decorator for this module.
+	"""
+	return getattr(func, '_is_coroutine', None) is _is_coroutine
+
 
 def coroutine(generator_func):
 	"""
@@ -34,6 +45,7 @@ def coroutine(generator_func):
 	@functools.wraps(generator_func)
 	def wrapped(*args, **kwargs):
 		return _generator_future(generator_func, *args, **kwargs)
+	wrapped._is_coroutine = _is_coroutine
 	return wrapped
 
 

--- a/man/portage.5
+++ b/man/portage.5
@@ -1025,6 +1025,41 @@ If set to true, then sync of a given repository will not trigger postsync
 hooks unless hooks would have executed for a master repository or the
 repository has changed since the previous sync operation.
 .TP
+.B sync\-rcu = yes|no
+Enable read\-copy\-update (RCU) behavior for sync operations. The current
+latest immutable version of a repository will be referenced by a symlink
+found where the repository would normally be located (see the \fBlocation\fR
+setting). Repository consumers should resolve the cannonical path of this
+symlink before attempt to access the repository, and all operations should
+be read\-only, since the repository is considered immutable. Updates occur
+by atomic replacement of the symlink, which causes new consumers to use the
+new immutable version, while any earlier consumers continue to use the
+cannonical path that was resolved earlier. This option requires
+sync\-allow\-hardlinks and sync\-rcu\-store\-dir options to be enabled, and
+currently also requires that sync\-type is set to rsync. This option is
+disabled by default, since the symlink usage would require special handling
+for scenarios involving bind mounts and chroots.
+.TP
+.B sync\-rcu\-store\-dir
+Directory path reserved for sync\-rcu storage. This directory must have a
+unique value for each repository (do not set it in the DEFAULT section).
+This directory must not contain any other files or directories aside from
+those that are created automatically when sync\-rcu is enabled.
+.TP
+.B sync\-rcu\-spare\-snapshots = 1
+Number of spare snapshots for sync\-rcu to retain with expired ttl. This
+protects the previous latest snapshot from being removed immediately after
+a new version becomes available, since it might still be used by running
+processes.
+.TP
+.B sync\-rcu\-ttl\-days = 7
+Number of days for sync\-rcu to retain previous immutable snapshots of
+a repository. After the ttl of a particular snapshot has expired, it
+will be remove automatically (the latest snapshot is exempt, and
+sync\-rcu\-spare\-snapshots configures the number of previous snapshots
+that are exempt). If the ttl is set too low, then a snapshot could
+expire while it is in use by a running process.
+.TP
 .B sync\-type
 Specifies type of synchronization performed by `emerge \-\-sync`.
 .br


### PR DESCRIPTION
Add a boolean sync-rcu repos.conf setting that behaves as follows:

sync-rcu = yes|no

    Enable read-copy-update (RCU) behavior for sync operations. The
    current latest immutable version of a repository will be referenced
    by a symlink found where the repository would normally be located
    (see the location setting). Repository consumers should resolve
    the cannonical path of this symlink before attempt to access
    the repository, and all operations should be read-only, since
    the repository is considered immutable. Updates occur by atomic
    replacement of the symlink, which causes new consumers to use the
    new immutable version, while any earlier consumers continue to
    use the cannonical path that was resolved earlier. This option
    requires sync-allow-hardlinks and sync-rcu-store-dir options to
    be enabled, and currently also requires that sync-type is set
    to rsync. This option is disabled by default, since the symlink
    usage would require special handling for scenarios involving bind
    mounts and chroots.

sync-rcu-store-dir

    Directory path reserved for sync-rcu storage. This directory must
    have a unique value for each repository (do not set it in the
    DEFAULT section).  This directory must not contain any other files
    or directories aside from those that are created automatically
    when sync-rcu is enabled.

sync-rcu-spare-snapshots = 1

    Number of spare snapshots for sync-rcu to retain with expired
    ttl. This protects the previous latest snapshot from being removed
    immediately after a new version becomes available, since it might
    still be used by running processes.

sync-rcu-ttl-days = 7

    Number of days for sync-rcu to retain previous immutable snapshots
    of a repository. After the ttl of a particular snapshot has
    expired, it will be remove automatically (the latest snapshot
    is exempt, and sync-rcu-spare-snapshots configures the number of
    previous snapshots that are exempt). If the ttl is set too low,
    then a snapshot could expire while it is in use by a running
    process.

Bug: https://bugs.gentoo.org/662070