### PR TITLE
SequentialTaskQueue: cancel unstarted tasks when appropriate (bug 711322)

### DIFF
--- a/lib/_emerge/CompositeTask.py
+++ b/lib/_emerge/CompositeTask.py
@@ -20,6 +20,10 @@ class CompositeTask(AsynchronousTask):
 				self._async_wait()
 			else:
 				self._current_task.cancel()
+		elif self.returncode is None:
+			# Assume that the task has not started yet.
+			self._was_cancelled()
+			self._async_wait()
 
 	def _poll(self):
 		"""

--- a/lib/_emerge/SequentialTaskQueue.py
+++ b/lib/_emerge/SequentialTaskQueue.py
@@ -74,7 +74,10 @@ class SequentialTaskQueue(SlotObject):
 		"""
 		Clear the task queue and asynchronously terminate any running tasks.
 		"""
+		for task in self._task_queue:
+			task.cancel()
 		self._task_queue.clear()
+
 		for task in list(self.running_tasks):
 			task.cancel()
 


### PR DESCRIPTION
When the clear method is called, cancel any tasks which have not
started yet, in order to ensure that their start/exit listeners are
called. This fixes a case where emerge would hang after SIGINT.

Also fix the CompositeTask _cancel method to react appropriately to
the cancel event when the task has not started yet.

Bug: https://bugs.gentoo.org/711322
Signed-off-by: Zac Medico <zmedico@gentoo.org>