### PR TITLE
manjaro now uses arch ID_LIKE

### DIFF
--- a/bin/etc-update
+++ b/bin/etc-update
@@ -37,7 +37,7 @@ OS_RELEASE_POSSIBLE_IDS=$(source /etc/os-release >/dev/null 2>&1; echo ":${ID}:$
 case ${OS_RELEASE_POSSIBLE_IDS} in
 	*:suse:*|*:opensuse:*|*:opensuse-tumbleweed:*) OS_FAMILY='rpm';;
 	*:fedora:*|*:rhel:*) OS_FAMILY='rpm';;
-	*:arch:*|*:manjaro:*|*:antergos:*) OS_FAMILY='arch' NEW_EXT='pacnew';;
+	*:arch:*|*:antergos:*) OS_FAMILY='arch' NEW_EXT='pacnew';;
 	*) OS_FAMILY='gentoo';;
 esac
 


### PR DESCRIPTION
Signed-off-by: Kewl Fft <kewl@alto.eu.org>

See [os-release](https://gitlab.manjaro.org/packages/core/filesystem/blob/master/os-release)
