### PR TITLE
x11-module-rebuild: support SYMLINK_LIB=no (bug 693980)

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -76,7 +76,7 @@ files = /lib/modules
 # excluding the package that owns /usr/bin/Xorg.
 [x11-module-rebuild]
 class = portage.sets.dbapi.OwnerSet
-files = /usr/lib/xorg/modules
+files = /usr/lib*/xorg/modules
 exclude-files = /usr/bin/Xorg
 
 # Binary packages that have a different build time from a currently

--- a/lib/portage/_sets/__init__.py
+++ b/lib/portage/_sets/__init__.py
@@ -142,7 +142,7 @@ class SetConfig(object):
 		parser.remove_section("x11-module-rebuild")
 		parser.add_section("x11-module-rebuild")
 		parser.set("x11-module-rebuild", "class", "portage.sets.dbapi.OwnerSet")
-		parser.set("x11-module-rebuild", "files", "/usr/lib/xorg/modules")
+		parser.set("x11-module-rebuild", "files", "/usr/lib*/xorg/modules")
 		parser.set("x11-module-rebuild", "exclude-files", "/usr/bin/Xorg")
 
 	def update(self, setname, options):

--- a/lib/portage/_sets/dbapi.py
+++ b/lib/portage/_sets/dbapi.py
@@ -1,8 +1,9 @@
-# Copyright 2007-2014 Gentoo Foundation
+# Copyright 2007-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import division
 
+import glob
 import re
 import time
 
@@ -67,11 +68,19 @@ class OwnerSet(PackageSet):
 
 	def mapPathsToAtoms(self, paths, exclude_paths=None):
 		"""
-		All paths must begin with a slash, must include EPREFIX, and
-		must not include ROOT.
+		All paths must begin with a slash, and must not include EROOT.
+		Supports globs.
 		"""
 		rValue = set()
 		vardb = self._db
+
+		eroot = vardb.settings['EROOT']
+		expanded_paths = []
+		for p in paths:
+			expanded_paths.extend(expanded_p[len(eroot)-1:] for expanded_p in
+				glob.iglob(os.path.join(eroot, p.lstrip(os.sep))))
+		paths = expanded_paths
+
 		pkg_str = vardb._pkg_str
 		if exclude_paths is None:
 			for link, p in vardb._owners.iter_owners(paths):


### PR DESCRIPTION
Use a lib* glob to support SYMLINK_LIB=no.

Bug: https://bugs.gentoo.org/693980
Signed-off-by: Zac Medico <zmedico@gentoo.org>