### PR TITLE
pid-sandbox: whitelist selected pkg_* phases (bug 673794)

### DIFF
--- a/lib/_emerge/AbstractEbuildProcess.py
+++ b/lib/_emerge/AbstractEbuildProcess.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -22,6 +22,10 @@ from portage.util.futures import asyncio
 from portage.util._pty import _create_pty_or_pipe
 from portage.util import apply_secpass_permissions
 
+portage.proxy.lazyimport.lazyimport(globals(),
+	'portage.package.ebuild.doebuild:_global_pid_phases',
+)
+
 class AbstractEbuildProcess(SpawnProcess):
 
 	__slots__ = ('phase', 'settings',) + \
@@ -30,7 +34,6 @@ class AbstractEbuildProcess(SpawnProcess):
 
 	_phases_without_builddir = ('clean', 'cleanrm', 'depend', 'help',)
 	_phases_interactive_whitelist = ('config',)
-	_phases_without_cgroup = ('preinst', 'postinst', 'prerm', 'postrm', 'config')
 
 	# Number of milliseconds to allow natural exit of the ebuild
 	# process after it has called the exit command via IPC. It
@@ -71,7 +74,7 @@ class AbstractEbuildProcess(SpawnProcess):
 		# Check if the cgroup hierarchy is in place. If it's not, mount it.
 		if (os.geteuid() == 0 and platform.system() == 'Linux'
 				and 'cgroup' in self.settings.features
-				and self.phase not in self._phases_without_cgroup):
+				and self.phase not in _global_pid_phases):
 			cgroup_root = '/sys/fs/cgroup'
 			cgroup_portage = os.path.join(cgroup_root, 'portage')
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2018 Gentoo Authors
+# Copyright 2010-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import unicode_literals
@@ -110,6 +110,9 @@ _ipc_phases = frozenset([
 	"preinst", "postinst", "prerm", "postrm",
 ])
 
+# phases which execute in the global PID namespace
+_global_pid_phases = frozenset(['preinst', 'postinst', 'prerm', 'postrm', 'config'])
+
 # phases in which networking access is allowed
 _networked_phases = frozenset([
 	# for VCS fetching
@@ -153,7 +156,8 @@ def _doebuild_spawn(phase, settings, actionmap=None, **kwargs):
 	kwargs['networked'] = 'network-sandbox' not in settings.features or \
 		phase in _networked_phases or \
 		'network-sandbox' in settings['PORTAGE_RESTRICT'].split()
-	kwargs['pidns'] = 'pid-sandbox' in settings.features
+	kwargs['pidns'] = ('pid-sandbox' in settings.features and
+		phase not in _global_pid_phases)
 
 	if phase == 'depend':
 		kwargs['droppriv'] = 'userpriv' in settings.features


### PR DESCRIPTION
Whitelist the same phases that are whitelisted for FEATURES=cgroup,
since pid-sandbox is less valuable and is likely to have unintended
consenquences during these phases.

Bug: https://bugs.gentoo.org/673794
Signed-off-by: Zac Medico <zmedico@gentoo.org>