### PR TITLE
eqawarn: output to build log regardless of --quiet (bug 713818)

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}/eapi.sh" || exit 1
@@ -270,7 +270,7 @@ eqawarn() {
 	__elog_base QA "$*"
 	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo >&2
 	echo -e "$@" | while read -r ; do
-		__vecho " $WARN*$NORMAL $REPLY"
+		echo " $WARN*$NORMAL $REPLY" >&2
 	done
 	LAST_E_CMD="eqawarn"
 	return 0


### PR DESCRIPTION
Make eqwarn output to the build log regardless of --quiet, via echo
to stderr instead of __vecho. This __vecho usage was originally
introduced in commit c53f52941c88, which was during the time when
build output went to the tty regardless of --quiet mode (that
changed in commit 0398470e5029).

Bug: https://bugs.gentoo.org/713818
Signed-off-by: Zac Medico <zmedico@gentoo.org>