### PR TITLE
depclean: do not eliminate upgrades (bug 707108)

### DIFF
--- a/lib/portage/tests/resolver/test_or_choices.py
+++ b/lib/portage/tests/resolver/test_or_choices.py
@@ -387,13 +387,13 @@ class OrChoicesTestCase(TestCase):
 		}
 
 		test_cases = (
-			# Demonstrate bug 707108, where a new python slot is erroneosly
+			# Test for bug 707108, where a new python slot was erroneously
 			# removed by emerge --depclean.
 			ResolverPlaygroundTestCase(
 				[],
 				options={"--depclean": True},
 				success=True,
-				cleanlist=['dev-lang/python-3.8'],
+				cleanlist=[],
 			),
 		)
 


### PR DESCRIPTION
For depclean actions, prefer choices where all packages have been
pulled into the graph, except for choices that eliminate upgrades.
This solves the test case for bug 707108, where depclean eliminated
a new slot of python that had been pulled in by a world update.
This should also prevent non-deterministic elimination of the
latest vala slot that was reported in bug 693790.

NOTE: There's a common perception (expressed in bug 705700) that
emerge is pulling in an "unecessary" python slot in cases when that
python slot is not enabled in PYTHON_TARGETS. However, the so-called
"unnecessary" slot is practically indistinguishable from a desirable
upgrade such as the missed llvm slot upgrade that was reported in
bug 706278. Therefore, be advised that emerge must pull in the
highest visible slot (regardless of PYTHON_TARGETS) in order to
ensure that a desirable upgrade is not missed.

Fixes: f7d83d75c6b0 ("dep_zapdeps: adjust || preference for slot upgrades (bug 706278)")
Bug: https://bugs.gentoo.org/707108
Bug: https://bugs.gentoo.org/706278
Bug: https://bugs.gentoo.org/705700
Bug: https://bugs.gentoo.org/693790
Signed-off-by: Zac Medico <zmedico@gentoo.org>