### PR TITLE
improve OS_RELEASE_ID definition

### DIFF
--- a/bin/etc-update
+++ b/bin/etc-update
@@ -32,7 +32,8 @@ get_config() {
 		"${PORTAGE_CONFIGROOT}"etc/etc-update.conf)
 }
 
-OS_RELEASE_ID=$(cat /etc/os-release 2>/dev/null | grep '^ID=' | cut -d'=' -f2 | sed -e 's/"//g')
+OS_RELEASE_ID=$(source /etc/os-release >/dev/null 2>&1; echo "${ID}")
+
 
 case $OS_RELEASE_ID in
 	suse|opensuse|opensuse-leap|opensuse-tumbleweed) OS_FAMILY='rpm' ;;

--- a/bin/etc-update
+++ b/bin/etc-update
@@ -34,7 +34,6 @@ get_config() {
 
 OS_RELEASE_ID=$(source /etc/os-release >/dev/null 2>&1; echo "${ID}")
 
-
 case $OS_RELEASE_ID in
 	suse|opensuse|opensuse-leap|opensuse-tumbleweed) OS_FAMILY='rpm' ;;
 	fedora|rhel) OS_FAMILY='rpm' ;;


### PR DESCRIPTION
adopt the [proposal](https://github.com/gentoo/portage/pull/349#issuecomment-425483117) fixing `OS_RELEASE_ID`
