### PR TITLE
get_mirror_url: urlquote only for ftp, http, and https (bug 741474)

### DIFF
--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -513,8 +513,12 @@ def get_mirror_url(mirror_url, filename, mysettings, cache_path=None):
 				json.dump(cache, f)
 				f.close()
 
-	return (mirror_url + "/distfiles/" +
-			urlquote(mirror_conf.get_best_supported_layout().get_path(filename)))
+	# For some protocols, urlquote is required for correct behavior,
+	# and it must not be used for other protocols like rsync and sftp.
+	path = mirror_conf.get_best_supported_layout().get_path(filename)
+	if urlparse(mirror_url).scheme in ('ftp', 'http', 'https'):
+		path = urlquote(path)
+	return mirror_url + "/distfiles/" + path
 
 
 def fetch(myuris, mysettings, listonly=0, fetchonly=0,


### PR DESCRIPTION
It's necessary to use urlquote for correct behavior with ftp, http,
and https, since it's possible for file names to contain percent
encoded characters that need to be protected by an additional layer
of percent encoding. For other protocols such as sftp and rsync,
all characters are interpreted literally, so urlquote must not be
used.

Fixes: c238d5f7ed264179c263f5a2da983c4ee50b4f00
Bug: https://bugs.gentoo.org/719810
Bug: https://bugs.gentoo.org/741474
Signed-off-by: Zac Medico <zmedico@gentoo.org>