### PR TITLE
_doebuild_path: Respect order defined in ROOTPATH (bug 667662)

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -212,6 +212,7 @@ def _doebuild_path(settings, eapi=None):
 	eprefix = portage.const.EPREFIX
 	prerootpath = [x for x in settings.get("PREROOTPATH", "").split(":") if x]
 	rootpath = [x for x in settings.get("ROOTPATH", "").split(":") if x]
+	rootpath_set = frozenset(rootpath)
 	overrides = [x for x in settings.get(
 		"__PORTAGE_TEST_PATH_OVERRIDE", "").split(":") if x]
 
@@ -243,7 +244,10 @@ def _doebuild_path(settings, eapi=None):
 
 	for prefix in prefixes:
 		for x in ("usr/local/sbin", "usr/local/bin", "usr/sbin", "usr/bin", "sbin", "bin"):
-			path.append(os.path.join(prefix, x))
+			# Respect order defined in ROOTPATH
+			x_abs = os.path.join(prefix, x)
+			if x_abs not in rootpath_set:
+				path.append(x_abs)
 
 	path.extend(rootpath)
 	settings["PATH"] = ":".join(path)


### PR DESCRIPTION
Respect the order of paths defined in /etc/env.d/*, so that
packages like llvm can rely on ordering relative to paths
defined in /etc/env.d/50baselayout since baselayout-2.6.

See: https://gitweb.gentoo.org/proj/baselayout.git/commit/?id=277e5b9e55717873b87eb541a95f4f2ae0c60a4d
Bug: https://bugs.gentoo.org/667662
Signed-off-by: Zac Medico <zmedico@gentoo.org>