### PR TITLE
AsyncioEventLoop: enable SIGINT in exception handler (bug 672540)

### DIFF
--- a/lib/portage/util/_eventloop/asyncio_event_loop.py
+++ b/lib/portage/util/_eventloop/asyncio_event_loop.py
@@ -73,6 +73,11 @@ class AsyncioEventLoop(_AbstractEventLoop):
 			# aid in diagnosis of the problem. If there's no tty, then
 			# exit immediately.
 			if all(s.isatty() for s in (sys.stdout, sys.stderr, sys.stdin)):
+				# Restore default SIGINT handler, since emerge's Scheduler
+				# has a SIGINT handler which delays exit until after
+				# cleanup, and cleanup cannot occur here since the event
+				# loop is suspended (see bug 672540).
+				signal.signal(signal.SIGINT, signal.SIG_DFL)
 				pdb.set_trace()
 			else:
 				# Normally emerge will wait for all coroutines to complete


### PR DESCRIPTION
Before the exception handler invokes the pdb shell, enable SIGINT so
that the user can exit with Control-C (otherwise SIGKILL is needed).

Bug: https://bugs.gentoo.org/672540
Signed-off-by: Zac Medico <zmedico@gentoo.org>