### PR TITLE
emerge: deprecate --changelog option (bug 693096)

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2908,6 +2908,11 @@ def run_action(emerge_config):
 
 	adjust_configs(emerge_config.opts, emerge_config.trees)
 
+	if "--changelog" in emerge_config.opts:
+		writemsg_level(
+			" %s The emerge --changelog (or -l) option is deprecated\n" %
+			warn("*"), level=logging.WARNING, noiselevel=-1)
+
 	if profile_check(emerge_config.trees, emerge_config.action) != os.EX_OK:
 		return 1
 

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -492,6 +492,8 @@ information about \fBFEATURES\fR settings).
 .BR \-\-changelog ", " \-l
 Use this in conjunction with the \fB\-\-pretend\fR option.  This will
 show the ChangeLog entries for all the packages that will be upgraded.
+This option is deprecated because ChangeLog files are no longer
+distributed with Gentoo's ebuild repository.
 .TP
 .BR "\-\-color < y | n >"
 Enable or disable color output.  This option will override \fINOCOLOR\fR


### PR DESCRIPTION
The emerge --changelog option is not very useful since the
gentoo repository no longer includes ChangeLog files.

Bug: https://bugs.gentoo.org/693096
Signed-off-by: Zac Medico <zmedico@gentoo.org>