### PR TITLE
AsynchronousTask: schedule start listeners via call_soon (bug 711322)

### DIFF
--- a/lib/_emerge/AsynchronousTask.py
+++ b/lib/_emerge/AsynchronousTask.py
@@ -167,7 +167,7 @@ class AsynchronousTask(SlotObject):
 			self._start_listeners = None
 
 			for f in start_listeners:
-				f(self)
+				self.scheduler.call_soon(f, self)
 
 	def addExitListener(self, f):
 		"""


### PR DESCRIPTION
Schedule start listeners via call_soon, in order to avoid callback races
like the SequentialTaskQueue exit listener race that triggered bug
711322. Callbacks scheduled via call_soon are placed in a fifo queue,
ensuring that they execute in an order that is unsurprising relative to
other callbacks.

Bug: https://bugs.gentoo.org/711322
Signed-off-by: Zac Medico <zmedico@gentoo.org>