### PR TITLE
emerge: Fail with helpful message when --jobs=""

### DIFF
--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -1072,7 +1072,7 @@ def parse_opts(tmpcmdline, silent=False):
 
 		myoptions.deep = deep
 
-	if myoptions.jobs:
+	if myoptions.jobs is not None:
 		jobs = None
 		if myoptions.jobs == "True":
 			jobs = True


### PR DESCRIPTION
Reported by Kobboi on the irc channel:

> oops, my portage is broken: TypeError: '>=' not supported between instances of 'int' and 'str'
> false alarm (though maybe using --jobs= (without value) could be handled more nicely than a python error :) )