### PR TITLE
_better_cache._scan_cat: avoid stat calls (bug 725934)

### DIFF
--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -164,8 +164,13 @@ class _better_cache(object):
 					raise
 				continue
 			for p in pkg_list:
-				if os.path.isdir(cat_dir + "/" + p):
-					self._items[cat + "/" + p].append(repo)
+				try:
+					atom = Atom("%s/%s" % (cat, p))
+				except InvalidAtom:
+					continue
+				if atom != atom.cp:
+					continue
+				self._items[atom.cp].append(repo)
 		self._scanned_cats.add(cat)
 
 


### PR DESCRIPTION
When processing category listdir results, do not use os.path.isdir to
identify packages, in order to avoid unecessary stat calls. Instead,
use the Atom class to validate package names. This may cause creation
of some cache entries for non-packages, but it will not do any harm
since these entries will never be accessed via the `__getitem__` method.

Bug: https://bugs.gentoo.org/725934
Signed-off-by: Zac Medico <zmedico@gentoo.org>