### PR TITLE
_serialize_tasks: limit scope of dropped circular dependencies

### DIFF
--- a/lib/portage/tests/resolver/test_merge_order.py
+++ b/lib/portage/tests/resolver/test_merge_order.py
@@ -81,6 +81,13 @@ class MergeOrderTestCase(TestCase):
 				"DEPEND": "app-misc/circ-satisfied-a",
 				"RDEPEND": "app-misc/circ-satisfied-a",
 			},
+			"app-misc/circ-direct-a-1": {
+				"RDEPEND": "app-misc/circ-direct-b",
+			},
+			"app-misc/circ-direct-b-1": {
+				"RDEPEND": "app-misc/circ-direct-a",
+				"DEPEND": "app-misc/circ-direct-a",
+			},
 			"app-misc/circ-smallest-a-1": {
 				"RDEPEND": "app-misc/circ-smallest-b",
 			},
@@ -220,6 +227,13 @@ class MergeOrderTestCase(TestCase):
 		}
 
 		installed = {
+			"app-misc/circ-direct-a-1": {
+				"RDEPEND": "app-misc/circ-direct-b",
+			},
+			"app-misc/circ-direct-b-1": {
+				"RDEPEND": "app-misc/circ-direct-a",
+				"DEPEND": "app-misc/circ-direct-a",
+			},
 			"app-misc/circ-buildtime-a-0": {},
 			"app-misc/circ-satisfied-a-0": {
 				"RDEPEND": "app-misc/circ-satisfied-b",
@@ -296,6 +310,12 @@ class MergeOrderTestCase(TestCase):
 
 		test_cases = (
 			ResolverPlaygroundTestCase(
+				["app-misc/circ-direct-a", "app-misc/circ-direct-b"],
+				success = True,
+				all_permutations = True,
+				mergelist = ["app-misc/circ-direct-a-1", "app-misc/circ-direct-b-1"],
+			),
+			ResolverPlaygroundTestCase(
 				["app-misc/some-app-a"],
 				success = True,
 				ambiguous_merge_order = True,
@@ -321,9 +341,8 @@ class MergeOrderTestCase(TestCase):
 				ambiguous_merge_order = True,
 				# The following merge order assertion reflects optimal order for
 				# a circular relationship which is DEPEND in one direction and
-				# RDEPEND in the other. The assertion currently fails, and the
-				# patch for bug 690436 will fix it.
-				#merge_order_assertions = (("app-misc/circ-buildtime-a-1", "app-misc/circ-buildtime-c-1"),),
+				# RDEPEND in the other.
+				merge_order_assertions = (("app-misc/circ-buildtime-a-1", "app-misc/circ-buildtime-c-1"),),
 				mergelist = [("app-misc/circ-buildtime-b-1", "app-misc/circ-buildtime-c-1", "app-misc/circ-buildtime-a-1"), "app-misc/some-app-c-1"]),
 			# Test optimal merge order for a circular dep that is
 			# RDEPEND in one direction and PDEPEND in the other.


### PR DESCRIPTION
Ensure that all members of a buildtime dependency cycle are merged
as a group, such that packages which depend on one or more members
of the group will only be merged *after* the entire group has been
merged.

This extends runtime cycle handling to also handle buildtime cycles
in cases where the buildtime dependencies happen to be satisfied by
installed packages. In situations when this is necessary, it is
desirable to rely on the old installed instances of these packages
as little as possible, since they might have been broken by the
upgrade of a package that is a member of the dependency cycle.
Upgrading members of the cycle as a group effectively minimizes
reliance on the old installed package instances, avoiding some cases
of bug 199856. For example, it should avoid bug 703676, where
libspectre reportedly failed to build against an old installed
instance of ghostscript-gpl.

Bug: https://bugs.gentoo.org/199856
Bug: https://bugs.gentoo.org/690436
Bug: https://bugs.gentoo.org/703676