### PR TITLE
man/emerge.1: Fix typo in --with-bdeps description

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1095,7 +1095,7 @@ The default is set to "y" (on).
 In dependency calculations, pull in build time dependencies
 that are not strictly required. This option is automatically enabled for
 installation actions, meaning they will be installed, and defaults to
-\(aqy\(aq for the \fB\-\-depclean\fR action, meaning they will not be
+"y" for the \fB\-\-depclean\fR action, meaning they will not be
 removed. In order to prevent the \fB\-\-with\-bdeps\fR option from being
 automatically enabled for installation actions, specify
 \fB\-\-with\-bdeps\-auto=n\fR in either the command line or


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>