### PR TITLE
Support FEATURES=ccache-permission-adjust (bug 657582)

### DIFF
--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -51,6 +51,7 @@ FETCHCOMMAND_SFTP="bash -c \"x=\\\${2#sftp://} ; host=\\\${x%%/*} ; port=\\\${ho
 
 # Default user options
 FEATURES="assume-digests binpkg-docompress binpkg-dostrip binpkg-logs
+          ccache-permission-adjust
           config-protect-if-modified distlocks ebuild-locks
           fixlafiles merge-sync multilib-strict news
           parallel-fetch preserve-libs protect-owned

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -132,6 +132,7 @@ SUPPORTED_FEATURES       = frozenset([
 	"candy",
 	"case-insensitive-fs",
 	"ccache",
+	"ccache-permission-adjust",
 	"cgroup",
 	"chflags",
 	"clean-logs",

--- a/lib/portage/package/ebuild/prepare_build_dirs.py
+++ b/lib/portage/package/ebuild/prepare_build_dirs.py
@@ -157,10 +157,12 @@ def _prepare_features_dirs(mysettings):
 
 	features_dirs = {
 		"ccache":{
+			"adjust": "ccache-permission-adjust" in mysettings.features,
 			"basedir_var":"CCACHE_DIR",
 			"default_dir":os.path.join(mysettings["PORTAGE_TMPDIR"], "ccache"),
 			"always_recurse":False},
 		"distcc":{
+			"adjust": True,
 			"basedir_var":"DISTCC_DIR",
 			"default_dir":os.path.join(mysettings["BUILD_PREFIX"], ".distcc"),
 			"subdirs":("lock", "state"),
@@ -174,7 +176,7 @@ def _prepare_features_dirs(mysettings):
 		"userpriv" in mysettings.features and \
 		"userpriv" not in restrict
 	for myfeature, kwargs in features_dirs.items():
-		if myfeature in mysettings.features:
+		if myfeature in mysettings.features and kwargs['adjust']:
 			failure = False
 			basedir = mysettings.get(kwargs["basedir_var"])
 			if basedir is None or not basedir.strip():

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -350,6 +350,10 @@ like "File not recognized: File truncated"), try recompiling the application
 with ccache disabled before reporting a bug. Unless you are doing development
 work, do not enable ccache.
 .TP
+.B ccache\-permission\-adjust
+Enable automatic permission adjustment for \fBCCACHE_DIR\fR when
+FEATURES=\fBccache\fR is enabled. This feature is enabled by default.
+.TP
 .B cgroup
 Use Linux control group to control processes spawned by ebuilds. This allows
 emerge to safely kill all subprocesses when ebuild phase exits.


### PR DESCRIPTION
Automatic CCACHE_DIR permission adjustments can cause problems for
some users, therefore add a FEATURES flag so that it can be disabled.

Bug: https://bugs.gentoo.org/657582
Signed-off-by: Zac Medico <zmedico@gentoo.org>