### PR TITLE
Fix ACCEPT_LICENSE="-*" to behave as intended (bug 686406)

### DIFF
--- a/lib/portage/package/ebuild/_config/helper.py
+++ b/lib/portage/package/ebuild/_config/helper.py
@@ -57,7 +57,9 @@ def prune_incremental(split):
 			break
 		elif x == '-*':
 			if i == 0:
-				split = []
+				# Preserve the last -*, since otherwise an empty value
+				# would trigger fallback to a default value.
+				split = ['-*']
 			else:
 				split = split[-i:]
 			break


### PR DESCRIPTION
Fix prune_incremental to preserve the last -*, since otherwise an
empty value would trigger fallback to a default value. This ensures
that `ACCEPT_LICENSE="-*"` behaves as intended.

Signed-off-by: Zac Medico <zmedico@gentoo.org>