### PR TITLE
bin/ebuild: Fix to work with installed package

### DIFF
--- a/bin/ebuild
+++ b/bin/ebuild
@@ -1,5 +1,5 @@
 #!/usr/bin/python -b
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function
@@ -311,6 +311,11 @@ except PortageKeyError:
 
 root_config = RootConfig(portage.settings,
 	portage.db[portage.settings['EROOT']], None)
+
+cpv = portage.versions._pkg_str(cpv,
+	metadata=metadata,
+	settings=portage.settings,
+	db=portage.db[portage.settings['EROOT']][mytree].dbapi)
 
 pkg = Package(built=(pkg_type != "ebuild"), cpv=cpv,
 	installed=(pkg_type=="installed"),


### PR DESCRIPTION
Fix the following AttributeError error:
```
# ebuild /var/db/pkg/sys-apps/portage-2.3.71/portage-2.3.71.ebuild clean pretend clean
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.6/ebuild", line 318, in <module>
    type_name=pkg_type)
  File "/usr/lib64/python3.6/site-packages/_emerge/Package.py", line 72, in __init__
    db = self.cpv._db
AttributeError: 'str' object has no attribute '_db'
```
Bug: https://bugs.gentoo.org/532674
Fixes: bfe7892202b8 ("_pkg_str: add _db attribute (bug 640318)")
Signed-off-by: Zac Medico <zmedico@gentoo.org>