### PR TITLE
async_iter_completed: fix InvalidStateError in finally clause (bug 738766)

### DIFF
--- a/lib/portage/util/futures/iter_completed.py
+++ b/lib/portage/util/futures/iter_completed.py
@@ -109,7 +109,6 @@ def async_iter_completed(futures, max_jobs=None, max_load=None, loop=None):
 		# cleanup in case of interruption by SIGINT, etc
 		if not loop.is_closed():
 			scheduler.cancel()
-			scheduler.wait()
 
 
 def iter_gather(futures, max_jobs=None, max_load=None, loop=None):


### PR DESCRIPTION
Do not attempt to wait for the TaskScheduler instance in the finally
clause, since it will always raise InvalidStateError if its status
is not available yet (which is normal if it has remaining tasks with
done callbacks that have not been scheduled yet).

Bug: https://bugs.gentoo.org/738766
Signed-off-by: Zac Medico <zmedico@gentoo.org>