### PR TITLE
emerge: use parse_intermixed_args when available (bug 784566)

### DIFF
--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -834,7 +834,7 @@ def parse_opts(tmpcmdline, silent=False):
 
 	tmpcmdline = insert_optional_args(tmpcmdline)
 
-	myoptions = parser.parse_args(args=tmpcmdline)
+	myoptions = getattr(parser, "parse_intermixed_args", parser.parse_args)(args=tmpcmdline)
 
 	if myoptions.alert in true_y:
 		myoptions.alert = True

--- a/lib/portage/tests/emerge/test_simple.py
+++ b/lib/portage/tests/emerge/test_simple.py
@@ -1,6 +1,7 @@
 # Copyright 2011-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import argparse
 import subprocess
 
 import portage
@@ -289,7 +290,14 @@ call_has_and_best_version() {
 			port=binhost_server.server_port,
 			path=binhost_remote_path)
 
-		test_commands = (
+		test_commands = ()
+
+		if hasattr(argparse.ArgumentParser, "parse_intermixed_args"):
+			test_commands += (
+				emerge_cmd + ("--oneshot", "dev-libs/A", "-v", "dev-libs/A"),
+			)
+
+		test_commands += (
 			emerge_cmd + ("--usepkgonly", "--root", cross_root, "--quickpkg-direct=y", "--quickpkg-direct-root", "/", "dev-libs/A"),
 			emerge_cmd + ("--usepkgonly", "--quickpkg-direct=y", "--quickpkg-direct-root", cross_root, "dev-libs/A"),
 			env_update_cmd,


### PR DESCRIPTION
The included unit test case previously failed with this error:

  emerge: error: unrecognized arguments: dev-libs/A

Bug: https://bugs.gentoo.org/784566
Signed-off-by: Zac Medico <zmedico@gentoo.org>