### PR TITLE
do not use host PATH by default and prepend EPREFIX PATH.

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -211,7 +211,6 @@ def _doebuild_path(settings, eapi=None):
 	if portage_bin_path[0] != portage.const.PORTAGE_BIN_PATH:
 		# Add a fallback path for restarting failed builds (bug 547086)
 		portage_bin_path.append(portage.const.PORTAGE_BIN_PATH)
-	eprefix = portage.const.EPREFIX
 	prerootpath = [x for x in settings.get("PREROOTPATH", "").split(":") if x]
 	rootpath = [x for x in settings.get("ROOTPATH", "").split(":") if x]
 	rootpath_set = frozenset(rootpath)
@@ -219,9 +218,10 @@ def _doebuild_path(settings, eapi=None):
 		"__PORTAGE_TEST_PATH_OVERRIDE", "").split(":") if x]
 
 	prefixes = []
-	if eprefix:
-		prefixes.append(eprefix)
-	prefixes.append("/")
+	# settings["EPREFIX"] should take priority over portage.const.EPREFIX
+	if portage.const.EPREFIX != settings["EPREFIX"] and settings["ROOT"] == os.sep:
+		prefixes.append(settings["EPREFIX"])
+	prefixes.append(portage.const.EPREFIX)
 
 	path = overrides
 
@@ -245,6 +245,7 @@ def _doebuild_path(settings, eapi=None):
 	path.extend(prerootpath)
 
 	for prefix in prefixes:
+		prefix = prefix if prefix else "/"
 		for x in ("usr/local/sbin", "usr/local/bin", "usr/sbin", "usr/bin", "sbin", "bin"):
 			# Respect order defined in ROOTPATH
 			x_abs = os.path.join(prefix, x)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -10,6 +10,7 @@ from portage import os
 from portage import shutil
 from portage.const import (GLOBAL_CONFIG_PATH, PORTAGE_BASE_PATH,
 	USER_CONFIG_PATH)
+from portage.process import find_binary
 from portage.dep import Atom, _repo_separator
 from portage.package.ebuild.config import config
 from portage.package.ebuild.digestgen import digestgen
@@ -76,6 +77,16 @@ class ResolverPlayground(object):
 		self.debug = debug
 		if eprefix is None:
 			self.eprefix = normalize_path(tempfile.mkdtemp())
+
+			# EPREFIX/bin is used by fake true_binaries. Real binaries goes into EPREFIX/usr/bin
+			eubin = os.path.join(self.eprefix, "usr", "bin")
+			ensure_dirs(eubin)
+			essential_binaries = ("chown", "uname", "basename", "sort", "tr", "sed", "install")
+			essential_binaries += ("cp", "mkdir", "rm", "chmod", "ln", "bzip2", "find", "egrep")
+			essential_binaries += ("awk", "xargs", "grep", "cat", "mktemp", "uniq", "tar", "mv")
+			essential_binaries += ("head", "env")
+			for x in essential_binaries:
+				os.symlink(find_binary(x), os.path.join(eubin, x))
 		else:
 			self.eprefix = normalize_path(eprefix)
 


### PR DESCRIPTION
  EPREFIX could be overridden in cross-eprefix, in that case tools
  inside EPREFIX should be prioritized.

  Link necessary binary tools to the test environment.

Closes: https://bugs.gentoo.org/585986