### PR TITLE
bin/ebuild-helpers/portageq: match against portage/bin/ebuild-helpers

### DIFF
--- a/bin/ebuild-helpers/portageq
+++ b/bin/ebuild-helpers/portageq
@@ -13,7 +13,7 @@ set -f # in case ${PATH} contains any shell glob characters
 
 for path in ${PATH}; do
 	[[ -x ${path}/${scriptname} ]] || continue
-	[[ ${path} == ${PORTAGE_OVERRIDE_EPREFIX}/usr/lib*/portage/* ]] && continue
+	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
 	[[ ${path} == */._portage_reinstall_.* ]] && continue
 	[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
 	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \


### PR DESCRIPTION
  In case PORTAGE_OVERRIDE_EPREFIX is modified in the environment,
  the actual ebuild-helpers PATH will not match PORTAGE_OVERRIDE_EPREFIX.