### PR TITLE
ResolverPlayground: exclude internal wrappers from essential_binaries PATH

### DIFF
--- a/bin/ebuild-helpers/bsd/sed
+++ b/bin/ebuild-helpers/bsd/sed
@@ -16,7 +16,6 @@ else
 	for path in $PATH; do
 		if [[ -x ${path}/${scriptname} ]]; then
 			[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
-			[[ ${path} == */._portage_reinstall_.* ]] && continue
 			[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
 			exec "${path}/${scriptname}" "$@"
 			exit 0

--- a/bin/ebuild-helpers/bsd/sed
+++ b/bin/ebuild-helpers/bsd/sed
@@ -15,7 +15,7 @@ else
 
 	for path in $PATH; do
 		if [[ -x ${path}/${scriptname} ]]; then
-			[[ ${path} == ${PORTAGE_OVERRIDE_EPREFIX}/usr/lib*/portage/* ]] && continue
+			[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
 			[[ ${path} == */._portage_reinstall_.* ]] && continue
 			[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
 			exec "${path}/${scriptname}" "$@"

--- a/bin/ebuild-helpers/portageq
+++ b/bin/ebuild-helpers/portageq
@@ -14,7 +14,6 @@ set -f # in case ${PATH} contains any shell glob characters
 for path in ${PATH}; do
 	[[ -x ${path}/${scriptname} ]] || continue
 	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
-	[[ ${path} == */._portage_reinstall_.* ]] && continue
 	[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
 	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
 		exec "${PORTAGE_PYTHON:-/usr/bin/python}" \

--- a/bin/ebuild-helpers/unprivileged/chown
+++ b/bin/ebuild-helpers/unprivileged/chown
@@ -12,7 +12,6 @@ IFS=':'
 for path in ${PATH}; do
 	[[ -x ${path}/${scriptname} ]] || continue
 	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
-	[[ ${path} == */._portage_reinstall_.* ]] && continue
 	[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
 	IFS=$' \t\n'
 	output=$("${path}/${scriptname}" "$@" 2>&1)

--- a/bin/ebuild-helpers/unprivileged/chown
+++ b/bin/ebuild-helpers/unprivileged/chown
@@ -11,7 +11,7 @@ IFS=':'
 
 for path in ${PATH}; do
 	[[ -x ${path}/${scriptname} ]] || continue
-	[[ ${path} == ${PORTAGE_OVERRIDE_EPREFIX}/usr/lib*/portage/* ]] && continue
+	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
 	[[ ${path} == */._portage_reinstall_.* ]] && continue
 	[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
 	IFS=$' \t\n'

--- a/bin/ebuild-helpers/xattr/install
+++ b/bin/ebuild-helpers/xattr/install
@@ -29,7 +29,6 @@ set -f
 path=
 for x in ${PATH}; do
 	[[ ${x} == */portage/*/ebuild-helpers* ]] && continue
-	[[ ${x} == */._portage_reinstall_.* ]] && continue
 	path+=":${x}"
 done
 PATH=${path#:}

--- a/bin/ebuild-helpers/xattr/install
+++ b/bin/ebuild-helpers/xattr/install
@@ -28,7 +28,7 @@ IFS=':'
 set -f
 path=
 for x in ${PATH}; do
-	[[ ${x} == ${PORTAGE_OVERRIDE_EPREFIX}/usr/lib*/portage/* ]] && continue
+	[[ ${x} == */portage/*/ebuild-helpers* ]] && continue
 	[[ ${x} == */._portage_reinstall_.* ]] && continue
 	path+=":${x}"
 done


### PR DESCRIPTION
Ensure that essential_binaries symlinks do not refer to internal
wrapper scripts, in order to avoid infinite recursion. Use the
same ebuild-helpers pattern as the portageq wrapper script since
daeb75b345c4433218ab9e7a5319e8914092f048.

Fixes: 1b5edbb5ec70 ("_doebuild_path: do not use host PATH by default and prepend EPREFIX PATH")
Signed-off-by: Zac Medico <zmedico@gentoo.org>