### PR TITLE
anydbm: avoid interference between cleanse_keys and _eclasses_

### DIFF
--- a/lib/portage/cache/template.py
+++ b/lib/portage/cache/template.py
@@ -133,7 +133,7 @@ class database(object):
 		d = None
 		if self.cleanse_keys:
 			d=ProtectedDict(values)
-			for k, v in list(d.items()):
+			for k, v in list(item for item in d.items() if item[0] != "_eclasses_"):
 				if not v:
 					del d[k]
 		if "_eclasses_" in values:

--- a/lib/portage/tests/dbapi/test_auxdb.py
+++ b/lib/portage/tests/dbapi/test_auxdb.py
@@ -11,6 +11,13 @@ from portage.util.futures.compat_coroutine import coroutine
 
 class AuxdbTestCase(TestCase):
 
+	def test_anydbm(self):
+		try:
+			from portage.cache.anydbm import database
+		except ImportError:
+			self.skipTest('dbm import failed')
+		self._test_mod('portage.cache.anydbm.database')
+
 	def test_flat_hash_md5(self):
 		self._test_mod('portage.cache.flat_hash.md5_database')
 


### PR DESCRIPTION
Fix this AuxdbTestCase failure for anydbm:
```
test_anydbm (portage.tests.dbapi.test_auxdb.AuxdbTestCase) ... Exception in callback None()
handle: <Handle cancelled>
Traceback (most recent call last):
  File "/usr/lib64/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "lib/_emerge/EbuildMetadataPhase.py", line 143, in _output_handler
    self._async_waitpid()
  File "lib/_emerge/SubProcess.py", line 60, in _async_waitpid
    add_child_handler(self.pid, self._async_waitpid_cb)
  File "/usr/lib64/python3.6/asyncio/unix_events.py", line 873, in add_child_handler
    self._do_waitpid(pid)
  File "/usr/lib64/python3.6/asyncio/unix_events.py", line 919, in _do_waitpid
    callback(pid, returncode, *args)
  File "lib/_emerge/EbuildMetadataPhase.py", line 207, in _async_waitpid_cb
    self.repo_path, metadata, self.ebuild_hash)
  File "lib/portage/dbapi/porttree.py", line 545, in _write_cache
    cache[cpv] = metadata
  File "lib/portage/cache/template.py", line 146, in __setitem__
    d["_eclasses_"] = self._internal_eclasses(d["_eclasses_"],
  File "lib/portage/cache/mappings.py", line 213, in __getitem__
    raise KeyError(key)
KeyError: '_eclasses_'
```
Signed-off-by: Zac Medico <zmedico@gentoo.org>