### PR TITLE
Subprocess: delay unregister in _async_wait (bug 711174)

### DIFF
--- a/lib/_emerge/SubProcess.py
+++ b/lib/_emerge/SubProcess.py
@@ -1,10 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
 
 from portage import os
 from portage.util import writemsg_level
+from portage.util.futures import asyncio
 from _emerge.AbstractPollTask import AbstractPollTask
 import signal
 import errno
@@ -39,6 +40,14 @@ class SubProcess(AbstractPollTask):
 	def isAlive(self):
 		return self.pid is not None and \
 			self.returncode is None
+
+	def _async_wait(self):
+		if self.returncode is None:
+			raise asyncio.InvalidStateError('Result is not ready for %s' % (self,))
+		else:
+			# This calls _unregister, so don't call it until pid status
+			# is available.
+			super(SubProcess, self)._async_wait()
 
 	def _async_waitpid(self):
 		"""


### PR DESCRIPTION
Since the super class AbstractPollTask _async_wait method
calls _unregister, it can trigger premature _unregister before
pid status is available. Therefore, only call the super class
_async_wait method after pid status is available. This should
help prevent premature _unregister events that trigger reading
of build logs before they're closed as in bug 658806 and
bug 711174.

Bug: https://bugs.gentoo.org/711174
Signed-off-by: Zac Medico <zmedico@gentoo.org>