### PR TITLE
Bugfix: emerge --fetchonly --quiet is too verbose. 

### DIFF
--- a/lib/_emerge/EbuildBuild.py
+++ b/lib/_emerge/EbuildBuild.py
@@ -23,6 +23,7 @@ from portage.package.ebuild.digestcheck import digestcheck
 from portage.package.ebuild.doebuild import _check_temp_dir
 from portage.package.ebuild._spawn_nofetch import SpawnNofetchWithoutBuilddir
 from portage.util._async.AsyncTaskFuture import AsyncTaskFuture
+from portage.util.path import first_existing
 
 
 class EbuildBuild(CompositeTask):
@@ -137,6 +138,15 @@ class EbuildBuild(CompositeTask):
 		pkg = self.pkg
 		settings = self.settings
 
+		quiet_setting = settings.get('PORTAGE_QUIET', False)
+		fetch_log = None
+		logwrite_access = False
+		if quiet_setting:
+			fetch_log = os.path.join(
+					_emerge.emergelog._emerge_log_dir,
+					'emerge-fetch.log')
+			logwrite_access = os.access(first_existing(fetch_log), os.W_OK)
+
 		if opts.fetchonly:
 			if opts.pretend:
 				fetcher = EbuildFetchonly(
@@ -165,11 +175,17 @@ class EbuildBuild(CompositeTask):
 				ebuild_path=self._ebuild_path,
 				fetchall=self.opts.fetch_all_uri,
 				fetchonly=self.opts.fetchonly,
-				background=False,
-				logfile=None,
+				background=quiet_setting if logwrite_access else False,
+				logfile=fetch_log if logwrite_access else None,
 				pkg=self.pkg,
 				scheduler=self.scheduler)
-			self._start_task(fetcher, self._fetchonly_exit)
+
+			if fetch_log and logwrite_access:
+				fetcher.addExitListener(self._fetchonly_exit)
+				self._task_queued(fetcher)
+				self.scheduler.fetch.schedule(fetcher, force_queue=True)
+			else:
+				self._start_task(fetcher, self._fetchonly_exit)
 			return
 
 		self._build_dir = EbuildBuildDir(

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -560,7 +560,7 @@ class Scheduler(PollScheduler):
 			if pargs:
 				self.status = pargs[0]
 
-	def _schedule_fetch(self, fetcher):
+	def _schedule_fetch(self, fetcher, force_queue=False):
 		"""
 		Schedule a fetcher, in order to control the number of concurrent
 		fetchers. If self._max_jobs is greater than 1 then the fetch
@@ -571,7 +571,7 @@ class Scheduler(PollScheduler):
 		would be required before it would be possible to enable
 		concurrent fetching within the parallel-fetch queue.
 		"""
-		if self._max_jobs > 1:
+		if self._max_jobs > 1 and not force_queue:
 			fetcher.start()
 		else:
 			self._task_queues.fetch.addFront(fetcher)


### PR DESCRIPTION
https://bugs.gentoo.org/285614

I noticed that EbuildFetcher does not pipe out file download progress to pty if it is instantiated with the background kwarg. Since we have access to the --quiet setting in `EbuildBuild.py` when the fetcher is instantiated, it seems to me that we can use that value to determine whether to print the fetch progress.