### PR TITLE
Typofix: Use just one definite article

### DIFF
--- a/doc/package/ebuild/eapi/4.docbook
+++ b/doc/package/ebuild/eapi/4.docbook
@@ -153,7 +153,7 @@ This new REQUIRED_USE metadata key is used to specify what USE flag combinations
 It's a semi common occurrence that an ebuild may need to state that they disallow USE flags in specific combinations- either mysql or sqlite for example, but not both.
 </para>
 <para>
-Existing solutions rely on checking the the USE configuration in pkg_setup which is non-optimal due to pkg_setup being ran potentially hours after the initial emerge -p invocation.
+Existing solutions rely on checking the USE configuration in pkg_setup which is non-optimal due to pkg_setup being ran potentially hours after the initial emerge -p invocation.
 </para>
 <para>
 Current versions of EAPI4 support a phase hook pkg_pretend that is intended to move pre-build checks to just after resolution. It has been proposed that pkg_pretend should continue the tradition of adhoc shell code validating the USE state- this too is non optimal for the following reasons-

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -10061,7 +10061,7 @@ def _resume_depgraph(settings, trees, mtimedb, myopts, myparams, spinner):
 
 				# If this package was pulled in by a parent
 				# package scheduled for merge, removing this
-				# package may cause the the parent package's
+				# package may cause the parent package's
 				# dependency to become unsatisfied.
 				for parent_node, atom in \
 					mydepgraph._dynamic_config._parent_atoms.get(pkg, []):

--- a/lib/portage/cache/template.py
+++ b/lib/portage/cache/template.py
@@ -293,7 +293,7 @@ def serialize_eclasses(eclass_dict, chf_type='mtime', paths=True):
 	"""takes a dict, returns a string representing said dict"""
 	"""The "new format", which causes older versions of <portage-2.1.2 to
 	traceback with a ValueError due to failed int() conversion.  This format
-	isn't currently written, but the the capability to read it is already built
+	isn't currently written, but the capability to read it is already built
 	in.
 	return "\t".join(["%s\t%s" % (k, str(v)) \
 		for k, v in eclass_dict.iteritems()])

--- a/lib/portage/package/ebuild/_config/KeywordsManager.py
+++ b/lib/portage/package/ebuild/_config/KeywordsManager.py
@@ -144,7 +144,7 @@ class KeywordsManager:
 		"""
 		Take a package and return a list of any KEYWORDS that the user may
 		need to accept for the given package. If the KEYWORDS are empty
-		and the the ** keyword has not been accepted, the returned list will
+		and the ** keyword has not been accepted, the returned list will
 		contain ** alone (in order to distinguish from the case of "none
 		missing").
 

--- a/lib/portage/package/ebuild/_config/UseManager.py
+++ b/lib/portage/package/ebuild/_config/UseManager.py
@@ -116,7 +116,7 @@ class UseManager:
 			directory
 		@type recursive: bool
 		@param eapi_filter: a function that accepts a single eapi
-			argument, and returns true if the the current file type
+			argument, and returns true if the current file type
 			is supported by the given EAPI
 		@type eapi_filter: callable
 		@param eapi: the EAPI of the current profile node, which allows
@@ -165,7 +165,7 @@ class UseManager:
 			directory
 		@type recursive: bool
 		@param eapi_filter: a function that accepts a single eapi
-			argument, and returns true if the the current file type
+			argument, and returns true if the current file type
 			is supported by the given EAPI
 		@type eapi_filter: callable
 		@param user_config: current file is part of the local

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -2033,7 +2033,7 @@ class config:
 		"""
 		Take a package and return a list of any KEYWORDS that the user may
 		need to accept for the given package. If the KEYWORDS are empty
-		and the the ** keyword has not been accepted, the returned list will
+		and the ** keyword has not been accepted, the returned list will
 		contain ** alone (in order to distinguish from the case of "none
 		missing").
 

--- a/lib/portage/util/netlink.py
+++ b/lib/portage/util/netlink.py
@@ -70,7 +70,7 @@ class RtNetlink:
 
 	def send_message(self, msg):
 		self.sock.sendto(msg, self.addr)
-		# Messages are variable length, but 128 is enough for the the ones we care about.
+		# Messages are variable length, but 128 is enough for the ones we care about.
 		resp = self.sock.recv(128)
 		return parse_message(resp)
 

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -529,7 +529,7 @@ the corresponding ebuild and eclasses to be sourced again for each phase, in
 order to account for modifications.
 .TP
 .B noclean
-Do not delete the the source and temporary files after the merge process.
+Do not delete the source and temporary files after the merge process.
 .TP
 .B nodoc
 Do not install doc files (/usr/share/doc).


### PR DESCRIPTION
I first noticed this in make.conf(5) but it turned out there were many
more occurences of these; fixed with find & sed.

Signed-off-by: Petr Šabata <contyk@redhat.com>