### PR TITLE
ecompress: optimize docompress -x precompressed comparison

### DIFF
--- a/bin/ecompress
+++ b/bin/ecompress
@@ -19,29 +19,30 @@ while [[ $# -gt 0 ]] ; do
 		shift
 
 		skip_dirs=()
-		skip_files=()
+		> "${T}/.ecompress_skip_files" || die
 		for skip; do
 			if [[ -d ${ED%/}/${skip#/} ]]; then
 				skip_dirs+=( "${ED%/}/${skip#/}" )
 			else
 				rm -f "${ED%/}/${skip#/}.ecompress" || die
-				skip_files+=("${ED%/}/${skip#/}")
+				printf -- '%s\n' "${EPREFIX}/${skip#/}" >> "${T}/.ecompress_skip_files" || die
 			fi
 		done
 
 		if [[ ${#skip_dirs[@]} -gt 0 ]]; then
-			while read -r -d ''; do
-				skip_files+=("${REPLY%.ecompress}")
+			while read -r -d '' skip; do
+				skip=${skip%.ecompress}
+				printf -- '%s\n' "${skip#${D%/}}" >> "${T}/.ecompress_skip_files" || die
 			done < <(find "${skip_dirs[@]}" -name '*.ecompress' -print0 -delete || die)
 		fi
 
-		if [[ ${#skip_files[@]} -gt 0 && -s ${T}/.ecompress_had_precompressed ]]; then
-			sed_args=()
-			for f in "${skip_files[@]}"; do
-				sed_args+=("s|^${f}\$||;")
-			done
-			sed_args+=('/^$/d')
-			sed -f - -i "${T}/.ecompress_had_precompressed" <<< "${sed_args[@]}" || die
+		if [[ -s ${T}/.ecompress_skip_files && -s ${T}/.ecompress_had_precompressed ]]; then
+			# Filter skipped files from ${T}/.ecompress_had_precompressed,
+			# using temporary files since these lists can be extremely large.
+			LC_COLLATE=C sort -u "${T}/.ecompress_skip_files" > "${T}/.ecompress_skip_files_sorted" || die
+			LC_COLLATE=C sort -u "${T}/.ecompress_had_precompressed" > "${T}/.ecompress_had_precompressed_sorted" || die
+			LC_COLLATE=C comm -13 "${T}/.ecompress_skip_files_sorted" "${T}/.ecompress_had_precompressed_sorted" > "${T}/.ecompress_had_precompressed" || die
+			rm -f "${T}/.ecompress_had_precompressed_sorted" "${T}/.ecompress_skip_files"{,_sorted}
 		fi
 
 		exit 0
@@ -81,7 +82,7 @@ while [[ $# -gt 0 ]] ; do
 								continue 2
 							fi
 						done
-						echo "${path}" >> "${T}"/.ecompress_had_precompressed
+						printf -- '%s\n' "${path#${D%/}}" >> "${T}"/.ecompress_had_precompressed || die
 						;;
 				esac
 
@@ -196,7 +197,7 @@ if [[ -s ${T}/.ecompress_had_precompressed ]]; then
 	eqawarn
 	n=0
 	while read -r f; do
-		eqawarn "  ${f#${D%/}}"
+		eqawarn "  ${f}"
 		if [[ $(( n++ )) -eq 10 ]]; then
 			eqawarn "  ..."
 			break

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -91,6 +91,7 @@ class ResolverPlayground(object):
 				"chgrp",
 				"chmod",
 				"chown",
+				"comm",
 				"cp",
 				"egrep",
 				"env",


### PR DESCRIPTION
Use sort and comm with temporary files in order to compare lists
of docompress -x and precompressed files, since the file lists
can be extremely large. Also strip ${D%/} from paths in order to
reduce length.

Bug: https://bugs.gentoo.org/721516
Suggested-by: Robin H. Johnson <robbat2@gentoo.org>
Signed-off-by: Zac Medico <zmedico@gentoo.org>