### PR TITLE
Remove internal OrderedDict implementation

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import division, print_function, unicode_literals
@@ -12,11 +12,11 @@ import stat
 import sys
 import textwrap
 import warnings
-from collections import deque
+from collections import deque, OrderedDict
 from itertools import chain
 
 import portage
-from portage import os, OrderedDict
+from portage import os
 from portage import _unicode_decode, _unicode_encode, _encodings
 from portage.const import PORTAGE_PACKAGE_ATOM, USER_CONFIG_PATH, VCS_DIRS
 from portage.dbapi import dbapi

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2019 Gentoo Foundation
+# Copyright 1998-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import unicode_literals
@@ -112,11 +112,7 @@ try:
 		'time',
 	)
 
-	try:
-		from collections import OrderedDict
-	except ImportError:
-		proxy.lazyimport.lazyimport(globals(),
-			'portage.cache.mappings:OrderedDict')
+	from collections import OrderedDict
 
 	import portage.const
 	from portage.const import VDB_PATH, PRIVATE_PATH, CACHE_PATH, DEPCACHE_PATH, \

--- a/lib/portage/cache/mappings.py
+++ b/lib/portage/cache/mappings.py
@@ -1,4 +1,4 @@
-# Copyright: 2005-2009 Gentoo Foundation
+# Copyright: 2005-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # Author(s): Brian Harring (ferringb@gentoo.org)
 
@@ -183,34 +183,6 @@ class UserDict(MutableMapping):
 
 	def clear(self):
 		self.data.clear()
-
-	if sys.hexversion >= 0x3000000:
-		keys = __iter__
-
-class OrderedDict(UserDict):
-
-	__slots__ = ('_order',)
-
-	def __init__(self, *args, **kwargs):
-		self._order = []
-		UserDict.__init__(self, *args, **kwargs)
-
-	def __iter__(self):
-		return iter(self._order)
-
-	def __setitem__(self, key, item):
-		new_key = key not in self
-		UserDict.__setitem__(self, key, item)
-		if new_key:
-			self._order.append(key)
-
-	def __delitem__(self, key):
-		UserDict.__delitem__(self, key)
-		self._order.remove(key)
-
-	def clear(self):
-		UserDict.clear(self)
-		del self._order[:]
 
 	if sys.hexversion >= 0x3000000:
 		keys = __iter__

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2018 Gentoo Foundation
+# Copyright 1998-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import unicode_literals
@@ -34,7 +34,6 @@ from portage import eclass_cache, \
 from portage import os
 from portage import _encodings
 from portage import _unicode_encode
-from portage import OrderedDict
 from portage.util._eventloop.EventLoop import EventLoop
 from portage.util.futures import asyncio
 from portage.util.futures.compat_coroutine import coroutine, coroutine_return
@@ -48,6 +47,8 @@ import warnings
 import errno
 import collections
 import functools
+
+from collections import OrderedDict
 
 try:
 	from urllib.parse import urlparse

--- a/lib/portage/news.py
+++ b/lib/portage/news.py
@@ -1,5 +1,5 @@
 # portage: news management code
-# Copyright 2006-2017 Gentoo Foundation
+# Copyright 2006-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function, unicode_literals
@@ -9,13 +9,14 @@ __all__ = ["NewsManager", "NewsItem", "DisplayRestriction",
 	"DisplayInstalledRestriction",
 	"count_unread_news", "display_news_notifications"]
 
+from collections import OrderedDict
+
 import fnmatch
 import io
 import logging
 import os as _os
 import re
 import portage
-from portage import OrderedDict
 from portage import os
 from portage import _encodings
 from portage import _unicode_decode

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2017 Gentoo Foundation
+# Copyright 2010-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function
@@ -14,6 +14,8 @@ import stat
 import sys
 import tempfile
 
+from collections import OrderedDict
+
 try:
 	from urllib.parse import urlparse
 except ImportError:
@@ -27,7 +29,7 @@ portage.proxy.lazyimport.lazyimport(globals(),
 	'portage.package.ebuild.prepare_build_dirs:prepare_build_dirs',
 )
 
-from portage import OrderedDict, os, selinux, shutil, _encodings, \
+from portage import os, selinux, shutil, _encodings, \
 	_shell_quote, _unicode_encode
 from portage.checksum import (get_valid_checksum_keys, perform_md5, verify_all,
 	_filter_unaccelarated_hashes, _hash_filter, _apply_hash_filter)

--- a/lib/portage/sync/__init__.py
+++ b/lib/portage/sync/__init__.py
@@ -1,9 +1,10 @@
-# Copyright 2014-2015 Gentoo Foundation
+# Copyright 2014-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import os
 
-from portage import OrderedDict
+from collections import OrderedDict
+
 from portage.module import Modules
 from portage.sync.controller import SyncManager
 from portage.sync.config_checks import check_type

--- a/lib/portage/sync/controller.py
+++ b/lib/portage/sync/controller.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 Gentoo Foundation
+# Copyright 2014-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function
@@ -9,6 +9,8 @@ import logging
 import grp
 import pwd
 import warnings
+
+from collections import OrderedDict
 
 import portage
 from portage import os
@@ -22,7 +24,6 @@ warn = create_color_func("WARN")
 from portage.package.ebuild.doebuild import _check_temp_dir
 from portage.metadata import action_metadata
 from portage.util._async.AsyncFunction import AsyncFunction
-from portage import OrderedDict
 from portage import _unicode_decode
 from portage import util
 from _emerge.CompositeTask import CompositeTask


### PR DESCRIPTION
This is no longer needed becuase collections.OrderedDict is available
since Python 2.7.

Signed-off-by: Zac Medico <zmedico@gentoo.org>