### PR TITLE
UserWarning if /etc/portage/package.keywords exists

### DIFF
--- a/lib/portage/package/ebuild/_config/KeywordsManager.py
+++ b/lib/portage/package/ebuild/_config/KeywordsManager.py
@@ -5,6 +5,8 @@ __all__ = (
 	'KeywordsManager',
 )
 
+import warnings
+
 from _emerge.Package import Package
 from portage import os
 from portage.dep import ExtendedAtomDict, _repo_separator, _slot_separator
@@ -54,13 +56,20 @@ class KeywordsManager(object):
 		self.pkeywordsdict = ExtendedAtomDict(dict)
 
 		if user_config:
+			user_accept_kwrds_path = os.path.join(abs_user_config, "package.accept_keywords")
+			user_kwrds_path = os.path.join(abs_user_config, "package.keywords")
 			pkgdict = grabdict_package(
-				os.path.join(abs_user_config, "package.keywords"),
+				user_kwrds_path,
 				recursive=1, allow_wildcard=True, allow_repo=True,
 				verify_eapi=False, allow_build_id=True)
 
+			if pkgdict:
+				warnings.warn(_("%s is deprecated, use %s instead") %
+					(user_kwrds_path, user_accept_kwrds_path),
+					UserWarning)
+
 			for k, v in grabdict_package(
-				os.path.join(abs_user_config, "package.accept_keywords"),
+				user_accept_kwrds_path,
 				recursive=1, allow_wildcard=True, allow_repo=True,
 				verify_eapi=False, allow_build_id=True).items():
 				pkgdict.setdefault(k, []).extend(v)


### PR DESCRIPTION
The /etc/portage/package.keywords file has been long deprecated
in favor of /etc/portage/package.accept_keywords. The file would
be useful if we could make it behave like package.keywords in
profiles (see bug 491166), but it's safest if we trigger a
UserWarning for some time before we change the meaning in a
future version of portage. The message looks like this:

UserWarning: /etc/portage/package.keywords is deprecated, use /etc/portage/package.accept_keywords instead

Bug: https://bugs.gentoo.org/491166
Bug: https://bugs.gentoo.org/607852
Signed-off-by: Zac Medico <zmedico@gentoo.org>