### PR TITLE
tox: call pylint for whole repo

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -14,6 +14,7 @@
 disable=all
 enable=
         cyclic-import,
+        import-error,
         import-self,
         misplaced-future,
         missing-final-newline,

--- a/setup.py
+++ b/setup.py
@@ -606,21 +606,6 @@ class test(Command):
 		])
 
 
-class lint(Command):
-	""" run lint """
-
-	user_options = []
-
-	def initialize_options(self):
-		pass
-
-	def finalize_options(self):
-		pass
-
-	def run(self):
-		subprocess.check_call(['pylint', 'lib'])
-
-
 def find_packages():
 	for dirpath, _dirnames, filenames in os.walk('lib'):
 		if '__init__.py' in filenames:
@@ -721,7 +706,6 @@ setup(
 		'install_scripts_sbin': x_install_scripts_sbin,
 		'sdist': x_sdist,
 		'test': test,
-		'lint': lint,
 	},
 
 	classifiers = [

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ deps =
 setenv =
 	PYTHONPATH={toxinidir}/lib
 commands =
-	python -b -Wd setup.py lint
+	bash -c 'rm -rf build && PYTHONPATH=$PWD/lib:$PWD/repoman/lib pylint *'
 	python -b -Wd setup.py test
 	python -b -Wd repoman/setup.py test


### PR DESCRIPTION
In addition to checking the whole repo, this fixes the
import-error check.

Signed-off-by: Zac Medico <zmedico@gentoo.org>