### PR TITLE
file_copy: handle EUCLEAN from copy_file_range (bug 674332)

### DIFF
--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -271,8 +271,15 @@ _reflink_linux_file_copy(PyObject *self, PyObject *args)
 
                 if (copyfunc_ret < 0) {
                     error = errno;
-                    if ((errno == EXDEV || errno == ENOSYS || errno == EOPNOTSUPP) &&
-                        copyfunc == cfr_wrapper) {
+                    if ((
+                               errno == EXDEV
+                            || errno == ENOSYS
+                            || errno == EOPNOTSUPP
+#ifdef EUCLEAN
+                            || errno == EUCLEAN
+#endif
+                        )
+                        && copyfunc == cfr_wrapper) {
                         /* Use sendfile instead of copy_file_range for
                          * cross-device copies, or when the copy_file_range
                          * syscall is not available (less than Linux 4.5).


### PR DESCRIPTION
EXT4 can set the errno to EUCLEAN for copy_file_range.

Bug: https://bugs.gentoo.org/674332
Signed-off-by: Zac Medico <zmedico@gentoo.org>