### PR TITLE
find_smallest_cycle: enhance search prioritization

### DIFF
--- a/lib/_emerge/DepPriorityNormalRange.py
+++ b/lib/_emerge/DepPriorityNormalRange.py
@@ -14,6 +14,7 @@ class DepPriorityNormalRange:
 	"""
 	MEDIUM      = 3
 	MEDIUM_SOFT = 2
+	MEDIUM_POST = 2
 	SOFT        = 1
 	NONE        = 0
 
@@ -37,6 +38,7 @@ class DepPriorityNormalRange:
 
 	ignore_medium      = _ignore_runtime
 	ignore_medium_soft = _ignore_runtime_post
+	ignore_medium_post = _ignore_runtime_post
 	ignore_soft        = _ignore_optional
 
 DepPriorityNormalRange.ignore_priority = (

--- a/lib/_emerge/DepPrioritySatisfiedRange.py
+++ b/lib/_emerge/DepPrioritySatisfiedRange.py
@@ -8,17 +8,18 @@ class DepPrioritySatisfiedRange:
 
 	not satisfied and buildtime                    HARD
 	not satisfied and runtime              7       MEDIUM
-	not satisfied and runtime_post         6       MEDIUM_SOFT
-	satisfied and buildtime_slot_op        5       SOFT
-	satisfied and buildtime                4       SOFT
-	satisfied and runtime                  3       SOFT
-	satisfied and runtime_post             2       SOFT
+	satisfied and buildtime_slot_op        6       MEDIUM_SOFT
+	satisfied and buildtime                5       MEDIUM_SOFT
+	satisfied and runtime                  4       MEDIUM_SOFT
+	runtime_post                           3       MEDIUM_POST
+	satisfied and runtime_post             2       MEDIUM_POST
 	optional                               1       SOFT
 	(none of the above)                    0       NONE
 	"""
 	MEDIUM      = 7
 	MEDIUM_SOFT = 6
-	SOFT        = 5
+	MEDIUM_POST = 3
+	SOFT        = 1
 	NONE        = 0
 
 	@classmethod
@@ -35,6 +36,18 @@ class DepPrioritySatisfiedRange:
 			return True
 		if not priority.satisfied:
 			return False
+		if priority.buildtime or priority.runtime:
+			return False
+		return bool(priority.runtime_post)
+
+	@classmethod
+	def _ignore_runtime_post(cls, priority):
+		if priority.__class__ is not DepPriority:
+			return False
+		if priority.optional:
+			return True
+		if priority.buildtime or priority.runtime:
+			return False
 		return bool(priority.runtime_post)
 
 	@classmethod
@@ -43,9 +56,11 @@ class DepPrioritySatisfiedRange:
 			return False
 		if priority.optional:
 			return True
-		if not priority.satisfied:
+		if priority.buildtime:
 			return False
-		return not priority.buildtime
+		if not priority.runtime:
+			return True
+		return bool(priority.satisfied)
 
 	@classmethod
 	def _ignore_satisfied_buildtime(cls, priority):
@@ -61,16 +76,11 @@ class DepPrioritySatisfiedRange:
 	def _ignore_satisfied_buildtime_slot_op(cls, priority):
 		if priority.__class__ is not DepPriority:
 			return False
-		return bool(priority.optional or \
-			priority.satisfied)
-
-	@classmethod
-	def _ignore_runtime_post(cls, priority):
-		if priority.__class__ is not DepPriority:
-			return False
-		return bool(priority.optional or \
-			priority.satisfied or \
-			priority.runtime_post)
+		if priority.optional:
+			return True
+		if priority.satisfied:
+			return True
+		return not priority.buildtime and not priority.runtime
 
 	@classmethod
 	def _ignore_runtime(cls, priority):
@@ -81,17 +91,18 @@ class DepPrioritySatisfiedRange:
 			not priority.buildtime)
 
 	ignore_medium      = _ignore_runtime
-	ignore_medium_soft = _ignore_runtime_post
-	ignore_soft        = _ignore_satisfied_buildtime
+	ignore_medium_soft = _ignore_satisfied_buildtime_slot_op
+	ignore_medium_post = _ignore_runtime_post
+	ignore_soft        = _ignore_optional
 
 
 DepPrioritySatisfiedRange.ignore_priority = (
 	None,
 	DepPrioritySatisfiedRange._ignore_optional,
 	DepPrioritySatisfiedRange._ignore_satisfied_runtime_post,
+	DepPrioritySatisfiedRange._ignore_runtime_post,
 	DepPrioritySatisfiedRange._ignore_satisfied_runtime,
 	DepPrioritySatisfiedRange._ignore_satisfied_buildtime,
 	DepPrioritySatisfiedRange._ignore_satisfied_buildtime_slot_op,
-	DepPrioritySatisfiedRange._ignore_runtime_post,
 	DepPrioritySatisfiedRange._ignore_runtime
 )

--- a/lib/portage/tests/resolver/test_merge_order.py
+++ b/lib/portage/tests/resolver/test_merge_order.py
@@ -490,6 +490,16 @@ class MergeOrderTestCase(TestCase):
 				success=True,
 				all_permutations = True,
 				mergelist = ['x11-base/xorg-server-1.14.1', 'media-libs/mesa-9.1.3']),
+			# Test prioritization of the find_smallest_cycle function, which should
+			# minimize the use of installed packages to break cycles. If installed
+			# packages must be used to break cycles, then it should prefer to do this
+			# for runtime dependencies over buildtime dependencies. If a package needs
+			# to be uninstalled in order to solve a blocker, then it should prefer to
+			# do this before it uses an installed package to break a cycle.
+			ResolverPlaygroundTestCase(
+				["app-misc/some-app-a", "app-misc/some-app-b", "app-misc/some-app-c", "app-misc/circ-buildtime-a", "app-misc/blocker-buildtime-unbuilt-a", "media-libs/mesa", "x11-base/xorg-server", "app-misc/circ-direct-a", "app-misc/circ-direct-b", "app-misc/circ-satisfied-a", "app-misc/circ-satisfied-b", "app-misc/circ-satisfied-c"],
+				success = True,
+				mergelist = ['app-misc/circ-post-runtime-a-1', 'app-misc/circ-post-runtime-c-1', 'app-misc/circ-post-runtime-b-1', 'app-misc/some-app-b-1', 'app-misc/circ-runtime-a-1', 'app-misc/circ-runtime-b-1', 'app-misc/circ-runtime-c-1', 'app-misc/some-app-a-1', 'app-misc/blocker-buildtime-unbuilt-a-1', '[uninstall]app-misc/installed-blocker-a-1', '!app-misc/installed-blocker-a', 'app-misc/circ-direct-a-1', 'app-misc/circ-direct-b-1', 'x11-base/xorg-server-1.14.1', 'media-libs/mesa-9.1.3', 'app-misc/circ-buildtime-a-1', 'app-misc/circ-buildtime-b-1', 'app-misc/circ-buildtime-c-1', 'app-misc/some-app-c-1', 'app-misc/circ-satisfied-a-1', 'app-misc/circ-satisfied-b-1', 'app-misc/circ-satisfied-c-1']),
 		)
 
 		playground = ResolverPlayground(ebuilds=ebuilds, installed=installed)


### PR DESCRIPTION
Enhance the find_smallest_cycle function to prioritize its
search so that it will minimize the use of installed packages
to break cycles. When installed packages must be used to
break cycles, it will now prefer to do this for runtime
dependencies over buildtime dependencies, since it's
preferable to build against latest versions of buildtime
dependencies whenever possible. This should solve some cases
of bug 199856 which have been triggered by unsafe reliance
on installed packages to break cycles.

The included unit test case demonstrates correct merge order
for a dependency calculation involving 6 independent cycles.
This test case fails with the master branch, due to a buildtime
dependency cycle of 3 packages being merged earlier than cycles
of 2 packages. We can generalize this to say that the master
branch may use an installed package to break an arbitrarily
sized cycle in a somewhat random location, even though that
cycle may be composed of smaller independent cycles which
would be safer to break individually.

Bug: https://bugs.gentoo.org/754903
Signed-off-by: Zac Medico <zmedico@gentoo.org>