### PR TITLE
Resolve pylint R0205 in portage.

### DIFF
--- a/lib/_emerge/BlockerCache.py
+++ b/lib/_emerge/BlockerCache.py
@@ -21,7 +21,7 @@ class BlockerCache(portage.cache.mappings.MutableMapping):
 	# it's wasteful to update it for every vdb change.
 	_cache_threshold = 5
 
-	class BlockerData(object):
+	class BlockerData:
 
 		__slots__ = ("__weakref__", "atoms", "counter")
 

--- a/lib/_emerge/BlockerDB.py
+++ b/lib/_emerge/BlockerDB.py
@@ -14,7 +14,7 @@ from _emerge.Package import Package
 from _emerge.show_invalid_depstring_notice import show_invalid_depstring_notice
 
 
-class BlockerDB(object):
+class BlockerDB:
 
 	def __init__(self, fake_vartree):
 		root_config = fake_vartree._root_config

--- a/lib/_emerge/DepPriorityNormalRange.py
+++ b/lib/_emerge/DepPriorityNormalRange.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.DepPriority import DepPriority
-class DepPriorityNormalRange(object):
+class DepPriorityNormalRange:
 	"""
 	DepPriority properties              Index      Category
 

--- a/lib/_emerge/DepPrioritySatisfiedRange.py
+++ b/lib/_emerge/DepPrioritySatisfiedRange.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.DepPriority import DepPriority
-class DepPrioritySatisfiedRange(object):
+class DepPrioritySatisfiedRange:
 	"""
 	DepPriority                         Index      Category
 

--- a/lib/_emerge/DependencyArg.py
+++ b/lib/_emerge/DependencyArg.py
@@ -5,7 +5,7 @@ import sys
 
 from portage import _encodings, _unicode_encode
 
-class DependencyArg(object):
+class DependencyArg:
 
 	__slots__ = ('arg', 'force_reinstall', 'internal', 'reset_depth', 'root_config')
 

--- a/lib/_emerge/FakeVartree.py
+++ b/lib/_emerge/FakeVartree.py
@@ -18,7 +18,7 @@ from portage.versions import _pkg_str
 from _emerge.resolver.DbapiProvidesIndex import PackageDbapiProvidesIndex
 
 
-class FakeVardbGetPath(object):
+class FakeVardbGetPath:
 	"""
 	Implements the vardbapi.getpath() method which is used in error handling
 	code for the Package class and vartree.get_provide().

--- a/lib/_emerge/JobStatusDisplay.py
+++ b/lib/_emerge/JobStatusDisplay.py
@@ -14,7 +14,7 @@ from portage.output import xtermTitle
 
 from _emerge.getloadavg import getloadavg
 
-class JobStatusDisplay(object):
+class JobStatusDisplay:
 
 	_bound_properties = ("curval", "failed", "running")
 

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -528,7 +528,7 @@ class Package(Task):
 		s += ")"
 		return s
 
-	class _use_class(object):
+	class _use_class:
 
 		__slots__ = ("enabled", "_expand", "_expand_hidden",
 			"_force", "_pkg", "_mask")
@@ -653,7 +653,7 @@ class Package(Task):
 
 		return use_str
 
-	class _iuse(object):
+	class _iuse:
 
 		__slots__ = ("__weakref__", "_iuse_implicit_match", "_pkg", "alias_mapping",
 			"all", "all_aliases", "enabled", "disabled", "tokens")

--- a/lib/_emerge/PollScheduler.py
+++ b/lib/_emerge/PollScheduler.py
@@ -14,7 +14,7 @@ from portage.util._eventloop.global_event_loop import global_event_loop
 
 from _emerge.getloadavg import getloadavg
 
-class PollScheduler(object):
+class PollScheduler:
 
 	# max time between loadavg checks (milliseconds)
 	_loadavg_latency = None

--- a/lib/_emerge/ProgressHandler.py
+++ b/lib/_emerge/ProgressHandler.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import time
-class ProgressHandler(object):
+class ProgressHandler:
 	def __init__(self):
 		self.curval = 0
 		self.maxval = 0

--- a/lib/_emerge/RootConfig.py
+++ b/lib/_emerge/RootConfig.py
@@ -1,7 +1,7 @@
 # Copyright 1999-2013 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-class RootConfig(object):
+class RootConfig:
 	"""This is used internally by depgraph to track information about a
 	particular $ROOT."""
 	__slots__ = ("mtimedb", "root", "setconfig", "sets", "settings", "trees")

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -120,7 +120,7 @@ class Scheduler(PollScheduler):
 		__slots__ = ("build_dir", "build_log", "pkg",
 			"postinst_failure", "returncode")
 
-	class _ConfigPool(object):
+	class _ConfigPool:
 		"""Interface for a task to temporarily allocate a config
 		instance from a pool. This allows a task to be constructed
 		long before the config instance actually becomes needed, like

--- a/lib/_emerge/UseFlagDisplay.py
+++ b/lib/_emerge/UseFlagDisplay.py
@@ -10,7 +10,7 @@ from portage.output import red
 from portage.util import cmp_sort_key
 from portage.output import blue
 
-class UseFlagDisplay(object):
+class UseFlagDisplay:
 
 	__slots__ = ('name', 'enabled', 'forced')
 

--- a/lib/_emerge/UserQuery.py
+++ b/lib/_emerge/UserQuery.py
@@ -10,7 +10,7 @@ from portage import _unicode_decode
 from portage.output import bold, create_color_func
 
 
-class UserQuery(object):
+class UserQuery:
 	"""The UserQuery class is used to prompt the user with a set of responses,
 	as well as accepting and handling the responses."""
 

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1557,7 +1557,7 @@ def action_deselect(settings, trees, opts, atoms):
 			world_set.unlock()
 	return os.EX_OK
 
-class _info_pkgs_ver(object):
+class _info_pkgs_ver:
 	def __init__(self, ver, repo_suffix, provide_suffix):
 		self.ver = ver
 		self.repo_suffix = repo_suffix

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -96,7 +96,7 @@ _dep_check_graph_interface = collections.namedtuple('_dep_check_graph_interface'
 	'want_update_pkg',
 ))
 
-class _scheduler_graph_config(object):
+class _scheduler_graph_config:
 	def __init__(self, trees, pkg_cache, graph, mergelist):
 		self.trees = trees
 		self.pkg_cache = pkg_cache
@@ -113,7 +113,7 @@ def _wildcard_set(atoms):
 		pkgs.add(x)
 	return pkgs
 
-class _frozen_depgraph_config(object):
+class _frozen_depgraph_config:
 
 	def __init__(self, settings, trees, myopts, params, spinner):
 		self.settings = settings
@@ -187,7 +187,7 @@ class _frozen_depgraph_config(object):
 		self.rebuild_if_new_ver = "--rebuild-if-new-ver" in myopts
 		self.rebuild_if_unbuilt = "--rebuild-if-unbuilt" in myopts
 
-class _depgraph_sets(object):
+class _depgraph_sets:
 	def __init__(self):
 		# contains all sets added to the graph
 		self.sets = {}
@@ -198,7 +198,7 @@ class _depgraph_sets(object):
 		self.atoms = InternalPackageSet(allow_repo=True)
 		self.atom_arg_map = {}
 
-class _rebuild_config(object):
+class _rebuild_config:
 	def __init__(self, frozen_config, backtrack_parameters):
 		self._graph = digraph()
 		self._frozen_config = frozen_config
@@ -367,7 +367,7 @@ class _use_changes(tuple):
 		return obj
 
 
-class _dynamic_depgraph_config(object):
+class _dynamic_depgraph_config:
 
 	"""
 	``dynamic_depgraph_config`` is an object that is used to collect settings and important data structures that are
@@ -591,7 +591,7 @@ class _dynamic_depgraph_config(object):
 			dbs.append((vardb, "installed", True, True, db_keys))
 			self._filtered_trees[myroot]["dbs"] = dbs
 
-class depgraph(object):
+class depgraph:
 
 	# Represents the depth of a node that is unreachable from explicit
 	# user arguments (or their deep dependencies). Such nodes are pulled
@@ -703,7 +703,7 @@ class depgraph(object):
 					self._dynamic_deps_proc_exit(pkg, fake_vartree))
 				yield proc
 
-	class _dynamic_deps_proc_exit(object):
+	class _dynamic_deps_proc_exit:
 
 		__slots__ = ('_pkg', '_fake_vartree')
 
@@ -5934,7 +5934,7 @@ class depgraph(object):
 
 		return build_time == inst_pkg.build_time
 
-	class _AutounmaskLevel(object):
+	class _AutounmaskLevel:
 		__slots__ = ("allow_use_changes", "allow_unstable_keywords", "allow_license_changes", \
 			"allow_missing_keywords", "allow_unmasks")
 

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -99,7 +99,7 @@ def insert_optional_args(args):
 	this feature natively.
 	"""
 
-	class valid_integers(object):
+	class valid_integers:
 		def __contains__(self, s):
 			try:
 				return int(s) >= 0
@@ -108,7 +108,7 @@ def insert_optional_args(args):
 
 	valid_integers = valid_integers()
 
-	class valid_floats(object):
+	class valid_floats:
 		def __contains__(self, s):
 			try:
 				return float(s) >= 0

--- a/lib/_emerge/resolver/DbapiProvidesIndex.py
+++ b/lib/_emerge/resolver/DbapiProvidesIndex.py
@@ -5,7 +5,7 @@ import bisect
 import collections
 import sys
 
-class DbapiProvidesIndex(object):
+class DbapiProvidesIndex:
 	"""
 	The DbapiProvidesIndex class is used to wrap existing dbapi
 	interfaces, index packages by the sonames that they provide, and

--- a/lib/_emerge/resolver/backtracking.py
+++ b/lib/_emerge/resolver/backtracking.py
@@ -3,7 +3,7 @@
 
 import copy
 
-class BacktrackParameter(object):
+class BacktrackParameter:
 
 	__slots__ = (
 		"circular_dependency",
@@ -65,7 +65,7 @@ class BacktrackParameter(object):
 			self.prune_rebuilds == other.prune_rebuilds
 
 
-class _BacktrackNode(object):
+class _BacktrackNode:
 
 	__slots__ = (
 		"parameter", "depth", "mask_steps", "terminal",
@@ -81,7 +81,7 @@ class _BacktrackNode(object):
 		return self.parameter == other.parameter
 
 
-class Backtracker(object):
+class Backtracker:
 
 	__slots__ = (
 		"_max_depth", "_unexplored_nodes", "_current_node", "_nodes", "_root",

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -13,7 +13,7 @@ from portage.util import writemsg_level
 from _emerge.DepPrioritySatisfiedRange import DepPrioritySatisfiedRange
 from _emerge.Package import Package
 
-class circular_dependency_handler(object):
+class circular_dependency_handler:
 
 	MAX_AFFECTING_USE = 10
 

--- a/lib/_emerge/resolver/output.py
+++ b/lib/_emerge/resolver/output.py
@@ -32,7 +32,7 @@ from _emerge.resolver.output_helpers import ( _DisplayConfig, _tree_display,
 	_PackageCounters, _create_use_string, _calc_changelog, PkgInfo)
 from _emerge.show_invalid_depstring_notice import show_invalid_depstring_notice
 
-class Display(object):
+class Display:
 	"""Formats and outputs the depgrah supplied it for merge/re-merge, etc.
 
 	__call__()

--- a/lib/_emerge/resolver/output_helpers.py
+++ b/lib/_emerge/resolver/output_helpers.py
@@ -28,7 +28,7 @@ from _emerge.Blocker import Blocker
 from _emerge.Package import Package
 
 
-class _RepoDisplay(object):
+class _RepoDisplay:
 	def __init__(self, roots):
 		self._shown_repos = {}
 		self._unknown_repo = False
@@ -77,7 +77,7 @@ class _RepoDisplay(object):
 		return "".join(output)
 
 
-class _PackageCounters(object):
+class _PackageCounters:
 
 	def __init__(self):
 		self.upgrades   = 0
@@ -155,7 +155,7 @@ class _PackageCounters(object):
 		return "".join(myoutput)
 
 
-class _DisplayConfig(object):
+class _DisplayConfig:
 
 	def __init__(self, depgraph, mylist, favorites, verbosity):
 		frozen_config = depgraph._frozen_config
@@ -585,7 +585,7 @@ def _find_changelog_tags(changelog):
 		_strip_header_comments(changelog[release_end:].splitlines())))
 	return divs
 
-class PkgInfo(object):
+class PkgInfo:
 	"""Simple class to hold instance attributes for current
 	information about the pkg being printed.
 	"""

--- a/lib/_emerge/resolver/package_tracker.py
+++ b/lib/_emerge/resolver/package_tracker.py
@@ -29,7 +29,7 @@ class PackageConflict(_PackageConflict):
 		return len(self.pkgs)
 
 
-class PackageTracker(object):
+class PackageTracker:
 	"""
 	**Behavior**
 
@@ -358,7 +358,7 @@ class PackageTracker(object):
 		return self.contains(pkg, installed=True)
 
 
-class PackageTrackerDbapiWrapper(object):
+class PackageTrackerDbapiWrapper:
 	"""
 	A wrpper class that provides parts of the legacy
 	dbapi interface. Remove it once all consumers have

--- a/lib/_emerge/resolver/slot_collision.py
+++ b/lib/_emerge/resolver/slot_collision.py
@@ -17,7 +17,7 @@ from portage.util import writemsg
 from portage.versions import cpv_getversion, vercmp
 
 
-class slot_conflict_handler(object):
+class slot_conflict_handler:
 	"""This class keeps track of all slot conflicts and provides
 	an interface to get possible solutions.
 
@@ -1069,7 +1069,7 @@ class slot_conflict_handler(object):
 		else:
 			return None
 
-class _configuration_generator(object):
+class _configuration_generator:
 	def __init__(self, conflict_pkgs):
 		#reorder packages such that installed packages come last
 		self.conflict_pkgs = []
@@ -1118,8 +1118,8 @@ class _configuration_generator(object):
 				solution_ids[other_id] = 0
 			return True
 
-class _solution_candidate_generator(object):
-	class _value_helper(object):
+class _solution_candidate_generator:
+	class _value_helper:
 		def __init__(self, value=None):
 			self.value = value
 		def __eq__(self, other):

--- a/lib/_emerge/search.py
+++ b/lib/_emerge/search.py
@@ -15,7 +15,7 @@ from portage.util.iterators.MultiIterGroupBy import MultiIterGroupBy
 
 from _emerge.Package import Package
 
-class search(object):
+class search:
 
 	#
 	# class constants
@@ -356,7 +356,7 @@ class search(object):
 	def output(self):
 		"""Outputs the results of the search."""
 
-		class msg(object):
+		class msg:
 			@staticmethod
 			def append(msg):
 				writemsg_stdout(msg, noiselevel=-1)

--- a/lib/_emerge/stdout_spinner.py
+++ b/lib/_emerge/stdout_spinner.py
@@ -7,7 +7,7 @@ import time
 
 from portage.output import darkgreen, green
 
-class stdout_spinner(object):
+class stdout_spinner:
 	scroll_msgs = [
 		"Gentoo Rocks ("+platform.system()+")",
 		"Thank you for using Gentoo. :)",

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -188,7 +188,7 @@ def _unicode_decode(s, encoding=_encodings['content'], errors='replace'):
 _native_string = _unicode_decode
 
 
-class _unicode_func_wrapper(object):
+class _unicode_func_wrapper:
 	"""
 	Wraps a function, converts arguments from unicode to bytes,
 	and return values to unicode from bytes. Function calls
@@ -247,7 +247,7 @@ class _unicode_func_wrapper(object):
 
 		return rval
 
-class _unicode_module_wrapper(object):
+class _unicode_module_wrapper:
 	"""
 	Wraps a module and wraps all functions with _unicode_func_wrapper.
 	"""
@@ -288,7 +288,7 @@ class _unicode_module_wrapper(object):
 			cache[attr] = result
 		return result
 
-class _eintr_func_wrapper(object):
+class _eintr_func_wrapper:
 	"""
 	Wraps a function and handles EINTR by calling the function as
 	many times as necessary (until it returns without raising EINTR).
@@ -397,7 +397,7 @@ bsd_chflags = None
 
 if platform.system() in ('FreeBSD',):
 	# TODO: remove this class?
-	class bsd_chflags(object):
+	class bsd_chflags:
 		chflags = os.chflags
 		lchflags = os.lchflags
 

--- a/lib/portage/_emirrordist/Config.py
+++ b/lib/portage/_emirrordist/Config.py
@@ -13,7 +13,7 @@ from portage import os
 from portage.package.ebuild.fetch import MirrorLayoutConfig
 from portage.util import grabdict, grablines
 
-class Config(object):
+class Config:
 	def __init__(self, options, portdb, event_loop):
 		self.options = options
 		self.portdb = portdb
@@ -96,7 +96,7 @@ class Config(object):
 
 		return self._LogFormatter(line_format, log_func)
 
-	class _LogFormatter(object):
+	class _LogFormatter:
 
 		__slots__ = ('_line_format', '_log_func')
 

--- a/lib/portage/_emirrordist/DeletionIterator.py
+++ b/lib/portage/_emirrordist/DeletionIterator.py
@@ -7,7 +7,7 @@ import stat
 from portage import os
 from .DeletionTask import DeletionTask
 
-class DeletionIterator(object):
+class DeletionIterator:
 
 	def __init__(self, config):
 		self._config = config

--- a/lib/portage/_emirrordist/FetchIterator.py
+++ b/lib/portage/_emirrordist/FetchIterator.py
@@ -15,7 +15,7 @@ from .FetchTask import FetchTask
 from _emerge.CompositeTask import CompositeTask
 
 
-class FetchIterator(object):
+class FetchIterator:
 
 	def __init__(self, config):
 		self._config = config

--- a/lib/portage/_selinux.py
+++ b/lib/portage/_selinux.py
@@ -105,7 +105,7 @@ def setfscreate(ctx="\n"):
 		raise OSError(
 			_("setfscreate: Failed setting fs create context \"%s\".") % ctx)
 
-class spawn_wrapper(object):
+class spawn_wrapper:
 	"""
 	Create a wrapper function for the given spawn function. When the wrapper
 	is called, it will adjust the arguments such that setexec() to be called

--- a/lib/portage/_sets/__init__.py
+++ b/lib/portage/_sets/__init__.py
@@ -39,7 +39,7 @@ def get_boolean(options, name, default):
 class SetConfigError(Exception):
 	pass
 
-class SetConfig(object):
+class SetConfig:
 	def __init__(self, paths, settings, trees):
 		self._parser = SafeConfigParser(
 			defaults={

--- a/lib/portage/_sets/base.py
+++ b/lib/portage/_sets/base.py
@@ -9,7 +9,7 @@ from portage.versions import cpv_getkey
 
 OPERATIONS = ["merge", "unmerge"]
 
-class PackageSet(object):
+class PackageSet:
 	# Set this to operations that are supported by your subclass. While 
 	# technically there is no difference between "merge" and "unmerge" regarding
 	# package sets, the latter doesn't make sense for some sets like "system"

--- a/lib/portage/cache/index/IndexStreamIterator.py
+++ b/lib/portage/cache/index/IndexStreamIterator.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-class IndexStreamIterator(object):
+class IndexStreamIterator:
 
 	def __init__(self, f, parser):
 

--- a/lib/portage/cache/mappings.py
+++ b/lib/portage/cache/mappings.py
@@ -8,7 +8,7 @@ __all__ = ["Mapping", "MutableMapping", "UserDict", "ProtectedDict",
 import sys
 import weakref
 
-class Mapping(object):
+class Mapping:
 	"""
 	In python-3.0, the UserDict.DictMixin class has been replaced by
 	Mapping and MutableMapping from the collections module, but 2to3
@@ -289,7 +289,7 @@ def slot_dict_class(keys, prefix="_val_"):
 	v = _slot_dict_classes.get((keys_set, prefix))
 	if v is None:
 
-		class SlotDict(object):
+		class SlotDict:
 
 			allowed_keys = keys_set
 			_prefix = prefix

--- a/lib/portage/cache/template.py
+++ b/lib/portage/cache/template.py
@@ -10,7 +10,7 @@ import warnings
 import operator
 
 
-class database(object):
+class database:
 	# this is for metadata/cache transfer.
 	# basically flags the cache needs be updated when transfered cache to cache.
 	# leave this.

--- a/lib/portage/checksum.py
+++ b/lib/portage/checksum.py
@@ -52,7 +52,7 @@ def _open_file(filename):
 		else:
 			raise
 
-class _generate_hash_function(object):
+class _generate_hash_function:
 
 	__slots__ = ("_hashobject",)
 
@@ -159,7 +159,7 @@ if False:
 		import binascii
 		import pygcrypt.hashcontext
 
-		class GCryptHashWrapper(object):
+		class GCryptHashWrapper:
 			def __init__(self, algo):
 				self._obj = pygcrypt.hashcontext.HashContext(algo=algo,
 						secure=False)
@@ -287,7 +287,7 @@ if "WHIRLPOOL" not in hashfunc_map:
 
 
 # There is only one implementation for size
-class SizeHash(object):
+class SizeHash:
 	def checksum_file(self, filename):
 		size = os.stat(filename).st_size
 		return (size, size)
@@ -361,7 +361,7 @@ def _filter_unaccelarated_hashes(digests):
 
 	return digests
 
-class _hash_filter(object):
+class _hash_filter:
 	"""
 	Implements filtering for PORTAGE_CHECKSUM_FILTER.
 	"""

--- a/lib/portage/dbapi/DummyTree.py
+++ b/lib/portage/dbapi/DummyTree.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-class DummyTree(object):
+class DummyTree:
 	"""
 	Most internal code only accesses the "dbapi" attribute of the
 	binarytree, portagetree, and vartree classes. DummyTree is useful

--- a/lib/portage/dbapi/IndexedPortdb.py
+++ b/lib/portage/dbapi/IndexedPortdb.py
@@ -17,7 +17,7 @@ from portage.cache.index.pkg_desc_index import \
 from portage.util.iterators.MultiIterGroupBy import MultiIterGroupBy
 from portage.versions import _pkg_str
 
-class IndexedPortdb(object):
+class IndexedPortdb:
 	"""
 	A portdbapi interface that uses a package description index to
 	improve performance. If the description index is missing for a
@@ -90,7 +90,7 @@ class IndexedPortdb(object):
 		if index_missing:
 			self._unindexed_cp_map = {}
 
-			class _NonIndexedStream(object):
+			class _NonIndexedStream:
 				def __iter__(self_):
 					for cp in self._portdb.cp_all(
 						trees = index_missing):

--- a/lib/portage/dbapi/IndexedVardb.py
+++ b/lib/portage/dbapi/IndexedVardb.py
@@ -6,7 +6,7 @@ from portage.dep import Atom
 from portage.exception import InvalidData
 from portage.versions import _pkg_str
 
-class IndexedVardb(object):
+class IndexedVardb:
 	"""
 	A vardbapi interface that sacrifices validation in order to
 	improve performance. It takes advantage of vardbdbapi._aux_cache,

--- a/lib/portage/dbapi/_ContentsCaseSensitivityManager.py
+++ b/lib/portage/dbapi/_ContentsCaseSensitivityManager.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-class ContentsCaseSensitivityManager(object):
+class ContentsCaseSensitivityManager:
 	"""
 	Implicitly handles case transformations that are needed for
 	case-insensitive support.

--- a/lib/portage/dbapi/_VdbMetadataDelta.py
+++ b/lib/portage/dbapi/_VdbMetadataDelta.py
@@ -10,7 +10,7 @@ from portage import _encodings
 from portage.util import atomic_ofstream
 from portage.versions import cpv_getkey
 
-class VdbMetadataDelta(object):
+class VdbMetadataDelta:
 
 	_format_version  = "1"
 

--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -24,7 +24,7 @@ from portage.exception import InvalidData
 from portage.localization import _
 from _emerge.Package import Package
 
-class dbapi(object):
+class dbapi:
 	_category_re = re.compile(r'^\w[-.+\w]*$', re.UNICODE)
 	_categories = None
 	_use_mutable = False

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -327,7 +327,7 @@ class bindbapi(fakedbapi):
 		return filesdict
 
 
-class binarytree(object):
+class binarytree:
 	"this tree scans for a list of all packages available in PKGDIR"
 	def __init__(self, _unused=DeprecationWarning, pkgdir=None,
 		virtual=DeprecationWarning, settings=None):

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -98,7 +98,7 @@ class _dummy_list(list):
 			pass
 
 
-class _better_cache(object):
+class _better_cache:
 
 	"""
 	The purpose of better_cache is to locate catpkgs in repositories using ``os.listdir()`` as much as possible, which
@@ -1311,7 +1311,7 @@ class portdbapi(dbapi):
 
 		return True
 
-class portagetree(object):
+class portagetree:
 	def __init__(self, root=DeprecationWarning, virtual=DeprecationWarning,
 		settings=None):
 		"""

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -1240,7 +1240,7 @@ class vardbapi(dbapi):
 		self._bump_mtime(pkg.mycpv)
 		pkg._clear_contents_cache()
 
-	class _owners_cache(object):
+	class _owners_cache:
 		"""
 		This class maintains an hash table that serves to index package
 		contents by mapping the basename of file to a list of possible
@@ -1306,7 +1306,7 @@ class vardbapi(dbapi):
 				counter = 0
 			return (str(cpv), counter, mtime)
 
-	class _owners_db(object):
+	class _owners_db:
 
 		def __init__(self, vardb):
 			self._vardb = vardb
@@ -1520,7 +1520,7 @@ class vardbapi(dbapi):
 				for result in search_future.result():
 					yield result
 
-class vartree(object):
+class vartree:
 	"this tree will scan a var/db/pkg database located at root (passed to init)"
 	def __init__(self, root=None, virtual=DeprecationWarning, categories=None,
 		settings=None):
@@ -1616,7 +1616,7 @@ class vartree(object):
 	def populate(self):
 		self.populated=1
 
-class dblink(object):
+class dblink:
 	"""
 	This class provides an interface to the installed package database
 	At present this is implemented as a text backend in /var/db/pkg.

--- a/lib/portage/dbapi/virtual.py
+++ b/lib/portage/dbapi/virtual.py
@@ -213,7 +213,7 @@ class fakedbapi(dbapi):
 			raise KeyError(cpv)
 		metadata.update(values)
 
-class testdbapi(object):
+class testdbapi:
 	"""A dbapi instance with completely fake functions to get by hitting disk
 	TODO(antarus): 
 	This class really needs to be rewritten to have better stubs; but these work for now.

--- a/lib/portage/debug.py
+++ b/lib/portage/debug.py
@@ -21,7 +21,7 @@ def set_trace(on=True):
 		sys.settrace(None)
 		threading.settrace(None)
 
-class trace_handler(object):
+class trace_handler:
 
 	def __init__(self):
 		python_system_paths = []
@@ -100,7 +100,7 @@ class trace_handler(object):
 				my_locals[k] = "omitted"
 		return my_locals
 
-class prefix_trimmer(object):
+class prefix_trimmer:
 	def __init__(self, prefix):
 		self.prefix = prefix
 		self.cut_index = len(prefix)

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -840,12 +840,12 @@ def flatten(mylist):
 			newlist.append(x)
 	return newlist
 
-class _use_dep(object):
+class _use_dep:
 
 	__slots__ = ("_eapi_attrs", "conditional", "missing_enabled", "missing_disabled",
 		"disabled", "enabled", "tokens", "required")
 
-	class _conditionals_class(object):
+	class _conditionals_class:
 		__slots__ = ("enabled", "disabled", "equal", "not_equal")
 
 		def items(self):
@@ -1222,10 +1222,10 @@ class Atom(str):
 	# Distiguishes soname atoms from other atom types
 	soname = False
 
-	class _blocker(object):
+	class _blocker:
 		__slots__ = ("overlap",)
 
-		class _overlap(object):
+		class _overlap:
 			__slots__ = ("forbid",)
 
 			def __init__(self, forbid=False):
@@ -2508,7 +2508,7 @@ def get_required_use_flags(required_use, eapi=None):
 
 	return frozenset(used_flags)
 
-class _RequiredUseLeaf(object):
+class _RequiredUseLeaf:
 
 	__slots__ = ('_satisfied', '_token')
 
@@ -2519,7 +2519,7 @@ class _RequiredUseLeaf(object):
 	def tounicode(self):
 		return self._token
 
-class _RequiredUseBranch(object):
+class _RequiredUseBranch:
 
 	__slots__ = ('_children', '_operator', '_parent', '_satisfied')
 

--- a/lib/portage/dep/soname/SonameAtom.py
+++ b/lib/portage/dep/soname/SonameAtom.py
@@ -5,7 +5,7 @@ import sys
 
 from portage import _encodings, _unicode_encode
 
-class SonameAtom(object):
+class SonameAtom:
 
 	__slots__ = ("multilib_category", "soname", "_hash_key",
 		"_hash_value")

--- a/lib/portage/dispatch_conf.py
+++ b/lib/portage/dispatch_conf.py
@@ -97,7 +97,7 @@ def diff_mixed(func, file1, file2):
 		if tempdir is not None:
 			shutil.rmtree(tempdir)
 
-class diff_mixed_wrapper(object):
+class diff_mixed_wrapper:
 
 	def __init__(self, f, *args):
 		self._func = f

--- a/lib/portage/eclass_cache.py
+++ b/lib/portage/eclass_cache.py
@@ -16,7 +16,7 @@ from portage import checksum
 from portage import _shell_quote
 
 
-class hashed_path(object):
+class hashed_path:
 
 	def __init__(self, location):
 		self.location = location
@@ -51,7 +51,7 @@ class hashed_path(object):
 	def __repr__(self):
 		return "<portage.eclass_cache.hashed_path('%s')>" % (self.location,)
 
-class cache(object):
+class cache:
 	"""
 	Maintains the cache information about eclasses used in ebuild.
 	"""

--- a/lib/portage/elog/messages.py
+++ b/lib/portage/elog/messages.py
@@ -172,7 +172,7 @@ _functions = { "einfo": ("INFO", "GOOD"),
 		"eerror": ("ERROR", "BAD"),
 }
 
-class _make_msgfunction(object):
+class _make_msgfunction:
 	__slots__ = ('_color', '_level')
 	def __init__(self, level, color):
 		self._level = level

--- a/lib/portage/emaint/main.py
+++ b/lib/portage/emaint/main.py
@@ -13,7 +13,7 @@ from portage.module import Modules
 from portage.progress import ProgressBar
 from portage.emaint.defaults import DEFAULT_OPTIONS
 
-class OptionItem(object):
+class OptionItem:
 	"""class to hold module ArgumentParser options data
 	"""
 
@@ -100,7 +100,7 @@ def module_opts(module_controller, module):
 	return _usage
 
 
-class TaskHandler(object):
+class TaskHandler:
 	"""Handles the running of the tasks it is given"""
 
 	def __init__(self, show_progress_bar=True, verbose=True, callback=None, module_output=None):

--- a/lib/portage/emaint/modules/binhost/binhost.py
+++ b/lib/portage/emaint/modules/binhost/binhost.py
@@ -12,7 +12,7 @@ from portage.versions import _pkg_str
 import sys
 
 
-class BinhostHandler(object):
+class BinhostHandler:
 
 	short_desc = "Generate a metadata index for binary packages"
 

--- a/lib/portage/emaint/modules/config/config.py
+++ b/lib/portage/emaint/modules/config/config.py
@@ -6,7 +6,7 @@ from portage import os
 from portage.const import PRIVATE_PATH
 from portage.util import grabdict, writedict
 
-class CleanConfig(object):
+class CleanConfig:
 
 	short_desc = "Discard any no longer installed configs from emerge's tracker list"
 

--- a/lib/portage/emaint/modules/logs/logs.py
+++ b/lib/portage/emaint/modules/logs/logs.py
@@ -14,7 +14,7 @@ ERROR_MESSAGES = {
 }
 
 
-class CleanLogs(object):
+class CleanLogs:
 
 	short_desc = "Clean PORTAGE_LOGDIR logs"
 

--- a/lib/portage/emaint/modules/merges/merges.py
+++ b/lib/portage/emaint/modules/merges/merges.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import time
 
-class TrackingFile(object):
+class TrackingFile:
 	"""File for keeping track of failed merges."""
 
 
@@ -80,7 +80,7 @@ class TrackingFile(object):
 		return self.load().items().__iter__()
 
 
-class MergesHandler(object):
+class MergesHandler:
 	"""Handle failed package merges."""
 
 	short_desc = "Remove failed merges"

--- a/lib/portage/emaint/modules/move/move.py
+++ b/lib/portage/emaint/modules/move/move.py
@@ -7,7 +7,7 @@ from portage.exception import InvalidData
 from _emerge.Package import Package
 from portage.versions import _pkg_str
 
-class MoveHandler(object):
+class MoveHandler:
 
 	def __init__(self, tree, porttree):
 		self._tree = tree

--- a/lib/portage/emaint/modules/resume/resume.py
+++ b/lib/portage/emaint/modules/resume/resume.py
@@ -4,7 +4,7 @@
 import portage
 
 
-class CleanResume(object):
+class CleanResume:
 
 	short_desc = "Discard emerge --resume merge lists"
 

--- a/lib/portage/emaint/modules/sync/sync.py
+++ b/lib/portage/emaint/modules/sync/sync.py
@@ -33,7 +33,7 @@ portage.proxy.lazyimport.lazyimport(globals(),
 warn = create_color_func("WARN")
 
 
-class SyncRepos(object):
+class SyncRepos:
 
 	short_desc = "Check repos.conf settings and/or sync repositories"
 

--- a/lib/portage/emaint/modules/world/world.py
+++ b/lib/portage/emaint/modules/world/world.py
@@ -5,7 +5,7 @@ import portage
 from portage import os
 
 
-class WorldHandler(object):
+class WorldHandler:
 
 	short_desc = "Fix problems in the world file"
 

--- a/lib/portage/env/loaders.py
+++ b/lib/portage/env/loaders.py
@@ -69,7 +69,7 @@ def RecursiveFileLoader(filename):
 		yield filename
 
 
-class DataLoader(object):
+class DataLoader:
 
 	def __init__(self, validator):
 		f = validator

--- a/lib/portage/getbinpkg.py
+++ b/lib/portage/getbinpkg.py
@@ -690,7 +690,7 @@ def dir_get_metadata(baseurl, conn=None, chunk_size=3000, verbose=1, usingcache=
 			break
 	# We may have metadata... now we run through the tbz2 list and check.
 
-	class CacheStats(object):
+	class CacheStats:
 		from time import time
 		def __init__(self, out):
 			self.misses = 0
@@ -799,7 +799,7 @@ def _cmp_cpv(d1, d2):
 	else:
 		return -1
 
-class PackageIndex(object):
+class PackageIndex:
 
 	def __init__(self,
 		allowed_pkg_keys=None,

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -84,7 +84,7 @@ def _get_lock_fn():
 _open_fds = {}
 _open_inodes = {}
 
-class _lock_manager(object):
+class _lock_manager:
 	__slots__ = ('fd', 'inode_key')
 	def __init__(self, fd, fstat_result, path):
 		self.fd = fd

--- a/lib/portage/manifest.py
+++ b/lib/portage/manifest.py
@@ -80,7 +80,7 @@ def parseManifest2(line):
 			name=match.group(2), hashes=hashes)
 	return myentry
 
-class ManifestEntry(object):
+class ManifestEntry:
 	__slots__ = ("type", "name", "hashes")
 	def __init__(self, **kwargs):
 		for k, v in kwargs.items():
@@ -108,7 +108,7 @@ class Manifest2Entry(ManifestEntry):
 		return not self.__eq__(other)
 
 
-class Manifest(object):
+class Manifest:
 	parsers = (parseManifest2,)
 	def __init__(self, pkgdir, distdir=None, fetchlist_dict=None,
 		manifest1_compat=DeprecationWarning, from_scratch=False, thin=False,

--- a/lib/portage/metadata.py
+++ b/lib/portage/metadata.py
@@ -32,7 +32,7 @@ def action_metadata(settings, portdb, myopts, porttrees=None):
 
 	auxdbkeys = portdb._known_keys
 
-	class TreeData(object):
+	class TreeData:
 		__slots__ = ('dest_db', 'eclass_db', 'path', 'src_db', 'valid_nodes')
 		def __init__(self, dest_db, eclass_db, path, src_db):
 			self.dest_db = dest_db

--- a/lib/portage/module.py
+++ b/lib/portage/module.py
@@ -19,7 +19,7 @@ class ModuleVersionError(PortageException):
 	'''An incompatible module version'''
 
 
-class Module(object):
+class Module:
 	"""Class to define and hold our plug-in module
 
 	@type name: string
@@ -83,7 +83,7 @@ class Module(object):
 		return mod_class
 
 
-class Modules(object):
+class Modules:
 	"""Dynamic modules system for loading and retrieving any of the
 	installed emaint modules and/or provided class's
 

--- a/lib/portage/news.py
+++ b/lib/portage/news.py
@@ -32,7 +32,7 @@ from portage.output import colorize
 from portage.exception import (InvalidLocation, OperationNotPermitted,
 	PermissionDenied, ReadOnlyFileSystem)
 
-class NewsManager(object):
+class NewsManager:
 	"""
 	This object manages GLEP 42 style news items.  It will cache news items
 	that have previously shown up and notify users when there are relevant news
@@ -200,7 +200,7 @@ _profileRE = re.compile("Display-If-Profile:(.*)\n")
 _keywordRE = re.compile("Display-If-Keyword:(.*)\n")
 _valid_profile_RE = re.compile(r'^[^*]+(/\*)?$')
 
-class NewsItem(object):
+class NewsItem:
 	"""
 	This class encapsulates a GLEP 42 style news item.
 	It's purpose is to wrap parsing of these news items such that portage can determine
@@ -313,7 +313,7 @@ class NewsItem(object):
 
 		self._parsed = True
 
-class DisplayRestriction(object):
+class DisplayRestriction:
 	"""
 	A base restriction object representing a restriction of display.
 	news items may have 'relevancy restrictions' preventing them from

--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -347,7 +347,7 @@ compat_functions_colors = [
 	"brown", "darkyellow", "red", "darkred",
 ]
 
-class create_color_func(object):
+class create_color_func:
 	__slots__ = ("_color_key",)
 	def __init__(self, color_key):
 		self._color_key = color_key
@@ -357,7 +357,7 @@ class create_color_func(object):
 for c in compat_functions_colors:
 	globals()[c] = create_color_func(c)
 
-class ConsoleStyleFile(object):
+class ConsoleStyleFile:
 	"""
 	A file-like object that behaves something like
 	the colorize() function. Style identifiers
@@ -482,7 +482,7 @@ def set_term_size(lines, columns, fd):
 	except CommandNotFound:
 		writemsg(_("portage: stty: command not found\n"), noiselevel=-1)
 
-class EOutput(object):
+class EOutput:
 	"""
 	Performs fancy terminal formatting for status and informational messages.
 
@@ -640,7 +640,7 @@ class EOutput(object):
 			self.__eend("ewend", errno, msg)
 		self.__last_e_cmd = "ewend"
 
-class ProgressBar(object):
+class ProgressBar:
 	"""The interface is copied from the ProgressBar class from the EasyDialogs
 	module (which is Mac only)."""
 	def __init__(self, title=None, maxval=0, label=None, max_desc_length=25):

--- a/lib/portage/package/ebuild/_config/KeywordsManager.py
+++ b/lib/portage/package/ebuild/_config/KeywordsManager.py
@@ -16,7 +16,7 @@ from portage.package.ebuild._config.helper import ordered_by_atom_specificity
 from portage.util import grabdict_package, stack_lists, writemsg
 from portage.versions import _pkg_str
 
-class KeywordsManager(object):
+class KeywordsManager:
 	"""Manager class to handle keywords processing and validation"""
 
 	def __init__(self, profiles, abs_user_config, user_config=True,

--- a/lib/portage/package/ebuild/_config/LicenseManager.py
+++ b/lib/portage/package/ebuild/_config/LicenseManager.py
@@ -15,7 +15,7 @@ from portage.versions import cpv_getkey, _pkg_str
 from portage.package.ebuild._config.helper import ordered_by_atom_specificity
 
 
-class LicenseManager(object):
+class LicenseManager:
 
 	def __init__(self, license_group_locations, abs_user_config, user_config=True):
 

--- a/lib/portage/package/ebuild/_config/LocationsManager.py
+++ b/lib/portage/package/ebuild/_config/LocationsManager.py
@@ -35,7 +35,7 @@ _profile_node = collections.namedtuple('_profile_node',
 _allow_parent_colon = frozenset(
 	["portage-2"])
 
-class LocationsManager(object):
+class LocationsManager:
 
 	def __init__(self, config_root=None, eprefix=None, config_profile_path=None, local_config=True, \
 		target_root=None, sysroot=None):

--- a/lib/portage/package/ebuild/_config/MaskManager.py
+++ b/lib/portage/package/ebuild/_config/MaskManager.py
@@ -13,7 +13,7 @@ from portage.localization import _
 from portage.util import append_repo, grabfile_package, stack_lists, writemsg
 from portage.versions import _pkg_str
 
-class MaskManager(object):
+class MaskManager:
 
 	def __init__(self, repositories, profiles, abs_user_config,
 		user_config=True, strict_umatched_removal=False):

--- a/lib/portage/package/ebuild/_config/UseManager.py
+++ b/lib/portage/package/ebuild/_config/UseManager.py
@@ -16,7 +16,7 @@ from portage.versions import _pkg_str
 
 from portage.package.ebuild._config.helper import ordered_by_atom_specificity
 
-class UseManager(object):
+class UseManager:
 
 	def __init__(self, repositories, profiles, abs_user_config, is_stable,
 		user_config=True):

--- a/lib/portage/package/ebuild/_config/VirtualsManager.py
+++ b/lib/portage/package/ebuild/_config/VirtualsManager.py
@@ -14,7 +14,7 @@ from portage.localization import _
 from portage.util import grabdict, stack_dictlist, writemsg
 from portage.versions import cpv_getkey
 
-class VirtualsManager(object):
+class VirtualsManager:
 
 	def __init__(self, *args, **kwargs):
 		if kwargs.get("_copy"):

--- a/lib/portage/package/ebuild/_config/features_set.py
+++ b/lib/portage/package/ebuild/_config/features_set.py
@@ -12,7 +12,7 @@ from portage.localization import _
 from portage.output import colorize
 from portage.util import writemsg_level
 
-class features_set(object):
+class features_set:
 	"""
 	Provides relevant set operations needed for access and modification of
 	config.features. The FEATURES variable is automatically synchronized

--- a/lib/portage/package/ebuild/_ipc/IpcCommand.py
+++ b/lib/portage/package/ebuild/_ipc/IpcCommand.py
@@ -1,7 +1,7 @@
 # Copyright 2010 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-class IpcCommand(object):
+class IpcCommand:
 
 	__slots__ = ()
 

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -117,7 +117,7 @@ def _lazy_iuse_regex(iuse_implicit):
 	regex = regex.replace("\\.\\*", ".*")
 	return regex
 
-class _iuse_implicit_match_cache(object):
+class _iuse_implicit_match_cache:
 
 	def __init__(self, settings):
 		self._iuse_implicit_re = re.compile("^(%s)$" % \
@@ -135,7 +135,7 @@ class _iuse_implicit_match_cache(object):
 			self._cache[flag] = m
 			return m
 
-class config(object):
+class config:
 	"""
 	This class encompasses the main portage configuration.  Data is pulled from
 	ROOT/PORTDIR/profiles/, from ROOT/etc/make.profile incrementally through all
@@ -1313,7 +1313,7 @@ class config(object):
 			self.useforce = self._use_manager.getUseForce()
 		self.regenerate()
 
-	class _lazy_vars(object):
+	class _lazy_vars:
 
 		__slots__ = ('built_use', 'settings', 'values')
 
@@ -1346,7 +1346,7 @@ class config(object):
 				restrict = set()
 			return ' '.join(sorted(restrict))
 
-	class _lazy_use_expand(object):
+	class _lazy_use_expand:
 		"""
 		Lazily evaluate USE_EXPAND variables since they are only needed when
 		an ebuild shell is spawned. Variables values are made consistent with

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1416,7 +1416,7 @@ def _validate_deps(mysettings, myroot, mydo, mydbapi):
 			mydbapi.aux_get(mysettings.mycpv, all_keys,
 			myrepo=mysettings.get("PORTAGE_REPO_NAME"))))
 
-	class FakeTree(object):
+	class FakeTree:
 		def __init__(self, mydb):
 			self.dbapi = mydb
 

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -346,7 +346,7 @@ _size_suffix_map = {
 }
 
 
-class FlatLayout(object):
+class FlatLayout:
 	def get_path(self, filename):
 		return filename
 
@@ -366,7 +366,7 @@ class FlatLayout(object):
 		return len(args) == 1
 
 
-class FilenameHashLayout(object):
+class FilenameHashLayout:
 	def __init__(self, algo, cutoffs):
 		self.algo = algo
 		self.cutoffs = [int(x) for x in cutoffs.split(':')]
@@ -415,7 +415,7 @@ class FilenameHashLayout(object):
 		return False
 
 
-class MirrorLayoutConfig(object):
+class MirrorLayoutConfig:
 	"""
 	Class to read layout.conf from a mirror.
 	"""

--- a/lib/portage/package/ebuild/getmaskingstatus.py
+++ b/lib/portage/package/ebuild/getmaskingstatus.py
@@ -13,7 +13,7 @@ from portage.package.ebuild.config import config
 from portage.versions import catpkgsplit, _pkg_str
 
 
-class _UnmaskHint(object):
+class _UnmaskHint:
 
 	__slots__ = ('key', 'value')
 
@@ -21,7 +21,7 @@ class _UnmaskHint(object):
 		self.key = key
 		self.value = value
 
-class _MaskReason(object):
+class _MaskReason:
 
 	__slots__ = ('category', 'message', 'unmask_hint')
 

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -737,7 +737,7 @@ def _exec(binary, mycommand, opt_name, fd_pipes,
 	os.execve(binary, myargs, env)
 
 
-class _unshare_validator(object):
+class _unshare_validator:
 	"""
 	In order to prevent failed unshare calls from corrupting the state
 	of an essential process, validate the relevant unshare call in a

--- a/lib/portage/progress.py
+++ b/lib/portage/progress.py
@@ -7,7 +7,7 @@ import signal
 import portage
 
 
-class ProgressHandler(object):
+class ProgressHandler:
 	def __init__(self):
 		self.reset()
 

--- a/lib/portage/proxy/objectproxy.py
+++ b/lib/portage/proxy/objectproxy.py
@@ -5,7 +5,7 @@ import sys
 
 __all__ = ['ObjectProxy']
 
-class ObjectProxy(object):
+class ObjectProxy:
 
 	"""
 	Object that acts as a proxy to another object, forwarding

--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -66,7 +66,7 @@ def _find_invalid_path_char(path, pos=0, endpos=None):
 
 	return -1
 
-class RepoConfig(object):
+class RepoConfig:
 	"""Stores config of one repository"""
 
 	__slots__ = (
@@ -531,7 +531,7 @@ class RepoConfig(object):
 		return "%s" % (d,)
 
 
-class RepoConfigLoader(object):
+class RepoConfigLoader:
 	"""Loads and store config of several repositories, loaded from PORTDIR_OVERLAY or repos.conf"""
 
 	@staticmethod

--- a/lib/portage/repository/storage/interface.py
+++ b/lib/portage/repository/storage/interface.py
@@ -11,7 +11,7 @@ class RepoStorageException(PortageException):
 	"""
 
 
-class RepoStorageInterface(object):
+class RepoStorageInterface:
 	"""
 	Abstract repository storage interface.
 

--- a/lib/portage/sync/config_checks.py
+++ b/lib/portage/sync/config_checks.py
@@ -34,7 +34,7 @@ def check_type(repo, logger, module_names):
 	return True
 
 
-class CheckSyncConfig(object):
+class CheckSyncConfig:
 	'''Base repos.conf settings checks class'''
 
 	def __init__(self, repo=None, logger=None):

--- a/lib/portage/sync/controller.py
+++ b/lib/portage/sync/controller.py
@@ -29,7 +29,7 @@ from portage import util
 from _emerge.CompositeTask import CompositeTask
 
 
-class TaskHandler(object):
+class TaskHandler:
 	"""Handles the running of the tasks it is given
 	"""
 
@@ -82,7 +82,7 @@ def print_results(results):
 		print("\n")
 
 
-class SyncManager(object):
+class SyncManager:
 	'''Main sync control module'''
 
 	def __init__(self, settings, logger):

--- a/lib/portage/sync/syncbase.py
+++ b/lib/portage/sync/syncbase.py
@@ -20,7 +20,7 @@ from portage.util.futures.retry import retry
 from portage.util.futures.executor.fork import ForkExecutor
 from . import _SUBMODULE_PATH_MAP
 
-class SyncBase(object):
+class SyncBase:
 	'''Base Sync class for subclassing'''
 
 	short_desc = "Perform sync operations on repositories"

--- a/lib/portage/tests/dep/testAtom.py
+++ b/lib/portage/tests/dep/testAtom.py
@@ -257,7 +257,7 @@ class TestAtom(TestCase):
 			("dev-libs/A[a,b=,!c=,d?,!e?,-f]", [], ["a", "b", "c", "d", "e", "f"], None),
 		)
 
-		class use_flag_validator(object):
+		class use_flag_validator:
 			def __init__(self, iuse):
 				self.iuse = iuse
 

--- a/lib/portage/tests/dep/test_isvalidatom.py
+++ b/lib/portage/tests/dep/test_isvalidatom.py
@@ -4,7 +4,7 @@
 from portage.tests import TestCase
 from portage.dep import isvalidatom
 
-class IsValidAtomTestCase(object):
+class IsValidAtomTestCase:
 	def __init__(self, atom, expected, allow_wildcard=False,
 		allow_repo=False, allow_build_id=False):
 		self.atom = atom

--- a/lib/portage/tests/dep/test_match_from_list.py
+++ b/lib/portage/tests/dep/test_match_from_list.py
@@ -7,7 +7,7 @@ from portage.dep import Atom, match_from_list, _repo_separator
 from portage.versions import catpkgsplit, _pkg_str
 
 
-class Package(object):
+class Package:
 	"""
 	Provides a minimal subset of attributes of _emerge.Package.Package
 	"""
@@ -31,11 +31,11 @@ class Package(object):
 			self.use = self._use_class([])
 			self.iuse = self._iuse_class([])
 
-	class _use_class(object):
+	class _use_class:
 		def __init__(self, use):
 			self.enabled = frozenset(use)
 
-	class _iuse_class(object):
+	class _iuse_class:
 		def __init__(self, iuse):
 			self.all = frozenset(iuse)
 

--- a/lib/portage/tests/dep/test_use_reduce.py
+++ b/lib/portage/tests/dep/test_use_reduce.py
@@ -5,7 +5,7 @@ from portage.tests import TestCase
 from portage.exception import InvalidDependString
 from portage.dep import Atom, use_reduce
 
-class UseReduceTestCase(object):
+class UseReduceTestCase:
 	def __init__(self, deparray, uselist=[], masklist=[],
 	             matchall=0, excludeall=[], is_src_uri=False,
 	             eapi='0', opconvert=False, flat=False, expected_result=None,

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -35,7 +35,7 @@ except ImportError:
 	cnf_path_repoman = None
 
 
-class ResolverPlayground(object):
+class ResolverPlayground:
 	"""
 	This class helps to create the necessary files on disk and
 	the needed settings instances, etc. for the resolver to do
@@ -641,7 +641,7 @@ class ResolverPlayground(object):
 		else:
 			shutil.rmtree(self.eroot)
 
-class ResolverPlaygroundTestCase(object):
+class ResolverPlaygroundTestCase:
 
 	def __init__(self, request, **kwargs):
 		self.all_permutations = kwargs.pop("all_permutations", False)
@@ -819,7 +819,7 @@ def _mergelist_str(x, depgraph):
 	return mergelist_str
 
 
-class ResolverPlaygroundResult(object):
+class ResolverPlaygroundResult:
 
 	checks = (
 		"success", "mergelist", "use_changes", "license_changes",
@@ -913,7 +913,7 @@ class ResolverPlaygroundResult(object):
 		if required_use_unsatisfied:
 			self.required_use_unsatisfied = set(required_use_unsatisfied)
 
-class ResolverPlaygroundDepcleanResult(object):
+class ResolverPlaygroundDepcleanResult:
 
 	checks = (
 		"success", "cleanlist", "ordered", "req_pkg_count",

--- a/lib/portage/tests/util/futures/asyncio/test_pipe_closed.py
+++ b/lib/portage/tests/util/futures/asyncio/test_pipe_closed.py
@@ -18,7 +18,7 @@ from portage.util.futures.unix_events import (
 )
 
 
-class _PipeClosedTestCase(object):
+class _PipeClosedTestCase:
 
 	def test_pipe(self):
 		read_end, write_end = os.pipe()

--- a/lib/portage/tests/util/futures/test_compat_coroutine.py
+++ b/lib/portage/tests/util/futures/test_compat_coroutine.py
@@ -123,7 +123,7 @@ class CompatCoroutineTestCase(TestCase):
 
 	def test_method_coroutine(self):
 
-		class Cubby(object):
+		class Cubby:
 
 			_empty = object()
 

--- a/lib/portage/tests/util/futures/test_retry.py
+++ b/lib/portage/tests/util/futures/test_retry.py
@@ -23,7 +23,7 @@ class SucceedLaterException(Exception):
 	pass
 
 
-class SucceedLater(object):
+class SucceedLater:
 	"""
 	A callable object that succeeds some duration of time has passed.
 	"""
@@ -48,7 +48,7 @@ class SucceedNeverException(Exception):
 	pass
 
 
-class SucceedNever(object):
+class SucceedNever:
 	"""
 	A callable object that never succeeds.
 	"""
@@ -60,7 +60,7 @@ class SucceedNever(object):
 		return result
 
 
-class HangForever(object):
+class HangForever:
 	"""
 	A callable object that sleeps forever.
 	"""

--- a/lib/portage/tests/util/test_socks5.py
+++ b/lib/portage/tests/util/test_socks5.py
@@ -51,7 +51,7 @@ class _Handler(BaseHTTPRequestHandler):
 		pass
 
 
-class AsyncHTTPServer(object):
+class AsyncHTTPServer:
 	def __init__(self, host, content, loop):
 		self._host = host
 		self._content = content

--- a/lib/portage/util/SlotObject.py
+++ b/lib/portage/util/SlotObject.py
@@ -1,7 +1,7 @@
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-class SlotObject(object):
+class SlotObject:
 	__slots__ = ("__weakref__",)
 
 	def __init__(self, **kwargs):

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -942,7 +942,7 @@ def dump_traceback(msg, noiselevel=1):
 		writemsg(error+"\n", noiselevel=noiselevel)
 	writemsg("====================================\n\n", noiselevel=noiselevel)
 
-class cmp_sort_key(object):
+class cmp_sort_key:
 	"""
 	In python-3.0 the list.sort() method no longer has a "cmp" keyword
 	argument. This class acts as an adapter which converts a cmp function
@@ -966,7 +966,7 @@ class cmp_sort_key(object):
 	def __call__(self, lhs):
 		return self._cmp_key(self._cmp_func, lhs)
 
-	class _cmp_key(object):
+	class _cmp_key:
 		__slots__ = ("_cmp_func", "_obj")
 
 		def __init__(self, cmp_func, obj):
@@ -1525,7 +1525,7 @@ class LazyItemsDict(UserDict):
 			UserDict.__setitem__(result, k_copy, deepcopy(self[k], memo))
 		return result
 
-	class _LazyItem(object):
+	class _LazyItem:
 
 		__slots__ = ('func', 'pargs', 'kwargs', 'singleton')
 
@@ -1560,7 +1560,7 @@ class LazyItemsDict(UserDict):
 			result.singleton = deepcopy(self.singleton, memo)
 			return result
 
-class ConfigProtect(object):
+class ConfigProtect:
 	def __init__(self, myroot, protect_list, mask_list,
 		case_insensitive=False):
 		self.myroot = myroot

--- a/lib/portage/util/_dyn_libs/LinkageMapELF.py
+++ b/lib/portage/util/_dyn_libs/LinkageMapELF.py
@@ -51,7 +51,7 @@ _approx_multilib_categories = {
 	"X86_64":        "x86_64",
 }
 
-class LinkageMapELF(object):
+class LinkageMapELF:
 
 	"""Models dynamic linker dependencies."""
 
@@ -59,7 +59,7 @@ class LinkageMapELF(object):
 	_soname_map_class = slot_dict_class(
 		("consumers", "providers"), prefix="")
 
-	class _obj_properties_class(object):
+	class _obj_properties_class:
 
 		__slots__ = ("arch", "needed", "runpaths", "soname", "alt_paths",
 			"owner",)
@@ -102,7 +102,7 @@ class LinkageMapELF(object):
 			self._obj_key_cache[path] = key
 		return key
 
-	class _ObjectKey(object):
+	class _ObjectKey:
 
 		"""Helper class used as _obj_properties keys for objects."""
 
@@ -485,7 +485,7 @@ class LinkageMapELF(object):
 
 		os = _os_merge
 
-		class _LibraryCache(object):
+		class _LibraryCache:
 
 			"""
 			Caches properties associated with paths.

--- a/lib/portage/util/_dyn_libs/NeededEntry.py
+++ b/lib/portage/util/_dyn_libs/NeededEntry.py
@@ -7,7 +7,7 @@ from portage import _encodings, _unicode_encode
 from portage.exception import InvalidData
 from portage.localization import _
 
-class NeededEntry(object):
+class NeededEntry:
 	"""
 	Represents one entry (line) from a NEEDED.ELF.2 file. The entry
 	must have 5 or more semicolon-delimited fields in order to be

--- a/lib/portage/util/_dyn_libs/PreservedLibsRegistry.py
+++ b/lib/portage/util/_dyn_libs/PreservedLibsRegistry.py
@@ -22,7 +22,7 @@ from portage.versions import cpv_getkey
 from portage.locks import lockfile, unlockfile
 
 
-class PreservedLibsRegistry(object):
+class PreservedLibsRegistry:
 	""" This class handles the tracking of preserved library objects """
 
 	# JSON read support has been available since portage-2.2.0_alpha89.

--- a/lib/portage/util/_dyn_libs/soname_deps.py
+++ b/lib/portage/util/_dyn_libs/soname_deps.py
@@ -15,7 +15,7 @@ from portage.util import (
 )
 
 
-class SonameDepsProcessor(object):
+class SonameDepsProcessor:
 	"""
 	Processes NEEDED.ELF.2 entries for one package, in order to generate
 	REQUIRES and PROVIDES metadata.

--- a/lib/portage/util/_eventloop/EventLoop.py
+++ b/lib/portage/util/_eventloop/EventLoop.py
@@ -39,7 +39,7 @@ from ..SlotObject import SlotObject
 from .PollConstants import PollConstants
 from .PollSelectAdapter import PollSelectAdapter
 
-class EventLoop(object):
+class EventLoop:
 	"""
 	An event loop, intended to be compatible with the GLib event loop.
 	Call the iteration method in order to execute one iteration of the
@@ -66,7 +66,7 @@ class EventLoop(object):
 		__slots__ = ("args", "function", "calling", "interval", "source_id",
 			"timestamp")
 
-	class _handle(object):
+	class _handle:
 		"""
 		A callback wrapper object, compatible with asyncio.Handle.
 		"""
@@ -83,7 +83,7 @@ class EventLoop(object):
 			"""
 			self._loop.source_remove(self._callback_id)
 
-	class _call_soon_callback(object):
+	class _call_soon_callback:
 		"""
 		Wraps a call_soon callback, and always returns False, since these
 		callbacks are only supposed to run once.
@@ -98,7 +98,7 @@ class EventLoop(object):
 			self._callback(*self._args)
 			return False
 
-	class _selector_callback(object):
+	class _selector_callback:
 		"""
 		Wraps an callback, and always returns True, for callbacks that
 		are supposed to run repeatedly.
@@ -1121,7 +1121,7 @@ def create_poll_instance():
 		return select.poll()
 	return PollSelectAdapter()
 
-class _epoll_adapter(object):
+class _epoll_adapter:
 	"""
 	Wraps a select.epoll instance in order to make it compatible
 	with select.poll instances. This is necessary since epoll instances

--- a/lib/portage/util/_eventloop/PollConstants.py
+++ b/lib/portage/util/_eventloop/PollConstants.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import select
-class PollConstants(object):
+class PollConstants:
 
 	"""
 	Provides POLL* constants that are equivalent to those from the

--- a/lib/portage/util/_eventloop/PollSelectAdapter.py
+++ b/lib/portage/util/_eventloop/PollSelectAdapter.py
@@ -6,7 +6,7 @@ from __future__ import division
 from .PollConstants import PollConstants
 import select
 
-class PollSelectAdapter(object):
+class PollSelectAdapter:
 
 	"""
 	Use select to emulate a poll object, for

--- a/lib/portage/util/_xattr.py
+++ b/lib/portage/util/_xattr.py
@@ -20,7 +20,7 @@ import subprocess
 from portage.exception import OperationNotSupported
 
 
-class _XattrGetAll(object):
+class _XattrGetAll:
 	"""Implement get_all() using list()/get() if there is no easy bulk method"""
 
 	@classmethod

--- a/lib/portage/util/backoff.py
+++ b/lib/portage/util/backoff.py
@@ -10,7 +10,7 @@ import random
 import sys
 
 
-class ExponentialBackoff(object):
+class ExponentialBackoff:
 	"""
 	An object that when called with number of previous tries, calculates
 	an exponential delay for the next try.

--- a/lib/portage/util/digraph.py
+++ b/lib/portage/util/digraph.py
@@ -9,7 +9,7 @@ import sys
 
 from portage.util import writemsg
 
-class digraph(object):
+class digraph:
 	"""
 	A directed graph object.
 	"""

--- a/lib/portage/util/elf/header.py
+++ b/lib/portage/util/elf/header.py
@@ -6,7 +6,7 @@ from portage.util.endian.decode import (decode_uint16_le,
 from portage.util.elf.constants import (E_ENTRY, E_MACHINE, E_TYPE,
 	EI_CLASS, ELFCLASS32, ELFCLASS64, ELFDATA2LSB, ELFDATA2MSB)
 
-class ELFHeader(object):
+class ELFHeader:
 
 	__slots__ = ('e_flags', 'e_machine', 'e_type', 'ei_class',
 		'ei_data')

--- a/lib/portage/util/formatter.py
+++ b/lib/portage/util/formatter.py
@@ -7,7 +7,7 @@
 import sys
 
 
-class AbstractFormatter(object):
+class AbstractFormatter:
 	"""The standard formatter."""
 
 	def __init__(self, writer):
@@ -35,7 +35,7 @@ class AbstractFormatter(object):
 		self.writer.new_styles(tuple(self.style_stack))
 
 
-class NullWriter(object):
+class NullWriter:
 	"""Minimal writer interface to use in testing & inheritance.
 
 	A writer which only provides the interface definition; no actions are

--- a/lib/portage/util/futures/_asyncio/process.py
+++ b/lib/portage/util/futures/_asyncio/process.py
@@ -12,7 +12,7 @@ from portage.util.futures._asyncio.streams import _reader, _writer
 from portage.util.futures.compat_coroutine import coroutine, coroutine_return
 
 
-class _Process(object):
+class _Process:
 	"""
 	Emulate a subset of the asyncio.subprocess.Process interface,
 	for python2.

--- a/lib/portage/util/futures/_asyncio/streams.py
+++ b/lib/portage/util/futures/_asyncio/streams.py
@@ -30,7 +30,7 @@ def _reader(input_file, loop=None):
 	return future
 
 
-class _Reader(object):
+class _Reader:
 	def __init__(self, future, input_file, loop):
 		self._future = future
 		self._pipe_reader = PipeReader(

--- a/lib/portage/util/futures/_asyncio/tasks.py
+++ b/lib/portage/util/futures/_asyncio/tasks.py
@@ -44,7 +44,7 @@ def wait(futures, loop=None, timeout=None, return_when=ALL_COMPLETED):
 	return result_future
 
 
-class _Waiter(object):
+class _Waiter:
 	def __init__(self, futures, timeout, return_when, result_future, loop):
 		self._futures = futures
 		self._completed = set()

--- a/lib/portage/util/futures/compat_coroutine.py
+++ b/lib/portage/util/futures/compat_coroutine.py
@@ -78,7 +78,7 @@ class _CoroutineReturnValue(Exception):
 		self.result = result
 
 
-class _GeneratorTask(object):
+class _GeneratorTask:
 	"""
 	Asynchronously executes the generator to completion, waiting for
 	the result of each Future that it yields, and sending the result

--- a/lib/portage/util/futures/executor/fork.py
+++ b/lib/portage/util/futures/executor/fork.py
@@ -16,7 +16,7 @@ from portage.util.futures import asyncio
 from portage.util.cpuinfo import get_cpu_count
 
 
-class ForkExecutor(object):
+class ForkExecutor:
 	"""
 	An implementation of concurrent.futures.Executor that forks a
 	new process for each task, with support for cancellation of tasks.

--- a/lib/portage/util/futures/futures.py
+++ b/lib/portage/util/futures/futures.py
@@ -28,7 +28,7 @@ _PENDING = 'PENDING'
 _CANCELLED = 'CANCELLED'
 _FINISHED = 'FINISHED'
 
-class _EventLoopFuture(object):
+class _EventLoopFuture:
 	"""
 	This class provides (a subset of) the asyncio.Future interface, for
 	use with the EventLoop class, because EventLoop is currently

--- a/lib/portage/util/futures/retry.py
+++ b/lib/portage/util/futures/retry.py
@@ -73,7 +73,7 @@ def _retry(loop, try_max, try_timeout, overall_timeout, delay_func,
 	return future
 
 
-class _Retry(object):
+class _Retry:
 	def __init__(self, future, loop, try_max, try_timeout, overall_timeout,
 		delay_func, reraise, func):
 		self._future = future

--- a/lib/portage/util/install_mask.py
+++ b/lib/portage/util/install_mask.py
@@ -33,7 +33,7 @@ _pattern = collections.namedtuple('_pattern', (
 ))
 
 
-class InstallMask(object):
+class InstallMask:
 	def __init__(self, install_mask):
 		"""
 		@param install_mask: INSTALL_MASK value

--- a/lib/portage/util/iterators/MultiIterGroupBy.py
+++ b/lib/portage/util/iterators/MultiIterGroupBy.py
@@ -3,7 +3,7 @@
 
 import bisect
 
-class MultiIterGroupBy(object):
+class MultiIterGroupBy:
 	"""
 	This class functions similarly to the itertools.groupby function,
 	except that it takes multiple source iterators as input. The source
@@ -78,7 +78,7 @@ class MultiIterGroupBy(object):
 				for k in yield_these:
 					yield key_map.pop(k)
 
-class _IteratorTracker(object):
+class _IteratorTracker:
 
 	__slots__ = ('current', 'iterator')
 

--- a/lib/portage/util/movefile.py
+++ b/lib/portage/util/movefile.py
@@ -41,7 +41,7 @@ def _get_xattr_excluder(pattern):
 
 	return value
 
-class _xattr_excluder(object):
+class _xattr_excluder:
 
 	__slots__ = ('_pattern_split',)
 

--- a/lib/portage/util/socks5.py
+++ b/lib/portage/util/socks5.py
@@ -15,7 +15,7 @@ from portage.util.futures.compat_coroutine import coroutine
 from portage.util.futures import asyncio
 
 
-class ProxyManager(object):
+class ProxyManager:
 	"""
 	A class to start and control a single running SOCKSv5 server process
 	for Portage.

--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -62,7 +62,7 @@ class _MetadataTreeBuilder(xml.etree.ElementTree.TreeBuilder):
 	def doctype(self, name, pubid, system):
 		pass
 
-class _Maintainer(object):
+class _Maintainer:
 	"""An object for representing one maintainer.
 
 	@type email: str or None
@@ -95,7 +95,7 @@ class _Maintainer(object):
 		return "<%s %r>" % (self.__class__.__name__, self.email)
 
 
-class _Useflag(object):
+class _Useflag:
 	"""An object for representing one USE flag.
 
 	@todo: Is there any way to have a keyword option to leave in
@@ -125,7 +125,7 @@ class _Useflag(object):
 		return "<%s %r>" % (self.__class__.__name__, self.name)
 
 
-class _Upstream(object):
+class _Upstream:
 	"""An object for representing one package's upstream.
 
 	@type maintainers: list
@@ -181,7 +181,7 @@ class _Upstream(object):
 		return [(e.text, e.get('type')) for e in self.node.findall('remote-id') if e.text]
 
 
-class MetaDataXML(object):
+class MetaDataXML:
 	"""Access metadata.xml"""
 
 	def __init__(self, metadata_xml_path, herds):

--- a/lib/portage/xpak.py
+++ b/lib/portage/xpak.py
@@ -274,7 +274,7 @@ def xpand(myid, mydest):
 		mydat.close()
 		startpos = startpos + namelen + 12
 
-class tbz2(object):
+class tbz2:
 	def __init__(self, myfile):
 		self.file = myfile
 		self.filestat = None

--- a/repoman/lib/repoman/actions.py
+++ b/repoman/lib/repoman/actions.py
@@ -41,7 +41,7 @@ from repoman import VERSION
 bad = create_color_func("BAD")
 
 
-class Actions(object):
+class Actions:
 	'''Handles post check result output and performs
 	the various vcs activities for committing the results'''
 

--- a/repoman/lib/repoman/copyrights.py
+++ b/repoman/lib/repoman/copyrights.py
@@ -20,7 +20,7 @@ _copyright_re2 = \
 	re.compile(br'^(# Copyright )(\d\d\d\d)( Gentoo (Foundation|Authors))\b')
 
 
-class _copyright_repl(object):
+class _copyright_repl:
 	__slots__ = ('year',)
 
 	def __init__(self, year):

--- a/repoman/lib/repoman/modules/commit/manifest.py
+++ b/repoman/lib/repoman/modules/commit/manifest.py
@@ -11,7 +11,7 @@ from portage.package.ebuild.digestgen import digestgen
 from portage.util import writemsg_level
 
 
-class Manifest(object):
+class Manifest:
 	'''Creates as well as checks pkg Manifest entries/files'''
 
 	def __init__(self, **kwargs):

--- a/repoman/lib/repoman/modules/linechecks/base.py
+++ b/repoman/lib/repoman/modules/linechecks/base.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 
-class LineCheck(object):
+class LineCheck:
 	"""Run a check on a line of an ebuild."""
 	"""A regular expression to determine whether to ignore the line"""
 	ignore_line = False

--- a/repoman/lib/repoman/modules/linechecks/config.py
+++ b/repoman/lib/repoman/modules/linechecks/config.py
@@ -35,7 +35,7 @@ def merge(dict1, dict2):
     return result
 
 
-class LineChecksConfig(object):
+class LineChecksConfig:
 	'''Holds our LineChecks configuration data and operation functions'''
 
 	def __init__(self, repo_settings):

--- a/repoman/lib/repoman/modules/linechecks/controller.py
+++ b/repoman/lib/repoman/modules/linechecks/controller.py
@@ -18,7 +18,7 @@ MODULES_PATH = os.path.dirname(__file__)
 logging.debug("LineChecks module path: %s", MODULES_PATH)
 
 
-class LineCheckController(object):
+class LineCheckController:
 	'''Initializes and runs the LineCheck checks'''
 
 	def __init__(self, repo_settings, linechecks):

--- a/repoman/lib/repoman/modules/scan/metadata/use_flags.py
+++ b/repoman/lib/repoman/modules/scan/metadata/use_flags.py
@@ -11,7 +11,7 @@ from portage import eapi
 from portage.eapi import eapi_has_iuse_defaults, eapi_has_required_use
 
 
-class USEFlagChecks(object):
+class USEFlagChecks:
 	'''Performs checks on USE flags listed in the ebuilds and metadata.xml'''
 
 	def __init__(self, **kwargs):

--- a/repoman/lib/repoman/modules/scan/module.py
+++ b/repoman/lib/repoman/modules/scan/module.py
@@ -19,7 +19,7 @@ MODULES_PATH = os.path.dirname(__file__)
 logging.debug("module path: %s", MODULES_PATH)
 
 
-class ModuleConfig(object):
+class ModuleConfig:
 	'''Holds the scan modules configuration information and
 	creates the ordered list of modulles to run'''
 

--- a/repoman/lib/repoman/modules/scan/scanbase.py
+++ b/repoman/lib/repoman/modules/scan/scanbase.py
@@ -1,7 +1,7 @@
 # -*- coding:utf-8 -*-
 
 
-class ScanBase(object):
+class ScanBase:
 	'''Skeleton class for performing a scan for one or more items
 	to check in a pkg directory or ebuild.'''
 

--- a/repoman/lib/repoman/modules/vcs/None/status.py
+++ b/repoman/lib/repoman/modules/vcs/None/status.py
@@ -3,7 +3,7 @@ None (non-VCS) module Status class submodule
 '''
 
 
-class Status(object):
+class Status:
 	'''Performs status checks on the svn repository'''
 
 	def __init__(self, qatracker, eadded):

--- a/repoman/lib/repoman/modules/vcs/bzr/status.py
+++ b/repoman/lib/repoman/modules/vcs/bzr/status.py
@@ -7,7 +7,7 @@ from portage import os
 from repoman._subprocess import repoman_popen
 
 
-class Status(object):
+class Status:
 	'''Performs status checks on the svn repository'''
 
 	def __init__(self, qatracker, eadded):

--- a/repoman/lib/repoman/modules/vcs/changes.py
+++ b/repoman/lib/repoman/modules/vcs/changes.py
@@ -13,7 +13,7 @@ from portage import _unicode_encode
 from portage.process import spawn
 
 
-class ChangesBase(object):
+class ChangesBase:
 	'''Base Class object to scan and hold the resultant data
 	for all changes to process.
 	'''

--- a/repoman/lib/repoman/modules/vcs/cvs/status.py
+++ b/repoman/lib/repoman/modules/vcs/cvs/status.py
@@ -13,7 +13,7 @@ from portage.output import red, green
 from portage import _unicode_encode, _unicode_decode
 
 
-class Status(object):
+class Status:
 	'''Performs status checks on the svn repository'''
 
 	def __init__(self, qatracker, eadded):

--- a/repoman/lib/repoman/modules/vcs/git/status.py
+++ b/repoman/lib/repoman/modules/vcs/git/status.py
@@ -9,7 +9,7 @@ from portage import os
 from repoman._subprocess import repoman_popen, repoman_getstatusoutput
 
 
-class Status(object):
+class Status:
 	'''Performs status checks on the git repository'''
 
 	def __init__(self, qatracker, eadded):

--- a/repoman/lib/repoman/modules/vcs/hg/status.py
+++ b/repoman/lib/repoman/modules/vcs/hg/status.py
@@ -7,7 +7,7 @@ from portage import os
 from repoman._subprocess import repoman_popen
 
 
-class Status(object):
+class Status:
 	'''Performs status checks on the svn repository'''
 
 	def __init__(self, qatracker, eadded):

--- a/repoman/lib/repoman/modules/vcs/settings.py
+++ b/repoman/lib/repoman/modules/vcs/settings.py
@@ -13,7 +13,7 @@ from repoman.modules.vcs.vcs import FindVCS
 from repoman.qa_tracker import QATracker
 
 
-class VCSSettings(object):
+class VCSSettings:
 	'''Holds various VCS settings'''
 
 	def __init__(self, options=None, repoman_settings=None, repo_settings=None):

--- a/repoman/lib/repoman/modules/vcs/svn/status.py
+++ b/repoman/lib/repoman/modules/vcs/svn/status.py
@@ -15,7 +15,7 @@ from portage import _unicode_encode, _unicode_decode
 from repoman._subprocess import repoman_popen
 
 
-class Status(object):
+class Status:
 	'''Performs status checks on the svn repository'''
 
 	def __init__(self, qatracker, eadded):

--- a/repoman/lib/repoman/profile.py
+++ b/repoman/lib/repoman/profile.py
@@ -7,7 +7,7 @@ from portage import os
 from portage.output import red
 
 
-class ProfileDesc(object):
+class ProfileDesc:
 	__slots__ = ('abs_path', 'arch', 'status', 'sub_path', 'tree_path',)
 
 	def __init__(self, arch, status, sub_path, tree_path):

--- a/repoman/lib/repoman/qa_data.py
+++ b/repoman/lib/repoman/qa_data.py
@@ -11,7 +11,7 @@ from repoman._portage import portage
 from repoman.config import load_config
 
 
-class QAData(object):
+class QAData:
 
 	def __init__(self):
 		# Create the main exported data variables

--- a/repoman/lib/repoman/qa_tracker.py
+++ b/repoman/lib/repoman/qa_tracker.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 
-class QATracker(object):
+class QATracker:
 	'''Track all occurrances of Q/A problems detected'''
 
 	def __init__(self, qacats=None, qawarnings=None):

--- a/repoman/lib/repoman/repos.py
+++ b/repoman/lib/repoman/repos.py
@@ -22,7 +22,7 @@ GPG_KEY_ID_REGEX = r'(0x)?([0-9a-fA-F]{8}){1,5}!?'
 bad = portage.output.create_color_func("BAD")
 
 
-class RepoSettings(object):
+class RepoSettings:
 	'''Holds our repo specific settings'''
 
 	def __init__(

--- a/repoman/lib/repoman/scanner.py
+++ b/repoman/lib/repoman/scanner.py
@@ -24,7 +24,7 @@ from repoman.modules.vcs.vcs import vcs_files_to_cps
 DATA_TYPES = {'dict': dict, 'Future': ExtendedFuture, 'list': list, 'set': set}
 
 
-class Scanner(object):
+class Scanner:
 	'''Primary scan class.  Operates all the small Q/A tests and checks'''
 
 	def __init__(self, repo_settings, myreporoot, config_root, options,

--- a/runtests
+++ b/runtests
@@ -23,7 +23,6 @@ import tempfile
 
 # These are the versions we fully support and require to pass tests.
 PYTHON_SUPPORTED_VERSIONS = [
-	'2.7',
 	'3.6',
 	'3.7',
 	'3.8'


### PR DESCRIPTION
Resolve pylint warning R0205. Its a py3k migration warning and we did a bunch of py3k refactoring recently.

R0205 basically says to not inherit from object in python3. Since we don't support python2 anymore; we don't need this inherit.

Also drop 2.7 from ./runtests as the 2.7 target will not pass after this change.