### PR TITLE
SyncRepos: suppress portage update message if PYTHON_TARGETS changed

### DIFF
--- a/lib/portage/emaint/modules/sync/sync.py
+++ b/lib/portage/emaint/modules/sync/sync.py
@@ -277,13 +277,45 @@ class SyncRepos:
 		mypvs = portage.best(
 			self.emerge_config.target_config.trees['vartree'].dbapi.match(
 				portage.const.PORTAGE_PACKAGE_ATOM))
+		try:
+			old_use = (
+				self.emerge_config.target_config.trees["vartree"]
+				.dbapi.aux_get(mypvs, ["USE"])[0]
+				.split()
+			)
+		except KeyError:
+			old_use = ()
 
-		chk_updated_cfg_files(self.emerge_config.target_config.root,
+		chk_updated_cfg_files(
+			self.emerge_config.target_config.root,
 			portage.util.shlex_split(
-				self.emerge_config.target_config.settings.get("CONFIG_PROTECT", "")))
+				self.emerge_config.target_config.settings.get("CONFIG_PROTECT", "")
+			),
+		)
 
 		msgs = []
-		if mybestpv != mypvs and "--quiet" not in self.emerge_config.opts:
+		if not mybestpv or mybestpv == mypvs or "--quiet" in self.emerge_config.opts:
+			return msgs
+
+		# Suggest to update to the latest available version of portage.
+		# Since changes to PYTHON_TARGETS cause complications, this message
+		# is suppressed if the new version has different PYTHON_TARGETS enabled
+		# than previous version.
+		portdb = self.emerge_config.target_config.trees["porttree"].dbapi
+		portdb.doebuild_settings.setcpv(mybestpv, mydb=portdb)
+		usemask = portdb.doebuild_settings.usemask
+		useforce = portdb.doebuild_settings.useforce
+		new_use = (
+			frozenset(portdb.doebuild_settings["PORTAGE_USE"].split()) | useforce
+		) - usemask
+		new_python_targets = frozenset(
+			x for x in new_use if x.startswith("python_targets_")
+		)
+		old_python_targets = frozenset(
+			x for x in old_use if x.startswith("python_targets_")
+		)
+
+		if new_python_targets == old_python_targets:
 			msgs.append('')
 			msgs.append(warn(" * ")+bold("An update to portage is available.")+" It is _highly_ recommended")
 			msgs.append(warn(" * ")+"that you update portage now, before any other packages are updated.")

--- a/lib/portage/tests/sync/test_sync_local.py
+++ b/lib/portage/tests/sync/test_sync_local.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 Gentoo Authors
+# Copyright 2014-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import datetime
@@ -55,14 +55,23 @@ class SyncLocalTestCase(TestCase):
 		}
 
 		ebuilds = {
-			"dev-libs/A-0": {}
+			"dev-libs/A-0": {},
+			"sys-apps/portage-3.0": {"IUSE": "+python_targets_python3_8"},
+		}
+
+		installed = {
+			"sys-apps/portage-2.3.99": {
+				"EAPI": "7",
+				"IUSE": "+python_targets_python3_8",
+				"USE": "python_targets_python3_8",
+			},
 		}
 
 		user_config = {
 			'make.conf': ('FEATURES="metadata-transfer"',)
 		}
 
-		playground = ResolverPlayground(ebuilds=ebuilds,
+		playground = ResolverPlayground(ebuilds=ebuilds, installed=installed,
 			profile=profile, user_config=user_config, debug=debug)
 		settings = playground.settings
 		eprefix = settings["EPREFIX"]


### PR DESCRIPTION
When PYTHON_TARGETS changed, the emerge --oneshot portage
suggestion a nuisance, therefore suppress it.

Bug: https://bugs.gentoo.org/722748
Signed-off-by: Zac Medico <zmedico@gentoo.org>