### PR TITLE
AbstractEbuildProcess: add _async_start coroutine (bug 709746)

### DIFF
--- a/lib/_emerge/MiscFunctionsProcess.py
+++ b/lib/_emerge/MiscFunctionsProcess.py
@@ -1,8 +1,9 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.AbstractEbuildProcess import AbstractEbuildProcess
 import portage
+from portage.util.futures.compat_coroutine import coroutine
 portage.proxy.lazyimport.lazyimport(globals(),
 	'portage.package.ebuild.doebuild:spawn'
 )
@@ -15,7 +16,8 @@ class MiscFunctionsProcess(AbstractEbuildProcess):
 
 	__slots__ = ('commands', 'ld_preload_sandbox')
 
-	def _start(self):
+	@coroutine
+	def _async_start(self):
 		settings = self.settings
 		portage_bin_path = settings["PORTAGE_BIN_PATH"]
 		misc_sh_binary = os.path.join(portage_bin_path,
@@ -26,7 +28,7 @@ class MiscFunctionsProcess(AbstractEbuildProcess):
 			self.settings.get("PORTAGE_BACKGROUND") != "subprocess":
 			self.logfile = settings.get("PORTAGE_LOG_FILE")
 
-		AbstractEbuildProcess._start(self)
+		yield AbstractEbuildProcess._async_start(self)
 
 	def _spawn(self, args, **kwargs):
 		# If self.ld_preload_sandbox is None, default to free=False,

--- a/lib/_emerge/TaskSequence.py
+++ b/lib/_emerge/TaskSequence.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -41,6 +41,11 @@ class TaskSequence(CompositeTask):
 			return
 
 		self._start_task(task, self._task_exit_handler)
+
+	def _current_task_start_cb(self, future):
+		CompositeTask._current_task_start_cb(self, future)
+		if self.cancelled:
+			self._task_queue.clear()
 
 	def _task_exit_handler(self, task):
 		if self._default_exit(task) != os.EX_OK:

--- a/lib/portage/tests/ebuild/test_doebuild_fd_pipes.py
+++ b/lib/portage/tests/ebuild/test_doebuild_fd_pipes.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2016 Gentoo Foundation
+# Copyright 2013-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import portage
@@ -8,6 +8,7 @@ from portage.tests.resolver.ResolverPlayground import ResolverPlayground
 from portage.package.ebuild._ipc.QueryCommand import QueryCommand
 from portage.util._async.ForkProcess import ForkProcess
 from portage.util._async.TaskScheduler import TaskScheduler
+from portage.util.futures import asyncio
 from _emerge.Package import Package
 from _emerge.PipeReader import PipeReader
 
@@ -54,6 +55,7 @@ class DoebuildFdPipesTestCase(TestCase):
 		self.assertEqual(true_binary is None, False,
 			"true command not found")
 
+		loop = asyncio._wrap_loop()
 		dev_null = open(os.devnull, 'wb')
 		playground = ResolverPlayground(ebuilds=ebuilds)
 		try:
@@ -115,7 +117,7 @@ class DoebuildFdPipesTestCase(TestCase):
 					max_jobs=2)
 
 				try:
-					task_scheduler.start()
+					loop.run_until_complete(task_scheduler.async_start())
 				finally:
 					# PipeReader closes pr
 					os.close(pw)

--- a/lib/portage/tests/ebuild/test_doebuild_spawn.py
+++ b/lib/portage/tests/ebuild/test_doebuild_spawn.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2015 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import textwrap
@@ -90,14 +90,14 @@ class DoebuildSpawnTestCase(TestCase):
 				ebuild_phase = EbuildPhase(background=False,
 					phase=phase, scheduler=scheduler,
 					settings=settings)
-				ebuild_phase.start()
+				scheduler.run_until_complete(ebuild_phase.async_start())
 				ebuild_phase.wait()
 				self.assertEqual(ebuild_phase.returncode, os.EX_OK)
 
 			ebuild_phase = MiscFunctionsProcess(background=False,
 				commands=['success_hooks'],
 				scheduler=scheduler, settings=settings)
-			ebuild_phase.start()
+			scheduler.run_until_complete(ebuild_phase.async_start())
 			ebuild_phase.wait()
 			self.assertEqual(ebuild_phase.returncode, os.EX_OK)
 

--- a/lib/portage/tests/ebuild/test_ipc_daemon.py
+++ b/lib/portage/tests/ebuild/test_ipc_daemon.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2016 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import tempfile
@@ -155,7 +155,7 @@ class IpcDaemonTestCase(TestCase):
 		task_scheduler.addExitListener(self._exit_callback)
 
 		try:
-			task_scheduler.start()
+			event_loop.run_until_complete(task_scheduler.async_start())
 			event_loop.run_until_complete(self._run_done)
 			event_loop.run_until_complete(task_scheduler.async_wait())
 		finally:

--- a/lib/portage/tests/ebuild/test_spawn.py
+++ b/lib/portage/tests/ebuild/test_spawn.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2013 Gentoo Foundation
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -34,7 +34,7 @@ class SpawnTestCase(TestCase):
 				},
 				scheduler=global_event_loop(),
 				logfile=logfile)
-			proc.start()
+			global_event_loop().run_until_complete(proc.async_start())
 			os.close(null_fd)
 			self.assertEqual(proc.wait(), os.EX_OK)
 			f = io.open(_unicode_encode(logfile,

--- a/lib/portage/tests/lazyimport/test_lazy_import_portage_baseline.py
+++ b/lib/portage/tests/lazyimport/test_lazy_import_portage_baseline.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2011 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import re
@@ -60,14 +60,14 @@ sys.stdout.write(" ".join(k for k in sys.modules
 			args=self._baseline_import_cmd,
 			env=env, fd_pipes={1:slave_fd},
 			scheduler=scheduler)
-		producer.start()
+		scheduler.run_until_complete(producer.async_start())
 		slave_file.close()
 
 		consumer = PipeReader(
 			input_files={"producer" : master_file},
 			scheduler=scheduler)
 
-		consumer.start()
+		scheduler.run_until_complete(consumer.async_start())
 		consumer.wait()
 		self.assertEqual(producer.wait(), os.EX_OK)
 		self.assertEqual(consumer.wait(), os.EX_OK)

--- a/lib/portage/tests/locks/test_asynchronous_lock.py
+++ b/lib/portage/tests/locks/test_asynchronous_lock.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2011 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import signal
@@ -29,7 +29,7 @@ class AsynchronousLockTestCase(TestCase):
 						scheduler=scheduler, _force_async=force_async,
 						_force_thread=True,
 						_force_dummy=force_dummy)
-					async_lock.start()
+					scheduler.run_until_complete(async_lock.async_start())
 					self.assertEqual(async_lock.wait(), os.EX_OK)
 					self.assertEqual(async_lock.returncode, os.EX_OK)
 					scheduler.run_until_complete(async_lock.async_unlock())
@@ -37,7 +37,7 @@ class AsynchronousLockTestCase(TestCase):
 				async_lock = AsynchronousLock(path=path,
 					scheduler=scheduler, _force_async=force_async,
 					_force_process=True)
-				async_lock.start()
+				scheduler.run_until_complete(async_lock.async_start())
 				self.assertEqual(async_lock.wait(), os.EX_OK)
 				self.assertEqual(async_lock.returncode, os.EX_OK)
 				scheduler.run_until_complete(async_lock.async_unlock())
@@ -63,7 +63,7 @@ class AsynchronousLockTestCase(TestCase):
 		try:
 			path = os.path.join(tempdir, 'lock_me')
 			lock1 = AsynchronousLock(path=path, scheduler=scheduler)
-			lock1.start()
+			scheduler.run_until_complete(lock1.async_start())
 			self.assertEqual(lock1.wait(), os.EX_OK)
 			self.assertEqual(lock1.returncode, os.EX_OK)
 
@@ -73,7 +73,7 @@ class AsynchronousLockTestCase(TestCase):
 			# one time concurrently.
 			lock2 = AsynchronousLock(path=path, scheduler=scheduler,
 				_force_async=True, _force_process=True)
-			lock2.start()
+			scheduler.run_until_complete(lock2.async_start())
 			# lock2 should be waiting for lock1 to release
 			self.assertEqual(lock2.poll(), None)
 			self.assertEqual(lock2.returncode, None)
@@ -104,12 +104,12 @@ class AsynchronousLockTestCase(TestCase):
 		try:
 			path = os.path.join(tempdir, 'lock_me')
 			lock1 = AsynchronousLock(path=path, scheduler=scheduler)
-			lock1.start()
+			scheduler.run_until_complete(lock1.async_start())
 			self.assertEqual(lock1.wait(), os.EX_OK)
 			self.assertEqual(lock1.returncode, os.EX_OK)
 			lock2 = AsynchronousLock(path=path, scheduler=scheduler,
 				_force_async=True, _force_process=True)
-			lock2.start()
+			scheduler.run_until_complete(lock2.async_start())
 			# lock2 should be waiting for lock1 to release
 			self.assertEqual(lock2.poll(), None)
 			self.assertEqual(lock2.returncode, None)
@@ -142,12 +142,12 @@ class AsynchronousLockTestCase(TestCase):
 		try:
 			path = os.path.join(tempdir, 'lock_me')
 			lock1 = AsynchronousLock(path=path, scheduler=scheduler)
-			lock1.start()
+			scheduler.run_until_complete(lock1.async_start())
 			self.assertEqual(lock1.wait(), os.EX_OK)
 			self.assertEqual(lock1.returncode, os.EX_OK)
 			lock2 = AsynchronousLock(path=path, scheduler=scheduler,
 				_force_async=True, _force_process=True)
-			lock2.start()
+			scheduler.run_until_complete(lock2.async_start())
 			# lock2 should be waiting for lock1 to release
 			self.assertEqual(lock2.poll(), None)
 			self.assertEqual(lock2.returncode, None)

--- a/lib/portage/tests/process/test_PopenProcess.py
+++ b/lib/portage/tests/process/test_PopenProcess.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2013 Gentoo Foundation
+# Copyright 2012-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
@@ -34,7 +34,7 @@ class PopenPipeTestCase(TestCase):
 		consumer = producer.pipe_reader
 		consumer.input_files = {"producer" : producer.proc.stdout}
 
-		producer.start()
+		global_event_loop().run_until_complete(producer.async_start())
 		producer.wait()
 
 		self.assertEqual(producer.returncode, os.EX_OK)
@@ -58,7 +58,7 @@ class PopenPipeTestCase(TestCase):
 
 			producer.pipe_reader = consumer
 
-			producer.start()
+			global_event_loop().run_until_complete(producer.async_start())
 			producer.wait()
 
 			self.assertEqual(producer.returncode, os.EX_OK)

--- a/lib/portage/tests/process/test_PopenProcessBlockingIO.py
+++ b/lib/portage/tests/process/test_PopenProcessBlockingIO.py
@@ -1,4 +1,4 @@
-# Copyright 2012 Gentoo Foundation
+# Copyright 2012-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
@@ -40,7 +40,7 @@ class PopenPipeBlockingIOTestCase(TestCase):
 		consumer = producer.pipe_reader
 		consumer.input_files = {"producer" : producer.proc.stdout}
 
-		producer.start()
+		global_event_loop().run_until_complete(producer.async_start())
 		producer.wait()
 
 		self.assertEqual(producer.returncode, os.EX_OK)

--- a/lib/portage/tests/process/test_poll.py
+++ b/lib/portage/tests/process/test_poll.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2019 Gentoo Authors
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -67,7 +67,7 @@ class PipeReaderTestCase(TestCase):
 			input_files={"producer" : master_file},
 			_use_array=self._use_array,
 			scheduler=scheduler)
-		consumer.start()
+		scheduler.run_until_complete(consumer.async_start())
 
 		producer = scheduler.run_until_complete(asyncio.create_subprocess_exec(
 			"bash", "-c", self._echo_cmd % test_string,

--- a/lib/portage/tests/util/test_file_copier.py
+++ b/lib/portage/tests/util/test_file_copier.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -28,7 +28,7 @@ class FileCopierTestCase(TestCase):
 				f.write(content)
 			os.chmod(src_path, file_mode)
 			copier = FileCopier(src_path=src_path, dest_path=dest_path, scheduler=loop)
-			copier.start()
+			loop.run_until_complete(copier.async_start())
 			loop.run_until_complete(copier.async_wait())
 			self.assertEqual(copier.returncode, 0)
 			copier.future.result()
@@ -39,7 +39,7 @@ class FileCopierTestCase(TestCase):
 			# failure due to nonexistent src_path
 			src_path = os.path.join(tempdir, 'does-not-exist')
 			copier = FileCopier(src_path=src_path, dest_path=dest_path, scheduler=loop)
-			copier.start()
+			loop.run_until_complete(copier.async_start())
 			loop.run_until_complete(copier.async_wait())
 			self.assertEqual(copier.returncode, 1)
 			self.assertEqual(copier.future.exception().errno, errno.ENOENT)


### PR DESCRIPTION
Convert the _start method to an _async_start coroutine, since
eventually this method will need to be a coroutine in order to write
messages to the build log as discussed in bug 709746.

Bug: https://bugs.gentoo.org/709746
Signed-off-by: Zac Medico <zmedico@gentoo.org>