### PR TITLE
emerge --search: auto-detect regular expressions (bug 737480)

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2036,6 +2036,7 @@ def action_search(root_config, myopts, myfiles, spinner):
 			search_index=myopts.get("--search-index", "y") != "n",
 			search_similarity=myopts.get("--search-similarity"),
 			fuzzy=myopts.get("--fuzzy-search") != "n",
+			regex_auto=myopts.get("--regex-search-auto") != "n",
 			)
 		for mysearch in myfiles:
 			try:

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -709,6 +709,12 @@ def parse_opts(tmpcmdline, silent=False):
 			"action" : "store"
 		},
 
+		"--regex-search-auto": {
+			"help"   : "Enable or disable automatic regular expression detection for search actions",
+			"choices": y_or_n,
+			"default": "y",
+		},
+
 		"--root": {
 		 "help"   : "specify the target root filesystem for merging packages",
 		 "action" : "store"

--- a/lib/_emerge/search.py
+++ b/lib/_emerge/search.py
@@ -28,7 +28,7 @@ class search:
 	#
 	def __init__(self, root_config, spinner, searchdesc,
 		verbose, usepkg, usepkgonly, search_index=True,
-		search_similarity=None, fuzzy=True):
+		search_similarity=None, fuzzy=True, regex_auto=False):
 		"""Searches the available and installed packages for the supplied search key.
 		The list of available and installed packages is created at object instantiation.
 		This makes successive searches faster."""
@@ -42,6 +42,7 @@ class search:
 		self.spinner = None
 		self.root_config = root_config
 		self.setconfig = root_config.setconfig
+		self.regex_auto = regex_auto
 		self.fuzzy = fuzzy
 		self.search_similarity = (80 if search_similarity is None
 			else search_similarity)
@@ -259,6 +260,15 @@ class search:
 		if '/' in self.searchkey:
 			match_category = 1
 		fuzzy = False
+
+		if self.regex_auto and not regexsearch and re.search(r'[\^\$\*\[\]\{\}\|\?]|\.\+', self.searchkey) is not None:
+			try:
+				re.compile(self.searchkey, re.I)
+			except Exception:
+				pass
+			else:
+				regexsearch = True
+
 		if regexsearch:
 			self.searchre=re.compile(self.searchkey,re.I)
 		else:

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -229,7 +229,9 @@ explicitly discarded by running `emaint \-\-fix cleanresume` (see
 .BR \-\-search ", " \-s
 Searches for matches of the supplied string in the ebuild repository.
 By default emerge uses a case-insensitive simple search, but you can
-enable a regular expression search by prefixing the search string with %.
+enable a regular expression search by prefixing the search string with %
+(the % prefix can often be omitted if the
+\fB\-\-regex\-search\-auto\fR option is enabled).
 For example, \fBemerge \-\-search "%^kde"\fR searches for any package whose
 name starts with "kde"; \fBemerge \-\-search "%gcc$"\fR searches for any
 package that ends with "gcc"; \fBemerge \-\-search "office"\fR searches for
@@ -763,6 +765,14 @@ matching packages due to \fB\-\-rebuild\fR.
 .BR "\-\-rebuild\-ignore " ATOMS
 A space separated list of package names or slot atoms. Emerge will not rebuild
 packages that depend on matching packages due to \fB\-\-rebuild\fR.
+.TP
+.BR "\-\-regex\-search\-auto < y | n >"
+Enable or disable automatic regular expression detection for search actions.
+If this option is enabled (the default), then regular expression search
+is automatically enabled when the search string is a valid regular expression
+which contains any of these commonly used regular expression characters or
+character sequences:
+^ $ * [ ] { } | ? .+
 .TP
 .BR \-\-oneshot ", " \-1
 Emerge as normal, but do not add the packages to the world file


### PR DESCRIPTION
Automatically detect regular expressions when the search string
contains any of these regular expression characters or character
sequences:

     ^ $ * [ ] { } | ? .+

This simplifies usage, so that users no longer have to remember
to prefix regular expressions with the % character. The new
behavior can be disabled by --regex-search-auto=n, in case the
regular expressions interpretation causes some kind of problem.

Note that fuzzy search and regular expression search are
mutually exclusive, and fuzzy search remains the default for
search strings that do not contain any regular expression
characters.

Bug: https://bugs.gentoo.org/737480
Signed-off-by: Zac Medico <zmedico@gentoo.org>