### PR TITLE
NeededEntry: don't use scanelf -q (bug 721336)

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -177,7 +177,11 @@ install_qa_check() {
 	if type -P scanelf > /dev/null ; then
 		# Save NEEDED information after removing self-contained providers
 		rm -f "$PORTAGE_BUILDDIR"/build-info/NEEDED{,.ELF.2}
-		scanelf -qyRF '%a;%p;%S;%r;%n' "${D%/}/" | { while IFS= read -r l; do
+		# We don't use scanelf -q, since that would omit libraries like
+		# musl's /usr/lib/libc.so which do not have any DT_NEEDED or
+		# DT_SONAME settings. Since we don't use scanelf -q, we have to
+		# handle the special rpath value "  -  " below.
+		scanelf -yRBF '%a;%p;%S;%r;%n' "${D%/}/" | { while IFS= read -r l; do
 			arch=${l%%;*}; l=${l#*;}
 			obj="/${l%%;*}"; l=${l#*;}
 			soname=${l%%;*}; l=${l#*;}

--- a/lib/portage/util/_dyn_libs/LinkageMapELF.py
+++ b/lib/portage/util/_dyn_libs/LinkageMapELF.py
@@ -272,7 +272,10 @@ class LinkageMapELF(object):
 					continue
 				plibs.update((x, cpv) for x in items)
 		if plibs:
-			args = [os.path.join(EPREFIX or "/", "usr/bin/scanelf"), "-qF", "%a;%F;%S;%r;%n"]
+			# We don't use scanelf -q, since that would omit libraries like
+			# musl's /usr/lib/libc.so which do not have any DT_NEEDED or
+			# DT_SONAME settings.
+			args = [os.path.join(EPREFIX or "/", "usr/bin/scanelf"), "-BF", "%a;%F;%S;%r;%n"]
 			args.extend(os.path.join(root, x.lstrip("." + os.sep)) \
 				for x in plibs)
 			try:

--- a/lib/portage/util/_dyn_libs/NeededEntry.py
+++ b/lib/portage/util/_dyn_libs/NeededEntry.py
@@ -52,6 +52,11 @@ class NeededEntry(object):
 
 		del fields[cls._MIN_FIELDS:]
 		obj.arch, obj.filename, obj.soname, rpaths, needed = fields
+		# We don't use scanelf -q, since that would omit libraries like
+		# musl's /usr/lib/libc.so which do not have any DT_NEEDED or
+		# DT_SONAME settings. Since we don't use scanelf -q, we have to
+		# handle the special rpath value "  -  " below.
+		rpaths = "" if rpaths == "  -  " else rpaths
 		obj.runpaths = tuple(filter(None, rpaths.split(":")))
 		obj.needed = tuple(filter(None, needed.split(",")))
 


### PR DESCRIPTION
We don't use scanelf -q, since that would omit libraries like
musl's /usr/lib/libc.so which do not have any DT_NEEDED or
DT_SONAME settings. Since we don't use scanelf -q, we have to
handle the special rpath value "  -  ".

Bug: https://bugs.gentoo.org/721336
Fixes: 25fbe7bc1a92 ("NeededEntry: infer implicit soname from file basename (bug 715162)")
Signed-off-by: Zac Medico <zmedico@gentoo.org>