### PR TITLE
_post_phase_userpriv_perms: handle $HOME (bug 713100)

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1765,9 +1765,10 @@ def _post_phase_userpriv_perms(mysettings):
 	if "userpriv" in mysettings.features and secpass >= 2:
 		""" Privileged phases may have left files that need to be made
 		writable to a less privileged user."""
-		apply_recursive_permissions(mysettings["T"],
-			uid=portage_uid, gid=portage_gid, dirmode=0o700, dirmask=0,
-			filemode=0o600, filemask=0)
+		for path in (mysettings["HOME"], mysettings["T"]):
+			apply_recursive_permissions(path,
+				uid=portage_uid, gid=portage_gid, dirmode=0o700, dirmask=0,
+				filemode=0o600, filemask=0)
 
 
 def _check_build_log(mysettings, out=None):


### PR DESCRIPTION
Ensure that the userpriv UID has appropriate permission for files
created in $HOME during privileged phases like pkg_setup, in the
same way as for $T. This prevents potential permission issues for
programs invoked during unprivileged phases, and it improves
alignment with PMS which specifies identical behavior for both
$HOME and $T.

Bug: https://bugs.gentoo.org/713100
Signed-off-by: Zac Medico <zmedico@gentoo.org>