### PR TITLE
tox.ini: py34: lxml<4.4.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@ skipsdist = True
 
 [testenv]
 deps =
-	lxml!=4.2.0
 	pygost
 	pyyaml
+	py34: lxml!=4.2.0,<4.4.0
+	py27,py35,py36,py37,pypy,pypy3: lxml!=4.2.0
 	py27,py34,py35,pypy: pyblake2
 	py27,py34,py35,pypy: pysha3
 setenv =


### PR DESCRIPTION
lxml-4.4.0 does not support py34.

Signed-off-by: Zac Medico <zmedico@gentoo.org>