### PR TITLE
git: drop privileges for gc and merge (bug 669496)

### DIFF
--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -220,7 +220,7 @@ def cleanup():
 	pass
 
 def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
-          uid=None, gid=None, groups=None, umask=None, logfile=None,
+          uid=None, gid=None, groups=None, umask=None, cwd=None, logfile=None,
           path_lookup=True, pre_exec=None,
           close_fds=(sys.version_info < (3, 4)), unshare_net=False,
           unshare_ipc=False, unshare_mount=False, unshare_pid=False,
@@ -248,6 +248,8 @@ def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
 	@type groups: List
 	@param umask: An integer representing the umask for the process (see man chmod for umask details)
 	@type umask: Integer
+	@param cwd: Current working directory
+	@type cwd: String
 	@param logfile: name of a file to use for logging purposes
 	@type logfile: String
 	@param path_lookup: If the binary is not fully specified then look for it in PATH
@@ -350,7 +352,7 @@ def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
 		if pid == 0:
 			try:
 				_exec(binary, mycommand, opt_name, fd_pipes,
-					env, gid, groups, uid, umask, pre_exec, close_fds,
+					env, gid, groups, uid, umask, cwd, pre_exec, close_fds,
 					unshare_net, unshare_ipc, unshare_mount, unshare_pid,
 					cgroup)
 			except SystemExit:
@@ -421,7 +423,8 @@ def spawn(mycommand, env={}, opt_name=None, fd_pipes=None, returnpid=False,
 	# Everything succeeded
 	return 0
 
-def _exec(binary, mycommand, opt_name, fd_pipes, env, gid, groups, uid, umask,
+def _exec(binary, mycommand, opt_name, fd_pipes,
+	env, gid, groups, uid, umask, cwd,
 	pre_exec, close_fds, unshare_net, unshare_ipc, unshare_mount, unshare_pid,
 	cgroup):
 
@@ -446,6 +449,8 @@ def _exec(binary, mycommand, opt_name, fd_pipes, env, gid, groups, uid, umask,
 	@type uid: Integer
 	@param umask: an int representing a unix umask (see man chmod for umask details)
 	@type umask: Integer
+	@param cwd: Current working directory
+	@type cwd: String
 	@param pre_exec: A function to be called with no arguments just prior to the exec call.
 	@type pre_exec: callable
 	@param unshare_net: If True, networking will be unshared from the spawned process
@@ -609,6 +614,8 @@ def _exec(binary, mycommand, opt_name, fd_pipes, env, gid, groups, uid, umask,
 		os.setuid(int(uid))
 	if umask:
 		os.umask(umask)
+	if cwd is not None:
+		os.chdir(cwd)
 	if pre_exec:
 		pre_exec()
 

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -147,8 +147,9 @@ class GitSync(NewBase):
 			gc_cmd = ['git', '-c', 'gc.autodetach=false', 'gc', '--auto']
 			if quiet:
 				gc_cmd.append('--quiet')
-			exitcode = subprocess.call(gc_cmd,
-				cwd=portage._unicode_encode(self.repo.location))
+			exitcode = portage.process.spawn(gc_cmd,
+				cwd=portage._unicode_encode(self.repo.location),
+				**self.spawn_kwargs)
 			if exitcode != os.EX_OK:
 				msg = "!!! git gc error in %s" % self.repo.location
 				self.logger(self.xterm_titles, msg)
@@ -186,8 +187,9 @@ class GitSync(NewBase):
 		merge_cmd.append('refs/remotes/%s' % remote_branch)
 		if quiet:
 			merge_cmd.append('--quiet')
-		exitcode = subprocess.call(merge_cmd,
-			cwd=portage._unicode_encode(self.repo.location))
+		exitcode = portage.process.spawn(merge_cmd,
+			cwd=portage._unicode_encode(self.repo.location),
+			**self.spawn_kwargs)
 
 		if exitcode != os.EX_OK:
 			msg = "!!! git merge error in %s" % self.repo.location


### PR DESCRIPTION
Use portage.process.spawn (with new cwd parameter) and self.spawn_kwargs
to drop privileges for git gc and merge commands.

Fixes: 3cd8cf93abb6 ("GitSync: abort checkout for signature problem (bug 660372)")
Fixes: 903c4b1a6768 ("GitSync: support sync-depth (bug 552814)")
Bug: https://bugs.gentoo.org/669496
Signed-off-by: Zac Medico <zmedico@gentoo.org>

Zac Medico (2):
  portage.process.spawn: add cwd parameter
  git: drop privileges for gc and merge (bug 669496)

 lib/portage/process.py                    | 13 ++++++++++---
 lib/portage/sync/modules/git/git.py       | 10 ++++++----
 lib/portage/tests/sync/test_sync_local.py |  9 ++++++++-
 3 files changed, 24 insertions(+), 8 deletions(-)