### PR TITLE
emerge: add --implicit-system-deps <y|n> option (bug 681312)

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -499,6 +499,10 @@ class Scheduler(PollScheduler):
 		added to the graph and traversed deeply (the depgraph "complete"
 		parameter will do this, triggered by emerge --complete-graph option).
 		"""
+		params = create_depgraph_params(self.myopts, None)
+		if not params["implicit_system_deps"]:
+			return
+
 		deep_system_deps = self._deep_system_deps
 		deep_system_deps.clear()
 		deep_system_deps.update(

--- a/lib/_emerge/create_depgraph_params.py
+++ b/lib/_emerge/create_depgraph_params.py
@@ -32,6 +32,8 @@ def create_depgraph_params(myopts, myaction):
 	#   packages, so that they do not trigger dependency resolution
 	#   failures, or cause packages to be rebuilt or replaced.
 	# ignore_world: ignore the @world package set and its dependencies
+	# implicit_system_deps: Assume that packages may have implicit dependencies
+	#   on packages which belong to the @system set.
 	# with_test_deps: pull in test deps for packages matched by arguments
 	# changed_deps: rebuild installed packages with outdated deps
 	# changed_deps_report: report installed packages with outdated deps
@@ -86,6 +88,8 @@ def create_depgraph_params(myopts, myaction):
 	dynamic_deps = myopts.get("--dynamic-deps", "y") != "n" and "--nodeps" not in myopts
 	if dynamic_deps:
 		myparams["dynamic_deps"] = True
+
+	myparams["implicit_system_deps"] =  myopts.get("--implicit-system-deps", "y") != "n"
 
 	if myaction == "remove":
 		myparams["remove"] = True

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7403,6 +7403,8 @@ class depgraph(object):
 		For optimal leaf node selection, promote deep system runtime deps and
 		order nodes from highest to lowest overall reference count.
 		"""
+		if not self._dynamic_config.myparams["implicit_system_deps"]:
+			return
 
 		node_info = {}
 		for node in mygraph.order:
@@ -8047,10 +8049,9 @@ class depgraph(object):
 						# by a normal replacement operation then abort.
 						skip = False
 						try:
-							for atom in root_config.sets[
-								"system"].iterAtomsForPackage(task):
+							if (self._dynamic_config.myparams["implicit_system_deps"] and
+								any(root_config.sets["system"].iterAtomsForPackage(task))):
 								skip = True
-								break
 						except portage.exception.InvalidDependString as e:
 							portage.writemsg("!!! Invalid PROVIDE in " + \
 								"'%svar/db/pkg/%s/PROVIDE': %s\n" % \

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -525,6 +525,12 @@ def parse_opts(tmpcmdline, silent=False):
 			"choices" : true_y_or_n
 		},
 
+		"--implicit-system-deps": {
+			"help": "Assume that packages may have implicit dependencies on"
+				"packages which belong to the @system set",
+			"choices": y_or_n
+		},
+
 		"--jobs": {
 
 			"shortopt" : "-j",

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -671,6 +671,13 @@ possible for it to make nonsensical changes which may lead to system
 breakage. Therefore, it is advisable to use \fB\-\-ask\fR together with
 this option.
 .TP
+.BR "\-\-implicit\-system\-deps < y | n >"
+Assume that packages may have implicit dependencies on packages which
+belong to the @system set. This option is enabled by default. One of the
+effects of disabling this option is to allow the \-\-jobs option to
+spawn jobs without accounting for the possiblity of implicit dependencies
+on packages that belong to the @system set.
+.TP
 .BR \-j\ [JOBS] ", "  \-\-jobs[=JOBS]
 Specifies the number of packages to build simultaneously. If this option is
 given without an argument, emerge will not limit the number of jobs that can


### PR DESCRIPTION
Assume that packages may have implicit dependencies on packages which
belong to the @system set. This option is enabled by default. One of
the effects of disabling this option is to allow the --jobs option
to spawn jobs without accounting for the possiblity of implicit
dependencies on packages that belong to the @system set (this causes
the @system set to behave more like the @profile set).

Bug: https://bugs.gentoo.org/681312