### PR TITLE
dephgraph: Allow elimination of highest version after slot conflict (bug 439688)

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -1501,15 +1501,6 @@ class depgraph:
 
 				matched = []
 				for pkg in conflict:
-					if (pkg is highest_pkg and
-						not highest_pkg.installed and
-						inst_pkg is not None and
-						inst_pkg.sub_slot != highest_pkg.sub_slot and
-						not self._downgrade_probe(highest_pkg)):
-						# If an upgrade is desired, force the highest
-						# version into the graph (bug #531656).
-						non_matching_forced.add(highest_pkg)
-
 					if atom.match(pkg.with_use(
 						self._pkg_use_enabled(pkg))) and \
 						not (is_arg_parent and pkg.installed):

--- a/lib/portage/tests/resolver/test_slot_change_without_revbump.py
+++ b/lib/portage/tests/resolver/test_slot_change_without_revbump.py
@@ -71,8 +71,8 @@ class SlotChangeWithoutRevBumpTestCase(TestCase):
 
 			# Test --changed-slot
 			ResolverPlaygroundTestCase(
-				["app-arch/libarchive"],
-				options = {"--changed-slot": True, "--usepkg": True},
+				["@world"],
+				options = {"--changed-slot": True, "--usepkg": True, "--update": True, "--deep": True},
 				success = True,
 				mergelist = ["app-arch/libarchive-3.1.1", "kde-base/ark-4.10.0"]),
 

--- a/lib/portage/tests/resolver/test_slot_conflict_rebuild.py
+++ b/lib/portage/tests/resolver/test_slot_conflict_rebuild.py
@@ -454,10 +454,7 @@ class SlotConflictRebuildTestCase(TestCase):
 		finally:
 			playground.cleanup()
 
-class SlotConflictRebuildGolangTestCase(TestCase):
-
 	def testSlotConflictRebuildGolang(self):
-		self.todo = True
 
 		ebuilds = {
 


### PR DESCRIPTION
After a slot conflict occurs, allow the highest version to be eliminated
from the graph when appropriate. This is needed for correct behavior in
cases the highest version cannot be installed because an older version
is required by some package. This reverts a change related to bug 531656
from commit a9064d08ef4c92a5d0d1bfb3dc8a01b7850812b0, and that change
no longer appears to be necessary, since the unit tests related to bug
531656 now pass without it.

Due to this change in slot conflict handling, the --changed-slot test
case related to bug 456208 will now fail unless we use an @world update to
trigger rebuilds, therefore fix it to do so.

Bug: https://bugs.gentoo.org/439688
Signed-off-by: Zac Medico <zmedico@gentoo.org>