### PR TITLE
setup.py: fix GLOBAL_CONFIG_PATH for prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -502,10 +502,13 @@ class x_install_lib(install_lib):
 			with codecs.open(path, "w", "utf-8") as f:
 				f.write(data)
 
-		val_dict = {
-			"GLOBAL_CONFIG_PATH": self.portage_confdir,
-		}
+		val_dict = {}
 		if create_entry_points:
+			val_dict.update(
+				{
+					"GLOBAL_CONFIG_PATH": self.portage_confdir,
+				}
+			)
 			re_sub_file(
 				"portage/const.py",
 				(


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/775053
Reported-by: Marien Zwart <marien.zwart@gmail.com>
Signed-off-by: Zac Medico <zmedico@gentoo.org>