### PR TITLE
Use an explicit empty dir for pkg_* phases [WIP]

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -186,9 +186,9 @@ export SANDBOX_ON=0
 # Ensure that $PWD is sane whenever possible, to protect against
 # exploitation of insecure search path for python -c in ebuilds.
 # See bug #239560, bug #469338, and bug #595028.
-if [[ -d ${HOME} ]]; then
-	# Use portage's temporary HOME directory if available.
-	cd "${HOME}" || die
+# EAPI 8 requires us to use an empty directory here.
+if [[ -d ${PORTAGE_BUILDDIR}/empty ]]; then
+	cd "${PORTAGE_BUILDDIR}/empty" || die
 else
 	cd "${PORTAGE_PYM_PATH}" || \
 		die "PORTAGE_PYM_PATH does not exist: '${PORTAGE_PYM_PATH}'"

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -278,7 +278,8 @@ __dyn_clean() {
 	cd "${PORTAGE_PYM_PATH}" || \
 		die "PORTAGE_PYM_PATH does not exist: '${PORTAGE_PYM_PATH}'"
 
-	rm -rf "${PORTAGE_BUILDDIR}/image" "${PORTAGE_BUILDDIR}/homedir"
+	rm -rf "${PORTAGE_BUILDDIR}/image" "${PORTAGE_BUILDDIR}/homedir" \
+		"${PORTAGE_BUILDDIR}/empty"
 	rm -f "${PORTAGE_BUILDDIR}/.installed"
 
 	if [[ $EMERGE_FROM = binary ]] || \

--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -21,7 +21,7 @@ from portage.util._dyn_libs.soname_deps_qa import (
 )
 from portage.package.ebuild.prepare_build_dirs import (_prepare_workdir,
 		_prepare_fake_distdir, _prepare_fake_filesdir)
-from portage.util import writemsg
+from portage.util import writemsg, ensure_dirs
 from portage.util._async.AsyncTaskFuture import AsyncTaskFuture
 from portage.util._async.BuildLogger import BuildLogger
 from portage.util.futures import asyncio
@@ -41,6 +41,7 @@ portage.proxy.lazyimport.lazyimport(globals(),
 	'portage.elog:messages@elog_messages',
 	'portage.package.ebuild.doebuild:_check_build_log,' + \
 		'_post_phase_cmds,_post_phase_userpriv_perms,' + \
+		'_post_phase_emptydir_cleanup,' +
 		'_post_src_install_soname_symlinks,' + \
 		'_post_src_install_uid_fix,_postinst_bsdflags,' + \
 		'_post_src_install_write_metadata,' + \
@@ -89,6 +90,7 @@ class EbuildPhase(CompositeTask):
 						'logging', self.phase))
 				except OSError:
 					pass
+			ensure_dirs(os.path.join(self.settings["PORTAGE_BUILDDIR"], "empty"))
 
 		if self.phase in ('nofetch', 'pretend', 'setup'):
 
@@ -270,6 +272,7 @@ class EbuildPhase(CompositeTask):
 
 		settings = self.settings
 		_post_phase_userpriv_perms(settings)
+		_post_phase_emptydir_cleanup(settings)
 
 		if self.phase == "unpack":
 			# Bump WORKDIR timestamp, in case tar gave it a timestamp

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1770,6 +1770,11 @@ def _post_phase_userpriv_perms(mysettings):
 				filemode=0o600, filemask=0)
 
 
+def _post_phase_emptydir_cleanup(mysettings):
+	empty_dir = os.path.join(mysettings["PORTAGE_BUILDDIR"], "empty")
+	shutil.rmtree(empty_dir, ignore_errors=True)
+
+
 def _check_build_log(mysettings, out=None):
 	"""
 	Search the content of $PORTAGE_LOG_FILE if it exists


### PR DESCRIPTION
Create and use an explicit ${PORTAGE_BUILDDIR}/empty as working
directory for pkg_* phases, as proposed for EAPI 8.

Note that this patch doesn't work fully -- empty is not cleared between
pkg_preinst and pkg_postinst, and between pkg_prerm and pkg_postrm.

Signed-off-by: Michał Górny <mgorny@gentoo.org>