### PR TITLE
_slot_confict_backtrack: group similar missed updates (bug 743115)

### DIFF
--- a/lib/_emerge/resolver/backtracking.py
+++ b/lib/_emerge/resolver/backtracking.py
@@ -166,13 +166,14 @@ class Backtracker:
 		self._feedback_slot_conflict(conflicts_data[0])
 
 	def _feedback_slot_conflict(self, conflict_data):
-		for pkg, parent_atoms in conflict_data:
+		for similar_pkgs in conflict_data:
 			new_node = copy.deepcopy(self._current_node)
 			new_node.depth += 1
 			new_node.mask_steps += 1
 			new_node.terminal = False
-			new_node.parameter.runtime_pkg_mask.setdefault(
-				pkg, {})["slot conflict"] = parent_atoms
+			for pkg, parent_atoms in similar_pkgs:
+				new_node.parameter.runtime_pkg_mask.setdefault(
+					pkg, {})["slot conflict"] = parent_atoms
 			self._add(new_node)
 
 

--- a/lib/portage/tests/resolver/test_slot_operator_missed_update.py
+++ b/lib/portage/tests/resolver/test_slot_operator_missed_update.py
@@ -90,7 +90,7 @@ class BacktrackMissedUpdateTestCase(TestCase):
 			# Bug 743115: missed updates trigger excessive backtracking
 			ResolverPlaygroundTestCase(
 				[">=dev-python/pypy3-7.3.2_rc", "@world"],
-				options={"--update": True, "--deep": True, "--backtrack": 10},
+				options={"--update": True, "--deep": True, "--backtrack": 4},
 				success=True,
 				mergelist=[
 					"dev-python/pypy3-7.3.2_rc2_p37-r1",


### PR DESCRIPTION
When a slot conflict occurs due to a missed update, and some other
similar update(s) are available, add the similar update(s) to the
runtime package mask for the same backtracking choice. This reduces
minimum number of backtrack tries required to solve the test case
for bug 743115 from 7 to 4, where the difference of 3 corresponds
to the number of other similar setuptools updates available.

Bug: https://bugs.gentoo.org/743115