### PR TITLE
emirrordist: fix DeletionTask to handle broken symlink

### DIFF
--- a/lib/portage/_emirrordist/DeletionTask.py
+++ b/lib/portage/_emirrordist/DeletionTask.py
@@ -28,6 +28,11 @@ class DeletionTask(CompositeTask):
 							recycle_path)
 				except OSError as e:
 					if e.errno != errno.EXDEV:
+						if os.path.islink(self.distfile_path) and not os.path.exists(self.distfile_path):
+							self._delete_links()
+							self._async_wait()
+							return
+
 						logging.error(("rename %s from distfiles to "
 							"recycle failed: %s") % (self.distfile, e))
 				else:


### PR DESCRIPTION
After rename of a nonexistent symlink target fails, detect a
broken symlink and simply delete it.

Fixes: 0d34d89d5028 ("emirrordist: Implement mirror layout.conf support")
Bug: https://bugs.gentoo.org/699400
Signed-off-by: Zac Medico <zmedico@gentoo.org>