### PR TITLE
Drop compat code for ancient python versions

### DIFF
--- a/lib/portage/_emirrordist/FetchTask.py
+++ b/lib/portage/_emirrordist/FetchTask.py
@@ -444,15 +444,6 @@ class FetchTask(CompositeTask):
 		args = [portage.util.varexpand(x, mydict=variables)
 			for x in args]
 
-		if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000 and \
-			not os.path.isabs(args[0]):
-			# Python 3.1 _execvp throws TypeError for non-absolute executable
-			# path passed as bytes (see https://bugs.python.org/issue8513).
-			fullname = portage.process.find_binary(args[0])
-			if fullname is None:
-				raise portage.exception.CommandNotFound(args[0])
-			args[0] = fullname
-
 		args = [_unicode_encode(x,
 			encoding=_encodings['fs'], errors='strict') for x in args]
 

--- a/lib/portage/data.py
+++ b/lib/portage/data.py
@@ -195,16 +195,6 @@ def _get_global(k):
 			# SIGPIPE problems with nss_ldap.
 			cmd = ["id", "-G", _portage_username]
 
-			if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000:
-				# Python 3.1 _execvp throws TypeError for non-absolute executable
-				# path passed as bytes (see https://bugs.python.org/issue8513).
-				fullname = portage.process.find_binary(cmd[0])
-				if fullname is None:
-					globals()[k] = v
-					_initialized_globals.add(k)
-					return v
-				cmd[0] = fullname
-
 			encoding = portage._encodings['content']
 			cmd = [portage._unicode_encode(x,
 				encoding=encoding, errors='strict') for x in cmd]

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -661,13 +661,6 @@ class vardbapi(dbapi):
 	def _aux_cache_init(self):
 		aux_cache = None
 		open_kwargs = {}
-		if sys.hexversion >= 0x3000000 and sys.hexversion < 0x3020000:
-			# Buffered io triggers extreme performance issues in
-			# Unpickler.load() (problem observed with python-3.0.1).
-			# Unfortunately, performance is still poor relative to
-			# python-2.x, but buffering makes it much worse (problem
-			# appears to be solved in Python >=3.2 at least).
-			open_kwargs["buffering"] = 0
 		try:
 			with open(_unicode_encode(self._aux_cache_filename,
 				encoding=_encodings['fs'], errors='strict'),

--- a/lib/portage/dispatch_conf.py
+++ b/lib/portage/dispatch_conf.py
@@ -41,15 +41,6 @@ def diffstatusoutput(cmd, file1, file2):
 	# raise a UnicodeDecodeError which makes the output inaccessible.
 	args = shlex_split(cmd % (file1, file2))
 
-	if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000 and \
-		not os.path.isabs(args[0]):
-		# Python 3.1 _execvp throws TypeError for non-absolute executable
-		# path passed as bytes (see https://bugs.python.org/issue8513).
-		fullname = portage.process.find_binary(args[0])
-		if fullname is None:
-			raise portage.exception.CommandNotFound(args[0])
-		args[0] = fullname
-
 	args = [portage._unicode_encode(x, errors='strict') for x in args]
 	proc = subprocess.Popen(args,
 		stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -1802,14 +1802,6 @@ def find_updated_config_files(target_root, config_protect):
 			mycommand += " ! -name '.*~' ! -iname '.*.bak' -print0"
 			cmd = shlex_split(mycommand)
 
-			if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000:
-				# Python 3.1 _execvp throws TypeError for non-absolute executable
-				# path passed as bytes (see https://bugs.python.org/issue8513).
-				fullname = portage.process.find_binary(cmd[0])
-				if fullname is None:
-					raise portage.exception.CommandNotFound(cmd[0])
-				cmd[0] = fullname
-
 			cmd = [_unicode_encode(arg, encoding=encoding, errors='strict')
 				for arg in cmd]
 			proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,

--- a/lib/portage/util/_desktop_entry.py
+++ b/lib/portage/util/_desktop_entry.py
@@ -42,14 +42,6 @@ _ShowIn_exemptions = (
 def validate_desktop_entry(path):
 	args = ["desktop-file-validate", path]
 
-	if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000:
-		# Python 3.1 _execvp throws TypeError for non-absolute executable
-		# path passed as bytes (see https://bugs.python.org/issue8513).
-		fullname = portage.process.find_binary(args[0])
-		if fullname is None:
-			raise portage.exception.CommandNotFound(args[0])
-		args[0] = fullname
-
 	args = [_unicode_encode(x, errors='strict') for x in args]
 	proc = subprocess.Popen(args,
 		stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -34,22 +34,14 @@ __all__ = ('MetaDataXML', 'parse_metadata_use')
 
 import sys
 
-if sys.hexversion < 0x2070000 or \
-	(sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000):
-	# Our _MetadataTreeBuilder usage is incompatible with
-	# cElementTree in Python 2.6, 3.0, and 3.1:
-	#  File "/usr/lib/python2.6/xml/etree/ElementTree.py", line 644, in findall
-	#    assert self._root is not None
+try:
+	import xml.etree.cElementTree as etree
+except (SystemExit, KeyboardInterrupt):
+	raise
+except (ImportError, SystemError, RuntimeError, Exception):
+	# broken or missing xml support
+	# https://bugs.python.org/issue14988
 	import xml.etree.ElementTree as etree
-else:
-	try:
-		import xml.etree.cElementTree as etree
-	except (SystemExit, KeyboardInterrupt):
-		raise
-	except (ImportError, SystemError, RuntimeError, Exception):
-		# broken or missing xml support
-		# https://bugs.python.org/issue14988
-		import xml.etree.ElementTree as etree
 
 try:
 	from xml.parsers.expat import ExpatError

--- a/repoman/lib/repoman/_subprocess.py
+++ b/repoman/lib/repoman/_subprocess.py
@@ -20,15 +20,6 @@ def repoman_getstatusoutput(cmd):
 	"""
 	args = portage.util.shlex_split(cmd)
 
-	if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000 and \
-		not os.path.isabs(args[0]):
-		# Python 3.1 _execvp throws TypeError for non-absolute executable
-		# path passed as bytes (see https://bugs.python.org/issue8513).
-		fullname = find_binary(args[0])
-		if fullname is None:
-			raise portage.exception.CommandNotFound(args[0])
-		args[0] = fullname
-
 	encoding = _encodings['fs']
 	args = [
 		_unicode_encode(x, encoding=encoding, errors='strict') for x in args]
@@ -52,15 +43,6 @@ class repoman_popen(portage.proxy.objectproxy.ObjectProxy):
 
 	def __init__(self, cmd):
 		args = portage.util.shlex_split(cmd)
-
-		if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000 and \
-			not os.path.isabs(args[0]):
-			# Python 3.1 _execvp throws TypeError for non-absolute executable
-			# path passed as bytes (see https://bugs.python.org/issue8513).
-			fullname = find_binary(args[0])
-			if fullname is None:
-				raise portage.exception.CommandNotFound(args[0])
-			args[0] = fullname
 
 		encoding = _encodings['fs']
 		args = [

--- a/repoman/lib/repoman/gpg.py
+++ b/repoman/lib/repoman/gpg.py
@@ -50,15 +50,6 @@ def gpgsign(filename, repoman_settings, options):
 		# Encode unicode manually for bug #310789.
 		gpgcmd = portage.util.shlex_split(gpgcmd)
 
-		if sys.hexversion < 0x3020000 and sys.hexversion >= 0x3000000 and \
-			not os.path.isabs(gpgcmd[0]):
-			# Python 3.1 _execvp throws TypeError for non-absolute executable
-			# path passed as bytes (see https://bugs.python.org/issue8513).
-			fullname = find_binary(gpgcmd[0])
-			if fullname is None:
-				raise portage.exception.CommandNotFound(gpgcmd[0])
-			gpgcmd[0] = fullname
-
 		gpgcmd = [
 			_unicode_encode(arg, encoding=_encodings['fs'], errors='strict')
 			for arg in gpgcmd]


### PR DESCRIPTION
Python 3.0 - Python 3.3 and Python 2.6 aren't supported any more. Drop code that maintains compatibility.