### PR TITLE
emerge: Disable profile deprecation warning inheritance (bug 753497)

### DIFF
--- a/lib/portage/package/ebuild/deprecated_profile_check.py
+++ b/lib/portage/package/ebuild/deprecated_profile_check.py
@@ -19,10 +19,11 @@ def deprecated_profile_check(settings=None):
 	if settings is not None:
 		config_root = settings["PORTAGE_CONFIGROOT"]
 		eprefix = settings["EPREFIX"]
-		for x in reversed(settings.profiles):
-			deprecated_profile_file = os.path.join(x, "deprecated")
-			if os.access(deprecated_profile_file, os.R_OK):
-				break
+		for x in reversed(settings._locations_manager.profiles_complex):
+			if x.show_deprecated_warning:
+				deprecated_profile_file = os.path.join(x.location, "deprecated")
+				if os.access(deprecated_profile_file, os.R_OK):
+					break
 		else:
 			deprecated_profile_file = None
 


### PR DESCRIPTION
According to PMS, a deprecated profile warning is not inherited. Since
the current profile node may have been inherited by a user profile
node, the deprecation warning may be relevant even if it is not a
top-level profile node. Therefore, consider the deprecated warning
to be irrelevant when the current profile node belongs to the same
repo as the previous profile node.

Bug: https://bugs.gentoo.org/753497
Signed-off-by: Zac Medico <zmedico@gentoo.org>