### PR TITLE
emaint --fix merges: add -y, --yes option

### DIFF
--- a/lib/portage/emaint/modules/merges/__init__.py
+++ b/lib/portage/emaint/modules/merges/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2014 Gentoo Foundation
+# Copyright 2005-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 doc = """Scan for failed merges and fix them."""
@@ -26,7 +26,17 @@ module_spec = {
 					'action': 'store_true',
 					'func': 'purge'
 				}
-			}
+			},
+			'opt_desc': {
+				'yes': {
+					"short": "-y",
+					"long": "--yes",
+					"help": ("(merges submodule only): Do not prompt for "
+						"emerge invocations"),
+					"action": "store_true",
+					"dest": "yes",
+				}
+			},
 		}
 	}
 }

--- a/lib/portage/emaint/modules/merges/merges.py
+++ b/lib/portage/emaint/modules/merges/merges.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2020 Gentoo Authors
+# Copyright 2005-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import portage
@@ -186,7 +186,7 @@ class MergesHandler:
 			pkg_atoms.add(pkg_atom)
 
 
-	def _emerge_pkg_atoms(self, module_output, pkg_atoms):
+	def _emerge_pkg_atoms(self, module_output, pkg_atoms, yes=False):
 		"""
 		Emerge the specified packages atoms.
 
@@ -194,6 +194,8 @@ class MergesHandler:
 		@type module_output: Class
 		@param pkg_atoms: packages atoms to emerge
 		@type pkg_atoms: set
+		@param yes: do not prompt for emerge invocations
+		@type yes: bool
 		@rtype: list
 		@return: List of results
 		"""
@@ -206,7 +208,7 @@ class MergesHandler:
 			portage._python_interpreter,
 			'-b',
 			os.path.join(EPREFIX or '/', 'usr', 'bin', 'emerge'),
-			'--ask',
+			'--ask=n' if yes else '--ask',
 			'--quiet',
 			'--oneshot',
 			'--complete-graph=y'
@@ -265,7 +267,8 @@ class MergesHandler:
 			errors.append(', '.join(sorted(failed_pkgs)))
 			return (False, errors)
 		self._remove_failed_dirs(failed_pkgs)
-		results = self._emerge_pkg_atoms(module_output, pkg_atoms)
+		results = self._emerge_pkg_atoms(module_output, pkg_atoms,
+			yes=kwargs.get('options', {}).get("yes", False))
 		# list any new failed merges
 		for pkg in sorted(self._scan()):
 			results.append("'%s' still found as a failed merge." % pkg)

--- a/man/emaint.1
+++ b/man/emaint.1
@@ -1,4 +1,4 @@
-.TH "EMAINT" "1" "Jan 2017" "Portage VERSION" "Portage"
+.TH "EMAINT" "1" "Feb 2021" "Portage VERSION" "Portage"
 .SH NAME
 emaint \- performs package management related system health checks and maintenance
 .SH SYNOPSIS
@@ -82,6 +82,10 @@ OPTION
 .BR \-t \ \fINUM\fR,\  \-\-time \ \fINUM\fR
 Changes the minimum age \fINUM\fR (in days) of the logs to be listed or
 deleted.
+.SH OPTIONS merges command only
+.TP
+.BR \-y ", " \-\-yes
+Do not prompt for emerge invocations.
 .SH OPTIONS sync command only
 .TP
 .BR \-a ", " \-\-auto


### PR DESCRIPTION
Since the emaint --fix merges uses emerge --ask, add
a -y, --yes option to use --ask=n instead.

Bug: https://bugs.gentoo.org/766767
Signed-off-by: Zac Medico <zmedico@gentoo.org>