### PR TITLE
rewrite has()

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -488,14 +488,9 @@ hasv() {
 }
 
 has() {
-	local needle=$1
-	shift
+	local -r -- IFS=$'\a'
 
-	local x
-	for x in "$@"; do
-		[ "${x}" = "${needle}" ] && return 0
-	done
-	return 1
+	[[ "${IFS}${*:2}${IFS}" == *"${IFS}${1}${IFS}"* ]]
 }
 
 __repo_attr() {


### PR DESCRIPTION
This version of has() contains following improvements:

- better performance in **all** cases
    - the worse the case is the bigger the improvement (more and longer elements with no matches)
- doesn't pollute tracing log
    - produces `2` lines for all cases whereas the current version produces  `4+2*N` where N is the number of elements in haystack until match is found

It's similar to @vapier's solution from [659eafd](https://github.com/gentoo/portage/commit/659eafddd5964820ce8bdc0d90f5fcf7df04b5b7?diff=unified#diff-cf78c96b7136955c12985f72986cc468R152), but this version handles whitespaces just fine, because it uses an exotic `\a` character as a separator.