### PR TITLE
man/ebuild.5: Fix $P and $PN example

### DIFF
--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -342,7 +342,7 @@ This variable must NEVER be modified.
 
 \fBExample\fR:
 .nf
-	x11\-base/xorg\-server\-1.20.5\-r2 \-\-> '\fIx11\-base/xorg\-server\-1.20.5\fR'
+	x11\-base/xorg\-server\-1.20.5\-r2 \-\-> '\fIxorg\-server\-1.20.5\fR'
 .fi
 .TP
 .B PN
@@ -350,7 +350,7 @@ Contains the name of the script without the version number.
 
 \fBExample\fR:
 .nf
-	x11\-base/xorg\-server\-1.20.5\-r2 \-\-> '\fIx11\-base/xorg\-server\fR'
+	x11\-base/xorg\-server\-1.20.5\-r2 \-\-> '\fIxorg\-server\fR'
 .fi
 .TP
 .B PV


### PR DESCRIPTION
Both variables do *not* include the package's category. So $PN,
instead of

x11-base/xorg-server

returns

xorg-server

Same goes for $PN.

This commit fixes the error which was introduced by
84b9b5c2a ("man/ebuild.5: Improvements to the ebuild(5) man page").

Closes: https://bugs.gentoo.org/731246
Signed-off-by: Florian Schmaus <flo@geekplace.eu>