### PR TITLE
MergeProcess: handle RETURNCODE_POSTINST_FAILURE in _proc_join_done

### DIFF
--- a/lib/portage/dbapi/_MergeProcess.py
+++ b/lib/portage/dbapi/_MergeProcess.py
@@ -195,15 +195,14 @@ class MergeProcess(ForkProcess):
 						prev_mtimes=self.prev_mtimes, counter=counter)
 			return rval
 
-	def _async_waitpid_cb(self, *args, **kwargs):
+	def _proc_join_done(self, proc, future):
 		"""
-		Override _async_waitpid_cb to perform cleanup that is
-		not necessarily idempotent.
+		Extend _proc_join_done to react to RETURNCODE_POSTINST_FAILURE.
 		"""
-		ForkProcess._async_waitpid_cb(self, *args, **kwargs)
-		if self.returncode == portage.const.RETURNCODE_POSTINST_FAILURE:
+		if proc.exitcode == portage.const.RETURNCODE_POSTINST_FAILURE:
 			self.postinst_failure = True
 			self.returncode = os.EX_OK
+		super(MergeProcess, self)._proc_join_done(proc, future)
 
 	def _unregister(self):
 		"""


### PR DESCRIPTION
Since ForkProcess now receives process exit status in the
_proc_join_done method instead of the _async_waitpid_cb method,
MergeProcess needs to handle RETURNCODE_POSTINST_FAILURE there
instead.

Fixes: 3561071e07ad ("MergeProcess: replace os.fork with multiprocessing.Process (bug 730192)")
Signed-off-by: Zac Medico <zmedico@gentoo.org>