### PR TITLE
dep_zapdeps: break more buildtime cycles (bug 705986)

### DIFF
--- a/lib/portage/dep/dep_check.py
+++ b/lib/portage/dep/dep_check.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2018 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import unicode_literals
@@ -570,8 +570,7 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 				circular_atom = None
 				if not (parent is None or priority is None) and \
 					(parent.onlydeps or
-					(all_in_graph and priority.buildtime and
-					not (priority.satisfied or priority.optional))):
+					(priority.buildtime and not priority.satisfied and not priority.optional)):
 						# Check if the atom would result in a direct circular
 						# dependency and try to avoid that if it seems likely
 						# to be unresolvable. This is only relevant for

--- a/lib/portage/tests/resolver/test_circular_choices.py
+++ b/lib/portage/tests/resolver/test_circular_choices.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2019 Gentoo Authors
+# Copyright 2011-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -184,17 +184,11 @@ class CircularPypyExeTestCase(TestCase):
 		}
 
 		test_cases = (
-			# Demonstrate bug 705986, where a USE change suggestion is given
-			# even though an || preference adjustment is available.
+			# Demonstrate bug 705986, where a USE change suggestion was given
+			# even though an || preference adjustment would solve the problem
+			# by pulling in pypy-exe-bin instead of pypy-exe.
 			ResolverPlaygroundTestCase(
 				['dev-python/pypy'],
-				circular_dependency_solutions = {'dev-python/pypy-7.3.0': {frozenset({('low-memory', True)})}},
-				success = False,
-			),
-			# Demonstrate explicit pypy-exe-bin argument used as a workaround
-			# for bug 705986.
-			ResolverPlaygroundTestCase(
-				['dev-python/pypy', 'dev-python/pypy-exe-bin'],
 				mergelist=['dev-python/pypy-exe-bin-7.3.0', 'dev-python/pypy-7.3.0'],
 				success = True,
 			),


### PR DESCRIPTION
Buildtime cycle breaking was not enabled in cases where
the all_in_graph variable was False, and this prevented the
pypy / pypy-exe dependency cycle from being broken as shown
in the test case for bug 705986. In order to break more
buildtime cycles, enable cycle breaking regardless of the
state of the all_in_graph variable.

Bug: https://bugs.gentoo.org/705986
Signed-off-by: Zac Medico <zmedico@gentoo.org>