### PR TITLE
_slot_confict_backtrack: consider masking a package matched by all parent atoms (bug 692746)

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -1768,6 +1768,11 @@ class depgraph(object):
 		debug = "--debug" in self._frozen_config.myopts
 		existing_node = next(self._dynamic_config._package_tracker.match(
 			root, slot_atom, installed=False))
+		if existing_node not in conflict_pkgs:
+			# Even though all parent atoms match existing_node,
+			# consider masking it in order to avoid a missed update
+			# as in bug 692746.
+			conflict_pkgs.append(existing_node)
 		# In order to avoid a missed update, first mask lower versions
 		# that conflict with higher versions (the backtracker visits
 		# these in reverse order).

--- a/lib/_emerge/resolver/backtracking.py
+++ b/lib/_emerge/resolver/backtracking.py
@@ -135,11 +135,20 @@ class Backtracker(object):
 				continue
 
 			entry_is_valid = False
+			any_conflict_parents = False
 
 			for ppkg, patom in runtime_pkg_mask[pkg].get("slot conflict", set()):
+				any_conflict_parents = True
 				if ppkg not in runtime_pkg_mask:
 					entry_is_valid = True
 					break
+			else:
+				if not any_conflict_parents:
+					# Even though pkg was involved in a slot conflict
+					# where it was matched by all involved parent atoms,
+					# consider masking it in order to avoid a missed
+					# update as in bug 692746.
+					entry_is_valid = True
 
 			if not entry_is_valid:
 				return False

--- a/lib/portage/tests/resolver/test_slot_conflict_update_virt.py
+++ b/lib/portage/tests/resolver/test_slot_conflict_update_virt.py
@@ -1,0 +1,79 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (ResolverPlayground,
+	ResolverPlaygroundTestCase)
+
+class SlotConflictUpdateVirtTestCase(TestCase):
+
+	def testSlotConflictUpdateVirt(self):
+
+		ebuilds = {
+			"dev-db/mysql-connector-c-6.1.11-r2" : {
+				"EAPI": "7",
+				"SLOT" : "0/18"
+			},
+
+			"dev-db/mysql-connector-c-8.0.17-r3" : {
+				"EAPI": "7",
+				"SLOT" : "0/21"
+			},
+
+			"virtual/libmysqlclient-18-r1" : {
+				"EAPI": "7",
+				"SLOT" : "0/18",
+				"RDEPEND": "dev-db/mysql-connector-c:0/18",
+			},
+
+			"virtual/libmysqlclient-21" : {
+				"EAPI": "7",
+				"SLOT" : "0/21",
+				"RDEPEND": "dev-db/mysql-connector-c:0/21",
+			},
+
+			"dev-perl/DBD-mysql-4.44.0" : {
+				"EAPI": "7",
+				"RDEPEND": "virtual/libmysqlclient:=",
+			},
+		}
+
+		installed = {
+			"dev-db/mysql-connector-c-6.1.11-r2" : {
+				"EAPI": "7",
+				"SLOT" : "0/18"
+			},
+
+			"virtual/libmysqlclient-18-r1" : {
+				"EAPI": "7",
+				"SLOT" : "0/18",
+				"RDEPEND": "dev-db/mysql-connector-c:0/18",
+			},
+
+			"dev-perl/DBD-mysql-4.44.0" : {
+				"EAPI": "7",
+				"RDEPEND": "virtual/libmysqlclient:0/18=",
+			},
+		}
+
+		world = ["dev-db/mysql-connector-c", "dev-perl/DBD-mysql"]
+
+		test_cases = (
+			# In order to avoid missed updates for bug 692746, consider
+			# masking a package matched by all parent atoms.
+			ResolverPlaygroundTestCase(
+				['@world'],
+				options = {"--update": True, "--deep": True},
+				success = True,
+				mergelist = ['dev-db/mysql-connector-c-8.0.17-r3', 'virtual/libmysqlclient-21', 'dev-perl/DBD-mysql-4.44.0']),
+		)
+
+		playground = ResolverPlayground(ebuilds=ebuilds,
+			installed=installed, world=world, debug=False)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+		finally:
+			playground.debug = False
+			playground.cleanup()

--- a/lib/portage/tests/resolver/test_slot_operator_complete_graph.py
+++ b/lib/portage/tests/resolver/test_slot_operator_complete_graph.py
@@ -115,7 +115,7 @@ class SlotOperatorCompleteGraphTestCase(TestCase):
 			ResolverPlaygroundTestCase(
 				["=app-misc/meta-pkg-2", "app-misc/C"],
 				options = {
-					"--backtrack": 5,
+					"--backtrack": 9,
 				},
 				success = True,
 				ambiguous_merge_order = True,

--- a/lib/portage/tests/resolver/test_slot_operator_runtime_pkg_mask.py
+++ b/lib/portage/tests/resolver/test_slot_operator_runtime_pkg_mask.py
@@ -110,7 +110,7 @@ class SlotOperatorRuntimePkgMaskTestCase(TestCase):
 			ResolverPlaygroundTestCase(
 				["=app-misc/meta-pkg-2"],
 				options = {
-					"--backtrack": 5,
+					"--backtrack": 12,
 				},
 				success = True,
 				ambiguous_merge_order = True,


### PR DESCRIPTION
When a slot conflict occurs involving a package that is matched by all
involved parent atoms, consider masking the package in order to avoid
a possible missed update. The included unit test demonstrates the case
fixed by this patch. There are 2 previously existing unit tests that
require larger backtracking values in order to succeed with this patch,
since more possible solutions are now considered.

Bug: https://bugs.gentoo.org/692746