### PR TITLE
Enable python3.7 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ python:
     - 3.6
     - pypy
 
+# See https://github.com/travis-ci/travis-ci/issues/9815
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: required
+
 # command to install dependencies
 install:
     - pip install tox

--- a/repoman/runtests
+++ b/repoman/runtests
@@ -24,14 +24,14 @@ import tempfile
 # These are the versions we fully support and require to pass tests.
 PYTHON_SUPPORTED_VERSIONS = [
 	'2.7',
-	'3.3',
 	'3.4',
+	'3.5',
+	'3.6'
 ]
 # The rest are just "nice to have".
 PYTHON_NICE_VERSIONS = [
 	'pypy',
-	'3.5',
-	'3.6',
+	'3.7'
 ]
 
 EPREFIX = os.environ.get('PORTAGE_OVERRIDE_EPREFIX', '/')

--- a/runtests
+++ b/runtests
@@ -24,14 +24,14 @@ import tempfile
 # These are the versions we fully support and require to pass tests.
 PYTHON_SUPPORTED_VERSIONS = [
 	'2.7',
-	'3.3',
 	'3.4',
+	'3.5',
+	'3.6'
 ]
 # The rest are just "nice to have".
 PYTHON_NICE_VERSIONS = [
 	'pypy',
-	'3.5',
-	'3.6',
+	'3.7'
 ]
 
 EPREFIX = os.environ.get('PORTAGE_OVERRIDE_EPREFIX', '/')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,pypy3
+envlist = py27,py34,py35,py36,py37,pypy,pypy3
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Reflect recent python versions in test scripts

Signed-off-by: Manuel Rüger <mrueg@gentoo.org>