### PR TITLE
GLEP 75 layout fixes

### DIFF
--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -12,7 +12,7 @@ portage.proxy.lazyimport.lazyimport(globals(),
 	'portage.dbapi.dep_expand:dep_expand',
 	'portage.dep:Atom,dep_getkey,match_from_list,use_reduce,_match_slot',
 	'portage.package.ebuild.doebuild:doebuild',
-	'portage.package.ebuild.fetch:_download_suffix',
+	'portage.package.ebuild.fetch:get_mirror_url,_download_suffix',
 	'portage.util:ensure_dirs,shlex_split,writemsg,writemsg_level',
 	'portage.util.listdir:listdir',
 	'portage.versions:best,catsplit,catpkgsplit,_pkgsplit@pkgsplit,ver_regexp,_pkg_str',
@@ -859,7 +859,7 @@ class portdbapi(dbapi):
 				if ro_distdirs is not None:
 					for x in shlex_split(ro_distdirs):
 						try:
-							mystat = os.stat(os.path.join(x, myfile))
+							mystat = os.stat(portage.package.ebuild.fetch.get_mirror_url(x, myfile, self.settings))
 						except OSError:
 							pass
 						else:

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -663,7 +663,10 @@ def get_mirror_url(mirror_url, filename, mysettings, cache_path=None):
 	else:
 		tmpfile = '.layout.conf.%s' % urlparse(mirror_url).hostname
 		try:
-			if fetch({tmpfile: (mirror_url + '/distfiles/layout.conf',)},
+			if mirror_url[0] == '/':
+				tmpfile = os.path.join(mirror_url, 'layout.conf')
+				mirror_conf.read_from_file(tmpfile)
+			elif fetch({tmpfile: (mirror_url + '/distfiles/layout.conf',)},
 					mysettings, force=1, try_mirrors=0):
 				tmpfile = os.path.join(mysettings['DISTDIR'], tmpfile)
 				mirror_conf.read_from_file(tmpfile)
@@ -683,8 +686,10 @@ def get_mirror_url(mirror_url, filename, mysettings, cache_path=None):
 	path = mirror_conf.get_best_supported_layout(filename=filename).get_path(filename)
 	if urlparse(mirror_url).scheme in ('ftp', 'http', 'https'):
 		path = urlquote(path)
-	return mirror_url + "/distfiles/" + path
-
+	if mirror_url[0] == '/':
+		return os.path.join(mirror_url, path)
+	else:
+		return mirror_url + "/distfiles/" + path
 
 def fetch(myuris, mysettings, listonly=0, fetchonly=0,
 	locks_in_subdir=".locks", use_locks=1, try_mirrors=1, digests=None,
@@ -1212,7 +1217,7 @@ def fetch(myuris, mysettings, listonly=0, fetchonly=0,
 				if distdir_writable and ro_distdirs:
 					readonly_file = None
 					for x in ro_distdirs:
-						filename = os.path.join(x, myfile)
+						filename = get_mirror_url(x, myfile, mysettings)
 						match, mystat = _check_distfile(
 							filename, pruned_digests, eout, hash_filter=hash_filter)
 						if match:

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -1249,7 +1249,7 @@ def fetch(myuris, mysettings, listonly=0, fetchonly=0,
 
 				if fsmirrors and not os.path.exists(myfile_path) and has_space:
 					for mydir in fsmirrors:
-						mirror_file = os.path.join(mydir, myfile)
+						mirror_file = get_mirror_url(mydir, myfile, mysettings)
 						try:
 							shutil.copyfile(mirror_file, download_path)
 							writemsg(_("Local mirror has file: %s\n") % myfile)


### PR DESCRIPTION
It is not uncommon for PORTAGE_RO_DISTDIRS or GENTOO_MIRRORS to be used to point to a literal local mirror, not just a flat copy of files from DISTDIR. The GLEP 75 layout changes break these use cases when the upstream mirror begins using a non-flat layout.

These changes support parsing a layout.conf present in a local mirror, restoring the ability to symlink/copy distfiles and fixing the emerge output to indicate when distfiles do (not) actually need to be fetched.