### PR TITLE
fetch: remove symlink created by FETCHCOMMAND_RSYNC (bug 698046)

### DIFF
--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -1283,7 +1283,8 @@ def fetch(myuris, mysettings, listonly=0, fetchonly=0,
 					# trust the return value from the fetcher.  Remove the
 					# empty file and try to download again.
 					try:
-						if os.stat(download_path).st_size == 0:
+						mystat = os.lstat(download_path)
+						if mystat.st_size == 0 or (stat.S_ISLNK(mystat.st_mode) and not os.path.exists(download_path)):
 							os.unlink(download_path)
 							fetched = 0
 							continue


### PR DESCRIPTION
This avoids confusing "No such file or directory" errors as demonstrated
by the following test case:
```
$ ln -s /foo/bar /tmp/sudo-1.8.29rc1.tar.gz
$ wget http://distfiles.gentoo.org/distfiles/sudo-1.8.29rc1.tar.gz -O /tmp/sudo-1.8.29rc1.tar.gz
/tmp/sudo-1.8.29rc1.tar.gz: No such file or directory
```
Bug: https://bugs.gentoo.org/698046
Signed-off-by: Zac Medico <zmedico@gentoo.org>