### PR TITLE
Support QA{,_STRICT}_INSTALL_PATHS variables (bug 667378)

### DIFF
--- a/bin/install-qa-check.d/08gentoo-paths
+++ b/bin/install-qa-check.d/08gentoo-paths
@@ -60,6 +60,27 @@ gentoo_path_check() {
 
 	${shopt_save}
 
+	if [[ ${#bad_paths[@]} -gt 0 && ${QA_INSTALL_PATHS} &&
+		${QA_STRICT_INSTALL_PATHS-unset} == unset ]]; then
+		local filtered_paths=()
+		local grep_args=()
+		local qa_install_paths
+		if [[ $(declare -p QA_INSTALL_PATHS) == "declare -a "* ]]; then
+			qa_install_paths=( "${QA_INSTALL_PATHS[@]}" )
+		else
+			set -f
+			qa_install_paths=( ${QA_INSTALL_PATHS} )
+			set +f
+		fi
+		for x in "${qa_install_paths[@]}"; do
+			grep_args+=( -e "^/${x#/}\$" )
+		done
+		while read -r -d ''; do
+			[[ ${REPLY} ]] && filtered_paths+=( "${REPLY}" )
+		done < <(printf -- '%s\0' "${bad_paths[@]}" | grep -zv "${grep_args[@]}")
+		bad_paths=( "${filtered_paths[@]}" )
+	fi
+
 	# report
 	# ------
 	if [[ -n ${bad_paths[@]} ]]; then

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -791,6 +791,13 @@ characters.
 This variable is intended to be used on files of binary packages which ignore
 CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, and LDFLAGS variables.
 .TP
+.B QA_INSTALL_PATHS
+This should contain a list of file paths (may be an array), relative to the
+image directory, of files that are exempt from QA notices regarding ebuilds
+that install files to unusual locations.
+The paths may contain regular expressions with escape\-quoted special
+characters.
+.TP
 .B QA_MULTILIB_PATHS
 This should contain a list of file paths, relative to the image directory, of
 files that should be ignored for the multilib\-strict checks.

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1060,6 +1060,10 @@ settings from ebuilds.  See also \fBebuild\fR(5).
 Set this to cause portage to ignore any \fIQA_FLAGS_IGNORED\fR override
 settings from ebuilds.  See also \fBebuild\fR(5).
 .TP
+\fBQA_STRICT_INSTALL_PATHS = \fI"set"\fR
+Set this to cause portage to ignore any \fIQA_INSTALL_PATHS\fR override
+settings from ebuilds.  See also \fBebuild\fR(5).
+.TP
 \fBQA_STRICT_MULTILIB_PATHS = \fI"set"\fR
 Set this to cause portage to ignore any \fIQA_MULTILIB_PATHS\fR override
 settings from ebuilds.  See also \fBebuild\fR(5).


### PR DESCRIPTION
The QA_INSTALL_PATHS variable exempts paths from "unexpected paths"
warnings generated by install-qa-check.d/08gentoo-paths. This is
useful for QT packages that are expected to install a directory
named /usr/share/doc/${PN}-${VERSION} (which may differ from the
usual /usr/share/doc/${PF} location as reported in bug 667280).

Bug: https://bugs.gentoo.org/667378
Signed-off-by: Zac Medico <zmedico@gentoo.org>