### PR TITLE
lib/portage/_sets/dbapi.py: add glob support to exclude-files parameter 

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -71,6 +71,7 @@ includes = bzr cvs darcs git-2 git-r3 golang-vcs mercurial subversion
 [module-rebuild]
 class = portage.sets.dbapi.OwnerSet
 files = /lib/modules
+exclude-files = /usr/src/linux*
 
 # Installed packages that own files inside /usr/lib/xorg/modules,
 # excluding the package that owns /usr/bin/Xorg.

--- a/lib/portage/_sets/dbapi.py
+++ b/lib/portage/_sets/dbapi.py
@@ -79,6 +79,12 @@ class OwnerSet(PackageSet):
 				glob.iglob(os.path.join(eroot, p.lstrip(os.sep))))
 		paths = expanded_paths
 
+		expanded_exclude_paths = []
+		for p in exclude_paths:
+			expanded_exclude_paths.extend(expanded_exc_p[len(eroot)-1:] for expanded_exc_p in
+				glob.iglob(os.path.join(eroot, p.lstrip(os.sep))))
+		exclude_paths = expanded_exclude_paths
+
 		pkg_str = vardb._pkg_str
 		if exclude_paths is None:
 			for link, p in vardb._owners.iter_owners(paths):


### PR DESCRIPTION
The module-rebuild package set is currently all packages which own files in /lib/modules. This leads to the following scenario/error:

- Using gentoo-kernel{-bin} package (Gentoo dist-kernel project by mgorny)
- gentoo-kernel{-bin} is now part of module-rebuild package set as it owns the kernel module files in /lib/modules/${KV_FULL}
- emerge --ask @module-rebuild will now wrongly list gentoo-kernel{-bin} alongside zfs, nvidia etc.

As far as I'm aware, all external kernel module packages are using linux-mod.eclass, so by changing the module-rebuild set to inherited linux-mod (as opposed to owned /lib/modules), we solve the above problem and emerge @module-rebuild will now allow rebuilding of all packages inheriting linux-mod.eclass, and no longer wrongly list gentoo-kernel{-bin} package as an external kernel module.

Tested on ~amd64 with zfs and a few other external kernel module packages.