### PR TITLE
_add_dep: less aggressive backtracking (bug 693836)

### DIFF
--- a/lib/portage/tests/resolver/test_aggressive_backtrack_downgrade.py
+++ b/lib/portage/tests/resolver/test_aggressive_backtrack_downgrade.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (ResolverPlayground,
+	ResolverPlaygroundTestCase)
+
+class AgressiveBacktrackDowngradeTestCase(TestCase):
+
+	def testAgressiveBacktrackDowngrade(self):
+
+		ebuilds = {
+			'www-client/firefox-69.0' : {
+				'EAPI': '7',
+				'RDEPEND': '=media-libs/libvpx-1.7*:0=[postproc] media-video/ffmpeg'
+			},
+
+			'www-client/firefox-60.9.0' : {
+				'EAPI': '7',
+				'RDEPEND': ''
+			},
+
+			'media-libs/libvpx-1.8.0' : {
+				'EAPI': '7',
+				'SLOT' : '0/6',
+				'IUSE': 'postproc',
+			},
+
+			'media-libs/libvpx-1.7.0' : {
+				'EAPI': '7',
+				'SLOT' : '0/5',
+				'IUSE': '+postproc',
+			},
+
+			'media-libs/libvpx-1.6.0' : {
+				'EAPI': '7',
+				'SLOT' : '0/4',
+				'IUSE': 'postproc',
+			},
+
+			'media-video/ffmpeg-4.2' : {
+				'EAPI': '7',
+				'RDEPEND': 'media-libs/libvpx:=',
+			},
+		}
+
+		installed = {
+			'www-client/firefox-69.0' : {
+				'EAPI': '7',
+				'RDEPEND': '=media-libs/libvpx-1.7*:0/5=[postproc] media-video/ffmpeg'
+			},
+
+			'media-libs/libvpx-1.7.0' : {
+				'EAPI': '7',
+				'SLOT' : '0/5',
+				'IUSE': '+postproc',
+				'USE': 'postproc',
+			},
+
+			'media-video/ffmpeg-4.2' : {
+				'EAPI': '7',
+				'RDEPEND': 'media-libs/libvpx:0/5=',
+			},
+		}
+
+		world = ['media-video/ffmpeg', 'www-client/firefox']
+
+		test_cases = (
+			# Test bug 693836, where an attempt to upgrade libvpx lead
+			# to aggressive backtracking which ultimately triggered an
+			# undesirable firefox downgrade like this:
+			# [ebuild     U  ] media-libs/libvpx-1.8.0 [1.7.0]
+			# [ebuild     UD ] www-client/firefox-60.9.0 [69.0]
+			# [ebuild  rR    ] media-video/ffmpeg-4.2
+			ResolverPlaygroundTestCase(
+				['@world'],
+				options = {'--update': True, '--deep': True},
+				success = True,
+				mergelist = [],
+			),
+		)
+
+		playground = ResolverPlayground(ebuilds=ebuilds,
+			installed=installed, world=world, debug=False)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+		finally:
+			playground.debug = False
+			playground.cleanup()


### PR DESCRIPTION
In order to suppress the sort of aggressive backtracking that can
trigger undesirable downgrades as in bug 693836, do not backtrack
for an unsatisfied dependency if there's an available package in
the runtime package mask which was involved in a slot conflict and
satisfied all involved parent atoms. Instead, discard the current
depgraph in favor of other backtracking configurations that may
exist. This case would not have been encountered prior to the fix
for bug 692746 which enabled backtracking for the type of slot
conflict that is detected here.

Fixes: 994ac00aa764 ("_slot_confict_backtrack: consider masking a package matched by all parent atoms (bug 692746)")
Bug: https://bugs.gentoo.org/693836
Signed-off-by: Zac Medico <zmedico@gentoo.org>