### PR TITLE
config.environ: delay export of A and AA (bug 720180)

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -26,6 +26,15 @@ ___eapi_has_S_WORKDIR_fallback() {
 
 # VARIABLES
 
+___eapi_exports_A() {
+	# https://bugs.gentoo.org/721088
+	true
+}
+
+___eapi_exports_AA() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
 ___eapi_has_prefix_variables() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ || " ${FEATURES} " == *" force-prefix "* ]]
 }

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -107,6 +107,39 @@ __bashpid() {
 	sh -c 'echo ${PPID}'
 }
 
+# @FUNCTION: ___eapi_vars_export
+# @DESCRIPTION:
+# Export variables for the current EAPI. Calls to this function should
+# be delayed until the last moment, since exporting these variables
+# may trigger E2BIG errors suring attempts to execute subprocesses.
+___eapi_vars_export() {
+	source "${T}/environment.unexported" || die
+
+	if ___eapi_exports_A; then
+		export A
+	fi
+
+	if ___eapi_exports_AA; then
+		export AA
+	fi
+}
+
+# @FUNCTION: ___eapi_vars_unexport
+# @DESCRIPTION:
+# Unexport variables that were exported for the current EAPI. This
+# function should be called after an ebuild phase, in order to unexport
+# variables that may trigger E2BIG errors during attempts to execute
+# subprocesses.
+___eapi_vars_unexport() {
+	if ___eapi_exports_A; then
+		export -n A
+	fi
+
+	if ___eapi_exports_AA; then
+		export -n AA
+	fi
+}
+
 __helpers_die() {
 	if ___eapi_helpers_can_die && [[ ${PORTAGE_NONFATAL} != 1 ]]; then
 		die "$@"
@@ -122,6 +155,7 @@ die() {
 
 	set +x # tracing only produces useless noise here
 	local IFS=$' \t\n'
+	___eapi_vars_unexport
 
 	if ___eapi_die_can_respect_nonfatal && [[ $1 == -n ]]; then
 		shift

--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -191,7 +191,7 @@ environ_whitelist += [
 # user config variables
 environ_whitelist += ["DOC_SYMLINKS_DIR", "INSTALL_MASK", "PKG_INSTALL_MASK"]
 
-environ_whitelist += ["A", "AA", "CATEGORY", "P", "PF", "PN", "PR", "PV", "PVR"]
+environ_whitelist += ["CATEGORY", "P", "PF", "PN", "PR", "PV", "PVR"]
 
 # misc variables inherited from the calling environment
 environ_whitelist += [
@@ -247,6 +247,13 @@ environ_whitelist = frozenset(environ_whitelist)
 
 environ_whitelist_re = re.compile(r"^(CCACHE_|DISTCC_).*")
 
+environ_unexported = frozenset(
+    [
+        "A",
+        "AA",
+    ]
+)
+
 # Filter selected variables in the config.environ() method so that
 # they don't needlessly propagate down into the ebuild environment.
 environ_filter = []
@@ -254,6 +261,7 @@ environ_filter = []
 # Exclude anything that could be extremely long here (like SRC_URI)
 # since that could cause execve() calls to fail with E2BIG errors. For
 # example, see bug #262647.
+environ_filter.extend(environ_unexported)
 environ_filter += [
     "DEPEND",
     "RDEPEND",


### PR DESCRIPTION
Since variables like A and AA can contain extremely large values which
may trigger E2BIG errors during attempts to execute subprocesses, delay
export until the last moment, and unexport when appropriate.

Bug: https://bugs.gentoo.org/720180
Signed-off-by: Zac Medico <zmedico@gentoo.org>