### PR TITLE
estrip: Report pre-stripped files even with RESTRICT=strip

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -308,7 +308,7 @@ process_elf() {
 # The existance of the section .symtab tells us that a binary is stripped.
 # We want to log already stripped binaries, as this may be a QA violation.
 # They prevent us from getting the splitdebug data.
-if ! ${RESTRICT_binchecks} && ! ${RESTRICT_strip} ; then
+if ! ${RESTRICT_binchecks} ; then
 	# We need to do the non-stripped scan serially first before we turn around
 	# and start stripping the files ourselves.  The log parsing can be done in
 	# parallel though.


### PR DESCRIPTION
The purpose of RESTRICT=strip is to prevent files from being stripped,
not to silence QA checks about pre-stripped files.

Signed-off-by: Zac Medico <zmedico@gentoo.org>