### PR TITLE
make.globals: add default BINPKG_COMPRESS setting (bug 715108)

### DIFF
--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # System-wide defaults for the Portage system
 
@@ -33,6 +33,9 @@ RPMDIR="/var/cache/rpm"
 
 # Temporary build directory
 PORTAGE_TMPDIR="/var/tmp"
+
+# The compression used for binary packages. Defaults to zstd when USE=zstd is enabled.
+BINPKG_COMPRESS="bzip2"
 
 # Fetching command (3 tries, passive ftp for firewall compatibility)
 FETCHCOMMAND="wget -t 3 -T 60 --passive-ftp -O \"\${DISTDIR}/\${FILE}\" \"\${URI}\""


### PR DESCRIPTION
The ebuild will have a default enabled USE=zstd which changes the
default to zstd here.

Bug: https://bugs.gentoo.org/715108
Bug: https://bugs.gentoo.org/719456
Signed-off-by: Zac Medico <zmedico@gentoo.org>