### PR TITLE
repoman: revert preserve_old_lib deprecation (bug 480244)

### DIFF
--- a/repoman/cnf/linechecks/linechecks.yaml
+++ b/repoman/cnf/linechecks/linechecks.yaml
@@ -25,7 +25,7 @@ errors:
     DEPRECATED_BINDNOW_FLAGS: 'Deprecated bindnow-flags call'
     EAPI_DEFINED_AFTER_INHERIT: 'EAPI defined after inherit'
     NO_AS_NEEDED: 'Upstream asneeded linking bug (no-as-needed)'
-    PRESERVE_OLD_LIB: 'Ebuild calls deprecated preserve_old_lib'
+    PRESERVE_OLD_LIB: 'Upstream ABI change workaround on line: %d'
     BUILT_WITH_USE: 'built_with_use'
     NO_OFFSET_WITH_HELPERS: 'Helper function is used with D, ROOT, ED, EROOT or EPREFIX'
     USEQ_ERROR: 'Ebuild calls deprecated useq function'

--- a/repoman/lib/repoman/modules/linechecks/deprecated/deprecated.py
+++ b/repoman/lib/repoman/modules/linechecks/deprecated/deprecated.py
@@ -19,8 +19,8 @@ class DeprecatedHasq(LineCheck):
 
 
 class PreserveOldLib(LineCheck):
-	"""Check for calls to the deprecated preserve_old_lib function."""
-	repoman_check_name = 'ebuild.minorsyn'
+	"""Check for calls to the preserve_old_lib function."""
+	repoman_check_name = 'upstream.workaround'
 	re = re.compile(r'.*preserve_old_lib')
 	error = 'PRESERVE_OLD_LIB'
 


### PR DESCRIPTION
Repoman should not report that preserve_old_lib is deprecated,
since preserve-libs is not covered by PMS.
This reverts commit 49cbc17bf7b99be586e158c1bd588cfe91dfe58c.

Bug: https://bugs.gentoo.org/480244
Bug: https://bugs.gentoo.org/692486
Signed-off-by: Zac Medico <zmedico@gentoo.org>