### PR TITLE
_GeneratorTask: throw CancelledError in cancelled coroutine (bug 711174)

### DIFF
--- a/lib/portage/tests/util/futures/test_compat_coroutine.py
+++ b/lib/portage/tests/util/futures/test_compat_coroutine.py
@@ -57,19 +57,40 @@ class CompatCoroutineTestCase(TestCase):
 			loop.run_until_complete(catching_coroutine(loop=loop)))
 
 	def test_cancelled_coroutine(self):
+		"""
+		Verify that a coroutine can handle (and reraise) asyncio.CancelledError
+		in order to perform any necessary cleanup. Note that the
+		asyncio.CancelledError will only be thrown in the coroutine if there's
+		an opportunity (yield) before the generator raises StopIteration.
+		"""
+		loop = asyncio.get_event_loop()
+		ready_for_exception = loop.create_future()
+		exception_in_coroutine = loop.create_future()
 
 		@coroutine
 		def cancelled_coroutine(loop=None):
 			loop = asyncio._wrap_loop(loop)
 			while True:
-				yield loop.create_future()
+				future = loop.create_future()
+				try:
+					ready_for_exception.set_result(None)
+					yield future
+				except Exception as e:
+					future.done() or future.cancel()
+					exception_in_coroutine.set_exception(e)
+					raise
+				else:
+					exception_in_coroutine.set_result(None)
 
-		loop = asyncio.get_event_loop()
 		future = cancelled_coroutine(loop=loop)
-		loop.call_soon(future.cancel)
+		loop.run_until_complete(ready_for_exception)
+		future.cancel()
 
 		self.assertRaises(asyncio.CancelledError,
 			loop.run_until_complete, future)
+
+		self.assertRaises(asyncio.CancelledError,
+			loop.run_until_complete, exception_in_coroutine)
 
 	def test_cancelled_future(self):
 		"""


### PR DESCRIPTION
Throw asyncio.CancelledError in a cancelled coroutine, ensuring
that the coroutine can handle this exception in order to perform
any necessary cleanup (like close the log file for bug 711174).
Note that the asyncio.CancelledError will only be thrown in the
coroutine if there's an opportunity (yield) before the generator
raises StopIteration.

Also fix the AsynchronousTask exit listener handling for
compatibility with this new behavior.

Fixes: 8074127bbc21 ("SpawnProcess: add _main coroutine")
Bug: https://bugs.gentoo.org/711174
Signed-off-by: Zac Medico <zmedico@gentoo.org>