### PR TITLE
pid-sandbox: pid-ns-init TIOCSCTTY after setsid (bug 675868)

### DIFF
--- a/bin/pid-ns-init
+++ b/bin/pid-ns-init
@@ -3,12 +3,14 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
+import fcntl
 import functools
 import os
 import platform
 import signal
 import subprocess
 import sys
+import termios
 
 
 KILL_SIGNALS = (
@@ -75,6 +77,17 @@ def main(argv):
 		# Isolate parent process from process group SIGSTOP (bug 675870)
 		setsid = True
 		os.setsid()
+		if sys.stdout.isatty():
+			try:
+				fcntl.ioctl(sys.stdout, termios.TIOCSCTTY, 0)
+			except OSError as e:
+				if e.errno == errno.EPERM:
+					# This means that stdout refers to the controlling terminal
+					# of the parent process, and in this case we do not want to
+					# steel it.
+					pass
+				else:
+					raise
 		proc = subprocess.Popen(args, executable=binary, **popen_kwargs)
 		main_child_pid = proc.pid
 


### PR DESCRIPTION
Set the controlling terminal to the stdout pty after calling setsid,
in order to avoid "No such device or address" ENXIO errors when
attempting to open /dev/tty.

Bug: https://bugs.gentoo.org/675868
Signed-off-by: Zac Medico <zmedico@gentoo.org>