### PR TITLE
pid-sandbox: handle EnvironmentError for python2 compat (bug 675868)

### DIFF
--- a/bin/pid-ns-init
+++ b/bin/pid-ns-init
@@ -80,7 +80,7 @@ def main(argv):
 		if sys.stdout.isatty():
 			try:
 				fcntl.ioctl(sys.stdout, termios.TIOCSCTTY, 0)
-			except OSError as e:
+			except EnvironmentError as e:
 				if e.errno == errno.EPERM:
 					# This means that stdout refers to the controlling terminal
 					# of the parent process, and in this case we do not want to
@@ -101,7 +101,7 @@ def main(argv):
 	while True:
 		try:
 			pid, status = os.wait()
-		except OSError as e:
+		except EnvironmentError as e:
 			if e.errno == errno.EINTR:
 				continue
 			raise


### PR DESCRIPTION
The fcntl.ioctl call raises IOError, which is different from OSError
for python2. Use EnvironmentError for compatibility.

Bug: https://bugs.gentoo.org/675868
Fixes: ce0656337268 ("pid-sandbox: pid-ns-init TIOCSCTTY after setsid (bug 675868)")