### PR TITLE
glsa-check: add --reverse option (bug 235970)

### DIFF
--- a/bin/glsa-check
+++ b/bin/glsa-check
@@ -68,6 +68,8 @@ parser.add_argument("-e", "--emergelike", action="store_false", dest="least_chan
 		help="Upgrade to latest version (not least-change)")
 parser.add_argument("-c", "--cve", action="store_true", dest="list_cve",
 		help="Show CVE IDs in listing mode")
+parser.add_argument("-r", "--reverse", action="store_true", dest="reverse",
+		help="List GLSAs in reverse order")
 
 options, params = parser.parse_known_args()
 
@@ -163,8 +165,7 @@ def summarylist(myglsalist, fd1=sys.stdout, fd2=sys.stderr, encoding="utf-8"):
 		fd2.write(green("[U]")+" means the system is not affected and\n")
 		fd2.write(red("[N]")+" indicates that the system might be affected.\n\n")
 
-	myglsalist.sort()
-	for myid in myglsalist:
+	for myid in sorted(myglsalist, reverse=options.reverse):
 		try:
 			myglsa = Glsa(myid, portage.settings, vardb, portdb)
 		except (GlsaTypeException, GlsaFormatException) as e:

--- a/man/glsa-check.1
+++ b/man/glsa-check.1
@@ -1,4 +1,4 @@
-.TH "GLSA\-CHECK" "1" "August 2019" "Portage VERSION" "Portage"
+.TH "GLSA\-CHECK" "1" "September 2019" "Portage VERSION" "Portage"
 .
 .SH "NAME"
 \fBglsa\-check\fR \- Tool to locally monitor and manage GLSAs
@@ -37,9 +37,6 @@
 \fBV\fR, \fB\-\-version\fR Show information about \fBglsa\-check\fR\.
 .
 .P
-\fB\-q\fR, \fB\-\-quiet\fR Be less verbose and do not send empty mail\.
-.
-.P
 \fB\-v\fR, \fB\-\-verbose\fR Print more messages\.
 .
 .P
@@ -50,6 +47,9 @@
 .
 .P
 \fB\-m\fR, \fB\-\-mail\fR Send a mail with the given GLSAs to the administrator\.
+.
+.P
+\fB\-r\fR, \fB\-\-reverse\fR List GLSAs in reverse order
 .
 .SH "EXAMPLES"
 \fBglsa\-check \-t all\fR Test the system against all GLSAs in the GLSA repository\.


### PR DESCRIPTION
Add --reverse option which causes GLSAs to be listed in reverse order,
so that the most recent GLSAs are listed earlier.

Suggested-by: Pavel Sanda <ps@twin.jikos.cz>
Bug: https://bugs.gentoo.org/235970
Signed-off-by: Zac Medico <zmedico@gentoo.org>