### PR TITLE
emerge: make --binpkg-respect-use=y imply --autounmask-use=n

### DIFF
--- a/lib/_emerge/create_depgraph_params.py
+++ b/lib/_emerge/create_depgraph_params.py
@@ -41,12 +41,22 @@ def create_depgraph_params(myopts, myaction):
 	# binpkg_changed_deps: reject binary packages with outdated deps
 	myparams = {"recurse" : True}
 
+	binpkg_respect_use = myopts.get("--binpkg-respect-use")
+	if binpkg_respect_use is not None:
+		myparams["binpkg_respect_use"] = binpkg_respect_use
+	elif "--usepkgonly" not in myopts:
+		# If --binpkg-respect-use is not explicitly specified, we enable
+		# the behavior automatically (like requested in bug #297549), as
+		# long as it doesn't strongly conflict with other options that
+		# have been specified.
+		myparams["binpkg_respect_use"] = "auto"
+
 	autounmask_keep_keywords = myopts.get("--autounmask-keep-keywords")
 	autounmask_keep_masks = myopts.get("--autounmask-keep-masks")
 
 	autounmask = myopts.get("--autounmask")
 	autounmask_license = myopts.get('--autounmask-license', 'y' if autounmask is True else 'n')
-	autounmask_use = myopts.get('--autounmask-use')
+	autounmask_use = 'n' if myparams.get('binpkg_respect_use') == 'y' else myopts.get('--autounmask-use')
 	if autounmask == 'n':
 		autounmask = False
 	else:
@@ -152,16 +162,6 @@ def create_depgraph_params(myopts, myaction):
 		myopts.get('--deep') is True and \
 		'--update' in myopts:
 		myparams['rebuilt_binaries'] = True
-
-	binpkg_respect_use = myopts.get('--binpkg-respect-use')
-	if binpkg_respect_use is not None:
-		myparams['binpkg_respect_use'] = binpkg_respect_use
-	elif '--usepkgonly' not in myopts:
-		# If --binpkg-respect-use is not explicitly specified, we enable
-		# the behavior automatically (like requested in bug #297549), as
-		# long as it doesn't strongly conflict with other options that
-		# have been specified.
-		myparams['binpkg_respect_use'] = 'auto'
 
 	binpkg_changed_deps = myopts.get('--binpkg-changed-deps')
 	if binpkg_changed_deps is not None:

--- a/lib/portage/tests/resolver/test_useflags.py
+++ b/lib/portage/tests/resolver/test_useflags.py
@@ -46,15 +46,23 @@ class UseFlagsTestCase(TestCase):
 				success = True,
 				mergelist = ["dev-libs/A-1"]),
 
-			# In the unit test case for bug 773469, the --autounmask-backtrack option
-			# is needed in order to trigger the --binpkg-respect-use=y behavior that
-			# appears confusingly similar to --binpkg-respect-use=n behavior.
+			# For bug 773469, we wanted --binpkg-respect-use=y to trigger a
+			# slot collision. Instead, a combination of default --autounmask-use
+			# combined with --autounmask-backtrack=y from EMERGE_DEFAULT_OPTS
+			# triggered this behavior which appeared confusingly similar to
+			#--binpkg-respect-use=n behavior.
+			#ResolverPlaygroundTestCase(
+			#	["dev-libs/C", "dev-libs/D"],
+			#	options={"--usepkg": True, "--binpkg-respect-use": "y", "--autounmask-backtrack": "y"},
+			#	success=True,
+			#	use_changes={"dev-libs/C-1": {"abi_x86_32": True}},
+			#	mergelist=["[binary]dev-libs/C-1", "[binary]dev-libs/D-1"],
 			ResolverPlaygroundTestCase(
 				["dev-libs/C", "dev-libs/D"],
 				options={"--usepkg": True, "--binpkg-respect-use": "y", "--autounmask-backtrack": "y"},
-				success=True,
-				use_changes={"dev-libs/C-1": {"abi_x86_32": True}},
-				mergelist=["[binary]dev-libs/C-1", "[binary]dev-libs/D-1"],
+				success=False,
+				slot_collision_solutions=[{"dev-libs/C-1": {"abi_x86_32": True}}],
+				mergelist=["dev-libs/C-1", "[binary]dev-libs/D-1"],
 			),
 
 			#--binpkg-respect-use=n: use binpkgs with different use flags

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1,4 +1,4 @@
-.TH "EMERGE" "1" "Feb 2021" "Portage VERSION" "Portage"
+.TH "EMERGE" "1" "Mar 2021" "Portage VERSION" "Portage"
 .SH "NAME"
 emerge \- Command\-line interface to the Portage system
 .SH "SYNOPSIS"
@@ -417,7 +417,8 @@ Allow autounmask package.license changes.
 .TP
 .BR "\-\-autounmask\-use < y | n >"
 Allow autounmask package.use changes. This option is enabled by default
-(either \fB\-\-autounmask=n\fR or \fB\-\-autounmask\-use=n\fR disables
+(any of \fB\-\-autounmask=n\fR, \fB\-\-autounmask\-use=n\fR,
+or \fB\-\-binpkg-\-respect\-use=y\fR  disables
 it). The \fBEMERGE_DEFAULT_OPTS\fR variable may be used to
 disable this option by default in \fBmake.conf\fR(5).
 .TP
@@ -448,7 +449,9 @@ Tells emerge to ignore binary packages if their USE flags
 don't match the current configuration. In order to help avoid issues
 with resolving inconsistent USE flag settings, this option is
 automatically enabled unless the \fB\-\-usepkgonly\fR option
-is enabled.
+is enabled. If \fB\-\-binpkg\-respect\-use\fR is given explicitly,
+then it implies \fB\-\-autounmask\-use=n\fR, because these options
+naturally oppose eachother.
 .TP
 .BR "\-\-buildpkg [ y | n ]" ", " \-b
 Tells emerge to build binary packages for all ebuilds processed in


### PR DESCRIPTION
If --binpkg-respect-use=y is given explicitly, then it implies
--autounmask-use=n, because these options naturally oppose
eachother.

Bug: https://bugs.gentoo.org/773469
Signed-off-by: Zac Medico <zmedico@gentoo.org>