### PR TITLE
Add FEATURES=pkgdir-index-trusted

### DIFF
--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -176,6 +176,7 @@ SUPPORTED_FEATURES       = frozenset([
 	"parallel-fetch",
 	"parallel-install",
 	"pid-sandbox",
+	"pkgdir-index-trusted",
 	"prelink-checksums",
 	"preserve-libs",
 	"protect-owned",

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -561,6 +561,14 @@ Supported only on Linux. Requires PID and mount namespace support
 in kernel. /proc is remounted inside the mount namespace to account
 for new PID namespace.
 .TP
+.B pkgdir\-index\-trusted
+Trust that the \fBPKGDIR\fR index file is valid, meaning that no packages
+have been manually added or removed since the last call to
+\fBemaint \-\-fix binhost\fR. This feature eliminates overhead involved
+with detection of packages that have been manually added or removed,
+which significantly improves performance in some cases, such as when
+\fBPKGDIR\fR resides on a high\-latency network file system.
+.TP
 .B prelink\-checksums
 If \fBprelink\fR(8) is installed then use it to undo any prelinks on files
 before computing checksums for merge and unmerge. This feature is


### PR DESCRIPTION
Trust that the PKGDIR index file is valid, meaning that no packages
have been manually added or removed since the last call to emaint --fix
binhost. This feature eliminates overhead involved with detection of
packages that have been manually added or removed, which significantly
improves performance in some cases, such as when PKGDIR resides on
a high-latency network file system.

Bug: https://bugs.gentoo.org/688902
Signed-off-by: Zac Medico <zmedico@gentoo.org>

@mattst88