### PR TITLE
doebuild: add missing whitespace in warning message

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -508,8 +508,8 @@ def doebuild_environment(myebuild, mydo, myroot=None, settings=None,
 						mysettings["PATH"] = p + ":" + mysettings["PATH"]
 						break
 				else:
-					writemsg(("Warning: %s requested but no masquerade dir"
-						+ "can be found in /usr/lib*/%s/bin\n") % (m, m))
+					writemsg(("Warning: %s requested but no masquerade dir "
+						"can be found in /usr/lib*/%s/bin\n") % (m, m))
 					mysettings.features.remove(feature)
 
 		if 'MAKEOPTS' not in mysettings:


### PR DESCRIPTION
Hi,
Here's a very trivial change to fix missing whitespace.