### PR TITLE
Add runtime fallback for _optimized_copyfile().

### DIFF
--- a/lib/portage/util/file_copy/__init__.py
+++ b/lib/portage/util/file_copy/__init__.py
@@ -4,12 +4,17 @@
 import os
 import shutil
 import tempfile
+import logging
+from portage.util         import writemsg_level
+from portage.localization import _
+
+fallback = False
 
 try:
 	from portage.util.file_copy.reflink_linux import file_copy as _file_copy
 except ImportError:
 	_file_copy = None
-
+	fallback   = True
 
 def _optimized_copyfile(src, dst):
 	"""
@@ -25,12 +30,28 @@ def _optimized_copyfile(src, dst):
 	@param dst: path of destination file
 	@type dst: str
 	"""
-	with open(src, 'rb', buffering=0) as src_file, \
-		open(dst, 'wb', buffering=0) as dst_file:
-		_file_copy(src_file.fileno(), dst_file.fileno())
+	global fallback
+	if fallback:
+		shutil.copyfile(src, dst)
+		return
 
+	try:
+		with open(src, 'rb', buffering=0) as src_file, \
+				open(dst, 'wb', buffering=0) as dst_file:
+					_file_copy(src_file.fileno(), dst_file.fileno())
+	except OSError as e:
+		if e.args[0] != 22: raise
+		# Got an 'Invalid argument', this means the user's
+		# kernel does not support this API, fallback to regular
+		# method of copying.
+		writemsg_level(_("!!! WARNING: _optimized_copyfile returned " \
+			"'Invalid argument' (errno=22), using fallback, " \
+			"incompatible kernel?") + "    ",
+			noiselevel=2, level=logging.WARNING)
+		fallback = True
+		shutil.copyfile(src, dst)
 
-if _file_copy is None:
+if fallback:
 	copyfile = shutil.copyfile
 else:
 	copyfile = _optimized_copyfile


### PR DESCRIPTION
In some situations, as described by this thread on Gentoo forums:

https://forums.gentoo.org/viewtopic-t-1088232-start-0.html

the build system's kernel interface is not compatible with the portage
_optimized_copyfile() implementation.

Check for this specific edge-case, where _optimized_copyfile() fails
with errno=22 (Invalid argument), invoke the fallback function and set a
flag to indicate that following invocations will also call the fallback
function.

Also print a warning message at noiselevel=2 when this happens.

In the case where errno=22 is caused by some other reason which the user
should know about, the fallback function should fail in the same (or
similar) way.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>