### PR TITLE
Require bash-5.0 in EAPI 8

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -253,7 +253,11 @@ ___eapi_bash_3_2() {
 }
 
 ___eapi_bash_4_2() {
-	! ___eapi_bash_3_2 "$@"
+	[[ ${1-${EAPI-0}} =~ ^(6|7)$ ]]
+}
+
+___eapi_bash_5_0() {
+	true
 }
 
 ___eapi_has_ENV_UNSET() {

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Prevent aliases from causing portage to act inappropriately.
@@ -23,6 +23,8 @@ __check_bash_version() {
 		maj=3 min=2
 	elif ___eapi_bash_4_2 ; then
 		maj=4 min=2
+	elif ___eapi_bash_5_0 ; then
+		maj=5 min=0
 	else
 		return
 	fi


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/636652
Signed-off-by: Michał Górny <mgorny@gentoo.org>