### PR TITLE
travis.yml: drop python 2.7 (bug 731114)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: bionic
 language: python
 python:
-    - 2.7
     - 3.6
     - 3.7
     - 3.8

--- a/repoman/setup.py
+++ b/repoman/setup.py
@@ -492,7 +492,7 @@ setup(
 		'Intended Audience :: System Administrators',
 		'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
 		'Operating System :: POSIX',
-		'Programming Language :: Python',
+		'Programming Language :: Python :: 3',
 		'Topic :: System :: Installation/Setup'
 	]
 )

--- a/setup.py
+++ b/setup.py
@@ -714,7 +714,7 @@ setup(
 		'Intended Audience :: System Administrators',
 		'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
 		'Operating System :: POSIX',
-		'Programming Language :: Python',
+		'Programming Language :: Python :: 3',
 		'Topic :: System :: Installation/Setup'
 	]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,pypy3
+envlist = py36,py37,py38,py39,pypy3
 skipsdist = True
 
 [testenv]
 deps =
 	pygost
 	pyyaml
-	py27,py36,py37,py38,py39,pypy3: lxml!=4.2.0
-	py27: pyblake2
-	py27: pysha3
+	py36,py37,py38,py39,pypy3: lxml!=4.2.0
 setenv =
 	PYTHONPATH={toxinidir}/lib
 commands =


### PR DESCRIPTION
It should be pretty safe to drop support for python2.7 at this point.

Bug: https://bugs.gentoo.org/731114
Signed-off-by: Zac Medico <zmedico@gentoo.org>