### PR TITLE
Deprecate EAPIs 4-slot-abi, 5-hdepend, and 7_pre1

### DIFF
--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -458,8 +458,21 @@ def abssymlink(symlink, target=None):
 
 _doebuild_manifest_exempt_depend = 0
 
-_testing_eapis = frozenset(["4-python", "4-slot-abi", "5-progress", "5-hdepend", "7_pre1", "7"])
-_deprecated_eapis = frozenset(["4_pre1", "3_pre2", "3_pre1", "5_pre1", "5_pre2", "6_pre1"])
+_testing_eapis = frozenset([
+	"4-python",
+	"4-slot-abi",
+	"5-progress",
+	"5-hdepend",
+	"7_pre1",
+])
+_deprecated_eapis = frozenset([
+	"4_pre1",
+	"3_pre2",
+	"3_pre1",
+	"5_pre1",
+	"5_pre2",
+	"6_pre1",
+])
 _supported_eapis = frozenset([str(x) for x in range(portage.const.EAPI + 1)] + list(_testing_eapis) + list(_deprecated_eapis))
 
 def _eapi_is_deprecated(eapi):

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -460,18 +460,18 @@ _doebuild_manifest_exempt_depend = 0
 
 _testing_eapis = frozenset([
 	"4-python",
-	"4-slot-abi",
 	"5-progress",
-	"5-hdepend",
-	"7_pre1",
 ])
 _deprecated_eapis = frozenset([
 	"4_pre1",
+	"4-slot-abi",
 	"3_pre2",
 	"3_pre1",
 	"5_pre1",
 	"5_pre2",
+	"5-hdepend",
 	"6_pre1",
+	"7_pre1",
 ])
 _supported_eapis = frozenset([str(x) for x in range(portage.const.EAPI + 1)] + list(_testing_eapis) + list(_deprecated_eapis))
 

--- a/lib/portage/tests/dep/testAtom.py
+++ b/lib/portage/tests/dep/testAtom.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2012 Gentoo Foundation
+# Copyright 2006-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -154,13 +154,13 @@ class TestAtom(TestCase):
 
 	def testSlotAbiAtom(self):
 		tests = (
-			("virtual/ffmpeg:0/53", "4-slot-abi", {"slot": "0", "sub_slot": "53", "slot_operator": None}),
-			("virtual/ffmpeg:0/53=", "4-slot-abi", {"slot": "0", "sub_slot": "53", "slot_operator": "="}),
-			("virtual/ffmpeg:=", "4-slot-abi", {"slot": None, "sub_slot": None, "slot_operator": "="}),
-			("virtual/ffmpeg:0=", "4-slot-abi", {"slot": "0", "sub_slot": None, "slot_operator": "="}),
-			("virtual/ffmpeg:*", "4-slot-abi", {"slot": None, "sub_slot": None, "slot_operator": "*"}),
-			("virtual/ffmpeg:0", "4-slot-abi", {"slot": "0", "sub_slot": None, "slot_operator": None}),
-			("virtual/ffmpeg", "4-slot-abi", {"slot": None, "sub_slot": None, "slot_operator": None}),
+			("virtual/ffmpeg:0/53", "5", {"slot": "0", "sub_slot": "53", "slot_operator": None}),
+			("virtual/ffmpeg:0/53=", "5", {"slot": "0", "sub_slot": "53", "slot_operator": "="}),
+			("virtual/ffmpeg:=", "5", {"slot": None, "sub_slot": None, "slot_operator": "="}),
+			("virtual/ffmpeg:0=", "5", {"slot": "0", "sub_slot": None, "slot_operator": "="}),
+			("virtual/ffmpeg:*", "5", {"slot": None, "sub_slot": None, "slot_operator": "*"}),
+			("virtual/ffmpeg:0", "5", {"slot": "0", "sub_slot": None, "slot_operator": None}),
+			("virtual/ffmpeg", "5", {"slot": None, "sub_slot": None, "slot_operator": None}),
 		)
 
 		for atom, eapi, parts in tests:

--- a/lib/portage/tests/emerge/test_emerge_slot_abi.py
+++ b/lib/portage/tests/emerge/test_emerge_slot_abi.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2015 Gentoo Foundation
+# Copyright 2012-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
@@ -24,30 +24,30 @@ class SlotAbiEmergeTestCase(TestCase):
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/glib-2.32.3" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.32"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2=",
 				"RDEPEND": "dev-libs/glib:2="
 			},
 		}
 		installed = {
 			"dev-libs/glib-1.2.10" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2/2.30=",
 				"RDEPEND": "dev-libs/glib:2/2.30="
 			},

--- a/lib/portage/tests/resolver/test_slot_abi.py
+++ b/lib/portage/tests/resolver/test_slot_abi.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2013 Gentoo Foundation
+# Copyright 2012-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -13,41 +13,41 @@ class SlotAbiTestCase(TestCase):
 	def testSubSlot(self):
 		ebuilds = {
 			"dev-libs/icu-49" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/49"
 			},
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:=",
 				"RDEPEND": "dev-libs/icu:="
 			},
 		}
 		binpkgs = {
 			"dev-libs/icu-49" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/49"
 			},
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:0/48=",
 				"RDEPEND": "dev-libs/icu:0/48="
 			},
 		}
 		installed = {
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:0/48=",
 				"RDEPEND": "dev-libs/icu:0/48="
 			},
@@ -137,7 +137,7 @@ class SlotAbiTestCase(TestCase):
 				"SLOT": "4.7"
 			},
 			"app-office/libreoffice-3.5.4.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND": ">=sys-libs/db-4:=",
 				"RDEPEND": ">=sys-libs/db-4:="
 			},
@@ -150,7 +150,7 @@ class SlotAbiTestCase(TestCase):
 				"SLOT": "4.7"
 			},
 			"app-office/libreoffice-3.5.4.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  ">=sys-libs/db-4:4.7/4.7=",
 				"RDEPEND": ">=sys-libs/db-4:4.7/4.7="
 			},
@@ -160,7 +160,7 @@ class SlotAbiTestCase(TestCase):
 				"SLOT": "4.7"
 			},
 			"app-office/libreoffice-3.5.4.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  ">=sys-libs/db-4:4.7/4.7=",
 				"RDEPEND": ">=sys-libs/db-4:4.7/4.7="
 			},
@@ -334,15 +334,15 @@ class SlotAbiTestCase(TestCase):
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/glib-2.32.3" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.32"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2=",
 				"RDEPEND": "dev-libs/glib:2="
 			},
@@ -352,30 +352,30 @@ class SlotAbiTestCase(TestCase):
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/glib-2.32.3" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.32"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2/2.30=",
 				"RDEPEND": "dev-libs/glib:2/2.30="
 			},
 		}
 		installed = {
 			"dev-libs/glib-1.2.10" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2/2.30=",
 				"RDEPEND": "dev-libs/glib:2/2.30="
 			},

--- a/lib/portage/tests/resolver/test_slot_abi_downgrade.py
+++ b/lib/portage/tests/resolver/test_slot_abi_downgrade.py
@@ -1,4 +1,4 @@
-# Copyright 2012 Gentoo Foundation
+# Copyright 2012-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -13,37 +13,37 @@ class SlotAbiDowngradeTestCase(TestCase):
 	def testSubSlot(self):
 		ebuilds = {
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:=",
 				"RDEPEND": "dev-libs/icu:="
 			},
 		}
 		binpkgs = {
 			"dev-libs/icu-49" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/49"
 			},
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:0/49=",
 				"RDEPEND": "dev-libs/icu:0/49="
 			},
 		}
 		installed = {
 			"dev-libs/icu-49" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/49"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:0/49=",
 				"RDEPEND": "dev-libs/icu:0/49="
 			},
@@ -118,11 +118,11 @@ class SlotAbiDowngradeTestCase(TestCase):
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2=",
 				"RDEPEND": "dev-libs/glib:2="
 			},
@@ -132,30 +132,30 @@ class SlotAbiDowngradeTestCase(TestCase):
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.30.2" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.30"
 			},
 			"dev-libs/glib-2.32.3" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.32"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2/2.32=",
 				"RDEPEND": "dev-libs/glib:2/2.32="
 			},
 		}
 		installed = {
 			"dev-libs/glib-1.2.10" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "1"
 			},
 			"dev-libs/glib-2.32.3" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "2/2.32"
 			},
 			"dev-libs/dbus-glib-0.98" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/glib:2/2.32=",
 				"RDEPEND": "dev-libs/glib:2/2.32="
 			},

--- a/lib/portage/tests/resolver/test_slot_collisions.py
+++ b/lib/portage/tests/resolver/test_slot_collisions.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2014 Gentoo Foundation
+# Copyright 2010-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -46,8 +46,8 @@ class SlotCollisionTestCase(TestCase):
 			"app-misc/E-1": { "RDEPEND": "dev-libs/E[foo?]", "IUSE": "foo", "EAPI": "2" },
 			"app-misc/F-1": { "RDEPEND": "=dev-libs/E-1", "IUSE": "foo", "EAPI": "2" },
 
-			"dev-lang/perl-5.12": {"SLOT": "0/5.12", "EAPI": "4-slot-abi"},
-			"dev-lang/perl-5.16": {"SLOT": "0/5.16", "EAPI": "4-slot-abi"},
+			"dev-lang/perl-5.12": {"SLOT": "0/5.12", "EAPI": "5"},
+			"dev-lang/perl-5.16": {"SLOT": "0/5.16", "EAPI": "5"},
 			}
 		installed = {
 			"dev-libs/A-1": { "PDEPEND": "foo? ( dev-libs/B )", "IUSE": "foo", "USE": "foo" }, 

--- a/lib/portage/tests/resolver/test_slot_operator_autounmask.py
+++ b/lib/portage/tests/resolver/test_slot_operator_autounmask.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Gentoo Foundation
+# Copyright 2013-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -13,15 +13,15 @@ class SlotOperatorAutoUnmaskTestCase(TestCase):
 	def testSubSlot(self):
 		ebuilds = {
 			"dev-libs/icu-49" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/49"
 			},
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:=",
 				"RDEPEND": "dev-libs/icu:=",
 				"KEYWORDS": "~x86"
@@ -29,26 +29,26 @@ class SlotOperatorAutoUnmaskTestCase(TestCase):
 		}
 		binpkgs = {
 			"dev-libs/icu-49" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/49"
 			},
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:0/48=",
 				"RDEPEND": "dev-libs/icu:0/48="
 			},
 		}
 		installed = {
 			"dev-libs/icu-4.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/48"
 			},
 			"dev-libs/libxml2-2.7.8" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"DEPEND":  "dev-libs/icu:0/48=",
 				"RDEPEND": "dev-libs/icu:0/48="
 			},

--- a/lib/portage/tests/resolver/test_targetroot.py
+++ b/lib/portage/tests/resolver/test_targetroot.py
@@ -1,4 +1,4 @@
-# Copyright 2012 Gentoo Foundation
+# Copyright 2012-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -9,9 +9,8 @@ class TargetRootTestCase(TestCase):
 	def testTargetRoot(self):
 		ebuilds = {
 			"dev-lang/python-3.2": {
-				"EAPI": "5-hdepend",
-				"IUSE": "targetroot",
-				"HDEPEND": "targetroot? ( ~dev-lang/python-3.2 )",
+				"EAPI": "7",
+				"BDEPEND": "~dev-lang/python-3.2",
 			},
 			"dev-libs/A-1": {
 				"EAPI": "4",
@@ -22,22 +21,29 @@ class TargetRootTestCase(TestCase):
 			"dev-libs/C-1": {},
 		}
 
+		installed = {
+			"dev-lang/python-3.2": {
+				"EAPI": "7",
+				"BDEPEND": "~dev-lang/python-3.2",
+			},
+		}
+
 		test_cases = (
 			ResolverPlaygroundTestCase(
 				["dev-lang/python"],
 				options = {},
 				success = True,
-				mergelist = ["dev-lang/python-3.2", "dev-lang/python-3.2{targetroot}"]),
+				mergelist = ["dev-lang/python-3.2{targetroot}"]),
 			ResolverPlaygroundTestCase(
 				["dev-lang/python"],
 				options = {"--root-deps": True},
 				success = True,
-				mergelist = ["dev-lang/python-3.2", "dev-lang/python-3.2{targetroot}"]),
+				mergelist = ["dev-lang/python-3.2{targetroot}"]),
 			ResolverPlaygroundTestCase(
 				["dev-lang/python"],
 				options = {"--root-deps": "rdeps"},
 				success = True,
-				mergelist = ["dev-lang/python-3.2", "dev-lang/python-3.2{targetroot}"]),
+				mergelist = ["dev-lang/python-3.2{targetroot}"]),
 			ResolverPlaygroundTestCase(
 				["dev-libs/A"],
 				options = {},
@@ -58,7 +64,7 @@ class TargetRootTestCase(TestCase):
 				mergelist = [("dev-libs/C-1{targetroot}"), "dev-libs/A-1{targetroot}"]),
 		)
 
-		playground = ResolverPlayground(ebuilds=ebuilds, targetroot=True,
+		playground = ResolverPlayground(ebuilds=ebuilds, installed=installed, targetroot=True,
 			debug=False)
 		try:
 			for test_case in test_cases:
@@ -75,7 +81,7 @@ class TargetRootTestCase(TestCase):
 				mergelist = ["dev-lang/python-3.2"]),
 		)
 
-		playground = ResolverPlayground(ebuilds=ebuilds, targetroot=False,
+		playground = ResolverPlayground(ebuilds=ebuilds, installed=installed, targetroot=False,
 			debug=False)
 		try:
 			for test_case in test_cases:

--- a/lib/portage/tests/update/test_move_slot_ent.py
+++ b/lib/portage/tests/update/test_move_slot_ent.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2013 Gentoo Foundation
+# Copyright 2012-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import textwrap
@@ -17,7 +17,7 @@ class MoveSlotEntTestCase(TestCase):
 		ebuilds = {
 
 			"dev-libs/A-2::dont_apply_updates" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/2.30",
 			},
 
@@ -26,7 +26,7 @@ class MoveSlotEntTestCase(TestCase):
 			},
 
 			"dev-libs/C-2.1::dont_apply_updates" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/2.1",
 			},
 
@@ -35,7 +35,7 @@ class MoveSlotEntTestCase(TestCase):
 		installed = {
 
 			"dev-libs/A-1::test_repo" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/2.30",
 			},
 
@@ -44,7 +44,7 @@ class MoveSlotEntTestCase(TestCase):
 			},
 
 			"dev-libs/C-1::test_repo" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/1",
 			},
 
@@ -53,12 +53,12 @@ class MoveSlotEntTestCase(TestCase):
 		binpkgs = {
 
 			"dev-libs/A-1::test_repo" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/2.30",
 			},
 
 			"dev-libs/A-2::dont_apply_updates" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/2.30",
 			},
 
@@ -71,12 +71,12 @@ class MoveSlotEntTestCase(TestCase):
 			},
 
 			"dev-libs/C-1::test_repo" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/1",
 			},
 
 			"dev-libs/C-2.1::dont_apply_updates" : {
-				"EAPI": "4-slot-abi",
+				"EAPI": "5",
 				"SLOT": "0/2.1",
 			},
 


### PR DESCRIPTION
All of these EAPIs are obsolete since their features are available in official EAPIs.