### PR TITLE
Make doconf, doenvd, doheader & doinitd ignore ins/exeopts in EAPI 8

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2012-2018 Gentoo Foundation
+# Copyright 2012-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # PHASES
@@ -236,6 +236,22 @@ ___eapi_domo_respects_into() {
 
 ___eapi_has_DESTTREE_INSDESTTREE() {
 	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6)$ ]]
+}
+
+___eapi_doconfd_respects_insopts() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
+}
+
+___eapi_doenvd_respects_insopts() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
+}
+
+___eapi_doheader_respects_insopts() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
+}
+
+___eapi_doinitd_respects_exeopts() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-progress|6|7)$ ]]
 }
 
 # OTHERS

--- a/bin/ebuild-helpers/doconfd
+++ b/bin/ebuild-helpers/doconfd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
@@ -13,4 +13,10 @@ export _E_INSDESTTREE_='/etc/conf.d/'
 if ___eapi_has_DESTTREE_INSDESTTREE; then
 	export INSDESTTREE=${_E_INSDESTTREE_}
 fi
+
+if ! ___eapi_doconfd_respects_insopts; then
+	export INSOPTIONS=-m0644
+	export DIROPTIONS=""
+fi
+
 exec doins "$@"

--- a/bin/ebuild-helpers/doenvd
+++ b/bin/ebuild-helpers/doenvd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
@@ -13,4 +13,10 @@ export _E_INSDESTTREE_='/etc/env.d/'
 if ___eapi_has_DESTTREE_INSDESTTREE; then
 	export INSDESTTREE=${_E_INSDESTTREE_}
 fi
+
+if ! ___eapi_doenvd_respects_insopts; then
+	export INSOPTIONS=-m0644
+	export DIROPTIONS=""
+fi
+
 exec doins "$@"

--- a/bin/ebuild-helpers/doheader
+++ b/bin/ebuild-helpers/doheader
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
@@ -17,4 +17,10 @@ export _E_INSDESTTREE_='/usr/include/'
 if ___eapi_has_DESTTREE_INSDESTTREE; then
 	export INSDESTTREE=${_E_INSDESTTREE_}
 fi
+
+if ! ___eapi_doheader_respects_insopts; then
+	export INSOPTIONS=-m0644
+	export DIROPTIONS=""
+fi
+
 exec doins "$@"

--- a/bin/ebuild-helpers/doinitd
+++ b/bin/ebuild-helpers/doinitd
@@ -1,11 +1,18 @@
 #!/bin/bash
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
 if [[ $# -lt 1 ]] ; then
 	source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 	__helpers_die "${0##*/}: at least one argument needed"
 	exit 1
+fi
+
+if ! ___eapi_doinitd_respects_exeopts; then
+	export EXEOPTIONS=-m0755
+	export DIROPTIONS=""
 fi
 
 _E_EXEDESTTREE_='/etc/init.d/' exec doexe "$@"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/657580
Signed-off-by: Michał Górny <mgorny@gentoo.org>