### PR TITLE
Bugfix 520378: Ensure EMERGE_LOG_DIR setting is respected

### DIFF
--- a/bin/regenworld
+++ b/bin/regenworld
@@ -57,7 +57,12 @@ if len(sys.argv) >= 2 and sys.argv[1] in ["-h", "--help"]:
 worldlist = portage.grabfile(world_file)
 syslist = [x for x in portage.settings.packages if issyspkg(x)]
 
-logfile = portage.grabfile(os.path.join(eroot, "var/log/emerge.log"))
+if portage.settings.get("EMERGE_LOG_DIR"):
+	logfile = portage.grabfile(os.path.join(
+			portage.settings["EMERGE_LOG_DIR"],
+			"emerge.log"))
+else:
+	logfile = portage.grabfile(os.path.join(eroot, "var/log/emerge.log"))
 biglist = [getpkginfo(x) for x in logfile if iscandidate(x)]
 tmplist = []
 for l in biglist:


### PR DESCRIPTION
https://bugs.gentoo.org/520378

The path hardcoding issue appears to be resolved. EMERGE_LOG_DIR is parsed in `lib/_emerge/actions.py` if it exists and set to a variable, `emergelog._emerge_log_dir`. The output referring to logs are all using that variable currently.

That said, the EMERGE_LOG_DIR setting is not completely integrated with the code. I found two places where the setting was being ignored. One of them relates to the recent bugfix for https://bugs.gentoo.org/285614.