### PR TITLE
repos.conf: remove mention of squashdelta from default config

### DIFF
--- a/cnf/repos.conf
+++ b/cnf/repos.conf
@@ -17,7 +17,3 @@ sync-openpgp-key-refresh-retry-delay-exp-base = 2
 sync-openpgp-key-refresh-retry-delay-max = 60
 sync-openpgp-key-refresh-retry-delay-mult = 4
 sync-webrsync-verify-signature = yes
-
-# for daily squashfs snapshots
-#sync-type = squashdelta
-#sync-uri = mirror://gentoo/../snapshots/squashfs


### PR DESCRIPTION
squashdelta was removed in 090c8c91dad9 ("portage/sync/modules: Remove the squashdelta module")

Bug:  https://bugs.gentoo.org/614422
