### PR TITLE
depgraph: respect --deep=<depth> with --update (bug 712298)

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import division, print_function, unicode_literals
@@ -6371,7 +6371,11 @@ class depgraph(object):
 					cpv = pkg.cpv
 					reinstall_for_flags = None
 
-					if not pkg.installed or \
+					if pkg.installed and parent is not None and not self._want_update_pkg(parent, pkg):
+						# Ensure that --deep=<depth> is respected even when the
+						# installed package is masked and --update is enabled.
+						pass
+					elif not pkg.installed or \
 						(matched_packages and not avoid_update):
 						# Only enforce visibility on installed packages
 						# if there is at least one other visible package

--- a/lib/portage/tests/resolver/test_depth.py
+++ b/lib/portage/tests/resolver/test_depth.py
@@ -1,4 +1,4 @@
-# Copyright 2011 Gentoo Foundation
+# Copyright 2011-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -8,6 +8,17 @@ from portage.tests.resolver.ResolverPlayground import (ResolverPlayground,
 class ResolverDepthTestCase(TestCase):
 
 	def testResolverDepth(self):
+
+		profile = {
+			"package.mask":
+				(
+					# Mask an installed package (for which an update is
+					# available) in order to test for bug 712298, where
+					# --update caused --deep=<depth> to be violated for
+					# such a package.
+					"<dev-libs/B-2",
+				),
+		}
 
 		ebuilds = {
 			"dev-libs/A-1": {"RDEPEND" : "dev-libs/B"},
@@ -65,6 +76,9 @@ class ResolverDepthTestCase(TestCase):
 		world = ["dev-libs/A"]
 
 		test_cases = (
+			# Test for bug 712298, where --update caused --deep=<depth>
+			# to be violated for dependencies that were masked. In this
+			# case, the installed dev-libs/B-1 dependency is masked.
 			ResolverPlaygroundTestCase(
 				["dev-libs/A"],
 				options = {"--update": True, "--deep": 0},
@@ -243,7 +257,7 @@ class ResolverDepthTestCase(TestCase):
 			)
 
 		playground = ResolverPlayground(ebuilds=ebuilds, installed=installed,
-			world=world)
+			profile=profile, world=world)
 		try:
 			for test_case in test_cases:
 				playground.run_TestCase(test_case)


### PR DESCRIPTION
Fix the _wrapped_select_pkg_highest_available_imp method to select an
installed package when appropriate for the current --deep=<depth>
setting, even with --update enabled. This prevents violation of the
current --deep=<depth> setting in cases where an installed package
which satisfies a dependency is masked for any reason.

Bug: https://bugs.gentoo.org/712298
Signed-off-by: Zac Medico <zmedico@gentoo.org>