### PR TITLE
Fix 'unused-import' for stdlib imports.

### DIFF
--- a/lib/_emerge/AbstractPollTask.py
+++ b/lib/_emerge/AbstractPollTask.py
@@ -3,7 +3,6 @@
 
 import array
 import errno
-import logging
 import os
 
 from portage.util import writemsg_level

--- a/lib/_emerge/BlockerCache.py
+++ b/lib/_emerge/BlockerCache.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
-import sys
 from portage.util import writemsg
 from portage.data import secpass
 import portage

--- a/lib/_emerge/BlockerDB.py
+++ b/lib/_emerge/BlockerDB.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 import portage
 from portage import os

--- a/lib/_emerge/DependencyArg.py
+++ b/lib/_emerge/DependencyArg.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage import _encodings, _unicode_encode
 

--- a/lib/_emerge/FakeVartree.py
+++ b/lib/_emerge/FakeVartree.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 import warnings
 
 import portage

--- a/lib/_emerge/FifoIpcDaemon.py
+++ b/lib/_emerge/FifoIpcDaemon.py
@@ -1,7 +1,6 @@
 # Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage import os
 from _emerge.AbstractPollTask import AbstractPollTask

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -1,8 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import functools
-import sys
 from itertools import chain
 import warnings
 

--- a/lib/_emerge/PackageVirtualDbapi.py
+++ b/lib/_emerge/PackageVirtualDbapi.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 from portage.dbapi import dbapi
 from portage.dbapi.dep_expand import dep_expand
 

--- a/lib/_emerge/PipeReader.py
+++ b/lib/_emerge/PipeReader.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import fcntl
-import sys
 
 from portage import os
 from _emerge.AbstractPollTask import AbstractPollTask

--- a/lib/_emerge/SequentialTaskQueue.py
+++ b/lib/_emerge/SequentialTaskQueue.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 from collections import deque
-import sys
 
 from portage.util.futures import asyncio
 from portage.util.futures.compat_coroutine import coroutine

--- a/lib/_emerge/TaskSequence.py
+++ b/lib/_emerge/TaskSequence.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 from collections import deque
 
 from portage import os

--- a/lib/_emerge/UseFlagDisplay.py
+++ b/lib/_emerge/UseFlagDisplay.py
@@ -3,7 +3,6 @@
 
 import collections
 from itertools import chain
-import sys
 
 from portage import _encodings, _unicode_encode
 from portage.output import red

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -8,12 +8,8 @@ import errno
 import logging
 import operator
 import platform
-import pwd
-import random
 import re
 import signal
-import socket
-import stat
 import subprocess
 import sys
 import tempfile

--- a/lib/_emerge/create_world_atom.py
+++ b/lib/_emerge/create_world_atom.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage.dep import Atom, _repo_separator
 from portage.exception import InvalidData

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -9,7 +9,6 @@ import functools
 import io
 import logging
 import stat
-import sys
 import textwrap
 import warnings
 from collections import deque, OrderedDict

--- a/lib/_emerge/emergelog.py
+++ b/lib/_emerge/emergelog.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import io
-import sys
 import time
 import portage
 from portage import os

--- a/lib/_emerge/resolver/DbapiProvidesIndex.py
+++ b/lib/_emerge/resolver/DbapiProvidesIndex.py
@@ -3,7 +3,6 @@
 
 import bisect
 import collections
-import sys
 
 class DbapiProvidesIndex:
 	"""

--- a/lib/_emerge/resolver/output.py
+++ b/lib/_emerge/resolver/output.py
@@ -8,7 +8,6 @@ __all__ = (
 	"Display", "format_unmatched_atom",
 	)
 
-import sys
 
 import portage
 from portage import os

--- a/lib/_emerge/resolver/output_helpers.py
+++ b/lib/_emerge/resolver/output_helpers.py
@@ -10,7 +10,6 @@ __all__ = (
 
 import io
 import re
-import sys
 
 from portage import os
 from portage import _encodings, _unicode_encode

--- a/lib/_emerge/resolver/slot_collision.py
+++ b/lib/_emerge/resolver/slot_collision.py
@@ -3,7 +3,6 @@
 
 from __future__ import print_function
 
-import sys
 
 from portage import _encodings, _unicode_encode
 from _emerge.AtomArg import AtomArg

--- a/lib/portage/_emirrordist/Config.py
+++ b/lib/portage/_emirrordist/Config.py
@@ -5,7 +5,6 @@ import copy
 import io
 import logging
 import shelve
-import sys
 import time
 
 import portage

--- a/lib/portage/_emirrordist/FetchTask.py
+++ b/lib/portage/_emirrordist/FetchTask.py
@@ -7,9 +7,7 @@ import collections
 import errno
 import logging
 import random
-import stat
 import subprocess
-import sys
 
 import portage
 from portage import _encodings, _unicode_encode

--- a/lib/portage/_emirrordist/MirrorDistTask.py
+++ b/lib/portage/_emirrordist/MirrorDistTask.py
@@ -3,7 +3,6 @@
 
 import errno
 import logging
-import sys
 import time
 
 try:

--- a/lib/portage/_selinux.py
+++ b/lib/portage/_selinux.py
@@ -5,7 +5,6 @@
 # the whole _selinux module itself will be wrapped.
 import os
 import shutil
-import sys
 import warnings
 
 try:

--- a/lib/portage/_sets/base.py
+++ b/lib/portage/_sets/base.py
@@ -1,7 +1,6 @@
 # Copyright 2007-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 from portage.dep import Atom, ExtendedAtomDict, best_match_to_list, match_from_list
 from portage.exception import InvalidAtom
 from portage.versions import cpv_getkey

--- a/lib/portage/cache/anydbm.py
+++ b/lib/portage/cache/anydbm.py
@@ -14,7 +14,6 @@ except ImportError:
 import pickle
 from portage import _unicode_encode
 from portage import os
-import sys
 from portage.cache import fs_template
 from portage.cache import cache_errors
 

--- a/lib/portage/cache/flat_hash.py
+++ b/lib/portage/cache/flat_hash.py
@@ -7,7 +7,6 @@ from portage.cache import cache_errors
 import errno
 import io
 import stat
-import sys
 import tempfile
 import os as _os
 from portage import os

--- a/lib/portage/cache/fs_template.py
+++ b/lib/portage/cache/fs_template.py
@@ -3,7 +3,6 @@
 # Author(s): Brian Harring (ferringb@gentoo.org)
 
 import os as _os
-import sys
 from portage.cache import template
 from portage import os
 

--- a/lib/portage/cache/index/pkg_desc_index.py
+++ b/lib/portage/cache/index/pkg_desc_index.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
-import sys
 
 from portage.versions import _pkg_str
 

--- a/lib/portage/cache/mappings.py
+++ b/lib/portage/cache/mappings.py
@@ -5,7 +5,6 @@
 __all__ = ["Mapping", "MutableMapping", "UserDict", "ProtectedDict",
 	"LazyLoad", "slot_dict_class"]
 
-import sys
 import weakref
 
 class Mapping:

--- a/lib/portage/cache/metadata.py
+++ b/lib/portage/cache/metadata.py
@@ -5,7 +5,6 @@
 import errno
 import re
 import stat
-import sys
 from operator import attrgetter
 from portage import os
 from portage import _encodings

--- a/lib/portage/cache/sql_template.py
+++ b/lib/portage/cache/sql_template.py
@@ -2,7 +2,6 @@
 # Author(s): Brian Harring (ferringb@gentoo.org)
 # License: GPL2
 
-import sys
 from portage.cache import template, cache_errors
 from portage.cache.template import reconstruct_eclasses
 

--- a/lib/portage/cache/sqlite.py
+++ b/lib/portage/cache/sqlite.py
@@ -4,7 +4,6 @@
 from __future__ import division
 
 import re
-import sys
 from portage.cache import fs_template
 from portage.cache import cache_errors
 from portage import os

--- a/lib/portage/cache/template.py
+++ b/lib/portage/cache/template.py
@@ -5,7 +5,6 @@
 from portage.cache import cache_errors
 from portage.cache.cache_errors import InvalidRestriction
 from portage.cache.mappings import ProtectedDict
-import sys
 import warnings
 import operator
 

--- a/lib/portage/checksum.py
+++ b/lib/portage/checksum.py
@@ -12,7 +12,6 @@ import errno
 import functools
 import hashlib
 import stat
-import sys
 import subprocess
 import tempfile
 

--- a/lib/portage/cvstree.py
+++ b/lib/portage/cvstree.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import io
 import re
 import stat
-import sys
 import time
 
 from portage import os

--- a/lib/portage/data.py
+++ b/lib/portage/data.py
@@ -2,7 +2,10 @@
 # Copyright 1998-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-import os, pwd, grp, platform, sys
+import grp
+import os
+import platform
+import pwd
 
 import portage
 portage.proxy.lazyimport.lazyimport(globals(),

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -44,7 +44,6 @@ import errno
 import io
 import stat
 import subprocess
-import sys
 import tempfile
 import textwrap
 import time

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -39,7 +39,6 @@ from portage.util.futures.iter_completed import iter_gather
 from _emerge.EbuildMetadataPhase import EbuildMetadataPhase
 
 import os as _os
-import sys
 import traceback
 import warnings
 import errno

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -97,7 +97,6 @@ import platform
 import pwd
 import re
 import stat
-import sys
 import tempfile
 import textwrap
 import time

--- a/lib/portage/dep/soname/SonameAtom.py
+++ b/lib/portage/dep/soname/SonameAtom.py
@@ -1,7 +1,6 @@
 # Copyright 2015-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage import _encodings, _unicode_encode
 

--- a/lib/portage/eclass_cache.py
+++ b/lib/portage/eclass_cache.py
@@ -5,7 +5,6 @@
 __all__ = ["cache"]
 
 import stat
-import sys
 import operator
 import warnings
 from portage.util import normalize_path

--- a/lib/portage/elog/mod_save_summary.py
+++ b/lib/portage/elog/mod_save_summary.py
@@ -4,7 +4,6 @@
 
 import errno
 import io
-import sys
 import time
 import portage
 from portage import os

--- a/lib/portage/elog/mod_syslog.py
+++ b/lib/portage/elog/mod_syslog.py
@@ -2,7 +2,6 @@
 # Copyright 2006-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 import syslog
 from portage.const import EBUILD_PHASES
 from portage import _encodings

--- a/lib/portage/emaint/modules/binhost/binhost.py
+++ b/lib/portage/emaint/modules/binhost/binhost.py
@@ -9,7 +9,6 @@ from portage import os
 from portage.util import writemsg
 from portage.versions import _pkg_str
 
-import sys
 
 
 class BinhostHandler:

--- a/lib/portage/emaint/modules/sync/sync.py
+++ b/lib/portage/emaint/modules/sync/sync.py
@@ -1,9 +1,7 @@
 # Copyright 2014-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import logging
 import os
-import sys
 
 import portage
 portage._internal_caller = True

--- a/lib/portage/exception.py
+++ b/lib/portage/exception.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import signal
-import sys
 from portage import _encodings, _unicode_encode, _unicode_decode
 from portage.localization import _
 

--- a/lib/portage/manifest.py
+++ b/lib/portage/manifest.py
@@ -6,7 +6,6 @@ import io
 import logging
 import re
 import stat
-import sys
 import warnings
 
 import portage

--- a/lib/portage/package/ebuild/getmaskingstatus.py
+++ b/lib/portage/package/ebuild/getmaskingstatus.py
@@ -3,7 +3,6 @@
 
 __all__ = ['getmaskingstatus']
 
-import sys
 
 import portage
 from portage import eapi_is_supported, _eapi_is_deprecated

--- a/lib/portage/proxy/objectproxy.py
+++ b/lib/portage/proxy/objectproxy.py
@@ -1,7 +1,6 @@
 # Copyright 2008-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 __all__ = ['ObjectProxy']
 

--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -4,7 +4,6 @@
 import io
 import logging
 import warnings
-import sys
 import re
 
 import portage

--- a/lib/portage/sync/getaddrinfo_validate.py
+++ b/lib/portage/sync/getaddrinfo_validate.py
@@ -1,7 +1,6 @@
 # Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 
 def getaddrinfo_validate(addrinfos):

--- a/lib/portage/sync/modules/rsync/rsync.py
+++ b/lib/portage/sync/modules/rsync/rsync.py
@@ -10,7 +10,6 @@ import datetime
 import io
 import re
 import random
-import subprocess
 import tempfile
 
 import portage

--- a/lib/portage/tests/dep/test_match_from_list.py
+++ b/lib/portage/tests/dep/test_match_from_list.py
@@ -1,7 +1,6 @@
 # Copyright 2006-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 from portage.tests import TestCase
 from portage.dep import Atom, match_from_list, _repo_separator
 from portage.versions import catpkgsplit, _pkg_str

--- a/lib/portage/tests/dep/test_soname_atom_pickle.py
+++ b/lib/portage/tests/dep/test_soname_atom_pickle.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage.dep.soname.SonameAtom import SonameAtom
 from portage.tests import TestCase

--- a/lib/portage/tests/ebuild/test_spawn.py
+++ b/lib/portage/tests/ebuild/test_spawn.py
@@ -3,7 +3,6 @@
 
 import errno
 import io
-import sys
 import tempfile
 import portage
 from portage import os

--- a/lib/portage/tests/lint/test_bash_syntax.py
+++ b/lib/portage/tests/lint/test_bash_syntax.py
@@ -4,7 +4,6 @@
 from itertools import chain
 import stat
 import subprocess
-import sys
 
 from portage.const import BASH_BINARY, PORTAGE_BASE_PATH, PORTAGE_BIN_PATH
 from portage.tests import TestCase

--- a/lib/portage/tests/process/test_poll.py
+++ b/lib/portage/tests/process/test_poll.py
@@ -5,7 +5,6 @@ import functools
 import pty
 import shutil
 import socket
-import sys
 import tempfile
 
 from portage import os

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -4,7 +4,6 @@
 import bz2
 from itertools import permutations
 import fnmatch
-import sys
 import tempfile
 import portage
 from portage import os

--- a/lib/portage/tests/sync/test_sync_local.py
+++ b/lib/portage/tests/sync/test_sync_local.py
@@ -5,7 +5,6 @@ import datetime
 import subprocess
 import sys
 import textwrap
-import time
 
 import portage
 from portage import os, shutil, _shell_quote

--- a/lib/portage/tests/unicode/test_string_format.py
+++ b/lib/portage/tests/unicode/test_string_format.py
@@ -1,7 +1,6 @@
 # Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage import _encodings, _unicode_encode
 from portage.exception import PortageException

--- a/lib/portage/tests/util/futures/asyncio/test_pipe_closed.py
+++ b/lib/portage/tests/util/futures/asyncio/test_pipe_closed.py
@@ -6,7 +6,6 @@ import os
 import pty
 import shutil
 import socket
-import sys
 import tempfile
 
 from portage.tests import TestCase

--- a/lib/portage/tests/util/futures/asyncio/test_subprocess_exec.py
+++ b/lib/portage/tests/util/futures/asyncio/test_subprocess_exec.py
@@ -3,7 +3,6 @@
 
 import os
 import subprocess
-import sys
 
 from portage.process import find_binary
 from portage.tests import TestCase

--- a/lib/portage/tests/util/futures/test_retry.py
+++ b/lib/portage/tests/util/futures/test_retry.py
@@ -8,7 +8,6 @@ try:
 except ImportError:
 	import dummy_threading as threading
 
-import sys
 import time
 
 from portage.tests import TestCase

--- a/lib/portage/tests/util/test_socks5.py
+++ b/lib/portage/tests/util/test_socks5.py
@@ -2,11 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
-import platform
 import shutil
 import socket
 import struct
-import sys
 import tempfile
 import time
 

--- a/lib/portage/util/_async/PipeLogger.py
+++ b/lib/portage/util/_async/PipeLogger.py
@@ -4,7 +4,6 @@
 import fcntl
 import errno
 import gzip
-import sys
 
 import portage
 from portage import os, _encodings, _unicode_encode

--- a/lib/portage/util/_compare_files.py
+++ b/lib/portage/util/_compare_files.py
@@ -6,7 +6,6 @@ __all__ = ["compare_files"]
 import io
 import os
 import stat
-import sys
 
 from portage import _encodings
 from portage import _unicode_encode

--- a/lib/portage/util/_desktop_entry.py
+++ b/lib/portage/util/_desktop_entry.py
@@ -1,7 +1,6 @@
 # Copyright 2012-2013 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-import io
 import re
 import subprocess
 import sys

--- a/lib/portage/util/_dyn_libs/LinkageMapELF.py
+++ b/lib/portage/util/_dyn_libs/LinkageMapELF.py
@@ -6,7 +6,6 @@ import errno
 import itertools
 import logging
 import subprocess
-import sys
 
 import portage
 from portage import _encodings

--- a/lib/portage/util/_dyn_libs/NeededEntry.py
+++ b/lib/portage/util/_dyn_libs/NeededEntry.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-import sys
 
 from portage import _encodings, _unicode_encode
 from portage.exception import InvalidData

--- a/lib/portage/util/_dyn_libs/PreservedLibsRegistry.py
+++ b/lib/portage/util/_dyn_libs/PreservedLibsRegistry.py
@@ -6,7 +6,6 @@ import json
 import logging
 import pickle
 import stat
-import sys
 
 from portage import abssymlink
 from portage import os

--- a/lib/portage/util/_eventloop/EventLoop.py
+++ b/lib/portage/util/_eventloop/EventLoop.py
@@ -10,7 +10,6 @@ import logging
 import os
 import select
 import signal
-import sys
 import time
 import traceback
 

--- a/lib/portage/util/_eventloop/global_event_loop.py
+++ b/lib/portage/util/_eventloop/global_event_loop.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import os
-import sys
 
 from .EventLoop import EventLoop
 from portage.util._eventloop.asyncio_event_loop import AsyncioEventLoop

--- a/lib/portage/util/_urlopen.py
+++ b/lib/portage/util/_urlopen.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import io
-import sys
 from datetime import datetime
 from time import mktime
 from email.utils import formatdate, parsedate

--- a/lib/portage/util/compression_probe.py
+++ b/lib/portage/util/compression_probe.py
@@ -4,7 +4,6 @@
 import ctypes
 import errno
 import re
-import sys
 
 
 from portage import _encodings, _unicode_encode

--- a/lib/portage/util/configparser.py
+++ b/lib/portage/util/configparser.py
@@ -9,7 +9,6 @@ __all__ = ['ConfigParserError', 'NoOptionError', 'ParsingError',
 # - RawConfigParser that provides no interpolation for values.
 
 import io
-import sys
 
 from configparser import (Error as ConfigParserError,
 	NoOptionError, ParsingError, RawConfigParser)

--- a/lib/portage/util/digraph.py
+++ b/lib/portage/util/digraph.py
@@ -5,7 +5,6 @@ __all__ = ['digraph']
 
 import bisect
 from collections import deque
-import sys
 
 from portage.util import writemsg
 

--- a/lib/portage/util/env_update.py
+++ b/lib/portage/util/env_update.py
@@ -7,7 +7,6 @@ import errno
 import glob
 import io
 import stat
-import sys
 import time
 
 import portage

--- a/lib/portage/util/install_mask.py
+++ b/lib/portage/util/install_mask.py
@@ -6,9 +6,7 @@ __all__ = ['install_mask_dir', 'InstallMask']
 import collections
 import errno
 import fnmatch
-import functools
 import operator
-import sys
 
 from portage import os, _unicode_decode
 from portage.exception import (

--- a/lib/portage/util/listdir.py
+++ b/lib/portage/util/listdir.py
@@ -5,7 +5,6 @@ __all__ = ['cacheddir', 'listdir']
 
 import errno
 import stat
-import sys
 
 
 from portage import os

--- a/lib/portage/util/movefile.py
+++ b/lib/portage/util/movefile.py
@@ -9,7 +9,6 @@ import errno
 import fnmatch
 import os as _os
 import stat
-import sys
 import textwrap
 
 import portage

--- a/lib/portage/util/mtimedb.py
+++ b/lib/portage/util/mtimedb.py
@@ -12,7 +12,6 @@ except ImportError:
 import errno
 import io
 import json
-import sys
 
 import portage
 from portage import _encodings

--- a/lib/portage/util/whirlpool.py
+++ b/lib/portage/util/whirlpool.py
@@ -25,7 +25,6 @@
 ##
 ## This Python implementation is therefore also placed in the public domain.
 
-import sys
 
 
 #block_size = 64

--- a/lib/portage/versions.py
+++ b/lib/portage/versions.py
@@ -9,7 +9,6 @@ __all__ = [
 ]
 
 import re
-import sys
 import warnings
 from functools import lru_cache
 

--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -30,7 +30,6 @@
 
 __all__ = ('MetaDataXML', 'parse_metadata_use')
 
-import sys
 
 try:
 	import xml.etree.cElementTree as etree

--- a/lib/portage/xpak.py
+++ b/lib/portage/xpak.py
@@ -24,7 +24,6 @@ __all__ = [
 
 import array
 import errno
-import sys
 
 import portage
 from portage import os


### PR DESCRIPTION
This is part of a cleanup to enable pylint. This is only stdlib modules;
there are hundreds of unused imports of other modules but its less clear
how safe those are to remove due to side effects.

Signed-off-by: Alec Warner <antarus@gentoo.org>
Change-Id: If9bee83bbbe1620b34a0f8d153637909af2b8512

Methodology:

pylint --disable=all --enable=unused-import lib/ > unused-import
awk -F: '/^lib/ { print $1 }' unused-import | xargs autoflake -i

Autoflake likes to remove extra pass statements, so I had to revert these to make a clean change.