### PR TITLE
NeededEntry: infer implicit soname from file basename (bug 715162)

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -183,6 +183,12 @@ install_qa_check() {
 			soname=${l%%;*}; l=${l#*;}
 			rpath=${l%%;*}; l=${l#*;}; [ "${rpath}" = "  -  " ] && rpath=""
 			needed=${l%%;*}; l=${l#*;}
+
+			# Infer implicit soname from basename (bug 715162).
+			if [[ -z ${soname} && $(file "${D%/}${obj}") == *"SB shared object"* ]]; then
+				soname=${obj##*/}
+			fi
+
 			echo "${obj} ${needed}"	>> "${PORTAGE_BUILDDIR}"/build-info/NEEDED
 			echo "${arch:3};${obj};${soname};${rpath};${needed}" >> "${PORTAGE_BUILDDIR}"/build-info/NEEDED.ELF.2
 		done }


### PR DESCRIPTION
For dynamic libraries, infer an implicit DT_SONAME setting from the
file basename, which is consistent with dynamic linking behavior in
practice. This makes it possible to resolve soname dependencies for
musl's libc.so which lacks a DT_SONAME setting.

Bug: https://bugs.gentoo.org/715162
Signed-off-by: Zac Medico <zmedico@gentoo.org>