### PR TITLE
AsynchronousTask: handle addStartListener after exit (bug 711322)

### DIFF
--- a/lib/_emerge/AsynchronousTask.py
+++ b/lib/_emerge/AsynchronousTask.py
@@ -156,6 +156,10 @@ class AsynchronousTask(SlotObject):
 			self._start_listeners = []
 		self._start_listeners.append(f)
 
+		# Ensure that start listeners are always called.
+		if self.returncode is not None:
+			self._start_hook()
+
 	def removeStartListener(self, f):
 		if self._start_listeners is None:
 			return
@@ -198,6 +202,10 @@ class AsynchronousTask(SlotObject):
 		used to trigger exit listeners when the returncode first
 		becomes available.
 		"""
+		# Ensure that start listeners are always called.
+		if self.returncode is not None:
+			self._start_hook()
+
 		if self.returncode is not None and \
 			self._exit_listeners is not None:
 

--- a/lib/portage/tests/util/futures/test_done_callback_after_exit.py
+++ b/lib/portage/tests/util/futures/test_done_callback_after_exit.py
@@ -36,5 +36,9 @@ class DoneCallbackAfterExitTestCase(TestCase):
 
 		for i in range(3):
 			event = loop.create_future()
+			task.addStartListener(lambda task: event.set_result(None))
+			loop.run_until_complete(event)
+
+			event = loop.create_future()
 			task.addExitListener(lambda task: event.set_result(None))
 			loop.run_until_complete(event)


### PR DESCRIPTION
When addStartListener is called after the task has already exited with
a returncode, immediately schedule the listener to be invoked via
call_soon. This behavior is similar to the Future add_done_callback
method (and addExitListener since commit 5d476c4e5002).

Signed-off-by: Zac Medico <zmedico@gentoo.org>