### PR TITLE
process: display relevant FEATURES when unshare fails

### DIFF
--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -628,8 +628,19 @@ def _exec(binary, mycommand, opt_name, fd_pipes,
 					if errno_value == 0 and libc.unshare(unshare_flags) != 0:
 						errno_value = ctypes.get_errno()
 					if errno_value != 0:
-						writemsg("Unable to unshare: %s\n" % (
-							errno.errorcode.get(errno_value, '?')),
+
+						involved_features = []
+						if unshare_ipc:
+							involved_features.append('ipc-sandbox')
+						if unshare_mount:
+							involved_features.append('mount-sandbox')
+						if unshare_net:
+							involved_features.append('network-sandbox')
+						if unshare_pid:
+							involved_features.append('pid-sandbox')
+
+						writemsg("Unable to unshare: %s (for FEATURES=\"%s\")\n" % (
+							errno.errorcode.get(errno_value, '?'), ' '.join(involved_features)),
 							noiselevel=-1)
 					else:
 						if unshare_pid:


### PR DESCRIPTION
For example, the message will now look like this:

Unable to unshare: EPERM (for FEATURES="ipc-sandbox mount-sandbox network-sandbox pid-sandbox")

Bug: https://bugs.gentoo.org/680456
Signed-off-by: Zac Medico <zmedico@gentoo.org>