### PR TITLE
Enable FEATURES=strict-keepdir behavior for new EAPIs

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -247,3 +247,7 @@ ___eapi_bash_4_2() {
 ___eapi_has_ENV_UNSET() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
 }
+
+___eapi_has_strict_keepdir() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|5|5-progress|6|7)$ ]]
+}

--- a/bin/install-qa-check.d/95empty-dirs
+++ b/bin/install-qa-check.d/95empty-dirs
@@ -17,7 +17,9 @@ find_empty_dirs() {
 	local warn_dirs=()
 	local d striparg=
 
-	[[ ${FEATURES} == *strict-keepdir* ]] && striparg=-delete
+	if ___eapi_has_strict_keepdir || [[ ${FEATURES} == *strict-keepdir* ]]; then
+		striparg=-delete
+	fi
 
 	while IFS= read -r -d $'\0' d; do
 		[[ ${d} == ${ED%/}/var/* ]] && warn_dirs+=( "${d}" )

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -649,6 +649,7 @@ dangerous (like missing or incorrect digests for ebuilds).
 .B strict-keepdir
 Have portage strictly require keepdir calls in ebuilds.  Empty
 directories installed without explicit keepdir will be removed.
+This feature is automatically enabled for \fBEAPI 8\fR and later.
 .TP
 .B stricter
 Have portage react strongly to conditions that may conflict with system


### PR DESCRIPTION
Suggested-by: Pacho Ramos <@pacho2>
Bug: https://bugs.gentoo.org/651678