### PR TITLE
setup.cfg: eliminate dash-separated portage-ext-modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install tox tox-gh-actions
     - name: Test ./setup.py install --root=/tmp/install-root
       run: |
-        printf "[build_ext]\nportage-ext-modules=true" >> setup.cfg
+        printf "[build_ext]\nportage_ext_modules=true" >> setup.cfg
         ./setup.py install --root=/tmp/install-root
     - name: Run tox targets for ${{ matrix.python-version }}
       run: |

--- a/README
+++ b/README
@@ -26,7 +26,7 @@ native extensions for all invocations of the build_ext command (the
 build_ext command is invoked automatically by other build commands):
 
    [build_ext]
-   portage-ext-modules=true
+   portage_ext_modules=true
 
 Currently, the native extensions only include libc bindings which are
 used to validate LC_CTYPE and LC_COLLATE behavior for EAPI 6. If the

--- a/setup.py
+++ b/setup.py
@@ -720,7 +720,7 @@ class build_ext(_build_ext):
 	]
 
 	boolean_options = _build_ext.boolean_options + [
-		'portage-ext-modules',
+		'portage_ext_modules',
 	]
 
 	def initialize_options(self):


### PR DESCRIPTION
```
 * QA Notice: setuptools warnings detected:
 *
 *      Usage of dash-separated 'portage-ext-modules' will not be supported in future versions. Please use the underscore name 'portage_ext_modules' instead
```
Reported-by: Patrick McLean <chutzpah@gentoo.org>
Signed-off-by: Zac Medico <zmedico@gentoo.org>