### PR TITLE
env-update: skip PATH in systemd user environment definition

### DIFF
--- a/lib/portage/util/env_update.py
+++ b/lib/portage/util/env_update.py
@@ -367,6 +367,11 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env,
 		systemd_gentoo_env.write(senvnotice)
 
 		for env_key in env_keys:
+			# Skip PATH since this makes it impossible to use
+			# "systemctl --user import-environment PATH".
+			if env_key == 'PATH':
+				continue
+
 			env_key_value = env[env_key]
 
 			# Skip variables with the empty string


### PR DESCRIPTION
Having PATH in the systemd user environment created by env-update
makes it impossible to use "systemclt --user import-environment PATH"
to set PATH in systemd user units according to the current value of
PATH. Using "systemclt --user import-environment PATH" is a well known
idiom, and hence should work. Therefore, we skip the creation of the
PATH entry by env-update.

Signed-off-by: Florian Schmaus <flo@geekplace.eu>