### PR TITLE
process: pass a string to socket.sethostname instead of bytes

### DIFF
--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -706,10 +706,10 @@ def _exec(binary, mycommand, opt_name, fd_pipes,
 						if unshare_net:
 							# use 'localhost' to avoid hostname resolution problems
 							try:
-								# pypy3 does not implement socket.sethostname()
+								# Old pypy3 versions do not implement socket.sethostname()
 								new_hostname = b'localhost'
 								if hasattr(socket, 'sethostname'):
-									socket.sethostname(new_hostname)
+									socket.sethostname(new_hostname.decode("ascii"))
 								else:
 									if libc.sethostname(new_hostname, len(new_hostname)) != 0:
 										errno_value = ctypes.get_errno()


### PR DESCRIPTION
Recent PyPy3 versions expect a string instead of a bytes object, CPython seems to be happy with both.

Bug: https://bugs.gentoo.org/716998