### PR TITLE
XARGS: use gxargs for USERLAND=BSD (bug 663256)

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -448,7 +448,11 @@ fi
 if [[ -z ${XARGS} ]] ; then
 	case ${USERLAND} in
 	BSD)
-		export XARGS="xargs"
+		if type -P gxargs > /dev/null; then
+			export XARGS="gxargs -r"
+		else
+			export XARGS="xargs"
+		fi
 		;;
 	*)
 		export XARGS="xargs -r"


### PR DESCRIPTION
For USERLAND=BSD, set XARGS="gxargs -r" if gxargs is available,
so the code from bug 630292 works for USERLAND=BSD.

Fixes: 50283f1abb77 (install-qa-check.d/60pngfix: parallel support (bug 630292))
Reported-by: Michał Górny <mgorny@gentoo.org>
Bug: https://bugs.gentoo.org/663256