### PR TITLE
emerge: disable --autounmask-license by default

### DIFF
--- a/lib/_emerge/create_depgraph_params.py
+++ b/lib/_emerge/create_depgraph_params.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
@@ -45,7 +45,7 @@ def create_depgraph_params(myopts, myaction):
 	autounmask_keep_masks = myopts.get("--autounmask-keep-masks")
 
 	autounmask = myopts.get("--autounmask")
-	autounmask_license = myopts.get('--autounmask-license')
+	autounmask_license = myopts.get('--autounmask-license', 'y' if autounmask is True else 'n')
 	autounmask_use = myopts.get('--autounmask-use')
 	if autounmask == 'n':
 		autounmask = False
@@ -53,7 +53,7 @@ def create_depgraph_params(myopts, myaction):
 		if autounmask is None:
 			if autounmask_use in (None, 'y'):
 				autounmask = True
-			elif autounmask_license in (None, 'y'):
+			if autounmask_license in ('y',):
 				autounmask = True
 
 			# Do not enable package.accept_keywords or package.mask
@@ -67,7 +67,7 @@ def create_depgraph_params(myopts, myaction):
 
 	myparams['autounmask'] = autounmask
 	myparams['autounmask_keep_use'] = True if autounmask_use == 'n' else False
-	myparams['autounmask_keep_license'] = True if autounmask_license == 'n' else False
+	myparams['autounmask_keep_license'] = False if autounmask_license == 'y' else True
 	myparams['autounmask_keep_keywords'] = False if autounmask_keep_keywords in (None, 'n') else True
 	myparams['autounmask_keep_masks'] = False if autounmask_keep_masks in (None, 'n') else True
 

--- a/lib/portage/tests/resolver/test_autounmask.py
+++ b/lib/portage/tests/resolver/test_autounmask.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2019 Gentoo Authors
+# Copyright 2010-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -440,12 +440,33 @@ class AutounmaskTestCase(TestCase):
 					mergelist=["dev-libs/A-1"],
 					license_changes={ "dev-libs/A-1": set(["TEST"]) }),
 
-				# Test default --autounmask-license
+				# Test that --autounmask enables --autounmask-license
 				ResolverPlaygroundTestCase(
 					["=dev-libs/A-1"],
+					options={"--autounmask": True},
 					success=False,
 					mergelist=["dev-libs/A-1"],
 					license_changes={ "dev-libs/A-1": set(["TEST"]) }),
+
+				# Test that --autounmask-license is not enabled by default
+				ResolverPlaygroundTestCase(
+					["=dev-libs/A-1"],
+					success=False,
+				),
+
+				# Test that --autounmask does not override --autounmask-license=n
+				ResolverPlaygroundTestCase(
+					["=dev-libs/A-1"],
+					options={"--autounmask": True, "--autounmask-license": "n"},
+					success=False,
+				),
+
+				# Test that --autounmask=n overrides --autounmask-license=y
+				ResolverPlaygroundTestCase(
+					["=dev-libs/A-1"],
+					options={"--autounmask": "n", "--autounmask-license": "y"},
+					success=False,
+				),
 
 				ResolverPlaygroundTestCase(
 					["=dev-libs/A-1"],

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1,4 +1,4 @@
-.TH "EMERGE" "1" "Nov 2020" "Portage VERSION" "Portage"
+.TH "EMERGE" "1" "Feb 2021" "Portage VERSION" "Portage"
 .SH "NAME"
 emerge \- Command\-line interface to the Portage system
 .SH "SYNOPSIS"
@@ -356,8 +356,8 @@ intended to be set in the \fBmake.conf\fR(5)
 Automatically unmask packages and generate package.use
 settings as necessary to satisfy dependencies. This option
 is disabled by default, except for portions of behavior
-which are controlled by the \fB\-\-autounmask\-use\fR and
-\fB\-\-autounmask\-license\fR options (\fB\-\-autounmask=n\fR
+which are controlled by the \fB\-\-autounmask\-use\fR
+(\fB\-\-autounmask=n\fR
 disables autounmask behavior entirely). If any configuration
 changes are required, then they will be displayed
 after the merge list and emerge will immediately
@@ -413,10 +413,7 @@ will be created. This leads to unsatisfied dependencies if
 no other solution exists.
 .TP
 .BR "\-\-autounmask\-license < y | n >"
-Allow autounmask package.license changes. This option is enabled by default
-(either \fB\-\-autounmask=n\fR or \fB\-\-autounmask\-license=n\fR disables
-it). The \fBEMERGE_DEFAULT_OPTS\fR variable may be used to
-disable this option by default in \fBmake.conf\fR(5).
+Allow autounmask package.license changes.
 .TP
 .BR "\-\-autounmask\-use < y | n >"
 Allow autounmask package.use changes. This option is enabled by default


### PR DESCRIPTION
Disable --autounmask-license by default, in order to limit user
exposure to risks associated with package.license changes.
The changes that this option suggests are only intended to be
accepted when a user has made a conscious decision to accept
the corresponding license(s). Creation of package.license
changes introduces a risk that users may erroneously accept the
changes due to some kind of accident or misunderstanding,
rather than due to conscious decisions about licenses.
These risks provide motivation to disable --autounmask-license
by default. The --autounmask-use option will remain as the
only autounmask option that is still enabled by default.

The unit tests demonstrate interactions between --autounmask
and --autounmask-license options. The --autounmask option
enables --autounmask-license unless --autounmask-license=n
has been specified. If --autounmask=n is used to disable
autounmask, then --autounmask-license=y has no effect.

Bug: https://bugs.gentoo.org/766773
Signed-off-by: Zac Medico <zmedico@gentoo.org>