### PR TITLE
emerge: Don't treat empty EPREFIX or PORTAGE_CONFIGROOT as unset

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2455,8 +2455,8 @@ def load_emerge_config(emerge_config=None, env=None, **kargs):
 	for k, envvar in (("config_root", "PORTAGE_CONFIGROOT"), ("target_root", "ROOT"),
 			("sysroot", "SYSROOT"), ("eprefix", "EPREFIX")):
 		v = env.get(envvar)
-		if v and v.strip():
-			kwargs[k] = v
+		if v is not None:
+			kwargs[k] = v.strip()
 	emerge_config.trees = portage.create_trees(trees=emerge_config.trees,
 				**kwargs)
 


### PR DESCRIPTION
If a prefix user wanted to build within a `ROOT` but without a prefix,
they previously had to set `EPREFIX=/` rather than `EPREFIX=` as the
latter was simply treated as unset.

Also applies to `ROOT` and `SYSROOT` but probably makes no difference to
these as they are blank by default. This should be safe to do as all
these variables get normalised anyway.

Bug: https://bugs.gentoo.org/642604
Signed-off-by: James Le Cuirot <chewi@gentoo.org>