### PR TITLE
cnf/sets/portage.conf: add golang-rebuild set

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -103,3 +103,9 @@ class = portage.sets.dbapi.UnavailableBinaries
 # to the matching portdb entry.
 [changed-deps]
 class = portage.sets.dbapi.ChangedDepsSet
+
+# Installed packages that inherit from known go related eclasses.
+[golang-rebuild]
+class = portage.sets.dbapi.VariableSet
+variable = INHERITED
+includes = golang-base golang-build golang-vcs golang-vcs-snapshot go-module


### PR DESCRIPTION
go-built binaries may contain security
vulnerabilities if a binary built with vulnerable compiler.
go is known to embed vulnerable code to all binaries it builds, if
vulnerability was present in the compiler or one of standard libraries.

This commit adds `golang-rebuild` set, which allows easy
rebuild of most go-compiled system packages.

simple 'emerge @golang-rebuild' should rebuild everything affected.
a prompt to run this command can be added to postinst message in
`dev-lang/go` ebuild.