### PR TITLE
Add binrepos.conf to support fetchcommand customization (bug 668302)

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -32,7 +32,8 @@ portage.proxy.lazyimport.lazyimport(globals(),
 from portage import os
 from portage import shutil
 from portage import _encodings, _unicode_decode
-from portage.const import _DEPCLEAN_LIB_CHECK_DEFAULT
+from portage.binrepo.config import BinRepoConfigLoader
+from portage.const import BINREPOS_CONF_FILE, _DEPCLEAN_LIB_CHECK_DEFAULT
 from portage.dbapi.dep_expand import dep_expand
 from portage.dbapi._expand_new_virt import expand_new_virt
 from portage.dbapi.IndexedPortdb import IndexedPortdb
@@ -1835,6 +1836,16 @@ def action_info(settings, trees, myopts, myfiles):
 	append("Repositories:\n")
 	for repo in repos:
 		append(repo.info_string())
+
+	binrepos_conf_path = os.path.join(settings['PORTAGE_CONFIGROOT'], BINREPOS_CONF_FILE)
+	binrepos_conf = BinRepoConfigLoader((binrepos_conf_path,), settings)
+	if binrepos_conf and any(repo.name for repo in binrepos_conf.values()):
+		append("Binary Repositories:\n")
+		for repo in reversed(list(binrepos_conf.values())):
+			# Omit repos from the PORTAGE_BINHOST variable, since they
+			# do not have a name to label them with.
+			if repo.name:
+				append(repo.info_string())
 
 	installed_sets = sorted(s for s in
 		root_config.sets['selected'].getNonAtoms() if s.startswith(SETPREFIX))

--- a/lib/portage/binrepo/config.py
+++ b/lib/portage/binrepo/config.py
@@ -15,7 +15,9 @@ class BinRepoConfig:
 	__slots__ = (
 		'name',
 		'name_fallback',
+		'fetchcommand',
 		'priority',
+		'resumecommand',
 		'sync_uri',
 	)
 	def __init__(self, opts):

--- a/lib/portage/binrepo/config.py
+++ b/lib/portage/binrepo/config.py
@@ -1,0 +1,131 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from collections import OrderedDict
+from collections.abc import Mapping
+from hashlib import md5
+
+from portage.localization import _
+from portage.util import _recursive_file_list, writemsg
+from portage.util.configparser import (SafeConfigParser, ConfigParserError,
+	read_configs)
+
+
+class BinRepoConfig:
+	__slots__ = (
+		'name',
+		'name_fallback',
+		'priority',
+		'sync_uri',
+	)
+	def __init__(self, opts):
+		"""
+		Create a BinRepoConfig with options in opts.
+		"""
+		for k in self.__slots__:
+			setattr(self, k, opts.get(k.replace('_', '-')))
+
+	def info_string(self):
+		"""
+		Returns a formatted string containing informations about the repository.
+		Used by emerge --info.
+		"""
+		indent = " " * 4
+		repo_msg = []
+		repo_msg.append(self.name or self.name_fallback)
+		if self.priority is not None:
+			repo_msg.append(indent + "priority: " + str(self.priority))
+		repo_msg.append(indent + "sync-uri: " + self.sync_uri)
+		repo_msg.append("")
+		return "\n".join(repo_msg)
+
+
+class BinRepoConfigLoader(Mapping):
+	def __init__(self, paths, settings):
+		"""Load config from files in paths"""
+
+		# Defaults for value interpolation.
+		parser_defaults = {
+			"EPREFIX" : settings["EPREFIX"],
+			"EROOT" : settings["EROOT"],
+			"PORTAGE_CONFIGROOT" : settings["PORTAGE_CONFIGROOT"],
+			"ROOT" : settings["ROOT"],
+		}
+
+		try:
+			parser = self._parse(paths, parser_defaults)
+		except ConfigParserError as e:
+			writemsg(
+				_("!!! Error while reading binrepo config file: %s\n") % e,
+				noiselevel=-1)
+			parser = SafeConfigParser(defaults=parser_defaults)
+
+		repos = []
+		sync_uris = []
+		for section_name in parser.sections():
+			repo_data = dict(parser[section_name].items())
+			repo_data['name'] = section_name
+			repo = BinRepoConfig(repo_data)
+			if repo.sync_uri is None:
+				writemsg(_("!!! Missing sync-uri setting for binrepo %s\n") % (repo.name,), noiselevel=-1)
+				continue
+
+			sync_uri = self._normalize_uri(repo.sync_uri)
+			sync_uris.append(sync_uri)
+			repo.sync_uri = sync_uri
+			if repo.priority is not None:
+				try:
+					repo.priority = int(repo.priority)
+				except ValueError:
+					repo.priority = None
+			repos.append(repo)
+
+		sync_uris = set(sync_uris)
+		current_priority = 0
+		for sync_uri in reversed(settings.get("PORTAGE_BINHOST", "").split()):
+			sync_uri = self._normalize_uri(sync_uri)
+			if sync_uri not in sync_uris:
+				current_priority += 1
+				sync_uris.add(sync_uri)
+				repos.append(BinRepoConfig({
+					'name-fallback': self._digest_uri(sync_uri),
+					'name': None,
+					'priority': current_priority,
+					'sync-uri': sync_uri,
+				}))
+
+		self._data = OrderedDict((repo.name or repo.name_fallback, repo) for repo in
+			sorted(repos, key=lambda repo: (repo.priority or 0, repo.name or repo.name_fallback)))
+
+	@staticmethod
+	def _digest_uri(uri):
+		return md5(uri.encode('utf_8')).hexdigest()
+
+	@staticmethod
+	def _normalize_uri(uri):
+		return uri.rstrip('/')
+
+	@staticmethod
+	def _parse(paths, defaults):
+		parser = SafeConfigParser(defaults=defaults)
+		recursive_paths = []
+		for p in paths:
+			if isinstance(p, str):
+				recursive_paths.extend(_recursive_file_list(p))
+			else:
+				recursive_paths.append(p)
+
+		read_configs(parser, recursive_paths)
+		return parser
+
+	def __iter__(self):
+		return iter(self._data)
+
+	def __contains__(self, key):
+		return key in self._data
+
+	def __getitem__(self, key):
+		return self._data[key]
+
+	def __len__(self):
+		return len(self._data)

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -28,6 +28,7 @@ import os
 
 # variables used with config_root (these need to be relative)
 USER_CONFIG_PATH         = "etc/portage"
+BINREPOS_CONF_FILE       = USER_CONFIG_PATH + "/binrepos.conf"
 MAKE_CONF_FILE           = USER_CONFIG_PATH + "/make.conf"
 MODULES_FILE_PATH        = USER_CONFIG_PATH + "/modules"
 CUSTOM_PROFILE_PATH      = USER_CONFIG_PATH + "/profile"

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -855,7 +855,8 @@ Each entry in the list must specify the full address of a directory
 serving tbz2's for your system (this directory must contain a 'Packages' index
 file). This is only used when running with
 the get binary pkg options are given to \fBemerge\fR.  Review \fBemerge\fR(1)
-for more information.
+for more information. The \fBPORTAGE_BINHOST\fR variable is deprecated in
+favor of the \fBbinrepos.conf\fR configuration file (see \fBportage\fR(5)).
 .TP
 \fBPORTAGE_BINHOST_HEADER_URI\fR = \
 \fI"ftp://login:pass@grp.mirror.site/pub/grp/i686/athlon\-xp/"\fR

--- a/man/portage.5
+++ b/man/portage.5
@@ -635,6 +635,20 @@ is intended to be used as a replacement for the \fBmake.conf\fR(5)
 .fi
 
 .RS
+.I Attributes supported in DEFAULT section:
+.RS
+.TP
+.B fetchcommand
+Specifies a \fBFETCHCOMMAND\fR used to fetch files from a repository,
+overriding the value from \fBmake.conf\fR(5).
+.TP
+.B resumecommand
+Specifies a \fBRESUMECOMMAND\fR used to fetch files from a repository,
+overriding the value from \fBmake.conf\fR(5).
+.RE
+.RE
+
+.RS
 .I Attributes supported in sections of repositories:
 .RS
 .TP

--- a/man/portage.5
+++ b/man/portage.5
@@ -47,6 +47,7 @@ virtuals
 .BR /etc/portage/
 .nf
 bashrc
+binrepos.conf
 categories
 color.map
 license_groups
@@ -619,6 +620,43 @@ different from the standard root environment.  The syntax is the same as for
 any other bash script.
 
 Additional package-specific bashrc files can be created in /etc/portage/env.
+.TP
+.BR binrepos.conf
+Specifies remote binary package repository configuration information. This
+is intended to be used as a replacement for the \fBmake.conf\fR(5)
+\fBPORTAGE_BINHOST\fR variable.
+
+.I Format:
+.nf
+\- comments begin with # (no inline comments)
+\- configuration of each repository is specified in a section starting with \
+"[${repository_name}]"
+\- attributes are specified in "${attribute} = ${value}" format
+.fi
+
+.RS
+.I Attributes supported in sections of repositories:
+.RS
+.TP
+.B priority
+Specifies priority of given repository. When a package exists in multiple
+repositories, those with higher priority are preferred.
+.TP
+.B sync\-uri
+Specifies URI of repository used for `emerge \-\-getbinpkg`.
+.RE
+.RE
+
+.I Example:
+.nf
+[example-binhost]
+# repos with higher priorities are preferred when packages with equal
+# versions are found in multiple repos
+priority = 9999
+# packages are fetched from here
+sync-uri = https://example.com/binhost
+
+.fi
 .TP
 .BR categories
 A simple list of valid categories that may be used in repositories and PKGDIR


### PR DESCRIPTION
Support /etc/portage/binrepos.conf as a replacement for the
PORTAGE_BINHOST variable. Behavior is similar to repos.conf,
initially supporting just the sync-uri attribute. Both binrepos.conf
and PORTAGE_BINHOST can be used simultaneously, in the same way that
repos.conf and PORTDIR_OVERLAY can be used simultaneously.

The emerge --info output for binrepos.conf looks like this:
```
Binary Repositories:

example-binhost
	sync-uri: https://example.com/binhost
```
Support customization of fetchcommand and resumecommand in
binrepos.conf, allowing customized authentication mechanisms for
each repository.