### PR TITLE
_hide_url_passwd: replace all occurrences (bug 713726)

### DIFF
--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -67,7 +67,7 @@ _userpriv_spawn_kwargs = (
 )
 
 def _hide_url_passwd(url):
-	return re.sub(r'//(.+):.+@(.+)', r'//\1:*password*@\2', url)
+	return re.sub(r'//([^:\s]+):[^@\s]+@', r'//\1:*password*@', url)
 
 
 def _want_userfetch(settings):


### PR DESCRIPTION
Adjust the regular expression to avoid overly-greedy .+ groups,
so that is will properly replace all occurrences, as necessary
for the purposes of bug 713726 since PORTAGE_BINHOST may contain
multiple values.

Bug: https://bugs.gentoo.org/713726
Signed-off-by: Zac Medico <zmedico@gentoo.org>