### PR TITLE
Scheduler: wakeup for empty merge queue (bug 711322)

### DIFF
--- a/lib/_emerge/SequentialTaskQueue.py
+++ b/lib/_emerge/SequentialTaskQueue.py
@@ -1,9 +1,11 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from collections import deque
 import sys
 
+from portage.util.futures import asyncio
+from portage.util.futures.compat_coroutine import coroutine
 from portage.util.SlotObject import SlotObject
 
 class SequentialTaskQueue(SlotObject):
@@ -41,12 +43,6 @@ class SequentialTaskQueue(SlotObject):
 				cancelled = getattr(task, "cancelled", None)
 				if not cancelled:
 					self.running_tasks.add(task)
-					# This callback will be invoked as soon as the task
-					# exits (before the future's done callback is called),
-					# and this is required in order for bool(self) to have
-					# an updated value for Scheduler._schedule to base
-					# assumptions upon. Delayed updates to bool(self) is
-					# what caused Scheduler to hang as in bug 711322.
 					task.addExitListener(self._task_exit)
 					task.start()
 		finally:
@@ -73,12 +69,18 @@ class SequentialTaskQueue(SlotObject):
 		for task in list(self.running_tasks):
 			task.cancel()
 
+	@coroutine
 	def wait(self):
 		"""
-		Synchronously wait for all running tasks to exit.
+		Wait for the queue to become empty. This method is a coroutine.
 		"""
-		while self.running_tasks:
-			next(iter(self.running_tasks)).wait()
+		while self:
+			task = next(iter(self.running_tasks), None)
+			if task is None:
+				# Wait for self.running_tasks to populate.
+				yield asyncio.sleep(0)
+			else:
+				yield task.async_wait()
 
 	def __bool__(self):
 		return bool(self._task_queue or self.running_tasks)


### PR DESCRIPTION
Add a wakeup callback to schedule a new merge when the merge queue
becomes empty. This prevents the scheduler from hanging in cases
where the order of _merge_exit callback invocation may cause the
the merge queue to appear non-empty when it is about to become
empty.

Bug: https://bugs.gentoo.org/711322
Bug: https://bugs.gentoo.org/716636
Signed-off-by: Zac Medico <zmedico@gentoo.org>