### PR TITLE
_backtrack_depgraph: fix premature backtracking termination (bug 693242)

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -9794,8 +9794,8 @@ def _backtrack_depgraph(settings, trees, myopts, myparams, myaction, myfiles, sp
 		elif mydepgraph.need_restart():
 			backtracked += 1
 			backtracker.feedback(mydepgraph.get_backtrack_infos())
-		else:
-			break
+		elif backtracker:
+			backtracked += 1
 
 	if not (success or mydepgraph.need_config_change()) and backtracked:
 


### PR DESCRIPTION
Make backtracking continue as long as the backtracker has remaining
nodes to explore. This fixes a case where it would terminate prematurely
when the depgraph.need_restart() method returned False, even the the
backtracker had remaining nodes to explore.

Bug: https://bugs.gentoo.org/693242
Signed-off-by: Zac Medico <zmedico@gentoo.org>