### PR TITLE
dep_zapdeps: prefer choices with all in graph (bug 649622)

### DIFF
--- a/lib/portage/dep/dep_check.py
+++ b/lib/portage/dep/dep_check.py
@@ -722,11 +722,9 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 					# Prefer upgrades.
 					(has_upgrade and not has_downgrade)
 
-					# For removal actions, prefer choices where all packages
-					# have been pulled into the graph, except for choices that
-					# eliminate upgrades.
-					or (graph_interface and graph_interface.removal_action and
-					choice_1.all_in_graph and not choice_2.all_in_graph and
+					# Prefer choices where all packages have been pulled into
+					# the graph, except for choices that eliminate upgrades.
+					or (choice_1.all_in_graph and not choice_2.all_in_graph and
 					not (has_downgrade and not has_upgrade))
 				):
 					# promote choice_1 in front of choice_2

--- a/lib/portage/tests/resolver/test_or_choices.py
+++ b/lib/portage/tests/resolver/test_or_choices.py
@@ -465,13 +465,13 @@ class OrChoicesTestCase(TestCase):
 
 		test_cases = (
 
-			# Test for bug 649622, where virtual/w3m is installed only
+			# Test for bug 649622, where virtual/w3m was pulled in only
 			# to be removed by the next emerge --depclean.
 			ResolverPlaygroundTestCase(
 				['@world'],
 				options = {'--update': True, '--deep': True},
 				success = True,
-				mergelist = ['virtual/w3m-0']
+				mergelist = []
 			),
 
 		)
@@ -499,7 +499,10 @@ class OrChoicesTestCase(TestCase):
 
 			# Test for bug 649622, where virtual/w3m is removed by
 			# emerge --depclean immediately after it's installed
-			# by a world update.
+			# by a world update. Note that removal of virtual/w3m here
+			# is essentially indistinguishable from removal of
+			# dev-util/cmake-bootstrap in the depclean test case for
+			# bug 703440.
 			ResolverPlaygroundTestCase(
 				[],
 				options={'--depclean': True},


### PR DESCRIPTION
Prefer choices where all packages have been pulled into the
graph (except for choices that eliminate upgrades). This
logic must be consistent between both update and removal
(depclean) actions in order to avoid pulling in packages
only to have them removed by depclean, as reported in
bug 649622 for virtual/w3m.

Bug: https://bugs.gentoo.org/649622
Signed-off-by: Zac Medico <zmedico@gentoo.org>