### PR TITLE
glsa-check: Forward port --quiet option from gentoolkit

### DIFF
--- a/bin/glsa-check
+++ b/bin/glsa-check
@@ -57,6 +57,8 @@ modes.add_argument("-m", "--mail", action="store_const",
 		help="Send a mail with the given GLSAs to the administrator")
 parser.add_argument("-V", "--version", action="store_true",
 		help="Show information about glsa-check")
+parser.add_argument("-q", "--quiet", action="store_true", dest="quiet",
+		help="Be less verbose and do not send empty mail")
 parser.add_argument("-v", "--verbose", action="store_true", dest="verbose",
 		help="Print more messages")
 parser.add_argument("-n", "--nocolor", action="store_true",
@@ -80,6 +82,7 @@ if options.version:
 mode = options.mode
 least_change = options.least_change
 list_cve = options.list_cve
+quiet = options.quiet
 verbose = options.verbose
 
 # Sanity checking
@@ -153,9 +156,10 @@ def summarylist(myglsalist, fd1=sys.stdout, fd2=sys.stderr, encoding="utf-8"):
 		fd2 = fd2.buffer
 	fd1 = codecs.getwriter(encoding)(fd1)
 	fd2 = codecs.getwriter(encoding)(fd2)
-	fd2.write(white("[A]")+" means this GLSA was marked as applied (injected),\n")
-	fd2.write(green("[U]")+" means the system is not affected and\n")
-	fd2.write(red("[N]")+" indicates that the system might be affected.\n\n")
+	if not quiet:
+		fd2.write(white("[A]")+" means this GLSA was marked as applied (injected),\n")
+		fd2.write(green("[U]")+" means the system is not affected and\n")
+		fd2.write(red("[N]")+" indicates that the system might be affected.\n\n")
 
 	myglsalist.sort()
 	for myid in myglsalist:
@@ -231,7 +235,7 @@ if mode in ["dump", "fix", "inject", "pretend"]:
 					# using emerge for the actual merging as it contains the dependency
 					# code and we want to be consistent in behaviour. Also this functionality
 					# will be integrated in emerge later, so it shouldn't hurt much.
-					emergecmd = "emerge --oneshot " + " =" + pkg
+					emergecmd = "emerge --oneshot" + (" --quiet" if quiet else "") + " =" + pkg
 					if verbose:
 						sys.stderr.write(emergecmd+"\n")
 					exitcode = os.system(emergecmd)
@@ -331,8 +335,9 @@ if mode == "mail":
 		myattachments.append(MIMEText(attachment, _charset="utf8"))
 		myfd.close()
 
-	mymessage = portage.mail.create_message(myfrom, myrecipient, mysubject, summary, myattachments)
-	portage.mail.send_mail(portage.settings, mymessage)
+	if glsalist or not quiet:
+		mymessage = portage.mail.create_message(myfrom, myrecipient, mysubject, summary, myattachments)
+		portage.mail.send_mail(portage.settings, mymessage)
 
 	sys.exit(0)
 

--- a/bin/glsa-check
+++ b/bin/glsa-check
@@ -222,10 +222,14 @@ if mode in ["dump", "fix", "inject", "pretend"]:
 		if mode == "dump":
 			myglsa.dump()
 		elif mode == "fix":
-			sys.stdout.write("Fixing GLSA "+myid+"\n")
+			if not quiet:
+				sys.stdout.write("Fixing GLSA "+myid+"\n")
 			if not myglsa.isVulnerable():
-				sys.stdout.write(">>> no vulnerable packages installed\n")
+				if not quiet:
+					sys.stdout.write(">>> no vulnerable packages installed\n")
 			else:
+				if quiet:
+					sys.stdout.write("Fixing GLSA "+myid+"\n")
 				mergelist = myglsa.getMergeList(least_change=least_change)
 				if mergelist == []:
 					sys.stdout.write(">>> cannot fix GLSA, no unaffected packages available\n")
@@ -247,10 +251,14 @@ if mode in ["dump", "fix", "inject", "pretend"]:
 			if len(mergelist):
 				sys.stdout.write("\n")
 		elif mode == "pretend":
-			sys.stdout.write("Checking GLSA "+myid+"\n")
+			if not quiet:
+				sys.stdout.write("Checking GLSA "+myid+"\n")
 			if not myglsa.isVulnerable():
-				sys.stdout.write(">>> no vulnerable packages installed\n")
+				if not quiet:
+					sys.stdout.write(">>> no vulnerable packages installed\n")
 			else:
+				if quiet:
+					sys.stdout.write("Checking GLSA "+myid+"\n")
 				mergedict = {}
 				for (vuln, update) in myglsa.getAffectionTable(least_change=least_change):
 					mergedict.setdefault(update, []).append(vuln)

--- a/man/glsa-check.1
+++ b/man/glsa-check.1
@@ -37,6 +37,9 @@
 \fBV\fR, \fB\-\-version\fR Show information about \fBglsa\-check\fR\.
 .
 .P
+\fB\-q\fR, \fB\-\-quiet\fR Be less verbose and do not send empty mail\.
+.
+.P
 \fB\-v\fR, \fB\-\-verbose\fR Print more messages\.
 .
 .P


### PR DESCRIPTION
Add a glsa-check --quiet option which is compatible with gentoolkit's
glsa-check.

Bug: https://bugs.gentoo.org/692872