### PR TITLE
Support second usev arg in EAPI 8

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2012-2018 Gentoo Foundation
+# Copyright 2012-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # PHASES
@@ -236,6 +236,10 @@ ___eapi_domo_respects_into() {
 
 ___eapi_has_DESTTREE_INSDESTTREE() {
 	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
+}
+
+___eapi_usev_has_second_arg() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
 }
 
 # OTHERS

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 if ___eapi_has_DESTTREE_INSDESTTREE; then
@@ -195,8 +195,12 @@ useq() {
 }
 
 usev() {
+	local nargs=1
+	___eapi_usev_has_second_arg && nargs=2
+	[[ ${#} -gt ${nargs} ]] && die "usev takes at most ${nargs} arguments"
+
 	if use ${1}; then
-		echo "${1#!}"
+		echo "${2:-${1#!}}"
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/744868
Signed-off-by: Michał Górny <mgorny@gentoo.org>