### PR TITLE
dep_zapdeps: adjust || preference for slot upgrades (bug 706278)

### DIFF
--- a/lib/portage/tests/resolver/test_or_choices.py
+++ b/lib/portage/tests/resolver/test_or_choices.py
@@ -288,6 +288,15 @@ class OrChoicesTestCase(TestCase):
 class OrChoicesLibpostprocTestCase(TestCase):
 
 	def testOrChoicesLibpostproc(self):
+		# This test case is expected to fail after the fix for bug 706278,
+		# since the "undesirable" slot upgrade which triggers a blocker conflict
+		# in this test case is practically indistinguishable from a desirable
+		# slot upgrade. This particular blocker conflict is no longer relevant,
+		# since current versions of media-libs/libpostproc are no longer
+		# compatible with any available media-video/ffmpeg slot. In order to
+		# solve this test case, some fancy backtracking (like for bug 382421)
+		# will be required.
+		self.todo = True
 
 		ebuilds = {
 			"media-video/ffmpeg-0.10" : {

--- a/lib/portage/tests/resolver/test_or_upgrade_installed.py
+++ b/lib/portage/tests/resolver/test_or_upgrade_installed.py
@@ -213,8 +213,7 @@ class OrUpgradeInstalledTestCase(TestCase):
 				['@world'],
 				options={'--update': True, '--deep': True},
 				success=True,
-				mergelist=[],
-				#mergelist=['sys-devel/llvm-9'],
+				mergelist=['sys-devel/llvm-9', 'media-libs/mesa-19.2.8'],
 			),
 		)
 


### PR DESCRIPTION
Prefer choices that include a slot upgrade when appropriate, like for
the || ( llvm:10 ... llvm:7 ) case reported in bug 706278. In order
to avoid pulling in inappropriate slot upgrades, like those which
should only be pulled in with --update and --deep, add a want_update
flag to each choice which is True for choices that pull in a new slot
for which an update is desirable.

Mark the test case for bug 480736 as todo, since the "undesirable"
slot upgrade which triggers a blocker conflict in this test case is
practically indistinguishable from a desirable slot upgrade. This
particular blocker conflict is no longer relevant, since current
versions of media-libs/libpostproc are no longer compatible with
any available media-video/ffmpeg slot. In order to solve this test
case, some fancy backtracking (like for bug 382421) will be required.

Bug: https://bugs.gentoo.org/706278
Bug: https://bugs.gentoo.org/480736
Signed-off-by: Zac Medico <zmedico@gentoo.org>