### PR TITLE
Ban hasq, hasv and useq in EAPI 8

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2012-2018 Gentoo Foundation
+# Copyright 2012-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # PHASES
@@ -126,6 +126,18 @@ ___eapi_has_in_iuse() {
 
 ___eapi_has_version_functions() {
 	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
+}
+
+___eapi_has_hasq() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
+}
+
+___eapi_has_hasv() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
+}
+
+___eapi_has_useq() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
 }
 
 ___eapi_has_master_repositories() {

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}/eapi.sh" || exit 1
@@ -475,11 +475,15 @@ ___parallel_xargs() {
 }
 
 hasq() {
+	___eapi_has_hasq || die "'${FUNCNAME}' banned in EAPI ${EAPI}"
+
 	eqawarn "QA Notice: The 'hasq' function is deprecated (replaced by 'has')"
 	has "$@"
 }
 
 hasv() {
+	___eapi_has_hasv || die "'${FUNCNAME}' banned in EAPI ${EAPI}"
+
 	if has "$@" ; then
 		echo "$1"
 		return 0

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 if ___eapi_has_DESTTREE_INSDESTTREE; then
@@ -190,6 +190,8 @@ dostrip() {
 }
 
 useq() {
+	___eapi_has_useq || die "'${FUNCNAME}' banned in EAPI ${EAPI}"
+
 	eqawarn "QA Notice: The 'useq' function is deprecated (replaced by 'use')"
 	use ${1}
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/199722
Signed-off-by: Michał Górny <mgorny@gentoo.org>