### PR TITLE
Keep https_proxy populated for curl downloads

### DIFF
--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -563,7 +563,7 @@ def create_trees(config_root=None, target_root=None, trees=None, env=None,
 		clean_env = {}
 		for k in ('PATH', 'PORTAGE_GRPNAME', 'PORTAGE_REPOSITORIES', 'PORTAGE_USERNAME',
 			'PYTHONPATH', 'SSH_AGENT_PID', 'SSH_AUTH_SOCK', 'TERM',
-			'ftp_proxy', 'http_proxy', 'no_proxy',
+			'ftp_proxy', 'http_proxy', 'https_proxy', 'no_proxy',
 			'__PORTAGE_TEST_HARDLINK_LOCKS'):
 			v = settings.get(k)
 			if v is not None:


### PR DESCRIPTION
When building Chromium OS behind a proxy, https_proxy needs to be set
for curl. Additional discussion can be found at [1]. Chromium configures
the chroot FETCHCOMMAND at [2].

Example fetch command:
curl --ipv4 -f -y 30 --retry 9 -L \
     --output /var/cache/chromeos-cache/distfiles/host/zlib-1.2.11.tar.gz \
     https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/zlib-1.2.11.tar.gz

Example error message:
>>> 13:49:14 === Start output for job zlib-1.2.11 ===
zlib-1.2.11: >>> Downloading 'https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/zlib-1.2.11.tar.gz'
zlib-1.2.11:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
zlib-1.2.11:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:02:10 --:--:--     0
zlib-1.2.11: curl: (7) Failed to connect to commondatastorage.googleapis.com port 443: Connection timed out
zlib-1.2.11: >>> Downloading 'https://commondatastorage.googleapis.com/chromeos-mirror/gentoo/distfiles/zlib-1.2.11.tar.gz'
zlib-1.2.11:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
zlib-1.2.11:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:02:11 --:--:--     0
zlib-1.2.11: curl: (7) Failed to connect to commondatastorage.googleapis.com port 443: Connection timed out
zlib-1.2.11: !!! Couldn't download 'zlib-1.2.11.tar.gz'. Aborting.
zlib-1.2.11:  * Fetch failed for sys-libs/zlib-1.2.11, Log file:
zlib-1.2.11:  *   /var/log/portage/sys-libs:zlib-1.2.11:20191108-204452.log

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1021751
[2] https://chromium.googlesource.com/chromiumos/platform/crosutils/+/master/sdk_lib/make_conf_util.sh

Signed-off-by: Edward Baker <edward.baker@intel.com>