### PR TITLE
PORTAGE_NICENESS: Consider autogroup scheduling

### DIFF
--- a/bin/pid-ns-init
+++ b/bin/pid-ns-init
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import termios
 
+from pathlib import Path
 
 KILL_SIGNALS = (
 	signal.SIGINT,
@@ -91,9 +92,24 @@ def main(argv):
 			'preexec_fn': functools.partial(preexec_fn, uid, gid, groups, umask),
 			'pass_fds': pass_fds,
 		}
+
+		# Try to obtain the current autogroup's nice value.
+		autogroup_nice = None
+		autogroup_file = Path("/proc/self/autogroup")
+		if autogroup_file.is_file():
+			with autogroup_file.open('r') as f:
+				line = f.readline()
+				autogroup_nice = line.split(' ')[2]
+
 		# Isolate parent process from process group SIGSTOP (bug 675870)
 		setsid = True
 		os.setsid()
+
+		if autogroup_nice:
+			# Set the previously obtained autogroup nice value again,
+			# since we created a new session with os.setsid() above.
+			autogroup_file.write_text(autogroup_nice)
+
 		if sys.stdout.isatty():
 			try:
 				fcntl.ioctl(sys.stdout, termios.TIOCSCTTY, 0)

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1,6 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import atexit
 import collections
 import logging
 import operator
@@ -14,6 +15,7 @@ import textwrap
 import time
 import warnings
 from itertools import chain
+from pathlib import Path
 
 import portage
 portage.proxy.lazyimport.lazyimport(globals(),
@@ -2634,13 +2636,40 @@ def apply_priorities(settings):
 	nice(settings)
 
 def nice(settings):
+	nice_value : str = settings.get("PORTAGE_NICENESS", "0")
+
 	try:
-		os.nice(int(settings.get("PORTAGE_NICENESS", "0")))
+		os.nice(int(nice_value))
 	except (OSError, ValueError) as e:
 		out = portage.output.EOutput()
-		out.eerror("Failed to change nice value to '%s'" % \
-			settings.get("PORTAGE_NICENESS", "0"))
+		out.eerror(f"Failed to change nice value to {nice_value}")
 		out.eerror("%s\n" % str(e))
+
+	autogroup_file = Path("/proc/self/autogroup")
+	if not autogroup_file.is_file():
+		# Autogroup scheduling is not enabled on this system.
+		return
+
+	with autogroup_file.open('r+') as f:
+		line = f.readline()
+		original_autogroup_nice_value = line.split(' ')[2]
+
+		# We need to restore the original nice value of the
+		# autogroup, as otherwise the session, e.g. the
+		# terminal where protage was executed in, would
+		# continue running with that value.
+		atexit.register(
+			lambda value: autogroup_file.open('w').write(value),
+			original_autogroup_nice_value
+		)
+
+		try:
+			f.write(nice_value)
+		except (OSError) as e:
+			out = portage.output.EOutput()
+			out.eerror(f"Failed to change autogroup's nice value to {nice_value}")
+			out.eerror("%s\n" % str(e))
+
 
 def ionice(settings):
 

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1031,6 +1031,14 @@ The value of this variable will be added to the current nice level that
 emerge is running at.  In other words, this will not set the nice level,
 it will increment it.  For more information about nice levels and what
 are acceptable ranges, see \fBnice\fR(1).
+.br
+If set and portage is run under Linux with autogroup scheduling (see
+\fBsched\fR(7)) enabled, then portage will set the nice value of its
+autogroup to PORTAGE_NICENESS. Upon exiting, portage will restore the
+original value. Note that if the function responsible for restoring the
+original value is not run, e.g., because portage's process was killed,
+then the autogroup will stay niced. In such a case, the value can be
+reset via corresponding autogroup pseudo-file in /proc.
 .TP
 \fBPORTAGE_RO_DISTDIRS\fR = \fI[space delimited list of directories]\fR
 When a given file does not exist in \fBDISTDIR\fR, search for the file


### PR DESCRIPTION
With Linux's autogroup scheduling feature (CONFIG_SCHED_AUTOGROUP)
setting a nice value on a per-process base has only an effect for
scheduling decisions relative to the other threads in the same
session (typically: the same terminal window). See the section "The
nice value and group scheduling" in the sched(7) man page.

Basically this means that portage "just" setting the nice value, has
no effect in presence of autogroup scheduling being active (which is
probably true for most (desktop) user systems).

This commit changes emerge to set the autogroup's nice value, instead
of the processes' nice value, in case autogroups are present (detected
by the existence of /proc/self/autogroup). The tricky part about
autogroup nice values is that we want restore the orignal nice value
once we are finished. As otherwise, the session, e.g. your terminal,
would continue using this value, and so would subsequently executed
processes. For that we use Python's atexit functinaly, to register a
function that will restore the orignal nice value of the autogroup.

Bug: https://bugs.gentoo.org/777492
Signed-off-by: Florian Schmaus <flo@geekplace.eu>