### PR TITLE
emerge --with-test-deps: allow circular deps

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -3325,10 +3325,6 @@ class depgraph(object):
 			pkg.iuse.is_valid_flag("test") and \
 			self._is_argument(pkg)
 
-		if with_test_deps:
-			use_enabled = set(use_enabled)
-			use_enabled.add("test")
-
 		if not pkg.built and \
 			"--buildpkgonly" in self._frozen_config.myopts and \
 			"deep" not in self._dynamic_config.myparams:
@@ -3430,6 +3426,21 @@ class depgraph(object):
 						noiselevel=-1, level=logging.DEBUG)
 
 				try:
+					if (with_test_deps and 'test' not in use_enabled and
+						pkg.iuse.is_valid_flag('test')):
+						test_deps = portage.dep.use_reduce(dep_string,
+							uselist=use_enabled | {'test'},
+							is_valid_flag=pkg.iuse.is_valid_flag,
+							opconvert=True, token_class=Atom,
+							eapi=pkg.eapi,
+							subset={'test'})
+
+						if test_deps and not self._add_pkg_dep_string(
+							pkg, dep_root, self._priority(runtime_post=True),
+							test_deps,
+							allow_unsatisfied):
+							return 0
+
 					dep_string = portage.dep.use_reduce(dep_string,
 						uselist=use_enabled,
 						is_valid_flag=pkg.iuse.is_valid_flag,

--- a/lib/portage/tests/resolver/test_with_test_deps.py
+++ b/lib/portage/tests/resolver/test_with_test_deps.py
@@ -21,7 +21,27 @@ class WithTestDepsTestCase(TestCase):
 			},
 			"app-misc/C-0": {
 				"EAPI": "5",
-			}
+			},
+			"app-misc/D-0": {
+				"EAPI": "5",
+				"IUSE": "test",
+				"DEPEND": "test? ( app-misc/E )"
+			},
+			"app-misc/E-0": {
+				"EAPI": "5",
+				"IUSE": "test",
+				"DEPEND": "test? ( app-misc/D )"
+			},
+			"app-misc/F-0": {
+				"EAPI": "5",
+				"IUSE": "+test",
+				"DEPEND": "test? ( app-misc/G )"
+			},
+			"app-misc/G-0": {
+				"EAPI": "5",
+				"IUSE": "+test",
+				"DEPEND": "test? ( app-misc/F )"
+			},
 		}
 
 		test_cases = (
@@ -32,6 +52,23 @@ class WithTestDepsTestCase(TestCase):
 				success = True,
 				options = { "--onlydeps": True, "--with-test-deps": True },
 				mergelist = ["app-misc/B-0"]),
+
+			# Test that --with-test-deps allows circular dependencies.
+			ResolverPlaygroundTestCase(
+				['app-misc/D'],
+				success = True,
+				options = {'--with-test-deps': True},
+				mergelist = [('app-misc/D-0', 'app-misc/E-0')],
+				ambiguous_merge_order=True),
+
+			# Test that --with-test-deps does not allow circular dependencies
+			# when USE=test is explicitly enabled.
+			ResolverPlaygroundTestCase(
+				['app-misc/F'],
+				success = False,
+				options = {'--with-test-deps': True},
+				circular_dependency_solutions = {'app-misc/G-0': {frozenset({('test', False)})}, 'app-misc/F-0': {frozenset({('test', False)})}},
+			)
 		)
 
 		playground = ResolverPlayground(ebuilds=ebuilds, debug=False)


### PR DESCRIPTION
When USE=test is not enabled, allow circular test dependencies
by treating them like PDEPEND. When USE=test is enabled, circular
dependencies are still not allowed, as shown in unit tests.

Suggested-by: Michał Górny <mgorny@gentoo.org>
Bug: https://bugs.gentoo.org/703348
Signed-off-by: Zac Medico <zmedico@gentoo.org>