### PR TITLE
Eliminate basestring/long/_unicode py3 compat

### DIFF
--- a/bin/egencache
+++ b/bin/egencache
@@ -75,9 +75,6 @@ else:
 	else:
 		from portage.xml.metadata import parse_metadata_use
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 def parse_args(args):
 	usage = "egencache [options] <action> ... [atom] ..."
@@ -344,7 +341,7 @@ class GenCache(object):
 						max_mtime = ec_hash.mtime
 				if max_mtime == sc.mtime:
 					max_mtime += 1
-				max_mtime = long(max_mtime)
+				max_mtime = int(max_mtime)
 				try:
 					os.utime(ebuild_hash.location, (max_mtime, max_mtime))
 				except OSError as e:
@@ -709,7 +706,7 @@ class GenChangeLogs(object):
 			# This cp has not been added to the repo.
 			return
 
-		lmod = long(lmod)
+		lmod = int(lmod)
 
 		try:
 			cmod = os.stat('ChangeLog')[stat.ST_MTIME]

--- a/lib/_emerge/BinpkgFetcher.py
+++ b/lib/_emerge/BinpkgFetcher.py
@@ -17,9 +17,6 @@ from portage import os
 from portage.util._async.AsyncTaskFuture import AsyncTaskFuture
 from portage.util._pty import _create_pty_or_pipe
 
-if sys.hexversion >= 0x3000000:
-	long = int
-
 
 class BinpkgFetcher(CompositeTask):
 
@@ -185,7 +182,7 @@ class _BinpkgFetcherProcess(SpawnProcess):
 					self.pkg.cpv)].get("_mtime_")
 				if remote_mtime is not None:
 					try:
-						remote_mtime = long(remote_mtime)
+						remote_mtime = int(remote_mtime)
 					except ValueError:
 						pass
 					else:

--- a/lib/_emerge/BlockerCache.py
+++ b/lib/_emerge/BlockerCache.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -12,13 +12,6 @@ try:
 	import cPickle as pickle
 except ImportError:
 	import pickle
-
-if sys.hexversion >= 0x3000000:
-	basestring = str
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
 
 class BlockerCache(portage.cache.mappings.MutableMapping):
 	"""This caches blockers of installed packages so that dep_check does not
@@ -82,7 +75,7 @@ class BlockerCache(portage.cache.mappings.MutableMapping):
 			# corruption is detected as soon as possible.
 			invalid_items = set()
 			for k, v in self._cache_data["blockers"].items():
-				if not isinstance(k, basestring):
+				if not isinstance(k, str):
 					invalid_items.add(k)
 					continue
 				try:
@@ -97,7 +90,7 @@ class BlockerCache(portage.cache.mappings.MutableMapping):
 					invalid_items.add(k)
 					continue
 				counter, atoms = v
-				if not isinstance(counter, (int, long)):
+				if not isinstance(counter, int):
 					invalid_items.add(k)
 					continue
 				if not isinstance(atoms, (list, tuple)):
@@ -105,7 +98,7 @@ class BlockerCache(portage.cache.mappings.MutableMapping):
 					continue
 				invalid_atom = False
 				for atom in atoms:
-					if not isinstance(atom, basestring):
+					if not isinstance(atom, str):
 						invalid_atom = True
 						break
 					if atom[:1] != "!" or \
@@ -164,8 +157,8 @@ class BlockerCache(portage.cache.mappings.MutableMapping):
 		@param blocker_data: An object with counter and atoms attributes.
 		@type blocker_data: BlockerData
 		"""
-		self._cache_data["blockers"][_unicode(cpv)] = (blocker_data.counter,
-			tuple(_unicode(x) for x in blocker_data.atoms))
+		self._cache_data["blockers"][str(cpv)] = (blocker_data.counter,
+			tuple(str(x) for x in blocker_data.atoms))
 		self._modified.add(cpv)
 
 	def __iter__(self):

--- a/lib/_emerge/BlockerDB.py
+++ b/lib/_emerge/BlockerDB.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -13,8 +13,6 @@ from _emerge.BlockerCache import BlockerCache
 from _emerge.Package import Package
 from _emerge.show_invalid_depstring_notice import show_invalid_depstring_notice
 
-if sys.hexversion >= 0x3000000:
-	long = int
 
 class BlockerDB(object):
 

--- a/lib/_emerge/FakeVartree.py
+++ b/lib/_emerge/FakeVartree.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -17,11 +17,6 @@ from portage.update import grab_updates, parse_updates, update_dbentries
 from portage.versions import _pkg_str
 from _emerge.resolver.DbapiProvidesIndex import PackageDbapiProvidesIndex
 
-if sys.hexversion >= 0x3000000:
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
 
 class FakeVardbGetPath(object):
 	"""
@@ -165,7 +160,7 @@ class FakeVartree(vartree):
 					raise _DynamicDepsNotApplicable()
 				for k, v in built_slot_operator_atoms.items():
 					live_metadata[k] += (" " +
-						" ".join(_unicode(atom) for atom in v))
+						" ".join(str(atom) for atom in v))
 
 			self.dbapi.aux_update(pkg.cpv, live_metadata)
 		except _DynamicDepsNotApplicable:
@@ -247,7 +242,7 @@ class FakeVartree(vartree):
 			if pkg is not None:
 				counter, mtime = real_vardb.aux_get(cpv, validation_keys)
 				try:
-					counter = long(counter)
+					counter = int(counter)
 				except ValueError:
 					counter = 0
 

--- a/lib/_emerge/JobStatusDisplay.py
+++ b/lib/_emerge/JobStatusDisplay.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import io
@@ -13,9 +13,6 @@ from portage import _unicode_encode
 from portage.output import xtermTitle
 
 from _emerge.getloadavg import getloadavg
-
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 class JobStatusDisplay(object):
 
@@ -59,7 +56,7 @@ class JobStatusDisplay(object):
 			object.__setattr__(self, "_term_codes", term_codes)
 		encoding = sys.getdefaultencoding()
 		for k, v in self._term_codes.items():
-			if not isinstance(v, basestring):
+			if not isinstance(v, str):
 				self._term_codes[k] = v.decode(encoding, 'replace')
 
 		if self._isatty:

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -18,13 +18,6 @@ from portage.eapi import _get_eapi_attrs, eapi_has_use_aliases
 from portage.exception import InvalidData, InvalidDependString
 from portage.localization import _
 from _emerge.Task import Task
-
-if sys.hexversion >= 0x3000000:
-	basestring = str
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
 
 class Package(Task):
 
@@ -220,7 +213,7 @@ class Package(Task):
 		else:
 			raise TypeError("root_config argument is required")
 
-		elements = [type_name, root, _unicode(cpv), operation]
+		elements = [type_name, root, str(cpv), operation]
 
 		# For installed (and binary) packages we don't care for the repo
 		# when it comes to hashing, because there can only be one cpv.
@@ -513,7 +506,7 @@ class Package(Task):
 			cpv_color = "PKG_NOMERGE"
 
 		build_id_str = ""
-		if isinstance(self.cpv.build_id, long) and self.cpv.build_id > 0:
+		if isinstance(self.cpv.build_id, int) and self.cpv.build_id > 0:
 			build_id_str = "-%s" % self.cpv.build_id
 
 		s = "(%s, %s" \
@@ -712,7 +705,7 @@ class Package(Task):
 			@return: True if all flags are valid USE values which may
 				be specified in USE dependencies, False otherwise.
 			"""
-			if isinstance(flags, basestring):
+			if isinstance(flags, str):
 				flags = [flags]
 
 			for flag in flags:
@@ -725,7 +718,7 @@ class Package(Task):
 			"""
 			@return: A list of flags missing from IUSE.
 			"""
-			if isinstance(flags, basestring):
+			if isinstance(flags, str):
 				flags = [flags]
 			missing_iuse = []
 			for flag in flags:
@@ -871,14 +864,14 @@ class _PackageMetadataWrapper(_PackageMetadataWrapperBase):
 			getattr(self, "_set_" + k.lower())(k, v)
 
 	def _set_inherited(self, k, v):
-		if isinstance(v, basestring):
+		if isinstance(v, str):
 			v = frozenset(v.split())
 		self._pkg.inherited = v
 
 	def _set_counter(self, k, v):
-		if isinstance(v, basestring):
+		if isinstance(v, str):
 			try:
-				v = long(v.strip())
+				v = int(v.strip())
 			except ValueError:
 				v = 0
 		self._pkg.counter = v
@@ -896,9 +889,9 @@ class _PackageMetadataWrapper(_PackageMetadataWrapperBase):
 				pass
 
 	def _set__mtime_(self, k, v):
-		if isinstance(v, basestring):
+		if isinstance(v, str):
 			try:
-				v = long(v.strip())
+				v = int(v.strip())
 			except ValueError:
 				v = 0
 		self._pkg.mtime = v

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -63,9 +63,6 @@ from _emerge.PackageMerge import PackageMerge
 from _emerge.PollScheduler import PollScheduler
 from _emerge.SequentialTaskQueue import SequentialTaskQueue
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
-
 # enums
 FAILURE = 1
 
@@ -1141,7 +1138,7 @@ class Scheduler(PollScheduler):
 					if phase not in logentries:
 						continue
 					for msgtype, msgcontent in logentries[phase]:
-						if isinstance(msgcontent, basestring):
+						if isinstance(msgcontent, str):
 							msgcontent = [msgcontent]
 						for line in msgcontent:
 							printer.eerror(line.strip("\n"))

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -94,11 +94,6 @@ from _emerge.UnmergeDepPriority import UnmergeDepPriority
 from _emerge.UseFlagDisplay import pkg_use_display
 from _emerge.UserQuery import UserQuery
 
-if sys.hexversion >= 0x3000000:
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
 
 def action_build(emerge_config, trees=DeprecationWarning,
 	mtimedb=DeprecationWarning, myopts=DeprecationWarning,
@@ -854,7 +849,7 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 						protected_set.add("=" + pkg.cpv)
 						continue
 				except portage.exception.InvalidDependString as e:
-					show_invalid_depstring_notice(pkg, _unicode(e))
+					show_invalid_depstring_notice(pkg, str(e))
 					del e
 					protected_set.add("=" + pkg.cpv)
 					continue
@@ -907,7 +902,7 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 					protected_set.add("=" + pkg.cpv)
 					continue
 			except portage.exception.InvalidDependString as e:
-				show_invalid_depstring_notice(pkg, _unicode(e))
+				show_invalid_depstring_notice(pkg, str(e))
 				del e
 				protected_set.add("=" + pkg.cpv)
 				continue
@@ -924,7 +919,7 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 				if excluded_set.findAtomForPackage(pkg):
 					required_sets['__excluded__'].add("=" + pkg.cpv)
 			except portage.exception.InvalidDependString as e:
-				show_invalid_depstring_notice(pkg, _unicode(e))
+				show_invalid_depstring_notice(pkg, str(e))
 				del e
 				required_sets['__excluded__'].add("=" + pkg.cpv)
 
@@ -989,14 +984,14 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 				# visible in the unevaluated form of the atom. In this
 				# case, we must display the unevaluated atom, so that
 				# the user can see the conditional USE deps that would
-				# otherwise be invisible. Use Atom(_unicode(atom)) to
+				# otherwise be invisible. Use Atom(str(atom)) to
 				# test for a package where this case would matter. This
 				# is not necessarily the same as atom.without_use,
-				# since Atom(_unicode(atom)) may still contain some
+				# since Atom(str(atom)) may still contain some
 				# USE dependencies that remain after evaluation of
 				# conditionals.
 				if atom.package and atom != atom.unevaluated_atom and \
-					vardb.match(Atom(_unicode(atom))):
+					vardb.match(Atom(str(atom))):
 					msg.append("  %s (%s) pulled in by:" %
 						(atom.unevaluated_atom, atom))
 				else:
@@ -1068,7 +1063,7 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 				key=operator.attrgetter('package'))
 			parent_strs.append("%s requires %s" %
 				(getattr(parent, "cpv", parent),
-				", ".join(_unicode(atom) for atom in atoms)))
+				", ".join(str(atom) for atom in atoms)))
 		parent_strs.sort()
 		msg = []
 		msg.append("  %s pulled in by:\n" % (child_node.cpv,))
@@ -1541,7 +1536,7 @@ def action_deselect(settings, trees, opts, atoms):
 
 				writemsg_stdout(
 					">>> %s %s from \"%s\" favorites file...\n" %
-					(action_desc, colorize("INFORM", _unicode(atom)),
+					(action_desc, colorize("INFORM", str(atom)),
 					filename), noiselevel=-1)
 
 			if '--ask' in opts:

--- a/lib/_emerge/create_world_atom.py
+++ b/lib/_emerge/create_world_atom.py
@@ -6,10 +6,6 @@ import sys
 from portage.dep import Atom, _repo_separator
 from portage.exception import InvalidData
 
-if sys.hexversion >= 0x3000000:
-	_unicode = str
-else:
-	_unicode = unicode
 
 def create_world_atom(pkg, args_set, root_config, before_install=False):
 	"""Create a new atom for the world file if one does not exist.  If the
@@ -43,7 +39,7 @@ def create_world_atom(pkg, args_set, root_config, before_install=False):
 	for cpv in portdb.match(Atom(cp)):
 		for repo in repos:
 			try:
-				available_slots.add(portdb._pkg_str(_unicode(cpv), repo).slot)
+				available_slots.add(portdb._pkg_str(str(cpv), repo).slot)
 			except (KeyError, InvalidData):
 				pass
 
@@ -98,7 +94,7 @@ def create_world_atom(pkg, args_set, root_config, before_install=False):
 					for repo in repos:
 						try:
 							matched_slots.add(
-								portdb._pkg_str(_unicode(cpv), repo).slot)
+								portdb._pkg_str(str(cpv), repo).slot)
 						except (KeyError, InvalidData):
 							pass
 

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -88,13 +88,6 @@ from _emerge.resolver.slot_collision import slot_conflict_handler
 from _emerge.resolver.circular_dependency import circular_dependency_handler
 from _emerge.resolver.output import Display, format_unmatched_atom
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
-
 # Exposes a depgraph interface to dep_check.
 _dep_check_graph_interface = collections.namedtuple('_dep_check_graph_interface',(
 	# Indicates a removal action, like depclean or prune.
@@ -311,7 +304,7 @@ class _rebuild_config(object):
 							["BUILD_TIME"])
 					except KeyError:
 						continue
-					if bin_build_time != _unicode(parent.build_time):
+					if bin_build_time != str(parent.build_time):
 						# 2) Remote binary package is valid, and local package
 						#    is not up to date. Force reinstall.
 						reinstall = True
@@ -5761,7 +5754,7 @@ class depgraph(object):
 						other_installed, other_keys in dbs:
 						try:
 							if portage.dep._match_slot(atom,
-								other_db._pkg_str(_unicode(cpv), None)):
+								other_db._pkg_str(str(cpv), None)):
 								slot_available = True
 								break
 						except (KeyError, InvalidData):
@@ -9263,7 +9256,7 @@ class depgraph(object):
 						filename = "world"
 					writemsg_stdout(
 						">>> Recording %s in \"%s\" favorites file...\n" %
-						(colorize("INFORM", _unicode(a)), filename), noiselevel=-1)
+						(colorize("INFORM", str(a)), filename), noiselevel=-1)
 				world_set.update(all_added)
 
 		if world_locked:
@@ -9458,7 +9451,7 @@ class depgraph(object):
 		depgraph_sets = self._dynamic_config.sets[root_config.root]
 		args = []
 		for x in favorites:
-			if not isinstance(x, basestring):
+			if not isinstance(x, str):
 				continue
 			if x in ("system", "world"):
 				x = SETPREFIX + x

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function
@@ -22,8 +22,6 @@ portage.proxy.lazyimport.lazyimport(globals(),
 from portage import os
 from portage.sync import _SUBMODULE_PATH_MAP
 
-if sys.hexversion >= 0x3000000:
-	long = int
 
 options=[
 "--alphabetical",

--- a/lib/_emerge/resolver/output.py
+++ b/lib/_emerge/resolver/output.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2019 Gentoo Authors
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """Resolver output display operation.
@@ -31,12 +31,6 @@ from _emerge.create_world_atom import create_world_atom
 from _emerge.resolver.output_helpers import ( _DisplayConfig, _tree_display,
 	_PackageCounters, _create_use_string, _calc_changelog, PkgInfo)
 from _emerge.show_invalid_depstring_notice import show_invalid_depstring_notice
-
-if sys.hexversion >= 0x3000000:
-	basestring = str
-	_unicode = str
-else:
-	_unicode = unicode
 
 class Display(object):
 	"""Formats and outputs the depgrah supplied it for merge/re-merge, etc.
@@ -86,19 +80,19 @@ class Display(object):
 			addl = "%s     " % (colorize(self.blocker_style, "B"),)
 		addl += self.empty_space_in_brackets()
 		self.resolved = dep_expand(
-			_unicode(blocker.atom).lstrip("!"), mydb=self.vardb,
+			str(blocker.atom).lstrip("!"), mydb=self.vardb,
 			settings=self.pkgsettings
 			)
 		if self.conf.columns and self.conf.quiet:
-			addl += " " + colorize(self.blocker_style, _unicode(self.resolved))
+			addl += " " + colorize(self.blocker_style, str(self.resolved))
 		else:
 			addl = "[%s %s] %s%s" % \
 				(colorize(self.blocker_style, "blocks"),
 				addl, self.indent,
-				colorize(self.blocker_style, _unicode(self.resolved))
+				colorize(self.blocker_style, str(self.resolved))
 				)
 		block_parents = self.conf.blocker_parents.parent_nodes(blocker)
-		block_parents = set(_unicode(pnode.cpv) for pnode in block_parents)
+		block_parents = set(str(pnode.cpv) for pnode in block_parents)
 		block_parents = ", ".join(block_parents)
 		if blocker.atom.blocker.overlap.forbid:
 			blocking_desc = "hard blocking"
@@ -107,7 +101,7 @@ class Display(object):
 		if self.resolved != blocker.atom:
 			addl += colorize(self.blocker_style,
 				" (\"%s\" is %s %s)" %
-				(_unicode(blocker.atom).lstrip("!"),
+				(str(blocker.atom).lstrip("!"),
 				blocking_desc, block_parents))
 		else:
 			addl += colorize(self.blocker_style,
@@ -314,7 +308,7 @@ class Display(object):
 				depstr, = db.aux_get(pkg.cpv,
 					["SRC_URI"], myrepo=pkg.repo)
 				show_invalid_depstring_notice(
-					pkg, _unicode(e))
+					pkg, str(e))
 				raise
 			except SignatureException:
 				# missing/invalid binary package SIZE signature
@@ -445,7 +439,7 @@ class Display(object):
 			ver_str = self._append_slot(ver_str, pkg, pkg_info)
 			ver_str = self._append_repository(ver_str, pkg, pkg_info)
 		if self.conf.quiet:
-			myprint = _unicode(pkg_info.attr_display) + " " + self.indent + \
+			myprint = str(pkg_info.attr_display) + " " + self.indent + \
 				self.pkgprint(pkg_info.cp, pkg_info)
 			myprint = myprint+darkblue(" "+ver_str)+" "
 			myprint = myprint+pkg_info.oldbest
@@ -484,7 +478,7 @@ class Display(object):
 			ver_str = self._append_slot(ver_str, pkg, pkg_info)
 			ver_str = self._append_repository(ver_str, pkg, pkg_info)
 		if self.conf.quiet:
-			myprint = _unicode(pkg_info.attr_display) + " " + self.indent + \
+			myprint = str(pkg_info.attr_display) + " " + self.indent + \
 				self.pkgprint(pkg_info.cp, pkg_info)
 			myprint = myprint+" "+green(ver_str)+" "
 			myprint = myprint+pkg_info.oldbest
@@ -541,7 +535,7 @@ class Display(object):
 		@param show_repos: bool.
 		"""
 		for msg in self.print_msg:
-			if isinstance(msg, basestring):
+			if isinstance(msg, str):
 				writemsg_stdout("%s\n" % (msg,), noiselevel=-1)
 				continue
 			myprint, self.verboseadd, repoadd = msg

--- a/lib/_emerge/resolver/output_helpers.py
+++ b/lib/_emerge/resolver/output_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2014 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """Contains private support functions for the Display class
@@ -26,10 +26,6 @@ from portage.versions import catpkgsplit
 
 from _emerge.Blocker import Blocker
 from _emerge.Package import Package
-
-
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 
 class _RepoDisplay(object):

--- a/lib/_emerge/resolver/slot_collision.py
+++ b/lib/_emerge/resolver/slot_collision.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2014 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import print_function
@@ -16,8 +16,6 @@ from portage._sets.base import InternalPackageSet
 from portage.util import writemsg
 from portage.versions import cpv_getversion, vercmp
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 class slot_conflict_handler(object):
 	"""This class keeps track of all slot conflicts and provides
@@ -1125,7 +1123,7 @@ class _solution_candidate_generator(object):
 		def __init__(self, value=None):
 			self.value = value
 		def __eq__(self, other):
-			if isinstance(other, basestring):
+			if isinstance(other, str):
 				return self.value == other
 			else:
 				return self.value == other.value

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2019 Gentoo Authors
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 VERSION = "HEAD"
@@ -133,10 +133,6 @@ except ImportError as e:
 	sys.stderr.write("    "+str(e)+"\n\n")
 	raise
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-	long = int
 
 # We use utf_8 encoding everywhere. Previously, we used
 # sys.getfilesystemencoding() for the 'merge' encoding, but that had
@@ -476,7 +472,7 @@ def _eapi_is_deprecated(eapi):
 	return eapi in _deprecated_eapis
 
 def eapi_is_supported(eapi):
-	if not isinstance(eapi, basestring):
+	if not isinstance(eapi, str):
 		# Only call str() when necessary since with python2 it
 		# can trigger UnicodeEncodeError if EAPI is corrupt.
 		eapi = str(eapi)
@@ -617,10 +613,10 @@ if VERSION == 'HEAD':
 								head_timestamp = None
 								if len(output_lines) > 3:
 									try:
-										head_timestamp = long(output_lines[3])
+										head_timestamp = int(output_lines[3])
 									except ValueError:
 										pass
-								timestamp = long(time.time())
+								timestamp = int(time.time())
 								if head_timestamp is not None and timestamp > head_timestamp:
 									timestamp = timestamp - head_timestamp
 								if not patchlevel:

--- a/lib/portage/_emirrordist/MirrorDistTask.py
+++ b/lib/portage/_emirrordist/MirrorDistTask.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Gentoo Foundation
+# Copyright 2013-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -18,9 +18,6 @@ from _emerge.CompositeTask import CompositeTask
 from .FetchIterator import FetchIterator
 from .DeletionIterator import DeletionIterator
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 class MirrorDistTask(CompositeTask):
 
@@ -111,7 +108,7 @@ class MirrorDistTask(CompositeTask):
 				recycle_db[filename] = (st.st_size, start_time)
 			else:
 				r_size, r_time = value
-				if long(r_size) != st.st_size:
+				if int(r_size) != st.st_size:
 					recycle_db[filename] = (st.st_size, start_time)
 				elif r_time + r_deletion_delay < start_time:
 					if self._config.options.dry_run:

--- a/lib/portage/_emirrordist/main.py
+++ b/lib/portage/_emirrordist/main.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2015 Gentoo Foundation
+# Copyright 2013-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
@@ -14,9 +14,6 @@ from portage.util._eventloop.global_event_loop import global_event_loop
 from .Config import Config
 from .MirrorDistTask import MirrorDistTask
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 seconds_per_day = 24 * 60 * 60
 
@@ -318,7 +315,7 @@ def emirrordist_main(args):
 			parser.error("--scheduled-deletion-log requires --deletion-db")
 
 	if options.deletion_delay is not None:
-		options.deletion_delay = long(options.deletion_delay)
+		options.deletion_delay = int(options.deletion_delay)
 		if options.deletion_db is None:
 			parser.error("--deletion-delay requires --deletion-db")
 
@@ -391,7 +388,7 @@ def emirrordist_main(args):
 
 	if options.recycle_deletion_delay is not None:
 		options.recycle_deletion_delay = \
-			long(options.recycle_deletion_delay)
+			int(options.recycle_deletion_delay)
 
 	if options.fetch_log_dir is not None:
 		options.fetch_log_dir = normalize_path(

--- a/lib/portage/_sets/base.py
+++ b/lib/portage/_sets/base.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2018 Gentoo Foundation
+# Copyright 2007-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -6,9 +6,6 @@ from portage.dep import Atom, ExtendedAtomDict, best_match_to_list, match_from_l
 from portage.exception import InvalidAtom
 from portage.versions import cpv_getkey
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 OPERATIONS = ["merge", "unmerge"]
 
@@ -74,7 +71,7 @@ class PackageSet(object):
 		self._nonatoms.clear()
 		for a in atoms:
 			if not isinstance(a, Atom):
-				if isinstance(a, basestring):
+				if isinstance(a, str):
 					a = a.strip()
 				if not a:
 					continue

--- a/lib/portage/cache/flat_hash.py
+++ b/lib/portage/cache/flat_hash.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2019 Gentoo Authors
+# Copyright 2005-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # Author(s): Brian Harring (ferringb@gentoo.org)
 
@@ -16,9 +16,6 @@ from portage import _unicode_encode
 from portage.exception import InvalidData
 from portage.versions import _pkg_str
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 class database(fs_template.FsBased):
 

--- a/lib/portage/cache/fs_template.py
+++ b/lib/portage/cache/fs_template.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2014 Gentoo Foundation
+# Copyright 2005-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # Author(s): Brian Harring (ferringb@gentoo.org)
 
@@ -14,9 +14,6 @@ lazyimport(globals(),
 )
 del lazyimport
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 class FsBased(template.database):
 	"""template wrapping fs needed options, and providing _ensure_access as a way to 
@@ -44,7 +41,7 @@ class FsBased(template.database):
 		try:
 			apply_permissions(path, gid=self._gid, mode=self._perms)
 			if mtime != -1:
-				mtime=long(mtime)
+				mtime=int(mtime)
 				os.utime(path, (mtime, mtime))
 		except (PortageException, EnvironmentError):
 			return False

--- a/lib/portage/cache/index/pkg_desc_index.py
+++ b/lib/portage/cache/index/pkg_desc_index.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Gentoo Foundation
+# Copyright 2014-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
@@ -6,15 +6,11 @@ import sys
 
 from portage.versions import _pkg_str
 
-if sys.hexversion >= 0x3000000:
-	_unicode = str
-else:
-	_unicode = unicode
 
 pkg_desc_index_node = collections.namedtuple("pkg_desc_index_node",
 	["cp", "cpv_list", "desc"])
 
-class pkg_node(_unicode):
+class pkg_node(str):
 	"""
 	A minimal package node class. For performance reasons, inputs
 	are not validated.
@@ -27,7 +23,7 @@ class pkg_node(_unicode):
 		self.__dict__['build_time'] = None
 
 	def __new__(cls, cp, version, repo=None):
-		return _unicode.__new__(cls, cp + "-" + version)
+		return str.__new__(cls, cp + "-" + version)
 
 	def __setattr__(self, name, value):
 		raise AttributeError("pkg_node instances are immutable",

--- a/lib/portage/cache/metadata.py
+++ b/lib/portage/cache/metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2018 Gentoo Foundation
+# Copyright 2005-2020 Gentoo Authors
 # Author(s): Brian Harring (ferringb@gentoo.org)
 # License: GPL2
 
@@ -15,10 +15,6 @@ import portage.eclass_cache
 from portage.cache.template import reconstruct_eclasses
 from portage.cache.mappings import ProtectedDict
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-	long = int
 
 # this is the old cache format, flat_list.  count maintained here.
 magic_line_count = 22
@@ -76,7 +72,7 @@ class database(flat_hash.database):
 					raise cache_errors.CacheCorruption(cpv, e)
 			else:
 				d["_eclasses_"] = {}
-		elif isinstance(d["_eclasses_"], basestring):
+		elif isinstance(d["_eclasses_"], str):
 			# We skip this if flat_hash.database._parse_data() was called above
 			# because it calls reconstruct_eclasses() internally.
 			d["_eclasses_"] = reconstruct_eclasses(None, d["_eclasses_"])

--- a/lib/portage/cache/sqlite.py
+++ b/lib/portage/cache/sqlite.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from __future__ import division
@@ -12,9 +12,6 @@ from portage import _unicode_decode
 from portage.util import writemsg
 from portage.localization import _
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 class database(fs_template.FsBased):
 
@@ -64,7 +61,7 @@ class database(fs_template.FsBased):
 
 	def _db_escape_string(self, s):
 		"""meta escaping, returns quoted string for use in sql statements"""
-		if not isinstance(s, basestring):
+		if not isinstance(s, str):
 			# Avoid potential UnicodeEncodeError in python-2.x by
 			# only calling str() when it's absolutely necessary.
 			s = str(s)

--- a/lib/portage/cache/template.py
+++ b/lib/portage/cache/template.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2014 Gentoo Foundation
+# Copyright 2005-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # Author(s): Brian Harring (ferringb@gentoo.org)
 
@@ -9,13 +9,6 @@ import sys
 import warnings
 import operator
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	_unicode = str
-	basestring = str
-	long = int
-else:
-	_unicode = unicode
 
 class database(object):
 	# this is for metadata/cache transfer.
@@ -94,10 +87,10 @@ class database(object):
 			d.pop('_mtime_', None)
 		else:
 			try:
-				mtime = long(mtime)
+				mtime = int(mtime)
 			except ValueError:
 				raise cache_errors.CacheCorruption(cpv,
-					'_mtime_ conversion to long failed: %s' % (mtime,))
+					'_mtime_ conversion to int failed: %s' % (mtime,))
 			d['_mtime_'] = mtime
 		return d
 
@@ -278,7 +271,7 @@ class database(object):
 		for key,match in match_dict.items():
 			# XXX this sucks.
 			try:
-				if isinstance(match, basestring):
+				if isinstance(match, str):
 					restricts[key] = re.compile(match).match
 				else:
 					restricts[key] = re.compile(match[0],match[1]).match
@@ -306,7 +299,7 @@ _keysorter = operator.itemgetter(0)
 def serialize_eclasses(eclass_dict, chf_type='mtime', paths=True):
 	"""takes a dict, returns a string representing said dict"""
 	"""The "new format", which causes older versions of <portage-2.1.2 to
-	traceback with a ValueError due to failed long() conversion.  This format
+	traceback with a ValueError due to failed int() conversion.  This format
 	isn't currently written, but the the capability to read it is already built
 	in.
 	return "\t".join(["%s\t%s" % (k, str(v)) \
@@ -335,7 +328,7 @@ def _md5_deserializer(md5):
 
 _chf_deserializers = {
 	'md5': _md5_deserializer,
-	'mtime': long,
+	'mtime': int,
 }
 
 

--- a/lib/portage/cvstree.py
+++ b/lib/portage/cvstree.py
@@ -14,9 +14,6 @@ from portage import os
 from portage import _encodings
 from portage import _unicode_encode
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 # [D]/Name/Version/Date/Flags/Tags
 

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2019 Gentoo Authors
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ["bindbapi", "binarytree"]
@@ -57,13 +57,6 @@ try:
 except ImportError:
 	from urlparse import urlparse
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	_unicode = str
-	basestring = str
-	long = int
-else:
-	_unicode = unicode
 
 class UseCachedCopyOfRemoteIndex(Exception):
 	# If the local copy is recent enough
@@ -164,9 +157,9 @@ class bindbapi(fakedbapi):
 			metadata_bytes = portage.xpak.tbz2(tbz2_path).get_data()
 			def getitem(k):
 				if k == "_mtime_":
-					return _unicode(st[stat.ST_MTIME])
+					return str(st[stat.ST_MTIME])
 				elif k == "SIZE":
-					return _unicode(st.st_size)
+					return str(st.st_size)
 				v = metadata_bytes.get(_unicode_encode(k,
 					encoding=_encodings['repo.content'],
 					errors='backslashreplace'))
@@ -468,7 +461,7 @@ class binarytree(object):
 		# sanity check
 		for atom in (origcp, newcp):
 			if not isjustname(atom):
-				raise InvalidPackageName(_unicode(atom))
+				raise InvalidPackageName(str(atom))
 		mynewcat = catsplit(newcp)[0]
 		origmatches=self.dbapi.cp_list(origcp)
 		moves = 0
@@ -492,7 +485,7 @@ class binarytree(object):
 			if not isvalidatom(newcp, eapi=mycpv.eapi):
 				continue
 
-			mynewcpv = mycpv.replace(mycpv_cp, _unicode(newcp), 1)
+			mynewcpv = mycpv.replace(mycpv_cp, str(newcp), 1)
 			myoldpkg = catsplit(mycpv)[1]
 			mynewpkg = catsplit(mynewcpv)[1]
 
@@ -725,12 +718,12 @@ class binarytree(object):
 						match = None
 						for d in possibilities:
 							try:
-								if long(d["_mtime_"]) != s[stat.ST_MTIME]:
+								if int(d["_mtime_"]) != s[stat.ST_MTIME]:
 									continue
 							except (KeyError, ValueError):
 								continue
 							try:
-								if long(d["SIZE"]) != long(s.st_size):
+								if int(d["SIZE"]) != int(s.st_size):
 									continue
 							except (KeyError, ValueError):
 								continue
@@ -817,7 +810,7 @@ class binarytree(object):
 
 					if pkg_metadata.get("BUILD_ID"):
 						try:
-							build_id = long(pkg_metadata["BUILD_ID"])
+							build_id = int(pkg_metadata["BUILD_ID"])
 						except ValueError:
 							writemsg(_("!!! Binary package has "
 								"invalid BUILD_ID: '%s'\n") %
@@ -847,8 +840,8 @@ class binarytree(object):
 							noiselevel=-1)
 						continue
 					if build_id is not None:
-						pkg_metadata["BUILD_ID"] = _unicode(build_id)
-					pkg_metadata["SIZE"] = _unicode(s.st_size)
+						pkg_metadata["BUILD_ID"] = str(build_id)
+					pkg_metadata["SIZE"] = str(s.st_size)
 					# Discard items used only for validation above.
 					pkg_metadata.pop("CATEGORY")
 					pkg_metadata.pop("PF")
@@ -862,13 +855,13 @@ class binarytree(object):
 						pkgindex._pkg_slot_dict())
 					if d:
 						try:
-							if long(d["_mtime_"]) != s[stat.ST_MTIME]:
+							if int(d["_mtime_"]) != s[stat.ST_MTIME]:
 								d.clear()
 						except (KeyError, ValueError):
 							d.clear()
 					if d:
 						try:
-							if long(d["SIZE"]) != long(s.st_size):
+							if int(d["SIZE"]) != int(s.st_size):
 								d.clear()
 						except (KeyError, ValueError):
 							d.clear()
@@ -1094,12 +1087,12 @@ class binarytree(object):
 				writemsg(_("\n\n!!! Error fetching binhost package" \
 					" info from '%s'\n") % _hide_url_passwd(base_url))
 				# With Python 2, the EnvironmentError message may
-				# contain bytes or unicode, so use _unicode to ensure
+				# contain bytes or unicode, so use str to ensure
 				# safety with all locales (bug #532784).
 				try:
-					error_msg = _unicode(e)
+					error_msg = str(e)
 				except UnicodeDecodeError as uerror:
-					error_msg = _unicode(uerror.object,
+					error_msg = str(uerror.object,
 						encoding='utf_8', errors='replace')
 				writemsg("!!! %s\n\n" % error_msg)
 				del e
@@ -1242,7 +1235,7 @@ class binarytree(object):
 				# attributes, so that we can later distinguish that it
 				# is identical to its remote counterpart.
 				build_id = self._parse_build_id(basename)
-				metadata["BUILD_ID"] = _unicode(build_id)
+				metadata["BUILD_ID"] = str(build_id)
 				cpv = _pkg_str(cpv, metadata=metadata,
 					settings=self.settings, db=self.dbapi)
 				binpkg = portage.xpak.tbz2(full_path)
@@ -1294,9 +1287,9 @@ class binarytree(object):
 		binary_metadata = portage.xpak.tbz2(filename).get_data()
 		for k in keys:
 			if k == "_mtime_":
-				metadata[k] = _unicode(st[stat.ST_MTIME])
+				metadata[k] = str(st[stat.ST_MTIME])
 			elif k == "SIZE":
-				metadata[k] = _unicode(st.st_size)
+				metadata[k] = str(st.st_size)
 			else:
 				v = binary_metadata.get(_unicode_encode(k))
 				if v is None:
@@ -1354,7 +1347,7 @@ class binarytree(object):
 		contents = codecs.getwriter(_encodings['repo.content'])(io.BytesIO())
 		pkgindex.write(contents)
 		contents = contents.getvalue()
-		atime = mtime = long(pkgindex.header["TIMESTAMP"])
+		atime = mtime = int(pkgindex.header["TIMESTAMP"])
 		output_files = [(atomic_ofstream(self._pkgindex_file, mode="wb"),
 			self._pkgindex_file, None)]
 
@@ -1389,8 +1382,8 @@ class binarytree(object):
 
 		d["CPV"] = cpv
 		st = os.lstat(pkg_path)
-		d["_mtime_"] = _unicode(st[stat.ST_MTIME])
-		d["SIZE"] = _unicode(st.st_size)
+		d["_mtime_"] = str(st[stat.ST_MTIME])
+		d["SIZE"] = str(st.st_size)
 
 		rel_path = pkg_path[len(self.pkgdir)+1:]
 		# record location if it's non-default
@@ -1469,7 +1462,7 @@ class binarytree(object):
 		"""
 		if not (self.settings.profile_path and
 			"IUSE_IMPLICIT" in self.settings):
-			header.setdefault("VERSION", _unicode(self._pkgindex_version))
+			header.setdefault("VERSION", str(self._pkgindex_version))
 			return
 
 		portdir = normalize_path(os.path.realpath(self.settings["PORTDIR"]))
@@ -1480,7 +1473,7 @@ class binarytree(object):
 			if profile_path.startswith(profiles_base):
 				profile_path = profile_path[len(profiles_base):]
 			header["PROFILE"] = profile_path
-		header["VERSION"] = _unicode(self._pkgindex_version)
+		header["VERSION"] = str(self._pkgindex_version)
 		base_uri = self.settings.get("PORTAGE_BINHOST_HEADER_URI")
 		if base_uri:
 			header["URI"] = base_uri
@@ -1655,7 +1648,7 @@ class binarytree(object):
 		if hyphen != -1:
 			build_id = filename[hyphen+1:-suffixlen]
 		try:
-			build_id = long(build_id)
+			build_id = int(build_id)
 		except ValueError:
 			pass
 		return build_id

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -53,10 +53,6 @@ try:
 except ImportError:
 	from urlparse import urlparse
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-	long = int
 
 def close_portdbapi_caches():
 	# The python interpreter does _not_ guarantee that destructors are
@@ -997,7 +993,7 @@ class portdbapi(dbapi):
 		# stable sort by version produces results ordered by
 		# (pkg.version, repo.priority).
 		if mytree is not None:
-			if isinstance(mytree, basestring):
+			if isinstance(mytree, str):
 				repos = [self.repositories.get_repo_for_location(mytree)]
 			else:
 				# assume it's iterable

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -107,13 +107,6 @@ try:
 except ImportError:
 	import pickle
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
 
 class vardbapi(dbapi):
 
@@ -351,7 +344,7 @@ class vardbapi(dbapi):
 	def cpv_counter(self, mycpv):
 		"This method will grab the COUNTER. Returns a counter value."
 		try:
-			return long(self.aux_get(mycpv, ["COUNTER"])[0])
+			return int(self.aux_get(mycpv, ["COUNTER"])[0])
 		except (KeyError, ValueError):
 			pass
 		writemsg_level(_("portage: COUNTER for %s was corrupted; " \
@@ -404,7 +397,7 @@ class vardbapi(dbapi):
 			if not isvalidatom(newcp, eapi=mycpv.eapi):
 				continue
 
-			mynewcpv = mycpv.replace(mycpv_cp, _unicode(newcp), 1)
+			mynewcpv = mycpv.replace(mycpv_cp, str(newcp), 1)
 			mynewcat = catsplit(newcp)[0]
 			origpath = self.getpath(mycpv)
 			if not os.path.exists(origpath):
@@ -759,7 +752,7 @@ class vardbapi(dbapi):
 				pkg_data = None
 			else:
 				cache_mtime, metadata = pkg_data
-				if not isinstance(cache_mtime, (float, long, int)) or \
+				if not isinstance(cache_mtime, (float, int)) or \
 					not isinstance(metadata, dict):
 					pkg_data = None
 
@@ -771,7 +764,7 @@ class vardbapi(dbapi):
 
 				# Handle truncated mtime in order to avoid cache
 				# invalidation for livecd squashfs (bug 564222).
-				elif long(cache_mtime) == mydir_stat.st_mtime:
+				elif int(cache_mtime) == mydir_stat.st_mtime:
 					cache_valid = True
 			else:
 				# Cache may contain integer mtime.
@@ -796,7 +789,7 @@ class vardbapi(dbapi):
 					cache_data.update(metadata)
 				for aux_key in cache_these:
 					cache_data[aux_key] = mydata[aux_key]
-				self._aux_cache["packages"][_unicode(mycpv)] = \
+				self._aux_cache["packages"][str(mycpv)] = \
 					(mydir_mtime, cache_data)
 				self._aux_cache["modified"].add(mycpv)
 
@@ -1090,7 +1083,7 @@ class vardbapi(dbapi):
 				mode='r', encoding=_encodings['repo.content'],
 				errors='replace') as f:
 				try:
-					counter = long(f.readline().strip())
+					counter = int(f.readline().strip())
 				except (OverflowError, ValueError) as e:
 					writemsg(_("!!! COUNTER file is corrupt: '%s'\n") %
 						self._counter_path, noiselevel=-1)
@@ -1249,7 +1242,7 @@ class vardbapi(dbapi):
 		if new_needed is not None:
 			f = atomic_ofstream(os.path.join(pkg.dbdir, LinkageMap._needed_aux_key))
 			for entry in new_needed:
-				f.write(_unicode(entry))
+				f.write(str(entry))
 			f.close()
 		f = atomic_ofstream(os.path.join(pkg.dbdir, "CONTENTS"))
 		write_contents(new_contents, root, f)
@@ -1321,7 +1314,7 @@ class vardbapi(dbapi):
 				counter = int(counter)
 			except ValueError:
 				counter = 0
-			return (_unicode(cpv), counter, mtime)
+			return (str(cpv), counter, mtime)
 
 	class _owners_db(object):
 
@@ -1450,7 +1443,7 @@ class vardbapi(dbapi):
 								len(hash_value) != 3:
 								continue
 							cpv, counter, mtime = hash_value
-							if not isinstance(cpv, basestring):
+							if not isinstance(cpv, str):
 								continue
 							try:
 								current_hash = hash_pkg(cpv)
@@ -3890,7 +3883,7 @@ class dblink(object):
 			for phase, messages in logentries.items():
 				for key, lines in messages:
 					funcname = funcnames[key]
-					if isinstance(lines, basestring):
+					if isinstance(lines, str):
 						lines = [lines]
 					for line in lines:
 						for line in line.split('\n'):
@@ -4908,7 +4901,7 @@ class dblink(object):
 			self._installed_instance is not None
 
 		# this is supposed to merge a list of files.  There will be 2 forms of argument passing.
-		if isinstance(stufftomerge, basestring):
+		if isinstance(stufftomerge, str):
 			#A directory is specified.  Figure out protection paths, listdir() it and process it.
 			mergelist = [join(stufftomerge, child) for child in \
 				os.listdir(join(srcroot, stufftomerge))]
@@ -5447,7 +5440,7 @@ class dblink(object):
 
 	def setfile(self,fname,data):
 		kwargs = {}
-		if fname == 'environment.bz2' or not isinstance(data, basestring):
+		if fname == 'environment.bz2' or not isinstance(data, str):
 			kwargs['mode'] = 'wb'
 		else:
 			kwargs['mode'] = 'w'
@@ -5504,7 +5497,7 @@ class dblink(object):
 
 		build_time = backup_dblink.getfile('BUILD_TIME')
 		try:
-			build_time = long(build_time.strip())
+			build_time = int(build_time.strip())
 		except ValueError:
 			build_time = 0
 

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -30,12 +30,6 @@ from portage.versions import _cp, _cpv, _pkg_str, _slot, _unknown_repo, _vr, \
 	catpkgsplit, vercmp, ververify
 import portage.cache.mappings
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-	_unicode = str
-else:
-	_unicode = unicode
 
 # \w is [a-zA-Z0-9_]
 
@@ -352,7 +346,7 @@ class paren_normalize(list):
 			return dest
 		i = iter(src)
 		for x in i:
-			if isinstance(x, basestring):
+			if isinstance(x, str):
 				if x in ('||', '^^'):
 					y = self._zap_parens(next(i), [], disjunction=True)
 					if len(y) == 1:
@@ -557,13 +551,12 @@ def _use_reduce_cached(depstr, uselist, masklist, matchall, excludeall, \
 						stack[level].extend(l)
 					continue
 
-				if stack[level] and isinstance(stack[level][-1],
-					basestring):
+				if stack[level] and isinstance(stack[level][-1], str):
 					if stack[level][-1] == "||" and not l:
 						#Optimize: || ( ) -> .
 						if not eapi_attrs.empty_groups_always_true:
 							# in EAPI 7+, we need to fail here
-							l.append((token_class or _unicode)("__const__/empty-any-of"))
+							l.append((token_class or str)("__const__/empty-any-of"))
 						stack[level].pop()
 					elif stack[level][-1][-1] == "?":
 						#The last token before the '(' that matches the current ')'
@@ -586,8 +579,7 @@ def _use_reduce_cached(depstr, uselist, masklist, matchall, excludeall, \
 					#ends in a non-operator. This is almost equivalent to stack[level][-1]=="||",
 					#expect that it skips empty levels.
 					while k>=0:
-						if stack[k] and isinstance(stack[k][-1],
-							basestring):
+						if stack[k] and isinstance(stack[k][-1], str):
 							if stack[k][-1] == "||":
 								return k
 							elif stack[k][-1][-1] != "?":
@@ -1228,7 +1220,7 @@ class _use_dep(object):
 		return _use_dep(tokens, self._eapi_attrs, enabled_flags=enabled_flags, disabled_flags=disabled_flags,
 			missing_enabled=missing_enabled, missing_disabled=missing_disabled, required=self.required)
 
-class Atom(_unicode):
+class Atom(str):
 
 	"""
 	For compatibility with existing atom string manipulation code, this
@@ -1255,7 +1247,7 @@ class Atom(_unicode):
 
 	def __new__(cls, s, unevaluated_atom=None, allow_wildcard=False, allow_repo=None,
 		_use=None, eapi=None, is_valid_flag=None, allow_build_id=None):
-		return _unicode.__new__(cls, s)
+		return str.__new__(cls, s)
 
 	def __init__(self, s, unevaluated_atom=None, allow_wildcard=False, allow_repo=None,
 		_use=None, eapi=None, is_valid_flag=None, allow_build_id=None):
@@ -1263,13 +1255,13 @@ class Atom(_unicode):
 			# This is an efficiency assertion, to ensure that the Atom
 			# constructor is not called redundantly.
 			raise TypeError(_("Expected %s, got %s") % \
-				(_unicode, type(s)))
+				(str, type(s)))
 
-		if not isinstance(s, _unicode):
-			# Avoid TypeError from _unicode.__init__ with PyPy.
+		if not isinstance(s, str):
+			# Avoid TypeError from str.__init__ with PyPy.
 			s = _unicode_decode(s)
 
-		_unicode.__init__(s)
+		str.__init__(s)
 
 		eapi_attrs = _get_eapi_attrs(eapi)
 		atom_re = _get_atom_re(eapi_attrs)
@@ -1436,7 +1428,7 @@ class Atom(_unicode):
 				unevaluated_atom.use is not None:
 				# unevaluated_atom.use is used for IUSE checks when matching
 				# packages, so it must not propagate to without_use
-				without_use = Atom(_unicode(self),
+				without_use = Atom(str(self),
 					allow_wildcard=allow_wildcard,
 					allow_repo=allow_repo,
 					eapi=eapi)
@@ -1452,9 +1444,9 @@ class Atom(_unicode):
 			self.__dict__['unevaluated_atom'] = self
 
 		if eapi is not None:
-			if not isinstance(eapi, basestring):
+			if not isinstance(eapi, str):
 				raise TypeError('expected eapi argument of ' + \
-					'%s, got %s: %s' % (basestring, type(eapi), eapi,))
+					'%s, got %s: %s' % (str, type(eapi), eapi,))
 			if self.slot and not eapi_attrs.slot_deps:
 				raise InvalidAtom(
 					_("Slot deps are not allowed in EAPI %s: '%s'") \
@@ -1516,7 +1508,7 @@ class Atom(_unicode):
 		if self.repo is not None:
 			atom += _repo_separator + self.repo
 		if self.use is not None:
-			atom += _unicode(self.use)
+			atom += str(self.use)
 		return Atom(atom,
 			allow_repo=True, allow_wildcard=True)
 
@@ -1532,7 +1524,7 @@ class Atom(_unicode):
 				atom += self.slot_operator
 		atom += _repo_separator + repo
 		if self.use is not None:
-			atom += _unicode(self.use)
+			atom += str(self.use)
 		return Atom(atom, allow_repo=True, allow_wildcard=True)
 
 	def with_slot(self, slot):
@@ -1540,7 +1532,7 @@ class Atom(_unicode):
 		if self.repo is not None:
 			atom += _repo_separator + self.repo
 		if self.use is not None:
-			atom += _unicode(self.use)
+			atom += str(self.use)
 		return Atom(atom, allow_repo=True, allow_wildcard=True)
 
 	def __setattr__(self, name, value):
@@ -1598,7 +1590,7 @@ class Atom(_unicode):
 			if self.slot_operator is not None:
 				atom += self.slot_operator
 		use_dep = self.use.evaluate_conditionals(use)
-		atom += _unicode(use_dep)
+		atom += str(use_dep)
 		return Atom(atom, unevaluated_atom=self, allow_repo=(self.repo is not None), _use=use_dep)
 
 	def violated_conditionals(self, other_use, is_valid_flag, parent_use=None):
@@ -1626,7 +1618,7 @@ class Atom(_unicode):
 			if self.slot_operator is not None:
 				atom += self.slot_operator
 		use_dep = self.use.violated_conditionals(other_use, is_valid_flag, parent_use)
-		atom += _unicode(use_dep)
+		atom += str(use_dep)
 		return Atom(atom, unevaluated_atom=self, allow_repo=(self.repo is not None), _use=use_dep)
 
 	def _eval_qa_conditionals(self, use_mask, use_force):
@@ -1642,7 +1634,7 @@ class Atom(_unicode):
 			if self.slot_operator is not None:
 				atom += self.slot_operator
 		use_dep = self.use._eval_qa_conditionals(use_mask, use_force)
-		atom += _unicode(use_dep)
+		atom += str(use_dep)
 		return Atom(atom, unevaluated_atom=self, allow_repo=(self.repo is not None), _use=use_dep)
 
 	def __copy__(self):
@@ -1738,7 +1730,7 @@ class ExtendedAtomDict(portage.cache.mappings.MutableMapping):
 
 	def __getitem__(self, cp):
 
-		if not isinstance(cp, basestring):
+		if not isinstance(cp, str):
 			raise KeyError(cp)
 
 		if '*' in cp:
@@ -1980,7 +1972,7 @@ def isvalidatom(atom, allow_blockers=False, allow_wildcard=False,
 
 	if eapi is not None and isinstance(atom, Atom) and atom.eapi != eapi:
 		# We'll construct a new atom with the given eapi.
-		atom = _unicode(atom)
+		atom = str(atom)
 
 	try:
 		if not isinstance(atom, Atom):

--- a/lib/portage/eclass_cache.py
+++ b/lib/portage/eclass_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2014 Gentoo Foundation
+# Copyright 2005-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # Author(s): Nicholas Carpaski (carpaski@gentoo.org), Brian Harring (ferringb@gentoo.org)
 
@@ -15,10 +15,6 @@ from portage import os
 from portage import checksum
 from portage import _shell_quote
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
-
 
 class hashed_path(object):
 
@@ -28,11 +24,11 @@ class hashed_path(object):
 	def __getattr__(self, attr):
 		if attr == 'mtime':
 			# use stat.ST_MTIME; accessing .st_mtime gets you a float
-			# depending on the python version, and long(float) introduces
+			# depending on the python version, and int(float) introduces
 			# some rounding issues that aren't present for people using
 			# the straight c api.
 			# thus use the defacto python compatibility work around;
-			# access via index, which guarantees you get the raw long.
+			# access via index, which guarantees you get the raw int.
 			try:
 				self.mtime = obj = os.stat(self.location)[stat.ST_MTIME]
 			except OSError as e:

--- a/lib/portage/elog/__init__.py
+++ b/lib/portage/elog/__init__.py
@@ -3,9 +3,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 import portage
 portage.proxy.lazyimport.lazyimport(globals(),
@@ -58,7 +55,7 @@ def _combine_logentries(logentries):
 			if previous_type != msgtype:
 				previous_type = msgtype
 				rValue.append("%s: %s" % (msgtype, phase))
-			if isinstance(msgcontent, basestring):
+			if isinstance(msgcontent, str):
 				rValue.append(msgcontent.rstrip("\n"))
 			else:
 				for line in msgcontent:

--- a/lib/portage/elog/mod_echo.py
+++ b/lib/portage/elog/mod_echo.py
@@ -9,9 +9,6 @@ from portage.output import EOutput, colorize
 from portage.const import EBUILD_PHASES
 from portage.localization import _
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 _items = []
 def process(mysettings, key, logentries, fulltext):
@@ -61,7 +58,7 @@ def _finalize():
 						"ERROR": printer.eerror,
 						"LOG": printer.einfo,
 						"QA": printer.ewarn}
-				if isinstance(msgcontent, basestring):
+				if isinstance(msgcontent, str):
 					msgcontent = [msgcontent]
 				for line in msgcontent:
 					fmap[msgtype](line.strip("\n"))

--- a/lib/portage/elog/mod_syslog.py
+++ b/lib/portage/elog/mod_syslog.py
@@ -7,9 +7,6 @@ import syslog
 from portage.const import EBUILD_PHASES
 from portage import _encodings
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 _pri = {
 	"INFO"   : syslog.LOG_INFO,
@@ -25,7 +22,7 @@ def process(mysettings, key, logentries, fulltext):
 		if not phase in logentries:
 			continue
 		for msgtype, msgcontent in logentries[phase]:
-			if isinstance(msgcontent, basestring):
+			if isinstance(msgcontent, str):
 				msgcontent = [msgcontent]
 			for line in msgcontent:
 				line = "%s: %s: %s" % (key, phase, line)

--- a/lib/portage/emaint/modules/binhost/binhost.py
+++ b/lib/portage/emaint/modules/binhost/binhost.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2014 Gentoo Foundation
+# Copyright 2005-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -11,9 +11,6 @@ from portage.versions import _pkg_str
 
 import sys
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 class BinhostHandler(object):
 
@@ -54,9 +51,9 @@ class BinhostHandler(object):
 			return False
 
 		try:
-			if long(mtime) != s[stat.ST_MTIME]:
+			if int(mtime) != s[stat.ST_MTIME]:
 				return True
-			if long(size) != long(s.st_size):
+			if int(size) != int(s.st_size):
 				return True
 		except ValueError:
 			return True

--- a/lib/portage/emaint/modules/sync/sync.py
+++ b/lib/portage/emaint/modules/sync/sync.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 Gentoo Authors
+# Copyright 2014-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
@@ -31,11 +31,6 @@ portage.proxy.lazyimport.lazyimport(globals(),
 )
 
 warn = create_color_func("WARN")
-
-if sys.hexversion >= 0x3000000:
-	_basestring = str
-else:
-	_basestring = basestring
 
 
 class SyncRepos(object):
@@ -125,7 +120,7 @@ class SyncRepos(object):
 			return_messages = options.get('return-messages', False)
 		else:
 			return_messages = False
-		if isinstance(repo_names, _basestring):
+		if isinstance(repo_names, str):
 			repo_names = repo_names.split()
 		success, repos, msgs = self._get_repos(auto_sync_only=False,
 			match_repos=repo_names)

--- a/lib/portage/exception.py
+++ b/lib/portage/exception.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2019 Gentoo Authors
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import signal
@@ -6,9 +6,6 @@ import sys
 from portage import _encodings, _unicode_encode, _unicode_decode
 from portage.localization import _
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 class PortageException(Exception):
 	"""General superclass for portage exceptions"""
@@ -24,7 +21,7 @@ class PortageException(Exception):
 	else:
 		def __init__(self, value):
 			self.value = value[:]
-			if isinstance(self.value, basestring):
+			if isinstance(self.value, str):
 				self.value = _unicode_decode(self.value,
 					encoding=_encodings['content'], errors='replace')
 
@@ -180,7 +177,7 @@ class UnsupportedAPIException(PortagePackageException):
 		self.cpv, self.eapi = cpv, eapi
 	def __str__(self):
 		eapi = self.eapi
-		if not isinstance(eapi, basestring):
+		if not isinstance(eapi, str):
 			eapi = str(eapi)
 		eapi = eapi.lstrip("-")
 		msg = _("Unable to do any operations on '%(cpv)s', since "

--- a/lib/portage/getbinpkg.py
+++ b/lib/portage/getbinpkg.py
@@ -62,9 +62,6 @@ else:
 
 _all_errors = tuple(_all_errors)
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 def make_metadata_dict(data):
 
@@ -908,7 +905,7 @@ class PackageIndex(object):
 
 	def write(self, pkgfile):
 		if self.modified:
-			self.header["TIMESTAMP"] = str(long(time.time()))
+			self.header["TIMESTAMP"] = str(int(time.time()))
 			self.header["PACKAGES"] = str(len(self.packages))
 		keys = list(self.header)
 		keys.sort()

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -23,9 +23,6 @@ from portage.util import writemsg
 from portage.util.install_mask import _raise_exc
 from portage.localization import _
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 HARDLINK_FD = -2
 _HARDLINK_POLL_LATENCY = 3 # seconds
@@ -167,7 +164,7 @@ def _lockfile_iteration(mypath, wantnewlockfile=False, unlinkfile=False,
 	# deprecated due to ambiguity in whether or not it's safe to close
 	# the file descriptor, making it prone to "Bad file descriptor" errors
 	# or file descriptor leaks.
-	if isinstance(mypath, basestring) and mypath[-1] == '/':
+	if isinstance(mypath, str) and mypath[-1] == '/':
 		mypath = mypath[:-1]
 
 	lockfilename_path = mypath
@@ -192,7 +189,7 @@ def _lockfile_iteration(mypath, wantnewlockfile=False, unlinkfile=False,
 	else:
 		lockfilename = mypath
 
-	if isinstance(mypath, basestring):
+	if isinstance(mypath, str):
 		if not os.path.exists(os.path.dirname(mypath)):
 			raise DirectoryNotFound(os.path.dirname(mypath))
 		preexisting = os.path.exists(lockfilename)
@@ -306,7 +303,7 @@ def _lockfile_iteration(mypath, wantnewlockfile=False, unlinkfile=False,
 				os.close(myfd)
 			lockfilename_path = _unicode_decode(lockfilename_path,
 				encoding=_encodings['fs'], errors='strict')
-			if not isinstance(lockfilename_path, basestring):
+			if not isinstance(lockfilename_path, str):
 				raise
 			link_success = hardlink_lockfile(lockfilename_path,
 				waiting_msg=waiting_msg, flags=flags)
@@ -319,7 +316,7 @@ def _lockfile_iteration(mypath, wantnewlockfile=False, unlinkfile=False,
 			raise
 
 	fstat_result = None
-	if isinstance(lockfilename, basestring) and myfd != HARDLINK_FD and unlinkfile:
+	if isinstance(lockfilename, str) and myfd != HARDLINK_FD and unlinkfile:
 		try:
 			(removed, fstat_result) = _lockfile_was_removed(myfd, lockfilename)
 		except Exception:
@@ -461,7 +458,7 @@ def unlockfile(mytuple):
 		return True
 	
 	# myfd may be None here due to myfd = mypath in lockfile()
-	if isinstance(lockfilename, basestring) and \
+	if isinstance(lockfilename, str) and \
 		not os.path.exists(lockfilename):
 		writemsg(_("lockfile does not exist '%s'\n") % lockfilename, 1)
 		if myfd is not None:
@@ -474,7 +471,7 @@ def unlockfile(mytuple):
 			unlinkfile = 1
 		locking_method(myfd, fcntl.LOCK_UN)
 	except OSError:
-		if isinstance(lockfilename, basestring):
+		if isinstance(lockfilename, str):
 			_open_fds[myfd].close()
 		raise IOError(_("Failed to unlock file '%s'\n") % lockfilename)
 
@@ -507,7 +504,7 @@ def unlockfile(mytuple):
 	# why test lockfilename?  because we may have been handed an
 	# fd originally, and the caller might not like having their
 	# open fd closed automatically on them.
-	if isinstance(lockfilename, basestring):
+	if isinstance(lockfilename, str):
 		_open_fds[myfd].close()
 
 	return True

--- a/lib/portage/mail.py
+++ b/lib/portage/mail.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2014 Gentoo Foundation
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Since python ebuilds remove the 'email' module when USE=build
@@ -20,9 +20,6 @@ from portage.localization import _
 import portage
 
 if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-
 	def _force_ascii_if_necessary(s):
 		# Force ascii encoding in order to avoid UnicodeEncodeError
 		# from smtplib.sendmail with python3 (bug #291331).
@@ -68,7 +65,7 @@ def create_message(sender, recipient, subject, body, attachments=None):
 		for x in attachments:
 			if isinstance(x, BaseMessage):
 				mymessage.attach(x)
-			elif isinstance(x, basestring):
+			elif isinstance(x, str):
 				if sys.hexversion < 0x3000000:
 					x = _unicode_encode(x,
 						encoding=_encodings['content'],

--- a/lib/portage/manifest.py
+++ b/lib/portage/manifest.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -31,12 +31,6 @@ _manifest_re = re.compile(
 	r'^(' + '|'.join(MANIFEST2_IDENTIFIERS) + r') (\S+)( \d+( \S+ \S+)+)$',
 	re.UNICODE)
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	_unicode = str
-	basestring = str
-else:
-	_unicode = unicode
 
 class FileNotInManifestException(PortageException):
 	pass
@@ -74,7 +68,7 @@ def guessThinManifestFileType(filename):
 	return "DIST"
 
 def parseManifest2(line):
-	if not isinstance(line, basestring):
+	if not isinstance(line, str):
 		line = ' '.join(line)
 	myentry = None
 	match = _manifest_re.match(line)
@@ -319,7 +313,7 @@ class Manifest(object):
 					# thin manifests with no DIST entries, myentries is
 					# non-empty for all currently known use cases.
 					write_atomic(self.getFullname(), "".join("%s\n" %
-						_unicode(myentry) for myentry in myentries))
+						str(myentry) for myentry in myentries))
 					self._apply_max_mtime(preserved_stats, myentries)
 					rval = True
 				else:

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2019 Gentoo Authors
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = [
@@ -66,9 +66,6 @@ from portage.package.ebuild._config.VirtualsManager import VirtualsManager
 from portage.package.ebuild._config.helper import ordered_by_atom_specificity, prune_incremental
 from portage.package.ebuild._config.unpack_dependencies import load_unpack_dependencies_configuration
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 _feature_flags_cache = {}
 
@@ -1448,7 +1445,7 @@ class config(object):
 		pkg = None
 		built_use = None
 		explicit_iuse = None
-		if not isinstance(mycpv, basestring):
+		if not isinstance(mycpv, str):
 			pkg = mycpv
 			mycpv = pkg.cpv
 			mydb = pkg._metadata
@@ -2733,7 +2730,7 @@ class config(object):
 
 	def __setitem__(self,mykey,myvalue):
 		"set a value; will be thrown away at reset() time"
-		if not isinstance(myvalue, basestring):
+		if not isinstance(myvalue, str):
 			raise ValueError("Invalid type being used as a value: '%s': '%s'" % (str(mykey),str(myvalue)))
 
 		# Avoid potential UnicodeDecodeError exceptions later.
@@ -2766,7 +2763,7 @@ class config(object):
 		for x, myvalue in self.iteritems():
 			if x in environ_filter:
 				continue
-			if not isinstance(myvalue, basestring):
+			if not isinstance(myvalue, str):
 				writemsg(_("!!! Non-string value in config: %s=%s\n") % \
 					(x, myvalue), noiselevel=-1)
 				continue

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -92,10 +92,6 @@ from _emerge.EbuildSpawnProcess import EbuildSpawnProcess
 from _emerge.Package import Package
 from _emerge.RootConfig import RootConfig
 
-if sys.hexversion >= 0x3000000:
-	_unicode = str
-else:
-	_unicode = unicode
 
 _unsandboxed_phases = frozenset([
 	"clean", "cleanrm", "config",
@@ -2397,7 +2393,7 @@ def _post_src_install_soname_symlinks(mysettings, out):
 
 		# Compute the multilib category and write it back to the file.
 		entry.multilib_category = compute_multilib_category(elf_header)
-		needed_file.write(_unicode(entry))
+		needed_file.write(str(entry))
 
 		if entry.multilib_category is None:
 			if not qa_prebuilt or qa_prebuilt.match(
@@ -2448,7 +2444,7 @@ def _post_src_install_soname_symlinks(mysettings, out):
 	if unrecognized_elf_files:
 		qa_msg = ["QA Notice: Unrecognized ELF file(s):"]
 		qa_msg.append("")
-		qa_msg.extend("\t%s" % _unicode(entry).rstrip()
+		qa_msg.extend("\t%s" % str(entry).rstrip()
 			for entry in unrecognized_elf_files)
 		qa_msg.append("")
 		for line in qa_msg:

--- a/lib/portage/package/ebuild/getmaskingstatus.py
+++ b/lib/portage/package/ebuild/getmaskingstatus.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2014 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ['getmaskingstatus']
@@ -12,9 +12,6 @@ from portage.localization import _
 from portage.package.ebuild.config import config
 from portage.versions import catpkgsplit, _pkg_str
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 class _UnmaskHint(object):
 
@@ -46,7 +43,7 @@ def _getmaskingstatus(mycpv, settings, portdb, myrepo=None):
 
 	metadata = None
 	installed = False
-	if not isinstance(mycpv, basestring):
+	if not isinstance(mycpv, str):
 		# emerge passed in a Package instance
 		pkg = mycpv
 		mycpv = pkg.cpv

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -40,9 +40,6 @@ try:
 except ImportError:
 	max_fd_limit = 256
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 # Support PEP 446 for Python >=3.4
 try:
@@ -287,7 +284,7 @@ def spawn(mycommand, env=None, opt_name=None, fd_pipes=None, returnpid=False,
 	"""
 
 	# mycommand is either a str or a list
-	if isinstance(mycommand, basestring):
+	if isinstance(mycommand, str):
 		mycommand = mycommand.split()
 
 	env = os.environ if env is None else env

--- a/lib/portage/proxy/lazyimport.py
+++ b/lib/portage/proxy/lazyimport.py
@@ -1,4 +1,4 @@
-# Copyright 2009-2014 Gentoo Foundation
+# Copyright 2009-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ['lazyimport']
@@ -13,9 +13,6 @@ except ImportError:
 
 from portage.proxy.objectproxy import ObjectProxy
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 _module_proxies = {}
 _module_proxies_lock = threading.RLock()
@@ -169,7 +166,7 @@ def lazyimport(scope, *args):
 		if len(parts) == 1:
 			name = s
 
-			if not name or not isinstance(name, basestring):
+			if not name or not isinstance(name, str):
 				raise ValueError(name)
 
 			components = name.split('.')

--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -26,9 +26,6 @@ from portage import _encodings
 from portage import manifest
 import portage.sync
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 # Characters prohibited by repoman's file.name check.
 _invalid_path_char_re = re.compile(r'[^a-zA-Z0-9._\-+/]')
@@ -669,7 +666,7 @@ class RepoConfigLoader(object):
 
 		recursive_paths = []
 		for p in paths:
-			if isinstance(p, basestring):
+			if isinstance(p, str):
 				recursive_paths.extend(_recursive_file_list(p))
 			else:
 				recursive_paths.append(p)

--- a/lib/portage/sync/getaddrinfo_validate.py
+++ b/lib/portage/sync/getaddrinfo_validate.py
@@ -1,10 +1,8 @@
-# Copyright 2010 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 def getaddrinfo_validate(addrinfos):
 	"""
@@ -19,7 +17,7 @@ def getaddrinfo_validate(addrinfos):
 				continue
 			if len(addrinfo[4]) < 2:
 				continue
-			if not isinstance(addrinfo[4][0], basestring):
+			if not isinstance(addrinfo[4][0], str):
 				continue
 		except TypeError:
 			continue

--- a/lib/portage/sync/modules/rsync/rsync.py
+++ b/lib/portage/sync/modules/rsync/rsync.py
@@ -36,11 +36,6 @@ try:
 except ImportError:
 	gemato = None
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	_unicode = str
-else:
-	_unicode = unicode
 
 SERVER_OUT_OF_DATE = -1
 EXCEEDED_MAX_RETRIES = -2
@@ -243,7 +238,7 @@ class RsyncSync(NewBase):
 			except socket.error as e:
 				writemsg_level(
 					"!!! getaddrinfo failed for '%s': %s\n"
-					% (_unicode_decode(hostname), _unicode(e)),
+					% (_unicode_decode(hostname), str(e)),
 					noiselevel=-1, level=logging.ERROR)
 
 			if addrinfos:

--- a/lib/portage/tests/dep/test_match_from_list.py
+++ b/lib/portage/tests/dep/test_match_from_list.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2014 Gentoo Foundation
+# Copyright 2006-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -6,9 +6,6 @@ from portage.tests import TestCase
 from portage.dep import Atom, match_from_list, _repo_separator
 from portage.versions import catpkgsplit, _pkg_str
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 class Package(object):
 	"""
@@ -43,7 +40,7 @@ class Package(object):
 			self.all = frozenset(iuse)
 
 		def is_valid_flag(self, flags):
-			if isinstance(flags, basestring):
+			if isinstance(flags, str):
 				flags = [flags]
 			for flag in flags:
 				if not flag in self.all:

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -34,9 +34,6 @@ try:
 except ImportError:
 	cnf_path_repoman = None
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 class ResolverPlayground(object):
 	"""
@@ -411,7 +408,7 @@ class ResolverPlayground(object):
 
 			for eclass_name, eclass_content in eclasses.items():
 				with open(os.path.join(eclass_dir, "{}.eclass".format(eclass_name)), 'wt') as f:
-					if isinstance(eclass_content, basestring):
+					if isinstance(eclass_content, str):
 						eclass_content = [eclass_content]
 					for line in eclass_content:
 						f.write("{}\n".format(line))
@@ -695,7 +692,7 @@ class ResolverPlaygroundTestCase(object):
 					if expected:
 						new_expected = []
 						for obj in expected:
-							if isinstance(obj, basestring):
+							if isinstance(obj, str):
 								if obj[:1] == "!":
 									new_expected.append(obj)
 									continue
@@ -720,7 +717,7 @@ class ResolverPlaygroundTestCase(object):
 					while got_stack and expected_stack:
 						got_token = got_stack.pop()
 						expected_obj = expected_stack.pop()
-						if isinstance(expected_obj, basestring):
+						if isinstance(expected_obj, str):
 							new_expected.append(expected_obj)
 							if got_token == expected_obj:
 								continue

--- a/lib/portage/tests/unicode/test_string_format.py
+++ b/lib/portage/tests/unicode/test_string_format.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2014 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -9,9 +9,6 @@ from portage.tests import TestCase
 from _emerge.DependencyArg import DependencyArg
 from _emerge.UseFlagDisplay import UseFlagDisplay
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 STR_IS_UNICODE = sys.hexversion >= 0x3000000
 
@@ -91,7 +88,7 @@ class StringFormatTestCase(TestCase):
 					# Use unicode_literals for unicode format string so that
 					# __unicode__() is called in Python 2.
 					formatted_str = "%s" % (e,)
-					self.assertEqual(isinstance(formatted_str, basestring), True)
+					self.assertEqual(isinstance(formatted_str, str), True)
 
 					if STR_IS_UNICODE:
 

--- a/lib/portage/update.py
+++ b/lib/portage/update.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -25,12 +25,6 @@ from portage.eapi import _get_eapi_attrs
 from portage.exception import DirectoryNotFound, InvalidAtom, PortageException
 from portage.localization import _
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
-	_unicode = str
-else:
-	_unicode = unicode
 
 ignored_dbentries = ("CONTENTS", "environment.bz2")
 
@@ -40,8 +34,8 @@ def update_dbentry(update_cmd, mycontent, eapi=None, parent=None):
 		eapi = parent.eapi
 
 	if update_cmd[0] == "move":
-		old_value = _unicode(update_cmd[1])
-		new_value = _unicode(update_cmd[2])
+		old_value = str(update_cmd[1])
+		new_value = str(update_cmd[2])
 
 		# Use isvalidatom() to check if this move is valid for the
 		# EAPI (characters allowed in package names may vary).
@@ -68,7 +62,7 @@ def update_dbentry(update_cmd, mycontent, eapi=None, parent=None):
 					match_from_list(new_atom, [parent]):
 					continue
 
-				split_content[i] = _unicode(new_atom)
+				split_content[i] = str(new_atom)
 				modified = True
 
 			if modified:
@@ -195,7 +189,7 @@ def grab_updates(updpath, prev_mtimes=None):
 		mystat = os.stat(file_path)
 		if update_data or \
 			file_path not in prev_mtimes or \
-			long(prev_mtimes[file_path]) != mystat[stat.ST_MTIME]:
+			int(prev_mtimes[file_path]) != mystat[stat.ST_MTIME]:
 			f = io.open(_unicode_encode(file_path,
 				encoding=_encodings['fs'], errors='strict'),
 				mode='r', encoding=_encodings['repo.content'], errors='replace')

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2004-2017 Gentoo Foundation
+# Copyright 2004-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ['apply_permissions', 'apply_recursive_permissions',
@@ -47,10 +47,6 @@ from portage.localization import _
 from portage.proxy.objectproxy import ObjectProxy
 from portage.cache.mappings import UserDict
 
-if sys.hexversion >= 0x3000000:
-	_unicode = str
-else:
-	_unicode = unicode
 
 noiselimit = 0
 
@@ -503,7 +499,7 @@ def grabfile_package(myfilename, compatlevel=0, recursive=0,
 			writemsg(_("--- Invalid atom in %s: %s\n") % (source_file, e),
 				noiselevel=-1)
 		else:
-			if pkg_orig == _unicode(pkg):
+			if pkg_orig == str(pkg):
 				# normal atom, so return as Atom instance
 				if remember_source_file:
 					atoms.append((pkg, source_file))

--- a/lib/portage/util/_dyn_libs/LinkageMapELF.py
+++ b/lib/portage/util/_dyn_libs/LinkageMapELF.py
@@ -27,10 +27,6 @@ from portage.util import writemsg_level
 from portage.util._dyn_libs.NeededEntry import NeededEntry
 from portage.util.elf.header import ELFHeader
 
-if sys.hexversion >= 0x3000000:
-	_unicode = str
-else:
-	_unicode = unicode
 
 # Map ELF e_machine values from NEEDED.ELF.2 to approximate multilib
 # categories. This approximation will produce incorrect results on x32
@@ -333,7 +329,7 @@ class LinkageMapELF(object):
 					entry.multilib_category = compute_multilib_category(elf_header)
 					entry.filename = entry.filename[root_len:]
 					owner = plibs.pop(entry.filename, None)
-					lines.append((owner, "scanelf", _unicode(entry)))
+					lines.append((owner, "scanelf", str(entry)))
 				proc.wait()
 				proc.stdout.close()
 

--- a/lib/portage/util/_dyn_libs/PreservedLibsRegistry.py
+++ b/lib/portage/util/_dyn_libs/PreservedLibsRegistry.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2014 Gentoo Foundation
+# Copyright 1998-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
@@ -25,9 +25,6 @@ from portage.util import writemsg_level
 from portage.versions import cpv_getkey
 from portage.locks import lockfile, unlockfile
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 class PreservedLibsRegistry(object):
 	""" This class handles the tracking of preserved library objects """
@@ -154,7 +151,7 @@ class PreservedLibsRegistry(object):
 		int conversion and a possible ValueError resulting
 		from vardb corruption.
 		"""
-		if not isinstance(counter, basestring):
+		if not isinstance(counter, str):
 			counter = str(counter)
 		return _unicode_decode(counter).strip()
 

--- a/lib/portage/util/_urlopen.py
+++ b/lib/portage/util/_urlopen.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2019 Gentoo Authors
+# Copyright 2012-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import io
@@ -16,9 +16,6 @@ except ImportError:
 	import urlparse as urllib_parse
 	import urllib2 as urllib_request
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 # to account for the difference between TIMESTAMP of the index' contents
 #  and the file-'mtime'
@@ -63,14 +60,14 @@ def urlopen(url, if_modified_since=None):
 		return hdl
 
 def _timestamp_to_http(timestamp):
-	dt = datetime.fromtimestamp(float(long(timestamp)+TIMESTAMP_TOLERANCE))
+	dt = datetime.fromtimestamp(float(int(timestamp)+TIMESTAMP_TOLERANCE))
 	stamp = mktime(dt.timetuple())
 	return formatdate(timeval=stamp, localtime=False, usegmt=True)
 
 def _http_to_timestamp(http_datetime_string):
 	tuple = parsedate(http_datetime_string)
 	timestamp = mktime(tuple)
-	return str(long(timestamp))
+	return str(int(timestamp))
 
 class CompressedResponseProcessor(urllib_request.HTTPBasicAuthHandler):
 	# Handler for compressed responses.

--- a/lib/portage/util/changelog.py
+++ b/lib/portage/util/changelog.py
@@ -1,21 +1,21 @@
 #!/usr/bin/python -b
-# Copyright 2009-2015 Gentoo Foundation
+# Copyright 2009-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 
 from portage.manifest import guessManifestFileType
-from portage.versions import _unicode, pkgsplit, vercmp
+from portage.versions import pkgsplit, vercmp
 
 
-class ChangeLogTypeSort(_unicode):
+class ChangeLogTypeSort(str):
 	"""
 	Helps to sort file names by file type and other criteria.
 	"""
 	def __new__(cls, status_change, file_name):
-		return _unicode.__new__(cls, status_change + file_name)
+		return str.__new__(cls, status_change + file_name)
 
 	def __init__(self, status_change, file_name):
-		_unicode.__init__(status_change + file_name)
+		str.__init__(status_change + file_name)
 		self.status_change = status_change
 		self.file_name = file_name
 		self.file_type = guessManifestFileType(file_name)

--- a/lib/portage/util/compression_probe.py
+++ b/lib/portage/util/compression_probe.py
@@ -6,8 +6,6 @@ import errno
 import re
 import sys
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 from portage import _encodings, _unicode_encode
 from portage.exception import FileNotFound, PermissionDenied
@@ -87,7 +85,7 @@ def compression_probe(f):
 	@rtype str or None
 	"""
 
-	open_file = isinstance(f, basestring)
+	open_file = isinstance(f, str)
 	if open_file:
 		try:
 			f = open(_unicode_encode(f,

--- a/lib/portage/util/configparser.py
+++ b/lib/portage/util/configparser.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Gentoo Foundation
+# Copyright 2016-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ['ConfigParserError', 'NoOptionError', 'ParsingError',
@@ -26,11 +26,6 @@ from portage import _encodings
 from portage import _unicode_encode
 
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
-
-
 def read_configs(parser, paths):
 	"""
 	Read configuration files from given paths into the specified
@@ -50,7 +45,7 @@ def read_configs(parser, paths):
 		source_kwarg = 'filename'
 
 	for p in paths:
-		if isinstance(p, basestring):
+		if isinstance(p, str):
 			f = None
 			try:
 				f = io.open(_unicode_encode(p,

--- a/lib/portage/util/env_update.py
+++ b/lib/portage/util/env_update.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2014 Gentoo Foundation
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ['env_update']
@@ -23,9 +23,6 @@ from portage.util.listdir import listdir
 from portage.dbapi.vartree import vartree
 from portage.package.ebuild.config import config
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 def env_update(makelinks=1, target_root=None, prev_mtimes=None, contents=None,
 	env=None, writemsg_level=None, vardbapi=None):
@@ -257,7 +254,7 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env,
 			if e.errno != errno.ENOENT:
 				raise
 
-	current_time = long(time.time())
+	current_time = int(time.time())
 	mtime_changed = False
 
 	lib_dirs = set()

--- a/lib/portage/util/install_mask.py
+++ b/lib/portage/util/install_mask.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Gentoo Authors
+# Copyright 2018-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ['install_mask_dir', 'InstallMask']
@@ -19,11 +19,6 @@ from portage.exception import (
 	ReadOnlyFileSystem,
 )
 from portage.util import normalize_path
-
-if sys.hexversion >= 0x3000000:
-	_unicode = str
-else:
-	_unicode = unicode
 
 
 def _defaultdict_tree():
@@ -152,7 +147,7 @@ def _raise_exc(e):
 	wrapper_cls = _exc_map.get(e.errno)
 	if wrapper_cls is None:
 		raise
-	wrapper = wrapper_cls(_unicode(e))
+	wrapper = wrapper_cls(str(e))
 	wrapper.__cause__ = e
 	raise wrapper
 

--- a/lib/portage/versions.py
+++ b/lib/portage/versions.py
@@ -13,11 +13,6 @@ import sys
 import warnings
 from functools import lru_cache
 
-if sys.hexversion < 0x3000000:
-	_unicode = unicode
-else:
-	_unicode = str
-	long = int
 
 import portage
 portage.proxy.lazyimport.lazyimport(globals(),
@@ -346,7 +341,7 @@ def catpkgsplit(mydata, silent=1, eapi=None):
 	retval = (cat, p_split[0], p_split[1], p_split[2])
 	return retval
 
-class _pkg_str(_unicode):
+class _pkg_str(str):
 	"""
 	This class represents a cpv. It inherits from str (unicode in python2) and
 	has attributes that cache results for use by functions like catpkgsplit and
@@ -365,15 +360,15 @@ class _pkg_str(_unicode):
 	def __new__(cls, cpv, metadata=None, settings=None, eapi=None,
 		repo=None, slot=None, build_time=None, build_id=None,
 		file_size=None, mtime=None, db=None):
-		return _unicode.__new__(cls, cpv)
+		return str.__new__(cls, cpv)
 
 	def __init__(self, cpv, metadata=None, settings=None, eapi=None,
 		repo=None, slot=None, build_time=None, build_id=None,
 		file_size=None, mtime=None, db=None):
-		if not isinstance(cpv, _unicode):
-			# Avoid TypeError from _unicode.__init__ with PyPy.
+		if not isinstance(cpv, str):
+			# Avoid TypeError from str.__init__ with PyPy.
 			cpv = _unicode_decode(cpv)
-		_unicode.__init__(cpv)
+		str.__init__(cpv)
 		if metadata is not None:
 			self.__dict__['_metadata'] = metadata
 			slot = metadata.get('SLOT', slot)
@@ -438,7 +433,7 @@ class _pkg_str(_unicode):
 	def _long(var, default):
 		if var is not None:
 			try:
-				var = long(var)
+				var = int(var)
 			except ValueError:
 				if var:
 					var = -1

--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2019 Gentoo Authors
+# Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """Provides an easy-to-use python interface to Gentoo's metadata.xml file.
@@ -52,10 +52,6 @@ import re
 import xml.etree.ElementTree
 from portage import _encodings, _unicode_encode
 from portage.util import cmp_sort_key, unique_everseen
-
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	basestring = str
 
 
 class _MetadataTreeBuilder(xml.etree.ElementTree.TreeBuilder):
@@ -477,12 +473,12 @@ def parse_metadata_use(xml_tree):
 				stack.append(flag)
 				while stack:
 					obj = stack.pop()
-					if isinstance(obj, basestring):
+					if isinstance(obj, str):
 						inner_text.append(obj)
 						continue
-					if isinstance(obj.text, basestring):
+					if isinstance(obj.text, str):
 						inner_text.append(obj.text)
-					if isinstance(obj.tail, basestring):
+					if isinstance(obj.tail, str):
 						stack.append(obj.tail)
 					stack.extend(reversed(obj))
 

--- a/repoman/lib/repoman/__init__.py
+++ b/repoman/lib/repoman/__init__.py
@@ -20,9 +20,6 @@ except ImportError as e:
 	sys.stderr.write("    "+str(e)+"\n\n")
 	raise
 
-if sys.hexversion >= 0x3000000:
-	# pylint: disable=W0622
-	long = int
 
 VERSION = "HEAD"
 
@@ -62,10 +59,10 @@ if VERSION == 'HEAD':
 								head_timestamp = None
 								if len(output_lines) > 3:
 									try:
-										head_timestamp = long(output_lines[3])
+										head_timestamp = int(output_lines[3])
 									except ValueError:
 										pass
-								timestamp = long(time.time())
+								timestamp = int(time.time())
 								if head_timestamp is not None and timestamp > head_timestamp:
 									timestamp = timestamp - head_timestamp
 								if not patchlevel:

--- a/repoman/lib/repoman/main.py
+++ b/repoman/lib/repoman/main.py
@@ -36,8 +36,6 @@ from repoman import utilities
 from repoman.modules.vcs.settings import VCSSettings
 from repoman import VERSION
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 bad = create_color_func("BAD")
 

--- a/repoman/lib/repoman/metadata.py
+++ b/repoman/lib/repoman/metadata.py
@@ -14,11 +14,6 @@ from portage import os
 from portage.output import green
 from portage.package.ebuild.fetch import fetch
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
-
-if sys.hexversion >= 0x3000000:
-	basestring = str
 
 # Note: This URI is hardcoded in all metadata.xml files.  We can't
 # change it without updating all the xml files in the tree.

--- a/repoman/lib/repoman/modules/scan/metadata/ebuild_metadata.py
+++ b/repoman/lib/repoman/modules/scan/metadata/ebuild_metadata.py
@@ -5,9 +5,6 @@
 import re
 import sys
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
-
 from repoman.modules.scan.scanbase import ScanBase
 
 from portage.dep import use_reduce
@@ -24,7 +21,7 @@ class EbuildMetadata(ScanBase):
 	def invalidchar(self, **kwargs):
 		ebuild = kwargs.get('ebuild').get()
 		for k, v in ebuild.metadata.items():
-			if not isinstance(v, basestring):
+			if not isinstance(v, str):
 				continue
 			m = NON_ASCII_RE.search(v)
 			if m is not None:

--- a/repoman/lib/repoman/utilities.py
+++ b/repoman/lib/repoman/utilities.py
@@ -50,9 +50,6 @@ from repoman.copyrights import update_copyright, update_copyright_year
 normalize_path = util.normalize_path
 util.initialize_logger()
 
-if sys.hexversion >= 0x3000000:
-	basestring = str
-
 
 def have_profile_dir(path, maxdepth=3, filename="profiles.desc"):
 	"""


### PR DESCRIPTION
Replace basestring and _unicode hacks with str, and long with int.

Signed-off-by: Michał Górny <mgorny@gentoo.org>