### PR TITLE
bin/ebuild-pyhelper: wrapper for portage python helpers

### DIFF
--- a/bin/chmod-lite
+++ b/bin/chmod-lite
@@ -1,10 +1,1 @@
-#!/bin/bash
-# Copyright 2015 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
-
-export __PORTAGE_HELPER_CWD=${PWD}
-
-# Use safe cwd, avoiding unsafe import for bug #469338.
-cd "${PORTAGE_PYM_PATH}" || exit 1
-PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
-	exec "${PORTAGE_PYTHON:-/usr/bin/python}" "$PORTAGE_BIN_PATH/chmod-lite.py" "$@"
+ebuild-pyhelper

--- a/bin/ebuild-ipc
+++ b/bin/ebuild-ipc
@@ -1,8 +1,1 @@
-#!/bin/bash
-# Copyright 2010-2013 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
-
-# Use safe cwd, avoiding unsafe import for bug #469338.
-cd "${PORTAGE_PYM_PATH}" || exit 1
-PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
-	exec "${PORTAGE_PYTHON:-/usr/bin/python}" "$PORTAGE_BIN_PATH/ebuild-ipc.py" "$@"
+ebuild-pyhelper

--- a/bin/ebuild-pyhelper
+++ b/bin/ebuild-pyhelper
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2010-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+export __PORTAGE_HELPER_CWD=${PWD}
+
+if [[ ${0##*/} == "ebuild-pyhelper" ]]; then
+	echo "ebuild-pyhelper: must be called via symlink" &>2
+	exit 1
+fi
+
+# Use safe cwd, avoiding unsafe import for bug #469338.
+cd "${PORTAGE_PYM_PATH}" || exit 1
+for path in "${PORTAGE_BIN_PATH}/${0##*/}"{.py,}; do
+	if [[ -x "${path}" ]]; then
+		PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
+			exec "${PORTAGE_PYTHON:-/usr/bin/python}" "${path}" "$@"
+	fi
+done
+echo "File not found: ${path}" >&2
+exit 1


### PR DESCRIPTION
Merge the shell script wrappers for chmod-lite and ebuild-ipc
into a single ebuild-pyhelper script.

Signed-off-by: Zac Medico <zmedico@gentoo.org>