### PR TITLE
file_copy: handle lseek SEEK_DATA EBADFD for GlusterFS (bug 705536)

### DIFF
--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -258,7 +258,7 @@ _reflink_linux_file_copy(PyObject *self, PyObject *args)
                     break;
                 } else if (len < 0) {
                     error = errno;
-                    if ((errno == EINVAL || errno == EOPNOTSUPP) && !offset_out) {
+                    if ((errno == EINVAL || errno == EOPNOTSUPP || errno == EBADFD) && !offset_out) {
                         lseek_works = 0;
                     }
                     break;


### PR DESCRIPTION
GlusterFS can set the errno to EBADFD for lseek SEEK_DATA.

Tested-by: Tomáš Mózes <hydrapolic@gmail.com>
Bug: https://bugs.gentoo.org/705536
Signed-off-by: Zac Medico <zmedico@gentoo.org>