### PR TITLE
ci: upgrade to pypy-3.7-v7.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         - '3.8'
         - '3.9'
         - '3.10.0-alpha.3'
-        - 'pypy-3.6'
+        - 'pypy-3.7-v7.3.3'
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    pypy-3.6: pypy3
+    pypy-3.7-v7.3.3: pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Signed-off-by: Zac Medico <zmedico@gentoo.org>