### PR TITLE
emirrordist: Support specifying custom --layout-conf

### DIFF
--- a/lib/portage/_emirrordist/Config.py
+++ b/lib/portage/_emirrordist/Config.py
@@ -74,8 +74,10 @@ class Config(object):
 				options.deletion_db, 'deletion')
 
 		self.layout_conf = MirrorLayoutConfig()
-		self.layout_conf.read_from_file(
-				os.path.join(self.distfiles, 'layout.conf'))
+		if options.layout_conf is None:
+			options.layout_conf = os.path.join(self.distfiles,
+					'layout.conf')
+		self.layout_conf.read_from_file(options.layout_conf)
 		self.layouts = self.layout_conf.get_all_layouts()
 
 	def _open_log(self, log_desc, log_path, mode):

--- a/lib/portage/_emirrordist/main.py
+++ b/lib/portage/_emirrordist/main.py
@@ -193,6 +193,12 @@ common_options = (
 			"distfiles between layouts",
 		"action"   : "store_true"
 	},
+	{
+		"longopt"  : "--layout-conf",
+		"help"     : "specifies layout.conf file to use instead of "
+			"the one present in the distfiles directory",
+		"metavar"  : "FILE"
+	},
 )
 
 def parse_args(args):


### PR DESCRIPTION
Support specifying custom layout.conf file to use.  This makes it
possible to start propagating new mirror layout without exposing it
to users.

Signed-off-by: Michał Górny <mgorny@gentoo.org>