### PR TITLE
AmbiguousPackageName: initialize self.args for pypy compat

### DIFF
--- a/lib/portage/exception.py
+++ b/lib/portage/exception.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2015 Gentoo Foundation
+# Copyright 1998-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import signal
@@ -149,6 +149,10 @@ class AmbiguousPackageName(ValueError, PortageException):
 	to the existence of multiple matches in different categories. This inherits
 	from ValueError, for backward compatibility with calling code that already
 	handles ValueError."""
+	def __init__(self, *args, **kwargs):
+		self.args = args
+		super(AmbiguousPackageName, self).__init__(*args, **kwargs)
+
 	def __str__(self):
 		return ValueError.__str__(self)
 


### PR DESCRIPTION
For pypy 7.1 self.args is empty, triggering this IndexError:
```
Traceback (most recent call last):
  File "<string>", line 53, in <module>
  File "/usr/lib/pypy2.7/site-packages/_emerge/main.py", line 1289, in emerge_main
    return run_action(emerge_config)
  File "/usr/lib/pypy2.7/site-packages/_emerge/actions.py", line 3230, in run_action
    emerge_config.args, spinner)
  File "/usr/lib/pypy2.7/site-packages/_emerge/actions.py", line 2081, in action_uninstall
    for i in e.args[0]:
IndexError: tuple index out of range
```
Bug: https://bugs.gentoo.org/692412
Signed-off-by: Zac Medico <zmedico@gentoo.org>