### PR TITLE
validate_desktop_entry: update _trivial_warnings regex (bug 733154)

### DIFF
--- a/lib/portage/util/_desktop_entry.py
+++ b/lib/portage/util/_desktop_entry.py
@@ -25,7 +25,12 @@ def parse_desktop_entry(path):
 
 	return parser
 
-_trivial_warnings = re.compile(r' looks redundant with value ')
+_trivial_warnings = re.compile(r' looks '
+	# >=desktop-file-utils-0.25
+	r'(?:the same as that of key|'
+
+	# <desktop-file-utils-0.25
+	r'redundant with value) ')
 
 _ignored_errors = (
 		# Ignore error for emacs.desktop:


### PR DESCRIPTION
The message has changed in desktop-file-utils-0.25.

See: https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/commit/e935a1b0c300d8fc97661e01a8200af14876e627
Bug: https://bugs.gentoo.org/733154
Signed-off-by: Zac Medico <zmedico@gentoo.org>