### PR TITLE
global_event_loop: return running loop for current thread

### DIFF
--- a/lib/portage/util/_eventloop/global_event_loop.py
+++ b/lib/portage/util/_eventloop/global_event_loop.py
@@ -1,28 +1,6 @@
-# Copyright 2012-2020 Gentoo Authors
+# Copyright 2012-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import portage
-from portage.util._eventloop.asyncio_event_loop import AsyncioEventLoop
+__all__ = ('global_event_loop',)
 
-_instances = {}
-
-
-def global_event_loop():
-	"""
-	Get a global EventLoop (or compatible object) instance which
-	belongs exclusively to the current process.
-	"""
-
-	pid = portage.getpid()
-	instance = _instances.get(pid)
-	if instance is not None:
-		return instance
-
-	constructor = AsyncioEventLoop
-
-	# Use the _asyncio_wrapper attribute, so that unit tests can compare
-	# the reference to one retured from _wrap_loop(), since they should
-	# not close the loop if it refers to a global event loop.
-	instance = constructor()._asyncio_wrapper
-	_instances[pid] = instance
-	return instance
+from portage.util.futures._asyncio import _safe_loop as global_event_loop


### PR DESCRIPTION
Like asyncio.get_event_loop(), return the running loop for the
current thread if there is one, and otherwise construct a new
one if needed. This allows the _safe_loop function to become
synonymous with the global_event_loop function.

For the case of "loop running in non-main thread" of API
consumer, this change makes portage compatible with PEP
492 coroutines with async and await syntax. Portage
internals can safely begin using async / await syntax instead
of compat_coroutine.

Bug: https://bugs.gentoo.org/763339
Signed-off-by: Zac Medico <zmedico@gentoo.org>