### PR TITLE
estrip: Fix inconsistent behavior between EAPI < 7 and EAPI >= 7

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/helper-functions.sh || exit 1
@@ -305,6 +305,23 @@ process_elf() {
 	[[ -n ${lockfile} ]] && rm -f "${lockfile}"
 }
 
+# Usage: process_ar <ar archive>
+process_ar() {
+	local x=$1
+
+	__vecho "   ${x:${#ED}}"
+
+	if ${strip_this} ; then
+		# If we have split debug enabled, then do not strip this.
+		# There is no concept of splitdebug for objects not yet
+		# linked in (only for finally linked ELFs), so we have to
+		# retain the debug info in the archive itself.
+		if ! ${FEATURES_splitdebug} || ${RESTRICT_splitdebug} ; then
+			${STRIP} -g "${x}" && ${RANLIB} "${x}"
+		fi
+	fi
+}
+
 # The existance of the section .symtab tells us that a binary is stripped.
 # We want to log already stripped binaries, as this may be a QA violation.
 # They prevent us from getting the splitdebug data.
@@ -416,17 +433,7 @@ do
 
 	buildid=
 	if [[ ${f} == *"current ar archive"* ]] ; then
-		__vecho "   ${x:${#ED}}"
-		if ${strip_this} ; then
-			# If we have split debug enabled, then do not strip this.
-			# There is no concept of splitdebug for objects not yet
-			# linked in (only for finally linked ELFs), so we have to
-			# retain the debug info in the archive itself.
-			if ! ${FEATURES_splitdebug} || ${RESTRICT_splitdebug} ; then
-				${STRIP} -g "${x}" &&
-				${RANLIB} "${x}"
-			fi
-		fi
+		process_ar "${x}"
 	elif [[ ${f} == *"SB executable"* || ${f} == *"SB pie executable"* ||
 		${f} == *"SB shared object"* ]] ; then
 		process_elf "${x}" "${inode_link}" ${PORTAGE_STRIP_FLAGS}

--- a/bin/estrip
+++ b/bin/estrip
@@ -239,17 +239,18 @@ save_elf_debug() {
 		local buildid_dir="${ED%/}/usr/lib/debug/.build-id/${buildid:0:2}"
 		local buildid_file="${buildid_dir}/${buildid:2}"
 		mkdir -p "${buildid_dir}"
-		[ -L "${buildid_file}".debug ] || ln -s "../../${x:${#D}}.debug" "${buildid_file}.debug"
-		[ -L "${buildid_file}" ] || ln -s "/${x:${#D}}" "${buildid_file}"
+		[ -L "${buildid_file}".debug ] || ln -s "../../${x:$((${#d_noslash} + 1))}.debug" "${buildid_file}.debug"
+		[ -L "${buildid_file}" ] || ln -s "/${x:$((${#d_noslash} + 1))}" "${buildid_file}"
 	fi
 }
 
 # Usage: process_elf <elf>
 process_elf() {
 	local x=$1 inode_link=$2 strip_flags=${*:3}
+	local ed_noslash=${ED%/}
 	local already_stripped lockfile xt_data
 
-	__vecho "   ${x:${#ED}}"
+	__vecho "   ${x:${#ed_noslash}}"
 
 	# If two processes try to debugedit or strip the same hardlink at the
 	# same time, it may corrupt files or cause loss of splitdebug info.
@@ -308,8 +309,9 @@ process_elf() {
 # Usage: process_ar <ar archive>
 process_ar() {
 	local x=$1
+	local ed_noslash=${ED%/}
 
-	__vecho "   ${x:${#ED}}"
+	__vecho "   ${x:${#ed_noslash}}"
 
 	if ${strip_this} ; then
 		# If we have split debug enabled, then do not strip this.


### PR DESCRIPTION
estrip: Fix inconsistent behavior between EAPI < 7 and EAPI >= 7.

Bug: https://bugs.gentoo.org/685532
Signed-off-by: Arfrever Frehtes Taifersar Arahesis <Arfrever@Apache.Org>