### PR TITLE
backtracking: adjust || preference to break dependency cycles

### DIFF
--- a/lib/_emerge/resolver/backtracking.py
+++ b/lib/_emerge/resolver/backtracking.py
@@ -6,12 +6,14 @@ import copy
 class BacktrackParameter(object):
 
 	__slots__ = (
+		"circular_dependency",
 		"needed_unstable_keywords", "runtime_pkg_mask", "needed_use_config_changes", "needed_license_changes",
 		"prune_rebuilds", "rebuild_list", "reinstall_list", "needed_p_mask_changes",
 		"slot_operator_mask_built", "slot_operator_replace_installed"
 	)
 
 	def __init__(self):
+		self.circular_dependency = {}
 		self.needed_unstable_keywords = set()
 		self.needed_p_mask_changes = set()
 		self.runtime_pkg_mask = {}
@@ -31,6 +33,7 @@ class BacktrackParameter(object):
 
 		#Shallow copies are enough here, as we only need to ensure that nobody adds stuff
 		#to our sets and dicts. The existing content is immutable.
+		result.circular_dependency = copy.copy(self.circular_dependency)
 		result.needed_unstable_keywords = copy.copy(self.needed_unstable_keywords)
 		result.needed_p_mask_changes = copy.copy(self.needed_p_mask_changes)
 		result.needed_use_config_changes = copy.copy(self.needed_use_config_changes)
@@ -49,7 +52,8 @@ class BacktrackParameter(object):
 		return result
 
 	def __eq__(self, other):
-		return self.needed_unstable_keywords == other.needed_unstable_keywords and \
+		return self.circular_dependency == other.circular_dependency and \
+			self.needed_unstable_keywords == other.needed_unstable_keywords and \
 			self.needed_p_mask_changes == other.needed_p_mask_changes and \
 			self.runtime_pkg_mask == other.runtime_pkg_mask and \
 			self.needed_use_config_changes == other.needed_use_config_changes and \
@@ -195,7 +199,10 @@ class Backtracker(object):
 		para = new_node.parameter
 
 		for change, data in changes.items():
-			if change == "needed_unstable_keywords":
+			if change == "circular_dependency":
+				for pkg, circular_children in data.items():
+					para.circular_dependency.setdefault(pkg, set()).update(circular_children)
+			elif change == "needed_unstable_keywords":
 				para.needed_unstable_keywords.update(data)
 			elif change == "needed_p_mask_changes":
 				para.needed_p_mask_changes.update(data)

--- a/lib/portage/dep/dep_check.py
+++ b/lib/portage/dep/dep_check.py
@@ -367,6 +367,7 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 	pkg_use_enabled = trees[myroot].get("pkg_use_enabled")
 	want_update_pkg = trees[myroot].get("want_update_pkg")
 	downgrade_probe = trees[myroot].get("downgrade_probe")
+	circular_dependency = trees[myroot].get("circular_dependency")
 	vardb = None
 	if "vartree" in trees[myroot]:
 		vardb = trees[myroot]["vartree"].dbapi
@@ -589,6 +590,15 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 							if match_from_list(atom, cpv_slot_list):
 								circular_atom = atom
 								break
+						else:
+							for circular_child in circular_dependency.get(parent, []):
+								for atom in atoms:
+									if not atom.blocker and atom.match(circular_child):
+										circular_atom = atom
+										break
+								if circular_atom is not None:
+									break
+
 				if circular_atom is not None:
 					other.append(this_choice)
 				else:


### PR DESCRIPTION
Store dependency cycle edges as backtracking parameters, and use them
to adjust || preferences in order to break dependency cycles. This
extends direct cycle breaking to handle indirect dependency cycles,
which solves the cmake-bootstrap test case for bug 703440. If any
cycle(s) remain unsolved by the next backtracking run, then backtracking
aborts and the cycle(s) are reported as usual.

Bug: https://bugs.gentoo.org/384107
Bug: https://bugs.gentoo.org/703440
Signed-off-by: Zac Medico <zmedico@gentoo.org>