### PR TITLE
repoman: add cmake-utils to deprecated eclasses

### DIFF
--- a/repoman/lib/repoman/modules/linechecks/deprecated/inherit.py
+++ b/repoman/lib/repoman/modules/linechecks/deprecated/inherit.py
@@ -17,6 +17,7 @@ class InheritDeprecated(LineCheck):
 		"bash-completion": "bash-completion-r1",
 		"boost-utils": False,
 		"clutter": "gnome2",
+		"cmake-utils": "cmake",
 		"confutils": False,
 		"distutils": "distutils-r1",
 		"epatch": "(eapply since EAPI 6)",


### PR DESCRIPTION
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>