### PR TITLE
portage/tests: Use pathlib for path handling

### DIFF
--- a/lib/portage/tests/__init__.py
+++ b/lib/portage/tests/__init__.py
@@ -62,11 +62,14 @@ def main():
 	suite = unittest.TestSuite()
 	basedir = Path(__file__).resolve().parent
 
-	usage = "usage: %s [options] [tests to run]" % Path(sys.argv[0]).name
+	argv0 = Path(sys.argv[0])
+
+	usage = "usage: %s [options] [tests to run]" % argv0.name
 	parser = argparse.ArgumentParser(usage=usage)
 	parser.add_argument("-l", "--list", help="list all tests",
 		action="store_true", dest="list_tests")
-	options, args = parser.parse_known_args(args=sys.argv)
+	parser.add_argument("tests", nargs='*', type=Path)
+	options = parser.parse_args(args=sys.argv)
 
 	if (os.environ.get('NOCOLOR') in ('yes', 'true') or
 		os.environ.get('TERM') == 'dumb' or
@@ -74,15 +77,15 @@ def main():
 		portage.output.nocolor()
 
 	if options.list_tests:
-		testdir = Path(sys.argv[0]).parent
+		testdir = argv0.parent
 		for mydir in getTestDirs(basedir):
 			testsubdir = mydir.name
 			for name in getTestNames(mydir):
 				print("%s/%s/%s.py" % (testdir, testsubdir, name))
 		return os.EX_OK
 
-	if len(args) > 1:
-		suite.addTests(getTestFromCommandLine(args[1:], basedir))
+	if len(options.tests) > 1:
+		suite.addTests(getTestFromCommandLine(options.tests[1:], basedir))
 	else:
 		for mydir in getTestDirs(basedir):
 			suite.addTests(getTests(mydir, basedir))
@@ -102,7 +105,7 @@ def my_import(name):
 def getTestFromCommandLine(args, base_path):
 	result = []
 	for arg in args:
-		realpath = Path(arg).resolve()
+		realpath = arg.resolve()
 		path = realpath.parent
 		f = realpath.relative_to(path)
 

--- a/lib/portage/tests/__init__.py
+++ b/lib/portage/tests/__init__.py
@@ -285,22 +285,6 @@ class TestCase(unittest.TestCase):
 			else: excName = str(excClass)
 			raise self.failureException("%s not raised: %s" % (excName, msg))
 
-	def assertExists(self, path):
-		"""Make sure |path| exists"""
-		if not os.path.exists(path):
-			msg = ['path is missing: %s' % (path,)]
-			while path != '/':
-				path = os.path.dirname(path)
-				if not path:
-					# If we're given something like "foo", abort once we get to "".
-					break
-				result = os.path.exists(path)
-				msg.append('\tos.path.exists(%s): %s' % (path, result))
-				if result:
-					msg.append('\tcontents: %r' % os.listdir(path))
-					break
-			raise self.failureException('\n'.join(msg))
-
 	def assertNotExists(self, path):
 		"""Make sure |path| does not exist"""
 		if os.path.exists(path):

--- a/repoman/lib/repoman/tests/__init__.py
+++ b/repoman/lib/repoman/tests/__init__.py
@@ -1,5 +1,5 @@
 # tests/__init__.py -- Portage Unit Test functionality
-# Copyright 2006-2020 Gentoo Authors
+# Copyright 2006-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
@@ -261,22 +261,6 @@ class TestCase(unittest.TestCase):
 			if hasattr(excClass, '__name__'): excName = excClass.__name__
 			else: excName = str(excClass)
 			raise self.failureException("%s not raised: %s" % (excName, msg))
-
-	def assertExists(self, path):
-		"""Make sure |path| exists"""
-		if not os.path.exists(path):
-			msg = ['path is missing: %s' % (path,)]
-			while path != '/':
-				path = os.path.dirname(path)
-				if not path:
-					# If we're given something like "foo", abort once we get to "".
-					break
-				result = os.path.exists(path)
-				msg.append('\tos.path.exists(%s): %s' % (path, result))
-				if result:
-					msg.append('\tcontents: %r' % os.listdir(path))
-					break
-			raise self.failureException('\n'.join(msg))
 
 	def assertNotExists(self, path):
 		"""Make sure |path| does not exist"""


### PR DESCRIPTION
This is mostly just a POC

While we don't have tests for the testing harness, it does successfully
test all the tests

Used pathlib docs as a reference for translation:
https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module

Signed-off-by: Marco Sirabella <marco@sirabella.org>
Signed-off-by: Zac Medico <zmedico@gentoo.org>