### PR TITLE
Disable autounmask package.keywords/mask changes by default

### DIFF
--- a/lib/_emerge/create_depgraph_params.py
+++ b/lib/_emerge/create_depgraph_params.py
@@ -7,6 +7,11 @@ from portage.util import writemsg_level
 def create_depgraph_params(myopts, myaction):
 	#configure emerge engine parameters
 	#
+	# autounmask:               enable autounmask
+	# autounmask_keep_keywords: prevent autounmask changes to package.accept_keywords
+	# autounmask_keep_license:  prevent autounmask changes to package.license
+	# autounmask_keep_masks:    prevent autounmask changes to package.mask
+	# autounmask_keep_use:      prevent autounmask changes to package.use
 	# self:      include _this_ package regardless of if it is merged.
 	# selective: exclude the package if it is merged
 	# recurse:   go into the dependencies
@@ -33,6 +38,36 @@ def create_depgraph_params(myopts, myaction):
 	# changed_slot: rebuild installed packages with outdated SLOT metadata
 	# binpkg_changed_deps: reject binary packages with outdated deps
 	myparams = {"recurse" : True}
+
+	autounmask_keep_keywords = myopts.get("--autounmask-keep-keywords")
+	autounmask_keep_masks = myopts.get("--autounmask-keep-masks")
+
+	autounmask = myopts.get("--autounmask")
+	autounmask_license = myopts.get('--autounmask-license')
+	autounmask_use = myopts.get('--autounmask-use')
+	if autounmask == 'n':
+		autounmask = False
+	else:
+		if autounmask is None:
+			if autounmask_use in (None, 'y'):
+				autounmask = True
+			elif autounmask_license in (None, 'y'):
+				autounmask = True
+
+			# Do not enable package.accept_keywords or package.mask
+			# changes by default.
+			if autounmask_keep_keywords is None:
+				autounmask_keep_keywords = True
+			if autounmask_keep_masks is None:
+				autounmask_keep_masks = True
+		else:
+			autounmask = True
+
+	myparams['autounmask'] = autounmask
+	myparams['autounmask_keep_use'] = True if autounmask_use == 'n' else False
+	myparams['autounmask_keep_license'] = True if autounmask_license == 'n' else False
+	myparams['autounmask_keep_keywords'] = False if autounmask_keep_keywords in (None, 'n') else True
+	myparams['autounmask_keep_masks'] = False if autounmask_keep_masks in (None, 'n') else True
 
 	bdeps = myopts.get("--with-bdeps")
 	if bdeps is not None:

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -495,7 +495,7 @@ class _dynamic_depgraph_config(object):
 		self._backtrack_infos = {}
 
 		self._buildpkgonly_deps_unsatisfied = False
-		self._autounmask = depgraph._frozen_config.myopts.get('--autounmask') != 'n'
+		self._autounmask = self.myparams['autounmask']
 		self._displayed_autounmask = False
 		self._success_without_autounmask = False
 		self._autounmask_backtrack_disabled = False
@@ -5907,15 +5907,19 @@ class depgraph(object):
 		if self._dynamic_config._autounmask is not True:
 			return
 
-		autounmask_keep_keywords = self._frozen_config.myopts.get("--autounmask-keep-keywords", "n") != "n"
-		autounmask_keep_masks = self._frozen_config.myopts.get("--autounmask-keep-masks", "n") != "n"
+		autounmask_keep_keywords = self._dynamic_config.myparams['autounmask_keep_keywords']
+		autounmask_keep_license = self._dynamic_config.myparams['autounmask_keep_license']
+		autounmask_keep_masks = self._dynamic_config.myparams['autounmask_keep_masks']
+		autounmask_keep_use = self._dynamic_config.myparams['autounmask_keep_use']
 		autounmask_level = self._AutounmaskLevel()
 
-		autounmask_level.allow_use_changes = True
-		yield autounmask_level
+		if not autounmask_keep_use:
+			autounmask_level.allow_use_changes = True
+			yield autounmask_level
 
-		autounmask_level.allow_license_changes = True
-		yield autounmask_level
+		if not autounmask_keep_license:
+			autounmask_level.allow_license_changes = True
+			yield autounmask_level
 
 		if not autounmask_keep_keywords:
 			autounmask_level.allow_unstable_keywords = True
@@ -9835,7 +9839,7 @@ def _backtrack_depgraph(settings, trees, myopts, myparams, myaction, myfiles, sp
 				"\n\nautounmask breakage detected\n\n",
 				noiselevel=-1, level=logging.DEBUG)
 			mydepgraph.display_problems()
-		myopts["--autounmask"] = "n"
+		myparams["autounmask"] = False
 		mydepgraph = depgraph(settings, trees, myopts, myparams, spinner,
 			frozen_config=frozen_config, allow_backtracking=False)
 		success, favorites = mydepgraph.select_files(myfiles)

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -347,9 +347,19 @@ def parse_opts(tmpcmdline, silent=False):
 			"choices" : true_y_or_n
 		},
 
+		"--autounmask-license": {
+			"help"    : "allow autounmask to change package.license",
+			"choices" : y_or_n
+		},
+
 		"--autounmask-unrestricted-atoms": {
 			"help"    : "write autounmask changes with >= atoms if possible",
 			"choices" : true_y_or_n
+		},
+
+		"--autounmask-use": {
+			"help"    : "allow autounmask to change package.use",
+			"choices" : y_or_n
 		},
 
 		"--autounmask-keep-keywords": {

--- a/lib/portage/tests/resolver/test_autounmask.py
+++ b/lib/portage/tests/resolver/test_autounmask.py
@@ -93,6 +93,26 @@ class AutounmaskTestCase(TestCase):
 					mergelist=["dev-libs/C-1", "dev-libs/B-1", "dev-libs/A-1"],
 					use_changes={ "dev-libs/B-1": {"foo": True} }),
 
+				ResolverPlaygroundTestCase(
+					["dev-libs/A:1"],
+					options={"--autounmask-use": "y"},
+					success=False,
+					mergelist=["dev-libs/C-1", "dev-libs/B-1", "dev-libs/A-1"],
+					use_changes={ "dev-libs/B-1": {"foo": True} }),
+
+				# Test default --autounmask-use
+				ResolverPlaygroundTestCase(
+					["dev-libs/A:1"],
+					success=False,
+					mergelist=["dev-libs/C-1", "dev-libs/B-1", "dev-libs/A-1"],
+					use_changes={ "dev-libs/B-1": {"foo": True} }),
+
+				# Explicitly disable --autounmask-use
+				ResolverPlaygroundTestCase(
+					["dev-libs/A:1"],
+					success=False,
+					options={"--autounmask-use": "n"}),
+
 				#Make sure we restart if needed.
 				ResolverPlaygroundTestCase(
 					["dev-libs/A:1", "dev-libs/B"],
@@ -408,16 +428,29 @@ class AutounmaskTestCase(TestCase):
 			}
 
 		test_cases = (
+				# --autounmask=n negates default --autounmask-license
 				ResolverPlaygroundTestCase(
 					["=dev-libs/A-1"],
 					options={"--autounmask": 'n'},
 					success=False),
 				ResolverPlaygroundTestCase(
 					["=dev-libs/A-1"],
-					options={"--autounmask": True},
+					options={"--autounmask-license": "y"},
 					success=False,
 					mergelist=["dev-libs/A-1"],
 					license_changes={ "dev-libs/A-1": set(["TEST"]) }),
+
+				# Test default --autounmask-license
+				ResolverPlaygroundTestCase(
+					["=dev-libs/A-1"],
+					success=False,
+					mergelist=["dev-libs/A-1"],
+					license_changes={ "dev-libs/A-1": set(["TEST"]) }),
+
+				ResolverPlaygroundTestCase(
+					["=dev-libs/A-1"],
+					options={"--autounmask-license": "n"},
+					success=False),
 
 				#Test license+keyword+use change at once.
 				ResolverPlaygroundTestCase(

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -352,16 +352,19 @@ intended to be set in the \fBmake.conf\fR(5)
 .TP
 .BR "\-\-autounmask [ y | n ]"
 Automatically unmask packages and generate package.use
-settings as necessary to satisfy dependencies. This
-option is enabled by default. If any configuration
+settings as necessary to satisfy dependencies. This option
+is disabled by default, except for portions of behavior
+which are controlled by the \fB\-\-autounmask\-use\fR and
+\fB\-\-autounmask\-license\fR options (\fB\-\-autounmask=n\fR
+disables autounmask behavior entirely). If any configuration
 changes are required, then they will be displayed
 after the merge list and emerge will immediately
 abort. If the displayed configuration changes are
 satisfactory, you should copy and paste them into
 the specified configuration file(s), or enable the
 \fB\-\-autounmask\-write\fR option. The
-\fBEMERGE_DEFAULT_OPTS\fR variable may be used to
-disable this option by default in \fBmake.conf\fR(5).
+\fBEMERGE_DEFAULT_OPTS\fR variable may be used to entirely
+enable or disable this option by default in \fBmake.conf\fR(5).
 .TP
 .BR "\-\-autounmask\-backtrack < y | n >"
 Allow backtracking after autounmask has detected that
@@ -406,6 +409,18 @@ the \-\-autounmask\-keep\-masks is also specified.
 If \-\-autounmask is enabled, no package.unmask or ** keyword changes
 will be created. This leads to unsatisfied dependencies if
 no other solution exists.
+.TP
+.BR "\-\-autounmask\-license < y | n >"
+Allow autounmask package.license changes. This option is enabled by default
+(either \fB\-\-autounmask=n\fR or \fB\-\-autounmask\-license=n\fR disables
+it). The \fBEMERGE_DEFAULT_OPTS\fR variable may be used to
+disable this option by default in \fBmake.conf\fR(5).
+.TP
+.BR "\-\-autounmask\-use < y | n >"
+Allow autounmask package.use changes. This option is enabled by default
+(either \fB\-\-autounmask=n\fR or \fB\-\-autounmask\-use=n\fR disables
+it). The \fBEMERGE_DEFAULT_OPTS\fR variable may be used to
+disable this option by default in \fBmake.conf\fR(5).
 .TP
 .BR "\-\-autounmask\-write [ y | n ]"
 If \-\-autounmask is enabled, changes are written


### PR DESCRIPTION
Add emerge --autounmask-license and --autounmask-use options which are
enabled by default, and disable package.keywords/mask changes by
default. For backward compatibility, previous behavior of
--autounmask=y and --autounmask=n is entirely preserved. Users can
get the old behavior simply by adding --autounmask to the make.conf
EMERGE_DEFAULT_OPTS variable.

Bug: https://bugs.gentoo.org/658648
Signed-off-by: Zac Medico <zmedico@gentoo.org>