### PR TITLE
xtermTitle: support alacritty

### DIFF
--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -234,7 +234,7 @@ def nc_len(mystr):
 	tmp = re.sub(esc_seq + "^m]+m", "", mystr);
 	return len(tmp)
 
-_legal_terms_re = re.compile(r'^(xterm|xterm-color|Eterm|aterm|rxvt|screen|kterm|rxvt-unicode|gnome|interix|tmux|st-256color)')
+_legal_terms_re = re.compile(r'^(xterm|xterm-color|Eterm|aterm|rxvt|screen|kterm|rxvt-unicode|gnome|interix|tmux|st-256color|alacritty)')
 _disable_xtermTitle = None
 _max_xtermTitle_len = 253
 


### PR DESCRIPTION
alacritty terminfo is included in ncurses-6.2 and so it is
picked up by default on most systems using alacritty terminal emulator,
which causes an issue of portage not updating window title.

Signed-off-by: Kirill Chibisov <contact@kchibisov.com>