### PR TITLE
HardlinkRcuRepoStorage: handle removed sync-rcu-store-dir (bug 734990)

### DIFF
--- a/lib/portage/repository/storage/hardlink_rcu.py
+++ b/lib/portage/repository/storage/hardlink_rcu.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Gentoo Foundation
+# Copyright 2018-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import datetime
@@ -204,6 +204,17 @@ class HardlinkRcuRepoStorage(RepoStorageInterface):
 		except OSError:
 			pass
 		os.symlink('snapshots/{}'.format(new_id), new_symlink)
+
+		# If SyncManager.pre_sync creates an empty directory where
+		# self._latest_symlink is suppose to be (which is normal if
+		# sync-rcu-store-dir has been removed), then we need to remove
+		# the directory or else rename will raise IsADirectoryError
+		# when we try to replace the directory with a symlink.
+		try:
+			os.rmdir(self._latest_symlink)
+		except OSError:
+			pass
+
 		os.rename(new_symlink, self._latest_symlink)
 
 		try:

--- a/lib/portage/tests/sync/test_sync_local.py
+++ b/lib/portage/tests/sync/test_sync_local.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Gentoo Foundation
+# Copyright 2014-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import datetime
@@ -71,6 +71,7 @@ class SyncLocalTestCase(TestCase):
 		distdir = os.path.join(eprefix, "distdir")
 		repo = settings.repositories["test_repo"]
 		metadata_dir = os.path.join(repo.location, "metadata")
+		rcu_store_dir = os.path.join(eprefix, 'var/repositories/test_repo_rcu_storedir')
 
 		cmds = {}
 		for cmd in ("emerge", "emaint"):
@@ -191,6 +192,10 @@ class SyncLocalTestCase(TestCase):
 			(homedir, lambda: os.mkdir(repo.user_location)),
 		)
 
+		delete_rcu_store_dir = (
+			(homedir, lambda: shutil.rmtree(rcu_store_dir)),
+		)
+
 		revert_rcu_layout = (
 			(homedir, lambda: os.rename(repo.user_location, repo.user_location + '.bak')),
 			(homedir, lambda: os.rename(os.path.realpath(repo.user_location + '.bak'), repo.user_location)),
@@ -289,7 +294,8 @@ class SyncLocalTestCase(TestCase):
 			for cwd, cmd in rename_repo + sync_cmds_auto_sync + sync_cmds + \
 				rsync_opts_repos + rsync_opts_repos_default + \
 				rsync_opts_repos_default_ovr + rsync_opts_repos_default_cancel + \
-				bump_timestamp_cmds + sync_rsync_rcu + sync_cmds + revert_rcu_layout + \
+				bump_timestamp_cmds + sync_rsync_rcu + sync_cmds + delete_rcu_store_dir + \
+				sync_cmds + revert_rcu_layout + \
 				delete_repo_location + sync_cmds + sync_cmds + \
 				bump_timestamp_cmds + sync_cmds + revert_rcu_layout + \
 				delete_sync_repo + git_repo_create + sync_type_git + \


### PR DESCRIPTION
If SyncManager.pre_sync creates an empty directory where
self._latest_symlink is suppose to be (which is normal if
sync-rcu-store-dir has been removed), then we need to remove
the directory or else rename will raise IsADirectoryError
when we try to replace the directory with a symlink.

Signed-off-by: Zac Medico <zmedico@gentoo.org>