### PR TITLE
AsynchronousTask: simplify isAlive (bug 711688)

### DIFF
--- a/lib/_emerge/AbstractPollTask.py
+++ b/lib/_emerge/AbstractPollTask.py
@@ -16,9 +16,6 @@ class AbstractPollTask(AsynchronousTask):
 
 	_bufsize = 4096
 
-	def isAlive(self):
-		return bool(self._registered)
-
 	def _read_array(self, f):
 		"""
 		NOTE: array.fromfile() is used here only for testing purposes,

--- a/lib/_emerge/CompositeTask.py
+++ b/lib/_emerge/CompositeTask.py
@@ -12,9 +12,6 @@ class CompositeTask(AsynchronousTask):
 
 	_TASK_QUEUED = -1
 
-	def isAlive(self):
-		return self._current_task is not None
-
 	def _cancel(self):
 		if self._current_task is not None:
 			if self._current_task is self._TASK_QUEUED:

--- a/lib/_emerge/FifoIpcDaemon.py
+++ b/lib/_emerge/FifoIpcDaemon.py
@@ -70,9 +70,6 @@ class FifoIpcDaemon(AbstractPollTask):
 			self._files.pipe_in,
 			self._input_handler)
 
-	def isAlive(self):
-		return self._registered
-
 	def _cancel(self):
 		if self.returncode is None:
 			self.returncode = 1

--- a/lib/_emerge/SubProcess.py
+++ b/lib/_emerge/SubProcess.py
@@ -24,7 +24,7 @@ class SubProcess(AbstractPollTask):
 		return self.returncode
 
 	def _cancel(self):
-		if self.isAlive():
+		if self.isAlive() and self.pid is not None:
 			try:
 				os.kill(self.pid, signal.SIGTERM)
 			except OSError as e:
@@ -36,10 +36,6 @@ class SubProcess(AbstractPollTask):
 						noiselevel=-1)
 				elif e.errno != errno.ESRCH:
 					raise
-
-	def isAlive(self):
-		return self.pid is not None and \
-			self.returncode is None
 
 	def _async_wait(self):
 		if self.returncode is None:


### PR DESCRIPTION
Simplify all AsynchronousTask subclasses to use the default
isAlive implementation, which returns True if self.returncode
is not None. This fixes cases where the method would erroneously
return False, leading to issues like bug 711688, where the
CompositeTask isAlive implementation returned False for a
BinpkgPrefetcher instance that was still in the process of
starting via its async_start method.

Fixes: d66e9ec0b105 ("AsynchronousTask: add coroutine async_start method")
Bug: https://bugs.gentoo.org/711688
Signed-off-by: Zac Medico <zmedico@gentoo.org>