### PR TITLE
Fix redefined-builtin errors for pylint.

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7476,7 +7476,7 @@ class depgraph:
 
 		mygraph.order.sort(key=cmp_sort_key(cmp_merge_preference))
 
-	def altlist(self, reversed=DeprecationWarning):
+	def altlist(self, reversed=DeprecationWarning): # pylint: disable=redefined-builtin
 
 		if reversed is not DeprecationWarning:
 			warnings.warn("The reversed parameter of "

--- a/lib/_emerge/help.py
+++ b/lib/_emerge/help.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 from portage.output import bold, turquoise, green
 
-def help():
+def _help():
 	print(bold("emerge:")+" command-line interface to the Portage system")
 	print(bold("Usage:"))
 	print("   "+turquoise("emerge")+" [ "+green("options")+" ] [ "+green("action")+" ] [ "+turquoise("ebuild")+" | "+turquoise("tbz2")+" | "+turquoise("file")+" | "+turquoise("@set")+" | "+turquoise("atom")+" ] [ ... ]")

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -16,7 +16,7 @@ portage.proxy.lazyimport.lazyimport(globals(),
 	'textwrap',
 	'_emerge.actions:load_emerge_config,run_action,' + \
 		'validate_ebuild_environment',
-	'_emerge.help:help@emerge_help',
+	'_emerge.help:_help@emerge_help',
 	'_emerge.is_valid_package_atom:insert_category_into_atom'
 )
 from portage import os

--- a/lib/_emerge/resolver/output_helpers.py
+++ b/lib/_emerge/resolver/output_helpers.py
@@ -469,7 +469,7 @@ def _prune_tree_display(display_list):
 				del display_list[i]
 
 
-def _calc_changelog(ebuildpath,current,next):
+def _calc_changelog(ebuildpath,current,next): # pylint: disable=redefined-builtin
 	if ebuildpath == None or not os.path.exists(ebuildpath):
 		return []
 	current = '-'.join(catpkgsplit(current)[1:])

--- a/lib/_emerge/resolver/slot_collision.py
+++ b/lib/_emerge/resolver/slot_collision.py
@@ -371,11 +371,11 @@ class slot_conflict_handler:
 					selected_for_display = set()
 					unconditional_use_deps = set()
 
-					for (type, sub_type), parents in collision_reasons.items():
-						#From each (type, sub_type) pair select at least one atom.
+					for (ctype, sub_type), parents in collision_reasons.items():
+						#From each (ctype, sub_type) pair select at least one atom.
 						#Try to select as few atoms as possible
 
-						if type == "version":
+						if ctype == "version":
 							#Find the atom with version that is as far away as possible.
 							best_matches = {}
 							for ppkg, atom, other_pkg in parents:
@@ -395,7 +395,7 @@ class slot_conflict_handler:
 							if not verboseconflicts:
 								selected_for_display.update(
 										best_matches.values())
-						elif type in ("soname", "slot"):
+						elif ctype in ("soname", "slot"):
 							# Check for packages that might need to
 							# be rebuilt, but cannot be rebuilt for
 							# some reason.
@@ -423,7 +423,7 @@ class slot_conflict_handler:
 								selected_for_display.add((ppkg, atom))
 								if not verboseconflicts:
 									break
-						elif type == "use":
+						elif ctype == "use":
 							#Prefer atoms with unconditional use deps over, because it's
 							#not possible to change them on the parent, which means there
 							#are fewer possible solutions.
@@ -464,7 +464,7 @@ class slot_conflict_handler:
 								# If the list is long, people can simply
 								# use a pager.
 								selected_for_display.add((ppkg, atom))
-						elif type == "AtomArg":
+						elif ctype == "AtomArg":
 							for ppkg, atom in parents:
 								selected_for_display.add((ppkg, atom))
 
@@ -736,9 +736,9 @@ class slot_conflict_handler:
 		all_involved_flags = []
 
 		#Go through all slot conflicts
-		for id, pkg in enumerate(config):
+		for idx, pkg in enumerate(config):
 			involved_flags = {}
-			for ppkg, atom in all_conflict_atoms_by_slotatom[id]:
+			for ppkg, atom in all_conflict_atoms_by_slotatom[idx]:
 				if not atom.package:
 					continue
 
@@ -846,8 +846,8 @@ class slot_conflict_handler:
 
 		if self.debug:
 			writemsg("All involved flags:\n", noiselevel=-1)
-			for id, involved_flags in enumerate(all_involved_flags):
-				writemsg("   %s\n" % (config[id],), noiselevel=-1)
+			for idx, involved_flags in enumerate(all_involved_flags):
+				writemsg("   %s\n" % (config[idx],), noiselevel=-1)
 				for flag, state in involved_flags.items():
 					writemsg("     " + flag + ": " + state + "\n", noiselevel=-1)
 
@@ -1095,11 +1095,11 @@ class _configuration_generator:
 				return None
 		
 		solution = []
-		for id, pkgs in enumerate(self.conflict_pkgs):
-			solution.append(pkgs[self.solution_ids[id]])
+		for idx, pkgs in enumerate(self.conflict_pkgs):
+			solution.append(pkgs[self.solution_ids[idx]])
 		return solution
 	
-	def _next(self, id=None):
+	def _next(self, id=None): # pylint: disabled=redefined-builtin
 		solution_ids = self.solution_ids
 		conflict_pkgs = self.conflict_pkgs
 		
@@ -1160,7 +1160,7 @@ class _solution_candidate_generator:
 
 		return self.all_involved_flags
 	
-	def _next(self, id=None):
+	def _next(self, id=None): # pylint: disabled=redefined-builtin
 		values = self.conditional_values
 		
 		if not values:

--- a/lib/_emerge/resolver/slot_collision.py
+++ b/lib/_emerge/resolver/slot_collision.py
@@ -1099,7 +1099,7 @@ class _configuration_generator:
 			solution.append(pkgs[self.solution_ids[idx]])
 		return solution
 	
-	def _next(self, id=None): # pylint: disabled=redefined-builtin
+	def _next(self, id=None): # pylint: disable=redefined-builtin
 		solution_ids = self.solution_ids
 		conflict_pkgs = self.conflict_pkgs
 		
@@ -1160,7 +1160,7 @@ class _solution_candidate_generator:
 
 		return self.all_involved_flags
 	
-	def _next(self, id=None): # pylint: disabled=redefined-builtin
+	def _next(self, id=None): # pylint: disable=redefined-builtin
 		values = self.conditional_values
 		
 		if not values:

--- a/lib/_emerge/search.py
+++ b/lib/_emerge/search.py
@@ -409,7 +409,7 @@ class search:
 
 					desc = metadata["DESCRIPTION"]
 					homepage = metadata["HOMEPAGE"]
-					license = metadata["LICENSE"] # pylint: disabled=redefined-builtin
+					license = metadata["LICENSE"] # pylint: disable=redefined-builtin
 
 					if masked:
 						msg.append(green("*") + "  " + \

--- a/lib/_emerge/search.py
+++ b/lib/_emerge/search.py
@@ -409,7 +409,7 @@ class search:
 
 					desc = metadata["DESCRIPTION"]
 					homepage = metadata["HOMEPAGE"]
-					license = metadata["LICENSE"]
+					license = metadata["LICENSE"] # pylint: disabled=redefined-builtin
 
 					if masked:
 						msg.append(green("*") + "  " + \

--- a/lib/portage/_sets/dbapi.py
+++ b/lib/portage/_sets/dbapi.py
@@ -418,9 +418,9 @@ class DateSet(EverythingSet):
 		elif len(formats) > 1:
 			raise SetConfigError(_("no more than one of these options is allowed: 'package', 'filestamp', 'seconds', 'date'"))
 
-		format = formats[0]
+		setformat = formats[0]
 
-		if (format == "package"):
+		if (setformat == "package"):
 			package = options.get("package")
 			try:
 				cpv = vardbapi.match(package)[0]
@@ -428,13 +428,13 @@ class DateSet(EverythingSet):
 				date = int(date)
 			except (KeyError, ValueError):
 				raise SetConfigError(_("cannot determine installation date of package %s") % package)
-		elif (format == "filestamp"):
+		elif (setformat == "filestamp"):
 			filestamp = options.get("filestamp")
 			try:
 				date = int(os.stat(filestamp).st_mtime)
 			except (OSError, ValueError):
 				raise SetConfigError(_("cannot determine 'filestamp' of '%s'") % filestamp)
-		elif (format == "seconds"):
+		elif (setformat == "seconds"):
 			try:
 				date = int(options.get("seconds"))
 			except ValueError:

--- a/lib/portage/cache/ebuild_xattr.py
+++ b/lib/portage/cache/ebuild_xattr.py
@@ -38,9 +38,9 @@ class database(fs_template.FsBased):
 		try:
 			return int(self.__get(path,'value_max_len'))
 		except NoValueException as e:
-			max = self.__calc_max(path)
-			self.__set(path,'value_max_len',str(max))
-			return max
+			maxattrlength = self.__calc_max(path)
+			self.__set(path,'value_max_len', str(maxattrlength))
+			return maxattrlength
 
 	def __calc_max(self,path):
 		""" Find out max attribute length supported by the file system """
@@ -102,48 +102,48 @@ class database(fs_template.FsBased):
 	def _getitem(self, cpv):
 		values = {}
 		path = self.__get_path(cpv)
-		all = {}
-		for tuple in xattr.get_all(path,namespace=self.ns):
-			key,value = tuple
-			all[key] = value
+		attrs = {
+			key: value
+			for key, value in xattr.get_all(path, namespace=self.ns)
+		}
 
 		if not '_mtime_' in all:
 			raise KeyError(cpv)
 
 		# We default to '' like other caches
 		for key in self.keys:
-			attr_value = all.get(key,'1:')
+			attr_value = attrs.get(key,'1:')
 			parts,sep,value = attr_value.partition(':')
 			parts = int(parts)
 			if parts > 1:
 				for i in range(1,parts):
-					value += all.get(key+str(i))
+					value += attrs.get(key+str(i))
 			values[key] = value
 
 		return values
 
 	def _setitem(self, cpv, values):
 		path = self.__get_path(cpv)
-		max = self.max_len
+		max_len = self.max_len
 		for key,value in values.items():
 			# mtime comes in as long so need to convert to strings
 			s = str(value)
 			# We need to split long values
 			value_len = len(s)
 			parts = 0
-			if value_len > max:
+			if value_len > max_len:
 				# Find out how many parts we need
-				parts = value_len/max
-				if value_len % max > 0:
+				parts = value_len/max_len
+				if value_len % max_len > 0:
 					parts += 1
 
 				# Only the first entry carries the number of parts
-				self.__set(path,key,'%s:%s'%(parts,s[0:max]))
+				self.__set(path,key,'%s:%s'%(parts,s[0:max_len]))
 
 				# Write out the rest
 				for i in range(1,parts):
-					start = i * max
-					val = s[start:start+max]
+					start = i * max_len
+					val = s[start:start+max_len]
 					self.__set(path,key+str(i),val)
 			else:
 				self.__set(path,key,"%s:%s"%(1,s))

--- a/lib/portage/cache/fs_template.py
+++ b/lib/portage/cache/fs_template.py
@@ -55,8 +55,8 @@ class FsBased(template.database):
 			path = self.location
 			base='/'
 
-		for dir in path.lstrip(os.path.sep).rstrip(os.path.sep).split(os.path.sep):
-			base = os.path.join(base,dir)
+		for d in path.lstrip(os.path.sep).rstrip(os.path.sep).split(os.path.sep):
+			base = os.path.join(base,d)
 			if ensure_dirs(base):
 				# We only call apply_permissions if ensure_dirs created
 				# a new directory, so as not to interfere with

--- a/lib/portage/cvstree.py
+++ b/lib/portage/cvstree.py
@@ -198,14 +198,14 @@ def findall(entries, recursive=0, basedir=""):
 	return [mynew, mychanged, mymissing, myunadded, myremoved]
 
 ignore_list = re.compile(r"(^|/)(RCS(|LOG)|SCCS|CVS(|\.adm)|cvslog\..*|tags|TAGS|\.(make\.state|nse_depinfo)|.*~|(\.|)#.*|,.*|_$.*|.*\$|\.del-.*|.*\.(old|BAK|bak|orig|rej|a|olb|o|obj|so|exe|Z|elc|ln)|core)$")
-def apply_cvsignore_filter(list):
+def apply_cvsignore_filter(files):
 	x = 0
-	while x < len(list):
-		if ignore_list.match(list[x].split("/")[-1]):
-			list.pop(x)
+	while x < len(files):
+		if ignore_list.match(files[x].split("/")[-1]):
+			files.pop(x)
 		else:
 			x += 1
-	return list
+	return files
 	
 def getentries(mydir, recursive=0):
 	"""Scans the given directory and returns a datadict of all the entries in

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -877,7 +877,7 @@ class portdbapi(dbapi):
 				filesdict[myfile] = int(checksums[myfile]["size"])
 		return filesdict
 
-	def fetch_check(self, mypkg, useflags=None, mysettings=None, all=False, myrepo=None):
+	def fetch_check(self, mypkg, useflags=None, mysettings=None, all=False, myrepo=None): # pylint: disabled=redefined-builtin
 		"""
 		TODO: account for PORTAGE_RO_DISTDIRS
 		"""

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -877,7 +877,7 @@ class portdbapi(dbapi):
 				filesdict[myfile] = int(checksums[myfile]["size"])
 		return filesdict
 
-	def fetch_check(self, mypkg, useflags=None, mysettings=None, all=False, myrepo=None): # pylint: disabled=redefined-builtin
+	def fetch_check(self, mypkg, useflags=None, mysettings=None, all=False, myrepo=None): # pylint: disable=redefined-builtin
 		"""
 		TODO: account for PORTAGE_RO_DISTDIRS
 		"""

--- a/lib/portage/glsa.py
+++ b/lib/portage/glsa.py
@@ -139,7 +139,7 @@ def getListElements(listnode):
 		if li.nodeType == xml.dom.Node.ELEMENT_NODE]
 	return rValue
 
-def getText(node, format, textfd = None):
+def getText(node, format, textfd = None): # pylint: disable=redefined-builtin
 	"""
 	This is the main parser function. It takes a node and traverses
 	recursive over the subnodes, getting the text of each (and the
@@ -210,7 +210,7 @@ def getText(node, format, textfd = None):
 		rValue = re.sub(r"[\s]{2,}", " ", rValue)
 	return rValue
 
-def getMultiTagsText(rootnode, tagname, format):
+def getMultiTagsText(rootnode, tagname, format): # pylint: disable=redefined-builtin
 	"""
 	Returns a list with the text of all subnodes of type I{tagname}
 	under I{rootnode} (which itself is not parsed) using the given I{format}.

--- a/lib/portage/manifest.py
+++ b/lib/portage/manifest.py
@@ -61,8 +61,8 @@ def guessManifestFileType(filename):
 		return "DIST"
 
 def guessThinManifestFileType(filename):
-	type = guessManifestFileType(filename)
-	if type != "DIST":
+	filetype = guessManifestFileType(filename)
+	if filetype != "DIST":
 		return None
 	return "DIST"
 

--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -257,10 +257,10 @@ class RepoConfig:
 		self.module_specific_options = {}
 
 		# Not implemented.
-		format = repo_opts.get('format')
-		if format is not None:
-			format = format.strip()
-		self.format = format
+		repo_format = repo_opts.get('format')
+		if repo_format is not None:
+			repo_format = repo_format.strip()
+		self.format = repo_format
 
 		self.user_location = None
 		location = repo_opts.get('location')

--- a/lib/portage/tests/bin/setup_env.py
+++ b/lib/portage/tests/bin/setup_env.py
@@ -73,17 +73,17 @@ def portage_func(func, args, exit_status=0):
 		fd_pipes=fd_pipes, pre_exec=pre_exec)
 	f.close()
 
-def create_portage_wrapper(bin):
+def create_portage_wrapper(f):
 	def derived_func(*args):
 		newargs = list(args)
-		newargs.insert(0, bin)
+		newargs.insert(0, f)
 		return portage_func(*newargs)
 	return derived_func
 
-for bin in os.listdir(os.path.join(bindir, 'ebuild-helpers')):
-	if bin.startswith('do') or \
-	   bin.startswith('new') or \
-	   bin.startswith('prep') or \
-	   bin in ('fowners', 'fperms'):
-		globals()[bin] = create_portage_wrapper(
-			os.path.join(bindir, 'ebuild-helpers', bin))
+for f in os.listdir(os.path.join(bindir, 'ebuild-helpers')):
+	if (f.startswith('do') or
+		f.startswith('new') or
+		f.startswith('prep') or
+		f in ('fowners', 'fperms')):
+		globals()[f] = create_portage_wrapper(
+			os.path.join(bindir, 'ebuild-helpers', f))

--- a/lib/portage/tests/sets/shell/testShell.py
+++ b/lib/portage/tests/sets/shell/testShell.py
@@ -17,12 +17,12 @@ class CommandOutputSetTestCase(TestCase):
 
 	def testCommand(self):
 		
-		input = set(test_cps)
+		params = set(test_cps)
 		command = find_binary("bash")
 		command += " -c '"
-		for a in input:
+		for a in params:
 		  command += " echo -e \"%s\" ; " % a
 		command += "'"
 		s = CommandOutputSet(command)
 		atoms = s.getAtoms()
-		self.assertEqual(atoms, input)
+		self.assertEqual(atoms, params)

--- a/lib/portage/util/_urlopen.py
+++ b/lib/portage/util/_urlopen.py
@@ -58,8 +58,7 @@ def _timestamp_to_http(timestamp):
 	return formatdate(timeval=stamp, localtime=False, usegmt=True)
 
 def _http_to_timestamp(http_datetime_string):
-	tuple = parsedate(http_datetime_string)
-	timestamp = mktime(tuple)
+	timestamp = mktime(parsedate(http_datetime_string))
 	return str(int(timestamp))
 
 class CompressedResponseProcessor(urllib_request.HTTPBasicAuthHandler):

--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -40,12 +40,14 @@ from portage.util._eventloop.asyncio_event_loop import AsyncioEventLoop as _Asyn
 from portage.util._eventloop.global_event_loop import (
 	global_event_loop as _global_event_loop,
 )
+# pylint: disable=redefined-builtin
 from portage.util.futures.futures import (
 	CancelledError,
 	Future,
 	InvalidStateError,
-	TimeoutError,
+        TimeoutError,
 )
+# pylint: enable=redefined-builtin
 from portage.util.futures._asyncio.process import _Process
 from portage.util.futures._asyncio.tasks import (
 	ALL_COMPLETED,

--- a/lib/portage/util/futures/_asyncio/process.py
+++ b/lib/portage/util/futures/_asyncio/process.py
@@ -39,7 +39,7 @@ class _Process:
 		return self._proc.returncode
 
 	@coroutine
-	def communicate(self, input=None):
+	def communicate(self, input=None): # pylint: disabled=redefined-builtin
 		"""
 		Read data from stdout and stderr, until end-of-file is reached.
 		Wait for process to terminate.

--- a/lib/portage/util/futures/_asyncio/process.py
+++ b/lib/portage/util/futures/_asyncio/process.py
@@ -39,7 +39,7 @@ class _Process:
 		return self._proc.returncode
 
 	@coroutine
-	def communicate(self, input=None): # pylint: disabled=redefined-builtin
+	def communicate(self, input=None): # pylint: disable=redefined-builtin
 		"""
 		Read data from stdout and stderr, until end-of-file is reached.
 		Wait for process to terminate.

--- a/lib/portage/util/futures/events.py
+++ b/lib/portage/util/futures/events.py
@@ -88,7 +88,7 @@ class AbstractEventLoop(_AbstractEventLoop):
 	def set_default_executor(self, executor):
 		raise NotImplementedError
 
-	def getaddrinfo(self, host, port, family=0, type=0, proto=0, flags=0): # pylint: disabled=redefined-builtin
+	def getaddrinfo(self, host, port, family=0, type=0, proto=0, flags=0): # pylint: disable=redefined-builtin
 		raise NotImplementedError
 
 	def getnameinfo(self, sockaddr, flags=0):

--- a/lib/portage/util/futures/events.py
+++ b/lib/portage/util/futures/events.py
@@ -88,7 +88,7 @@ class AbstractEventLoop(_AbstractEventLoop):
 	def set_default_executor(self, executor):
 		raise NotImplementedError
 
-	def getaddrinfo(self, host, port, family=0, type=0, proto=0, flags=0):
+	def getaddrinfo(self, host, port, family=0, type=0, proto=0, flags=0): # pylint: disabled=redefined-builtin
 		raise NotImplementedError
 
 	def getnameinfo(self, sockaddr, flags=0):

--- a/lib/portage/util/futures/futures.py
+++ b/lib/portage/util/futures/futures.py
@@ -12,12 +12,14 @@ __all__ = (
 	'TimeoutError',
 )
 
+# pylint: disable=redefined-builtin
 from asyncio import (
 	CancelledError,
 	Future,
 	InvalidStateError,
-	TimeoutError,
+        TimeoutError,
 )
+# pylint: enable=redefined-builtin
 
 import portage
 portage.proxy.lazyimport.lazyimport(globals(),

--- a/lib/portage/util/lafilefixer.py
+++ b/lib/portage/util/lafilefixer.py
@@ -109,18 +109,18 @@ def rewrite_lafile(contents):
 			#Two cases:
 			#1) /usr/lib64/libfoo.la, turn it into -lfoo and append -L/usr/lib64 to libladir
 			#2) libfoo.la, keep it
-			dir, file = _os.path.split(dep_libs_entry)
+			dirname, basename = _os.path.split(dep_libs_entry)
 
-			if not dir or not file.startswith(b"lib"):
+			if not dirname or not basename.startswith(b"lib"):
 				if dep_libs_entry not in new_dep_libs:
 					new_dep_libs.append(dep_libs_entry)
 			else:
 				#/usr/lib64/libfoo.la -> -lfoo
-				lib = b"-l" + file[3:-3]
+				lib = b"-l" + basename[3:-3]
 				if lib not in new_dep_libs:
 					new_dep_libs.append(lib)
 				#/usr/lib64/libfoo.la -> -L/usr/lib64
-				ladir = b"-L" + dir
+				ladir = b"-L" + dirname
 				if ladir not in libladir:
 					libladir.append(ladir)
 


### PR DESCRIPTION
Some of these are simple variable renames. A few of the uses were
refactored and some were simply disabled; often due to redefinition as
part of a function signature. I did not do any research in terms of API
changes so these were typically left as-is to avoid breaking callers.

Signed-off-by: Alec Warner <antarus@gentoo.org>