### PR TITLE
repoman: fix file.size-fatal to be 20 KiB

### DIFF
--- a/repoman/cnf/qa_data/qa_data.yaml
+++ b/repoman/cnf/qa_data/qa_data.yaml
@@ -60,7 +60,6 @@ qahelp:
     file:
         executable: "Ebuilds, digests, metadata.xml, Manifest, and ChangeLog do not need the executable bit"
         size: "Files in the files directory must be under 20 KiB"
-        size-fatal: "Files in the files directory must be under 60 KiB"
         empty: "Empty file in the files directory"
         name: "File/dir name must be composed of only the following chars: %s "
         UTF8: "File is not UTF8 compliant"

--- a/repoman/cnf/repository/qa_data.yaml
+++ b/repoman/cnf/repository/qa_data.yaml
@@ -59,7 +59,6 @@ qawarnings:
     - ebuild.badheader
     - ebuild.patches
     - file.empty
-    - file.size
     - HOMEPAGE.virtual
     - inherit.unused
     - inherit.deprecated

--- a/repoman/lib/repoman/modules/scan/fetch/fetches.py
+++ b/repoman/lib/repoman/modules/scan/fetch/fetches.py
@@ -120,12 +120,7 @@ class FetchChecks(ScanBase):
 							continue
 						filesdirlist.append(y + "/" + z)
 				# Current policy is no files over 20 KiB, these are the checks.
-				# File size between 20 KiB and 60 KiB causes a warning,
-				# while file size over 60 KiB causes an error.
-				elif mystat.st_size > 61440:
-					self.qatracker.add_error(
-						"file.size-fatal", "(%d KiB) %s/files/%s" % (
-							mystat.st_size // 1024, xpkg, y))
+				# File size over 20 KiB causes an error.
 				elif mystat.st_size > 20480:
 					self.qatracker.add_error(
 						"file.size", "(%d KiB) %s/files/%s" % (

--- a/repoman/man/repoman.1
+++ b/repoman/man/repoman.1
@@ -393,7 +393,7 @@ executable bit
 File/dir name must be composed of only the following chars: a-zA-Z0-9._-+:
 .TP
 .B file.size
-Files in the files directory must be under 20k
+Files in the files directory must be under 20 KiB
 .TP
 .B inherit.missing
 Ebuild uses functions from an eclass but does not inherit it


### PR DESCRIPTION
To obey devmanual's guidance, and in addition to match pkgcheck, I'd like repoman's file size check to report any over 20KiB extra file as fatal. There aren't many of those left in the tree, but updating this check surely helps getting rid of the last ones.
Tracker bug: https://bugs.gentoo.org/748144
