### PR TITLE
Allow a package to replace its own buildtime dependency

### DIFF
--- a/lib/portage/dep/dep_check.py
+++ b/lib/portage/dep/dep_check.py
@@ -405,9 +405,15 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 		for atom in atoms:
 			if atom.blocker:
 				continue
+
+			# It's not a downgrade if parent is replacing child.
+			replacing = (parent and graph_interface and
+				graph_interface.will_replace_child(parent, myroot, atom))
 			# Ignore USE dependencies here since we don't want USE
 			# settings to adversely affect || preference evaluation.
 			avail_pkg = mydbapi_match_pkgs(atom.without_use)
+			if not avail_pkg and replacing:
+				avail_pkg = [replacing]
 			if avail_pkg:
 				avail_pkg = avail_pkg[-1] # highest (ascending order)
 				avail_slot = Atom("%s:%s" % (atom.cp, avail_pkg.slot))
@@ -416,7 +422,7 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 				all_use_satisfied = False
 				break
 
-			if graph_db is not None and downgrade_probe is not None:
+			if not replacing and graph_db is not None and downgrade_probe is not None:
 				slot_matches = graph_db.match_pkgs(avail_slot)
 				if (len(slot_matches) > 1 and
 					avail_pkg < slot_matches[-1] and
@@ -463,7 +469,7 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 						avail_pkg = avail_pkg_use
 					avail_slot = Atom("%s:%s" % (atom.cp, avail_pkg.slot))
 
-			if downgrade_probe is not None and graph is not None:
+			if not replacing and downgrade_probe is not None and graph is not None:
 				highest_in_slot = mydbapi_match_pkgs(avail_slot)
 				highest_in_slot = (highest_in_slot[-1]
 					if highest_in_slot else None)
@@ -576,14 +582,14 @@ def dep_zapdeps(unreduced, reduced, myroot, use_binaries=0, trees=None,
 				this_choice.all_in_graph = all_in_graph
 
 				circular_atom = None
-				if not (parent is None or priority is None) and \
-					(parent.onlydeps or
-					(priority.buildtime and not priority.satisfied and not priority.optional)):
+				if parent and parent.onlydeps:
 						# Check if the atom would result in a direct circular
-						# dependency and try to avoid that if it seems likely
-						# to be unresolvable. This is only relevant for
-						# buildtime deps that aren't already satisfied by an
-						# installed package.
+						# dependency and avoid that for --onlydeps arguments
+						# since it can defeat the purpose of --onlydeps.
+						# This check should only be used for --onlydeps
+						# arguments, since it can interfere with circular
+						# dependency backtracking choices, causing the test
+						# case for bug 756961 to fail.
 						cpv_slot_list = [parent]
 						for atom in atoms:
 							if atom.blocker:

--- a/lib/portage/tests/resolver/test_circular_choices_rust.py
+++ b/lib/portage/tests/resolver/test_circular_choices_rust.py
@@ -1,0 +1,94 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+	ResolverPlayground,
+	ResolverPlaygroundTestCase,
+)
+
+
+class CircularRustTestCase(TestCase):
+	def testCircularPypyExe(self):
+
+		ebuilds = {
+			"dev-lang/rust-1.47.0-r2": {
+				"EAPI": "7",
+				"SLOT": "stable/1.47",
+				"BDEPEND": "|| ( =dev-lang/rust-1.46* =dev-lang/rust-bin-1.46* =dev-lang/rust-1.47* =dev-lang/rust-bin-1.47* )",
+			},
+			"dev-lang/rust-1.46.0": {
+				"EAPI": "7",
+				"SLOT": "stable/1.46",
+				"BDEPEND": "|| ( =dev-lang/rust-1.45* =dev-lang/rust-bin-1.45* =dev-lang/rust-1.46* =dev-lang/rust-bin-1.46* )",
+			},
+			"dev-lang/rust-bin-1.47.0": {
+				"EAPI": "7",
+			},
+			"dev-lang/rust-bin-1.46.0": {
+				"EAPI": "7",
+			},
+		}
+
+		installed = {
+			"dev-lang/rust-1.46.0": {
+				"EAPI": "7",
+				"SLOT": "stable/1.46",
+				"BDEPEND": "|| ( =dev-lang/rust-1.45* =dev-lang/rust-bin-1.45* =dev-lang/rust-1.46* =dev-lang/rust-bin-1.46* )",
+			},
+		}
+
+		test_cases = (
+			# Test bug 756961, where a circular dependency was reported
+			# when a package would replace its own builtime dependency.
+			# This needs to be tested with and without --update, since
+			# that affects package selection logic significantly,
+			# expecially for packages given as arguments.
+			ResolverPlaygroundTestCase(
+				["=dev-lang/rust-1.46*"],
+				mergelist=["dev-lang/rust-1.46.0"],
+				success=True,
+			),
+			ResolverPlaygroundTestCase(
+				["=dev-lang/rust-1.46*"],
+				options={"--update": True},
+				mergelist=[],
+				success=True,
+			),
+			ResolverPlaygroundTestCase(
+				["=dev-lang/rust-1.46*"],
+				options={"--deep": True, "--update": True},
+				mergelist=[],
+				success=True,
+			),
+			ResolverPlaygroundTestCase(
+				["dev-lang/rust"],
+				mergelist=["dev-lang/rust-1.47.0-r2"],
+				success=True,
+			),
+			ResolverPlaygroundTestCase(
+				["dev-lang/rust"],
+				options={"--update": True},
+				mergelist=["dev-lang/rust-1.47.0-r2"],
+				success=True,
+			),
+			ResolverPlaygroundTestCase(
+				["@world"],
+				options={"--deep": True, "--update": True},
+				mergelist=["dev-lang/rust-1.47.0-r2"],
+				success=True,
+			),
+		)
+
+		world = ["dev-lang/rust"]
+
+		playground = ResolverPlayground(
+			ebuilds=ebuilds, installed=installed, world=world, debug=False
+		)
+		try:
+			for test_case in test_cases:
+				playground.run_TestCase(test_case)
+				self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+		finally:
+			playground.debug = False
+			playground.cleanup()


### PR DESCRIPTION
If a package has a buildtime dependency on a previous version that
it will replace, then do not treat it as a slot conflict. This
solves inappropriate behavior for dev-lang/rust[system-bootstrap].

This requires adjustments to package selection logic in several
locations, in order to ensure that an installed package instance
will be selected to satisfy a buildtime dependency when
appropriate. Dependencies of the installed package will be
entirely ignored, but that has already been the case when using
installed package to break cycles, as discussed in bug 199856.

Bug: https://bugs.gentoo.org/756961
Signed-off-by: Zac Medico <zmedico@gentoo.org>