### PR TITLE
repos.conf: default sync-webrsync-verify-signature

### DIFF
--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -50,7 +50,7 @@ eval "$("${portageq}" envvar -v DISTDIR EPREFIX FEATURES \
 	FETCHCOMMAND GENTOO_MIRRORS \
 	PORTAGE_BIN_PATH PORTAGE_CONFIGROOT PORTAGE_GPG_DIR \
 	PORTAGE_NICENESS PORTAGE_REPOSITORIES PORTAGE_RSYNC_EXTRA_OPTS \
-	PORTAGE_RSYNC_OPTS PORTAGE_TMPDIR \
+	PORTAGE_RSYNC_OPTS PORTAGE_TEMP_GPG_DIR PORTAGE_TMPDIR \
 	USERLAND http_proxy ftp_proxy)"
 export http_proxy ftp_proxy
 
@@ -74,9 +74,21 @@ do_verbose=0
 do_debug=0
 keep=false
 
-if has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature | \
+has webrsync-gpg ${FEATURES} && webrsync_gpg=1 || webrsync_gpg=0
+
+if [[ ${webrsync_gpg} -eq 1 ]]; then
+	wecho "FEATURES=webrsync-gpg is deprecated, see the make.conf(5) man page."
+fi
+
+if [[ -n ${PORTAGE_TEMP_GPG_DIR} ]] ||
+	has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature |
 	LC_ALL=C tr '[:upper:]' '[:lower:]') true yes; then
-	if [[ ! -d ${PORTAGE_GPG_DIR} ]]; then
+	# If FEATURES=webrsync-gpg is enabled then allow direct emerge-webrsync
+	# calls for backward compatibility (this triggers a deprecation warning
+	# above). Since direct emerge-webrsync calls do not use gemato for secure
+	# key refresh, this behavior will not be supported in a future release.
+	if [[ ! ( -d ${PORTAGE_GPG_DIR} && ${webrsync_gpg} -eq 1 ) &&
+		-z ${PORTAGE_TEMP_GPG_DIR} ]]; then
 		eecho "Do not call ${argv0##*/} directly, instead call emerge --sync or emaint sync."
 		exit 1
 	fi
@@ -86,6 +98,7 @@ elif has webrsync-gpg ${FEATURES}; then
 else
 	WEBSYNC_VERIFY_SIGNATURE=0
 fi
+[[ -n ${PORTAGE_TEMP_GPG_DIR} ]] && PORTAGE_GPG_DIR=${PORTAGE_TEMP_GPG_DIR}
 if [ ${WEBSYNC_VERIFY_SIGNATURE} != 0 -a -z "${PORTAGE_GPG_DIR}" ]; then
 	eecho "please set PORTAGE_GPG_DIR in make.conf"
 	exit 1

--- a/cnf/repos.conf
+++ b/cnf/repos.conf
@@ -16,6 +16,7 @@ sync-openpgp-key-refresh-retry-overall-timeout = 1200
 sync-openpgp-key-refresh-retry-delay-exp-base = 2
 sync-openpgp-key-refresh-retry-delay-max = 60
 sync-openpgp-key-refresh-retry-delay-mult = 4
+sync-webrsync-verify-signature = yes
 
 # for daily squashfs snapshots
 #sync-type = squashdelta

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1205,6 +1205,10 @@ class config(object):
 			writemsg(_("!!! FEATURES=fakeroot is enabled, but the "
 				"fakeroot binary is not installed.\n"), noiselevel=-1)
 
+		if "webrsync-gpg" in self.features:
+			writemsg(_("!!! FEATURES=webrsync-gpg is deprecated, see the make.conf(5) man page.\n"),
+				noiselevel=-1)
+
 		if os.getuid() == 0 and not hasattr(os, "setgroups"):
 			warning_shown = False
 

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -88,6 +88,7 @@ class WebRsync(SyncBase):
 						openpgp_env.import_key(f)
 					self._refresh_keys(openpgp_env)
 					self.spawn_kwargs["env"]["PORTAGE_GPG_DIR"] = openpgp_env.home
+					self.spawn_kwargs["env"]["PORTAGE_TEMP_GPG_DIR"] = openpgp_env.home
 				except (GematoException, asyncio.TimeoutError) as e:
 					writemsg_level("!!! Verification impossible due to keyring problem:\n%s\n"
 							% (e,),

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1,4 +1,4 @@
-.TH "MAKE.CONF" "5" "Jun 2019" "Portage VERSION" "Portage"
+.TH "MAKE.CONF" "5" "Jul 2019" "Portage VERSION" "Portage"
 .SH "NAME"
 make.conf \- custom settings for Portage
 .SH "SYNOPSIS"
@@ -716,7 +716,9 @@ Portage would have to waste time validating ownership for each and every sync
 operation.
 .TP
 .B webrsync-gpg
-Enable GPG verification when using \fIemerge\-webrsync\fR.
+Enable GPG verification when using \fIemerge\-webrsync\fR. This feature is
+deprecated and has been replaced by the \fBrepos.conf\fR
+\fIsync\-webrsync\-verify\-signature\fR setting, see \fBportage\fR(5).
 .TP
 .B xattr
 Preserve extended attributes (filesystem-stored metadata) when installing

--- a/misc/emerge-delta-webrsync
+++ b/misc/emerge-delta-webrsync
@@ -48,7 +48,7 @@ eval "$("${portageq}" envvar -v DISTDIR EPREFIX FEATURES \
 	FETCHCOMMAND GENTOO_MIRRORS \
 	PORTAGE_BIN_PATH PORTAGE_CONFIGROOT PORTAGE_GPG_DIR \
 	PORTAGE_NICENESS PORTAGE_REPOSITORIES PORTAGE_RSYNC_EXTRA_OPTS \
-	PORTAGE_RSYNC_OPTS PORTAGE_TMPDIR \
+	PORTAGE_RSYNC_OPTS PORTAGE_TEMP_GPG_DIR PORTAGE_TMPDIR \
 	USERLAND http_proxy ftp_proxy)"
 export http_proxy ftp_proxy
 
@@ -114,9 +114,21 @@ if [[ ! -d $STATE_DIR ]]; then
 	exit -2
 fi
 
-if has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature | \
+has webrsync-gpg ${FEATURES} && webrsync_gpg=1 || webrsync_gpg=0
+
+if [[ ${webrsync_gpg} -eq 1 ]]; then
+	wecho "FEATURES=webrsync-gpg is deprecated, see the make.conf(5) man page."
+fi
+
+if [[ -n ${PORTAGE_TEMP_GPG_DIR} ]] ||
+	has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature |
 	LC_ALL=C tr '[:upper:]' '[:lower:]') true yes; then
-	if [[ ! -d ${PORTAGE_GPG_DIR} ]]; then
+	# If FEATURES=webrsync-gpg is enabled then allow direct emerge-webrsync
+	# calls for backward compatibility (this triggers a deprecation warning
+	# above). Since direct emerge-webrsync calls do not use gemato for secure
+	# key refresh, this behavior will not be supported in a future release.
+	if [[ ! ( -d ${PORTAGE_GPG_DIR} && ${webrsync_gpg} -eq 1 ) &&
+		-z ${PORTAGE_TEMP_GPG_DIR} ]]; then
 		eecho "Do not call ${argv0##*/} directly, instead call emerge --sync or emaint sync."
 		exit 1
 	fi
@@ -126,6 +138,7 @@ elif has webrsync-gpg ${FEATURES}; then
 else
 	WEBSYNC_VERIFY_SIGNATURE=0
 fi
+[[ -n ${PORTAGE_TEMP_GPG_DIR} ]] && PORTAGE_GPG_DIR=${PORTAGE_TEMP_GPG_DIR}
 if [ ${WEBSYNC_VERIFY_SIGNATURE} != 0 -a -z "${PORTAGE_GPG_DIR}" ]; then
 	eecho "please set PORTAGE_GPG_DIR in make.conf"
 	exit 1


### PR DESCRIPTION
Enable sync-webrsync-verify-signature by default in repos.conf (due to
dependencies the ebuild will make this conditional on USE=rsync-verify
in the same way as the default sync-rsync-verify-metamanifest value).
Use a new PORTAGE_TEMP_GPG_DIR variable to distinguish indirect
emerge-webrsync calls that use gemato for secure key refresh, and
disable direct emerge-webrsync calls.

Deprecate FEATURES=webrsync-gpg and use it to trigger a
backward-compatibility mode where direct emerge-webrsync calls are
allowed (but trigger a warning message). Since direct emerge-webrsync
calls do not use gemato for secure key refresh, this behavior will
not be supported in a future release.

Bug: https://bugs.gentoo.org/689506