### PR TITLE
lib/portage/xml/metadata.py: tolerate xml.parsers.expat import failures (bug 736912)

### DIFF
--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -34,7 +34,10 @@ __all__ = ('MetaDataXML', 'parse_metadata_use')
 import re
 import xml.etree.ElementTree as etree
 
-from xml.parsers.expat import ExpatError
+try:
+	from xml.parsers.expat import ExpatError
+except Exception:
+	ExpatError = SyntaxError
 
 from portage import _encodings, _unicode_encode
 from portage.util import cmp_sort_key, unique_everseen


### PR DESCRIPTION
Tolerate broken or missing xml support in python.
This reverts a behavior change from commit
935c47d972d986f1822850618442c19c97e300c3.

Fixes: 935c47d972d9 ("lib/portage/xml/metadata.py: fix ungrouped-imports w/refactor")
Bug: https://bugs.gentoo.org/736912
Signed-off-by: Zac Medico <zmedico@gentoo.org>