### PR TITLE
misc-functions.sh: restore canonicalize func (bug 675284)

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -43,6 +43,40 @@ install_symlink_html_docs() {
 	fi
 }
 
+# replacement for "readlink -f" or "realpath"
+READLINK_F_WORKS=""
+canonicalize() {
+	if [[ -z ${READLINK_F_WORKS} ]] ; then
+		if [[ $(readlink -f -- /../ 2>/dev/null) == "/" ]] ; then
+			READLINK_F_WORKS=true
+		else
+			READLINK_F_WORKS=false
+		fi
+	fi
+	if ${READLINK_F_WORKS} ; then
+		readlink -f -- "$@"
+		return
+	fi
+
+	local f=$1 b n=10 wd=$(pwd)
+	while (( n-- > 0 )); do
+		while [[ ${f: -1} = / && ${#f} -gt 1 ]]; do
+			f=${f%/}
+		done
+		b=${f##*/}
+		cd "${f%"${b}"}" 2>/dev/null || break
+		if [[ ! -L ${b} ]]; then
+			f=$(pwd -P)
+			echo "${f%/}/${b}"
+			cd "${wd}"
+			return 0
+		fi
+		f=$(readlink "${b}")
+	done
+	cd "${wd}"
+	return 1
+}
+
 install_qa_check() {
 	local d f i qa_var x paths qa_checks=() checks_run=()
 	if ! ___eapi_has_prefix_variables; then

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -99,6 +99,7 @@ class ResolverPlayground(object):
 				"mkdir",
 				"mktemp",
 				"mv",
+				"readlink",
 				"rm",
 				"sed",
 				"sort",


### PR DESCRIPTION
The canonicalize function is required by install-qa-check.d/05prefix.

Fixes: aa0a94198794 ("ecompress: Replace with implementation from portage[mgorny]")
Bug: https://bugs.gentoo.org/670484
Signed-off-by: Zac Medico <zmedico@gentoo.org>