### PR TITLE
make.conf: Treat __* variables as local and do not propagate them.

### DIFF
--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -370,6 +370,9 @@ class config:
 					_("Found 2 make.conf files, using both '%s' and '%s'") %
 					tuple(make_conf_paths), noiselevel=-1)
 
+			# __* variables set in make.conf are local and are not be propagated.
+			make_conf = {k: v for k, v in make_conf.items() if not k.startswith("__")}
+
 			# Allow ROOT setting to come from make.conf if it's not overridden
 			# by the constructor argument (from the calling environment).
 			locations_manager.set_root_override(make_conf.get("ROOT"))
@@ -620,6 +623,9 @@ class config:
 				mygcfg.update(getconfig(x,
 					tolerant=tolerant, allow_sourcing=True,
 					expand=expand_map, recursive=True) or {})
+
+			# __* variables set in make.conf are local and are not be propagated.
+			mygcfg = {k: v for k, v in mygcfg.items() if not k.startswith("__")}
 
 			# Don't allow the user to override certain variables in make.conf
 			profile_only_variables = self.configdict["defaults"].get(

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1,4 +1,4 @@
-.TH "MAKE.CONF" "5" "Jun 2020" "Portage VERSION" "Portage"
+.TH "MAKE.CONF" "5" "Sep 2020" "Portage VERSION" "Portage"
 .SH "NAME"
 make.conf \- custom settings for Portage
 .SH "SYNOPSIS"
@@ -35,6 +35,8 @@ and ACCEPT_KEYWORDS.  Incremental variables are propagated down from
 make.defaults to make.globals to make.conf to the environment
 settings.  Clearing these variables requires a clear\-all as in:
 export USE="\-*"
+.br
+__* variables set in make.conf are local and are not be propagated.
 .br
 In order to create per\-package environment settings, refer to
 \fBpackage.env\fR in \fBportage\fR(5).


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/740588
Signed-off-by: Arfrever Frehtes Taifersar Arahesis <Arfrever@Apache.Org>
Signed-off-by: Zac Medico <zmedico@gentoo.org>