### PR TITLE
WIP: Add @unsatisfied-deps package set (bug 248026)

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -115,3 +115,8 @@ class = portage.sets.dbapi.ChangedDepsSet
 class = portage.sets.dbapi.VariableSet
 variable = INHERITED
 includes = golang-base golang-build golang-vcs golang-vcs-snapshot go-module
+
+# Package set which contains all installed packages having one or more
+# unsatisfied runtime dependencies.
+[unsatisfied-deps]
+class = portage.sets.dbapi.UnsatisfiedDepsSet

--- a/doc/config/sets.docbook
+++ b/doc/config/sets.docbook
@@ -610,6 +610,13 @@
 			</itemizedlist>
 			</sect3>
 		</sect2>
+		<sect2 id='config-set-classes-UnsatisfiedDepsSet'>
+		<title>portage.sets.dbapi.UnsatisfiedDepsSet</title>
+		<para>
+		Package set which contains all installed packages
+		having one or more unsatisfied runtime dependencies.
+		</para>
+		</sect2>
 	</sect1>
 	
 	<sect1 id='config-set-defaults'>

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1000,9 +1000,16 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 				msg.append("    %s" % (parent,))
 				msg.append("")
 			msg.extend(textwrap.wrap(
-				"Have you forgotten to do a complete update prior " + \
-				"to depclean? The most comprehensive command for this " + \
+				"Have you forgotten to resolve unsatisfied dependencies prior "
+				"to depclean? The simplest possible command for this "
 				"purpose is as follows:", 65
+			))
+			msg.append("")
+			msg.append("  " + \
+				good("emerge @unsatisfied-deps"))
+			msg.append("")
+			msg.extend(textwrap.wrap(
+				"The most comprehensive possible update command is this:", 65
 			))
 			msg.append("")
 			msg.append("  " + \
@@ -1018,8 +1025,14 @@ def _calc_depclean(settings, trees, ldpath_mtimes,
 			msg.extend(textwrap.wrap(
 				"Also, note that it may be necessary to manually uninstall " + \
 				"packages that no longer exist in the repository, since " + \
-				"it may not be possible to satisfy their dependencies.", 65
+				"it may not be possible to satisfy their dependencies."
+				" The simplest possible command for this purpose is as follows,"
+				" but be careful to examine the resulting package list carefully:", 65
 			))
+			msg.append("")
+			msg.append("  " + \
+				good("emerge --ask --unmerge @unavailable"))
+			msg.append("")
 			if action == "prune":
 				msg.append("")
 				msg.append("If you would like to ignore " + \

--- a/lib/portage/_sets/__init__.py
+++ b/lib/portage/_sets/__init__.py
@@ -136,6 +136,10 @@ class SetConfig:
 		parser.add_section("preserved-rebuild")
 		parser.set("preserved-rebuild", "class", "portage.sets.libs.PreservedLibraryConsumerSet")
 
+		parser.remove_section("unsatisfied-deps")
+		parser.add_section("unsatisfied-deps")
+		parser.set("unsatisfied-deps", "class", "portage.sets.dbapi.UnsatisfiedDepsSet")
+
 		parser.remove_section("x11-module-rebuild")
 		parser.add_section("x11-module-rebuild")
 		parser.set("x11-module-rebuild", "class", "portage.sets.dbapi.OwnerSet")


### PR DESCRIPTION
If emerge --depclean fails to resolve any dependencies, then it will
now suggest emerge `@unsatisfied-deps` as the simplest possible
solution, and will also suggest to unmerge `@unavailable` where
appropriate at the end:
```
$ emerge --depclean

Calculating dependencies... done!
 * Dependencies could not be completely resolved due to
 * the following required packages not being installed:
 *
 *   virtual/cdrtools pulled in by:
 *     app-cdr/cdrdao-1.2.4
 *
 * Have you forgotten to resolve unsatisfied dependencies prior to
 * depclean? The simplest possible command for this purpose is as
 * follows:
 *
 *   emerge @unsatisfied-deps
 *
 * The most comprehensive possible update command is this:
 *
 *   emerge --update --newuse --deep --with-bdeps=y @world
 *
 * Note that the --with-bdeps=y option is not required in many
 * situations. Refer to the emerge manual page (run `man emerge`)
 * for more information about --with-bdeps.
 *
 * Also, note that it may be necessary to manually uninstall
 * packages that no longer exist in the repository, since it may not
 * be possible to satisfy their dependencies. The simplest possible
 * command for this purpose is as follows, but be careful to examine
 * the resulting package list carefully:
 *
 *   emerge --ask --unmerge @unavailable
 *
```
Bug: https://bugs.gentoo.org/248026
Signed-off-by: Zac Medico <zmedico@gentoo.org>