### PR TITLE
doebuild: Use ccache/distcc/icecream only in src_* phases

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -486,7 +486,10 @@ def doebuild_environment(myebuild, mydo, myroot=None, settings=None,
 		distcc = "distcc" in mysettings.features
 		icecream = "icecream" in mysettings.features
 
-		if ccache or distcc or icecream:
+		# run cc thingies only in src_* phases as otherwise they might
+		# create files with incorrect ownership and trip over
+		if (ccache or distcc or icecream) and mydo in ('unpack',
+				'prepare', 'configure', 'test', 'install'):
 			libdir = None
 			default_abi = mysettings.get("DEFAULT_ABI")
 			if default_abi:


### PR DESCRIPTION
Enable ccache/distcc/icecream only when src_* phases are executed.
There is generally little value from them in pkg_*, as these phases
use CC only to do a few tests at most.  These compilations generally
are not run in parallel and the programs are tiny, so usually
the overhead exceeds the gain.

On the other hand, running them in pkg_* phases results in files being
created with root ownership that breaks them afterwards when using
userpriv.  As a result, user not only loses the benefit of, say, distcc
but also frequently hits error messages that confuse some configure
scripts and result in miscompiled packages.

Bug: https://bugs.gentoo.org/581880
Signed-off-by: Michał Górny <mgorny@gentoo.org>