### PR TITLE
coroutine: do not require loop parameter

### DIFF
--- a/lib/portage/tests/dbapi/test_auxdb.py
+++ b/lib/portage/tests/dbapi/test_auxdb.py
@@ -1,10 +1,9 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
 from portage.tests.resolver.ResolverPlayground import ResolverPlayground
 from portage.util.futures import asyncio
-from portage.util.futures.compat_coroutine import coroutine, coroutine_return
 from portage.util.futures.executor.fork import ForkExecutor
 
 
@@ -65,7 +64,7 @@ class AuxdbTestCase(TestCase):
 		def test_func():
 			loop = asyncio._wrap_loop()
 			return loop.run_until_complete(self._test_mod_async(
-				ebuilds, ebuild_inherited, eclass_defined_phases, eclass_depend, portdb, loop=loop))
+				ebuilds, ebuild_inherited, eclass_defined_phases, eclass_depend, portdb))
 
 		self.assertTrue(test_func())
 
@@ -91,14 +90,13 @@ class AuxdbTestCase(TestCase):
 
 		self.assertEqual(auxdb[cpv]['RESTRICT'], 'test')
 
-	@coroutine
-	def _test_mod_async(self, ebuilds, ebuild_inherited, eclass_defined_phases, eclass_depend, portdb, loop=None):
+	async def _test_mod_async(self, ebuilds, ebuild_inherited, eclass_defined_phases, eclass_depend, portdb):
 
 		for cpv, metadata in ebuilds.items():
-			defined_phases, depend, eapi, inherited = yield portdb.async_aux_get(cpv, ['DEFINED_PHASES', 'DEPEND', 'EAPI', 'INHERITED'], loop=loop)
+			defined_phases, depend, eapi, inherited = await portdb.async_aux_get(cpv, ['DEFINED_PHASES', 'DEPEND', 'EAPI', 'INHERITED'])
 			self.assertEqual(defined_phases, eclass_defined_phases)
 			self.assertEqual(depend, eclass_depend)
 			self.assertEqual(eapi, metadata['EAPI'])
 			self.assertEqual(frozenset(inherited.split()), ebuild_inherited)
 
-		coroutine_return(True)
+		return True

--- a/lib/portage/tests/emerge/test_simple.py
+++ b/lib/portage/tests/emerge/test_simple.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2020 Gentoo Authors
+# Copyright 2011-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
@@ -14,7 +14,6 @@ from portage.tests.util.test_socks5 import AsyncHTTPServer
 from portage.util import (ensure_dirs, find_updated_config_files,
 	shlex_split)
 from portage.util.futures import asyncio
-from portage.util.futures.compat_coroutine import coroutine
 
 
 class BinhostContentMap(Mapping):
@@ -225,8 +224,7 @@ call_has_and_best_version() {
 		loop.run_until_complete(asyncio.ensure_future(
 			self._async_test_simple(playground, metadata_xml_files, loop=loop), loop=loop))
 
-	@coroutine
-	def _async_test_simple(self, playground, metadata_xml_files, loop=None):
+	async def _async_test_simple(self, playground, metadata_xml_files, loop):
 
 		debug = playground.debug
 		settings = playground.settings
@@ -548,14 +546,14 @@ move dev-util/git dev-vcs/git
 				else:
 					local_env = env
 
-				proc = yield asyncio.create_subprocess_exec(*args,
-					env=local_env, stderr=None, stdout=stdout, loop=loop)
+				proc = await asyncio.create_subprocess_exec(*args,
+					env=local_env, stderr=None, stdout=stdout)
 
 				if debug:
-					yield proc.wait()
+					await proc.wait()
 				else:
-					output, _err = yield proc.communicate()
-					yield proc.wait()
+					output, _err = await proc.communicate()
+					await proc.wait()
 					if proc.returncode != os.EX_OK:
 						portage.writemsg(output)
 

--- a/lib/portage/tests/process/test_AsyncFunction.py
+++ b/lib/portage/tests/process/test_AsyncFunction.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -9,7 +9,6 @@ from portage.tests import TestCase
 from portage.util._async.AsyncFunction import AsyncFunction
 from portage.util.futures import asyncio
 from portage.util.futures._asyncio.streams import _writer
-from portage.util.futures.compat_coroutine import coroutine
 from portage.util.futures.unix_events import _set_nonblocking
 
 
@@ -20,8 +19,7 @@ class AsyncFunctionTestCase(TestCase):
 		os.close(pw)
 		return ''.join(sys.stdin)
 
-	@coroutine
-	def _testAsyncFunctionStdin(self, loop=None):
+	async def _testAsyncFunctionStdin(self, loop):
 		test_string = '1\n2\n3\n'
 		pr, pw = os.pipe()
 		fd_pipes = {0:pr}
@@ -30,8 +28,8 @@ class AsyncFunctionTestCase(TestCase):
 		os.close(pr)
 		_set_nonblocking(pw)
 		with open(pw, mode='wb', buffering=0) as pipe_write:
-			yield _writer(pipe_write, test_string.encode('utf_8'), loop=loop)
-		self.assertEqual((yield reader.async_wait()), os.EX_OK)
+			await _writer(pipe_write, test_string.encode('utf_8'))
+		self.assertEqual((await reader.async_wait()), os.EX_OK)
 		self.assertEqual(reader.result, test_string)
 
 	def testAsyncFunctionStdin(self):

--- a/lib/portage/tests/util/futures/asyncio/test_child_watcher.py
+++ b/lib/portage/tests/util/futures/asyncio/test_child_watcher.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Gentoo Authors
+# Copyright 2018-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import os
@@ -7,7 +7,6 @@ from portage.process import find_binary, spawn
 from portage.tests import TestCase
 from portage.util._eventloop.global_event_loop import global_event_loop
 from portage.util.futures import asyncio
-from portage.util.futures.compat_coroutine import coroutine
 from portage.util.futures.unix_events import DefaultEventLoopPolicy
 
 
@@ -37,17 +36,16 @@ class ChildWatcherTestCase(TestCase):
 			def callback(pid, returncode, *args):
 				future.set_result((pid, returncode, args))
 
-			@coroutine
-			def watch_pid(loop=None):
+			async def watch_pid():
 
 				with asyncio.get_child_watcher() as watcher:
 					pids = spawn([true_binary], returnpid=True)
 					watcher.add_child_handler(pids[0], callback, *args_tuple)
 					self.assertEqual(
-						(yield future),
+						(await future),
 						(pids[0], os.EX_OK, args_tuple))
 
-			loop.run_until_complete(watch_pid(loop=loop))
+			loop.run_until_complete(watch_pid())
 		finally:
 			asyncio.set_event_loop_policy(initial_policy)
 			if loop not in (None, global_event_loop()):

--- a/lib/portage/util/futures/compat_coroutine.py
+++ b/lib/portage/util/futures/compat_coroutine.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Gentoo Foundation
+# Copyright 2018-2021 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -68,10 +68,6 @@ def _generator_future(generator_func, *args, **kwargs):
 	the default event loop.
 	"""
 	loop = kwargs.get('loop')
-	if loop is None and portage._internal_caller:
-		# Require an explicit loop parameter, in order to support
-		# local event loops (bug 737698).
-		raise AssertionError("Missing required argument 'loop'")
 	loop = asyncio._wrap_loop(loop)
 	result = loop.create_future()
 	_GeneratorTask(generator_func(*args, **kwargs), result, loop=loop)


### PR DESCRIPTION
The loop parameter is not needed since global_event_loop now
returns the running event loop for the current thread.

Bug: https://bugs.gentoo.org/737698
Bug: https://bugs.gentoo.org/763339
Signed-off-by: Zac Medico <zmedico@gentoo.org>