### PR TITLE
bindbapi.aux_update: fix spurious package file renames

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -214,7 +214,7 @@ class bindbapi(fakedbapi):
 				del mydata[k]
 		mytbz2.recompose_mem(portage.xpak.xpak_mem(mydata))
 		# inject will clear stale caches via cpv_inject.
-		self.bintree.inject(cpv, filename=tbz2path)
+		self.bintree.inject(cpv)
 
 
 	@coroutine


### PR DESCRIPTION
Omit the filename argument for the binarytree.inject method
in aux_update, since an in-place update is desired, and the
filename argument causes the file to be renamed when
binpkg-multi-instance is enabled.

Fixes: 328dd4712f88 ("binpkg-multi-instance 3 of 7")
Bug: https://bugs.gentoo.org/765847
Signed-off-by: Zac Medico <zmedico@gentoo.org>