### PR TITLE
repoman: Update copyright checks & updates for the new copyright policy

### DIFF
--- a/repoman/cnf/linechecks/linechecks.yaml
+++ b/repoman/cnf/linechecks/linechecks.yaml
@@ -9,7 +9,8 @@ repoman_version: 2.3.3
 # configuration file for the LineCheck plugins run via the multicheck
 # scan module
 errors:
-    COPYRIGHT_ERROR: 'Invalid Gentoo Copyright on line: %d'
+    COPYRIGHT_ERROR: 'Invalid Copyright on line: %d'
+    COPYRIGHT_DATE_ERROR: 'No copyright for last modification date before line %d'
     LICENSE_ERROR: 'Invalid Gentoo/GPL License on line: %d'
     ID_HEADER_ERROR: 'Stale CVS header on line: %d'
     NO_BLANK_LINE_ERROR: 'Non-blank line after header on line: %d'

--- a/repoman/lib/repoman/copyrights.py
+++ b/repoman/lib/repoman/copyrights.py
@@ -31,7 +31,7 @@ class _copyright_repl(object):
 			return matchobj.group(0)
 		else:
 			return matchobj.group(1) + matchobj.group(2) + \
-				b'-' + self.year + matchobj.group(3)
+				b'-' + self.year + b' Gentoo Authors'
 
 
 def update_copyright_year(year, line):
@@ -51,7 +51,7 @@ def update_copyright_year(year, line):
 	year = _unicode_encode(year)
 	line = _unicode_encode(line)
 
-	line = _copyright_re1.sub(br'\1-' + year + br'\2', line)
+	line = _copyright_re1.sub(br'\1-' + year + b' Gentoo Authors', line)
 	line = _copyright_re2.sub(_copyright_repl(year), line)
 	if not is_bytes:
 		line = _unicode_decode(line)

--- a/repoman/lib/repoman/copyrights.py
+++ b/repoman/lib/repoman/copyrights.py
@@ -15,9 +15,9 @@ from portage import util
 
 
 _copyright_re1 = \
-	re.compile(br'^(# Copyright \d\d\d\d)-\d\d\d\d( Gentoo Foundation)\b')
+	re.compile(br'^(# Copyright \d\d\d\d)-\d\d\d\d( Gentoo (Foundation|Authors))\b')
 _copyright_re2 = \
-	re.compile(br'^(# Copyright )(\d\d\d\d)( Gentoo Foundation)\b')
+	re.compile(br'^(# Copyright )(\d\d\d\d)( Gentoo (Foundation|Authors))\b')
 
 
 class _copyright_repl(object):

--- a/repoman/lib/repoman/tests/changelog/test_echangelog.py
+++ b/repoman/lib/repoman/tests/changelog/test_echangelog.py
@@ -30,7 +30,7 @@ class RepomanEchangelogTestCase(TestCase):
 		os.makedirs(self.pkgdir)
 
 		self.header_pkg = '# ChangeLog for %s/%s\n' % (self.cat, self.pkg)
-		self.header_copyright = '# Copyright 1999-%s Gentoo Foundation; Distributed under the GPL v2\n' % \
+		self.header_copyright = '# Copyright 1999-%s Gentoo Authors; Distributed under the GPL v2\n' % \
 			time.strftime('%Y', time.gmtime())
 		self.header_cvs = '# $Header: $\n'
 

--- a/repoman/lib/repoman/tests/simple/test_simple.py
+++ b/repoman/lib/repoman/tests/simple/test_simple.py
@@ -35,6 +35,16 @@ class SimpleRepomanTestCase(TestCase):
 				'# Copyright 1999 Gentoo Foundation; Distributed under the GPL v2',
 				'# Copyright 1999 Gentoo Foundation; Distributed under the GPL v2',
 			),
+			(
+				'2018',
+				'# Copyright 1999-2008 Gentoo Authors; Distributed under the GPL v2',
+				'# Copyright 1999-2018 Gentoo Authors; Distributed under the GPL v2',
+			),
+			(
+				'2018',
+				'# Copyright 2017 Gentoo Authors; Distributed under the GPL v2',
+				'# Copyright 2017-2018 Gentoo Authors; Distributed under the GPL v2',
+			),
 		)
 
 		for year, before, after in test_cases:

--- a/repoman/lib/repoman/tests/simple/test_simple.py
+++ b/repoman/lib/repoman/tests/simple/test_simple.py
@@ -23,12 +23,12 @@ class SimpleRepomanTestCase(TestCase):
 			(
 				'2011',
 				'# Copyright 1999-2008 Gentoo Foundation; Distributed under the GPL v2',
-				'# Copyright 1999-2011 Gentoo Foundation; Distributed under the GPL v2',
+				'# Copyright 1999-2011 Gentoo Authors; Distributed under the GPL v2',
 			),
 			(
 				'2011',
 				'# Copyright 1999 Gentoo Foundation; Distributed under the GPL v2',
-				'# Copyright 1999-2011 Gentoo Foundation; Distributed under the GPL v2',
+				'# Copyright 1999-2011 Gentoo Authors; Distributed under the GPL v2',
 			),
 			(
 				'1999',


### PR DESCRIPTION
1. Allow more free-form copyright notices for repoman checks.
2. Allow automatic copyright updates for 'Gentoo Authors' line (but not for other copyrights -- they are unclear).
3. Allow automatic update from 'Gentoo Foundation' to 'Gentoo Authors'.