### PR TITLE
depgraph: respect <foo-version:= for slot operator rebuild (bug 717140)

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -2068,9 +2068,15 @@ class depgraph(object):
 			for parent, atom in self._dynamic_config._parent_atoms.get(existing_pkg, []):
 				if isinstance(parent, Package):
 					if parent in built_slot_operator_parents:
-						# This parent may need to be rebuilt, so its
-						# dependencies aren't necessarily relevant.
-						continue
+						# This parent may need to be rebuilt, therefore
+						# discard its soname and built slot operator
+						# dependency components which are not necessarily
+						# relevant.
+						if atom.soname:
+							continue
+						elif atom.package and atom.slot_operator_built:
+							# This discards the slot/subslot component.
+							atom = atom.with_slot("=")
 
 					if replacement_parent is not None and \
 						(replacement_parent.slot_atom == parent.slot_atom

--- a/lib/portage/tests/resolver/test_slot_operator_reverse_deps.py
+++ b/lib/portage/tests/resolver/test_slot_operator_reverse_deps.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2016-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -122,7 +122,6 @@ class SlotOperatorReverseDepsLibGit2TestCase(TestCase):
 		trigger an upgrade to dev-libs/libgit2-1.0.0-r1, ultimately
 		resulting in an undesirable downgrade to dev-libs/libgit2-0.28.4-r1.
 		"""
-		self.todo = True
 
 		ebuilds = {
 


### PR DESCRIPTION
When searching for slot operator rebuilds, respect non slot-operator
components of parent dependencies, so that a <foo-version:= dependency
like the <dev-libs/libgit2-1:0=[ssh?] dependency from bug 717140 will
not be completely ignored. This will prevent erroneous attempts to
trigger slot operator rebuilds for upgrades that would break
<foo-version:= dependencies (which triggered upgrade/downgrade loops
when backtracking tried to resolve the breakage).

Fixes: d569a2d7275c ("_slot_operator_update_probe: fix bug #508762")
Bug: https://bugs.gentoo.org/717140
Signed-off-by: Zac Medico <zmedico@gentoo.org>