### PR TITLE
BinpkgEnvExtractor: fix subprocess logfile usage (bug 711174)

### DIFF
--- a/lib/_emerge/BinpkgEnvExtractor.py
+++ b/lib/_emerge/BinpkgEnvExtractor.py
@@ -33,12 +33,17 @@ class BinpkgEnvExtractor(CompositeTask):
 		shell_cmd = "${PORTAGE_BUNZIP2_COMMAND:-${PORTAGE_BZIP2_COMMAND} -d} -c -- %s > %s" % \
 			(_shell_quote(saved_env_path),
 			_shell_quote(dest_env_path))
+
+		logfile = None
+		if self.settings.get("PORTAGE_BACKGROUND") != "subprocess":
+			logfile = self.settings.get("PORTAGE_LOG_FILE")
+
 		extractor_proc = SpawnProcess(
 			args=[BASH_BINARY, "-c", shell_cmd],
 			background=self.background,
 			env=self.settings.environ(),
 			scheduler=self.scheduler,
-			logfile=self.settings.get('PORTAGE_LOG_FILE'))
+			logfile=logfile)
 
 		self._start_task(extractor_proc, self._extractor_exit)
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -4013,7 +4013,9 @@ class dblink:
 				# since we need it to have private ${T} etc... for things
 				# like elog.
 				settings_clone = portage.config(clone=self.settings)
-				settings_clone.pop("PORTAGE_BUILDDIR_LOCKED", None)
+				# This reset ensures that there is no unintended leakage
+				# of variables which should not be shared.
+				settings_clone.reset()
 				settings_clone.setcpv(cur_cpv, mydb=self.vartree.dbapi)
 				if self._preserve_libs and "preserve-libs" in \
 					settings_clone["PORTAGE_RESTRICT"].split():


### PR DESCRIPTION
Do not write to log file when in a MergeProcess subprocess,
since stdout and stderr are already redirected to the log
file by MergeProcess. This fixes log corruption when
BinpkgEnvExtractor is use to extract environment.bz2 prior
to pkg_prerm.

Bug: https://bugs.gentoo.org/711174
Signed-off-by: Zac Medico <zmedico@gentoo.org>