### PR TITLE
Change repoman exit code when nothing changed

### DIFF
--- a/repoman/lib/repoman/actions.py
+++ b/repoman/lib/repoman/actions.py
@@ -388,7 +388,7 @@ the whole commit message to abort.
 			print()
 			print("(Didn't find any changed files...)")
 			print()
-			sys.exit(1)
+			sys.exit(127)
 		return (changes.new, changes.changed, changes.removed,
 				changes.no_expansion, changes.expansion)
 


### PR DESCRIPTION
Signed-off-by: Mikle Kolyada <zlogene@gentoo.org>

Would be nice to get a code other than 1 on this, for better filtering the action in tools, this is not an error or a QA violation, so separate exit code should be useful.