### PR TITLE
ci: upgrade workflow to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
This will be the new default soon.

See: https://github.com/actions/virtual-environments/issues/1816
Signed-off-by: Zac Medico <zmedico@gentoo.org>