### PR TITLE
repoman: check IUSE in _match_use for USE defaults (bug 685482)

### DIFF
--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -314,12 +314,12 @@ class dbapi(object):
 				# Check masked and forced flags for repoman.
 				usemask = self.settings._getUseMask(pkg,
 					stable=self.settings._parent_stable)
-				if any(x in usemask for x in atom.use.enabled):
+				if any(x in usemask and iuse.get_real_flag(x) is not None for x in atom.use.enabled):
 					return False
 
 				useforce = self.settings._getUseForce(pkg,
 					stable=self.settings._parent_stable)
-				if any(x in useforce and x not in usemask
+				if any(x in useforce and x not in usemask and iuse.get_real_flag(x) is not None
 					for x in atom.use.disabled):
 					return False
 


### PR DESCRIPTION
This corrects a problem triggered with USE defaults where repoman
returns an incorrect negative match for an atom with USE defaults.
For example, it triggered this dependency.bad error:
```
RepoMan scours the neighborhood...
  dependency.bad [fatal]        2
   dev-libs/libxml2/libxml2-2.9.9-r1.ebuild: DEPEND: ~riscv(default/linux/riscv/17.0/rv64gc)
[     '>=dev-lang/python-exec-2:=[python_targets_python2_7(-)?,python_targets_python3_5(-)?,python_targets_python3_6(-)?,python_targets_python3_7(-)?,-python_single_target_python2_7(-),-python_single_target_python3_5(-),-python_single_target_python3_6(-),-python_single_target_python3_7(-)]']
   dev-libs/libxml2/libxml2-2.9.9-r1.ebuild: RDEPEND: ~riscv(default/linux/riscv/17.0/rv64gc)
[     '>=dev-lang/python-exec-2:=[python_targets_python2_7(-)?,python_targets_python3_5(-)?,python_targets_python3_6(-)?,python_targets_python3_7(-)?,-python_single_target_python2_7(-),-python_single_target_python3_5(-),-python_single_target_python3_6(-),-python_single_target_python3_7(-)]']
```
State in the _match_use method looked like this:
```
(Pdb) atom
'>=dev-lang/python-exec-2:=[python_targets_python3_7(-),-python_single_target_python2_7(-),-python_single_target_python3_5(-),-python_single_target_python3_6(-),-python_single_target_python3_7(-)]'
(Pdb) useforce
frozenset({'python_targets_pypy', 'python_targets_pypy3', 'python_targets_python3_5', 'big-endian', 'userland_GNU', 'python_targets_python3_7', 'riscv', 'python_single_target_python3_7', 'python_targets_python2_7', 'elibc_glibc', 'python_targets_python3_6', 'abi_riscv_lp64d', 'kernel_linux', 'python_targets_jython2_7'})
(Pdb) atom.use.disabled
frozenset({'python_single_target_python3_6', 'python_single_target_python2_7', 'python_single_target_python3_7', 'python_single_target_python3_5'})
(Pdb) atom.use.missing_disabled
frozenset({'python_single_target_python2_7', 'python_targets_python3_5', 'python_targets_python3_7', 'python_single_target_python3_5', 'python_single_target_python3_7', 'python_targets_python2_7', 'python_targets_python3_6', 'python_single_target_python3_6'})
```
Bug: https://bugs.gentoo.org/685482
Signed-off-by: Zac Medico <zmedico@gentoo.org>