### PR TITLE
_GeneratorTask: throw CancelledError in cancelled coroutine (bug 711174)

### DIFF
--- a/lib/portage/util/futures/compat_coroutine.py
+++ b/lib/portage/util/futures/compat_coroutine.py
@@ -87,21 +87,29 @@ class _GeneratorTask(object):
 	def __init__(self, generator, result, loop):
 		self._generator = generator
 		self._result = result
+		self._current_task = None
 		self._loop = loop
 		result.add_done_callback(self._cancel_callback)
 		loop.call_soon(self._next)
 
 	def _cancel_callback(self, result):
-		if result.cancelled():
-			self._generator.close()
+		if result.cancelled() and self._current_task is not None:
+			# The done callback for self._current_task invokes
+			# _next in either case here.
+			self._current_task.done() or self._current_task.cancel()
 
 	def _next(self, previous=None):
+		self._current_task = None
 		if self._result.cancelled():
 			if previous is not None:
 				# Consume exceptions, in order to avoid triggering
 				# the event loop's exception handler.
 				previous.cancelled() or previous.exception()
-			return
+
+			# This will throw asyncio.CancelledError in the coroutine if
+			# there's an opportunity (yield) before the generator raises
+			# StopIteration.
+			previous = self._result
 		try:
 			if previous is None:
 				future = next(self._generator)
@@ -124,5 +132,6 @@ class _GeneratorTask(object):
 			if not self._result.cancelled():
 				self._result.set_exception(e)
 		else:
-			future = asyncio.ensure_future(future, loop=self._loop)
-			future.add_done_callback(self._next)
+			self._current_task = asyncio.ensure_future(future, loop=self._loop)
+			self._current_task.add_done_callback(self._next)
+


### PR DESCRIPTION
Throw asyncio.CancelledError in a cancelled coroutine, ensuring
that the coroutine can handle this exception in order to perform
any necessary cleanup (like close the log file for bug 711174).
Note that the asyncio.CancelledError will only be thrown in the
coroutine if there's an opportunity (yield) before the generator
raises StopIteration.

Also fix the AsynchronousTask exit listener handling for
compatibility with this new behavior.

Fixes: 8074127bbc21 ("SpawnProcess: add _main coroutine")
Bug: https://bugs.gentoo.org/711174
Signed-off-by: Zac Medico <zmedico@gentoo.org>