### PR TITLE
WIP: Cgroup Freezer Support

### DIFF
--- a/bin/cgroup-freezer-release-agent
+++ b/bin/cgroup-freezer-release-agent
@@ -1,0 +1,6 @@
+#!/bin/sh
+# notify_on_release triggers for /sys/fs/freezer/portage too
+# We never want to call `rmdir` on this directory so if the
+# length of $1 is 8 (the same length as `/portage`)
+# skip the call to rmdir
+[ "${#1}" -gt 8 ] && exec rmdir "/sys/fs/cgroup/freezer/${1}"

--- a/lib/_emerge/SpawnProcess.py
+++ b/lib/_emerge/SpawnProcess.py
@@ -31,7 +31,7 @@ class SpawnProcess(SubProcess):
 
 	_spawn_kwarg_names = ("env", "opt_name", "fd_pipes",
 		"uid", "gid", "groups", "umask", "logfile",
-		"path_lookup", "pre_exec", "close_fds", "cgroup",
+		"path_lookup", "pre_exec", "close_fds", "cgroup", "cgroup_freezer",
 		"unshare_ipc", "unshare_mount", "unshare_pid", "unshare_net")
 
 	__slots__ = ("args",) + \

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -133,6 +133,7 @@ SUPPORTED_FEATURES       = frozenset([
 	"case-insensitive-fs",
 	"ccache",
 	"cgroup",
+	"cgroup-freezer",
 	"chflags",
 	"clean-logs",
 	"collision-protect",

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -225,7 +225,7 @@ def spawn(mycommand, env=None, opt_name=None, fd_pipes=None, returnpid=False,
           path_lookup=True, pre_exec=None,
           close_fds=(sys.version_info < (3, 4)), unshare_net=False,
           unshare_ipc=False, unshare_mount=False, unshare_pid=False,
-	  cgroup=None):
+	  cgroup=None, cgroup_freezer=None):
 	"""
 	Spawns a given command.
 	
@@ -377,7 +377,7 @@ def spawn(mycommand, env=None, opt_name=None, fd_pipes=None, returnpid=False,
 				_exec(binary, mycommand, opt_name, fd_pipes,
 					env, gid, groups, uid, umask, cwd, pre_exec, close_fds,
 					unshare_net, unshare_ipc, unshare_mount, unshare_pid,
-					unshare_flags, cgroup)
+					unshare_flags, cgroup, cgroup_freezer)
 			except SystemExit:
 				raise
 			except Exception as e:
@@ -449,7 +449,7 @@ def spawn(mycommand, env=None, opt_name=None, fd_pipes=None, returnpid=False,
 def _exec(binary, mycommand, opt_name, fd_pipes,
 	env, gid, groups, uid, umask, cwd,
 	pre_exec, close_fds, unshare_net, unshare_ipc, unshare_mount, unshare_pid,
-	unshare_flags, cgroup):
+	unshare_flags, cgroup, cgroup_freezer):
 
 	"""
 	Execute a given binary with options
@@ -489,6 +489,8 @@ def _exec(binary, mycommand, opt_name, fd_pipes,
 	@type unshare_flags: Integer
 	@param cgroup: CGroup path to bind the process to
 	@type cgroup: String
+	@param cgroup_freezer: CGroup freezer path to bind the process to
+	@type cgroup_freezer: String
 	@rtype: None
 	@return: Never returns (calls os.execve)
 	"""
@@ -535,12 +537,15 @@ def _exec(binary, mycommand, opt_name, fd_pipes,
 
 	_setup_pipes(fd_pipes, close_fds=close_fds, inheritable=True)
 
-	# Add to cgroup
-	# it's better to do it from the child since we can guarantee
-	# it is done before we start forking children
-	if cgroup:
-		with open(os.path.join(cgroup, 'cgroup.procs'), 'a') as f:
-			f.write('%d\n' % os.getpid())
+	cgroups = [cgroup, cgroup_freezer]
+
+	for cgrp in cgroups:
+		# Add to cgroup
+		# it's better to do it from the child since we can guarantee
+		# it is done before we start forking children
+		if cgrp:
+			with open(os.path.join(cgrp, 'cgroup.procs'), 'a') as f:
+				f.write('%d\n' % os.getpid())
 
 	# Unshare (while still uid==0)
 	if unshare_net or unshare_ipc or unshare_mount or unshare_pid:


### PR DESCRIPTION
This implements support for using the [cgroup-v1 freezer subsystem](https://raw.githubusercontent.com/torvalds/linux/v5.2/Documentation/cgroup-v1/freezer-subsystem.txt) and is largely a copy/paste job of the existing cgroup code which is only used for process tracking. This allows us to reliably pause/resume long-running `emerge` jobs (e.g `echo 'FROZEN' > /sys/fs/cgroup/freezer/portage/www-client:chromium*/freezer.state`)

The code works but I doubt is something you'd want to merge just yet. I'm posting this to start a discussion over whether or not this is something you'd be interested in. When writing this I largely duplicated a lot of existing boilerplate code, it made me wonder if there's perhaps a more generic way to handle this? Maybe we also want to limit CPU usage or memory usage using cgroups, etc.