### PR TITLE
ecompress: fix "Argument list too long" for sed (bug 727522)

### DIFF
--- a/bin/ecompress
+++ b/bin/ecompress
@@ -38,9 +38,10 @@ while [[ $# -gt 0 ]] ; do
 		if [[ ${#skip_files[@]} -gt 0 && -s ${T}/.ecompress_had_precompressed ]]; then
 			sed_args=()
 			for f in "${skip_files[@]}"; do
-				sed_args+=(-e "s|^${f}\$||")
+				sed_args+=("s|^${f}\$||;")
 			done
-			sed "${sed_args[@]}" -e '/^$/d' -i "${T}/.ecompress_had_precompressed" || die
+			sed_args+=('/^$/d')
+			sed -f - -i "${T}/.ecompress_had_precompressed" <<< "${sed_args[@]}" || die
 		fi
 
 		exit 0


### PR DESCRIPTION
Use sed -f to feed commands to sed via stdin, in order to avoid
the "Argument list too long" error reported in bug 727522.

Fixes: 5508bf7a6db5 ("ecompress: ignore docompress -x files in precompressed QA check (bug 721516)")
Bug: https://bugs.gentoo.org/727522
Signed-off-by: Zac Medico <zmedico@gentoo.org>