### PR TITLE
Fix exposing evaluated PROPERTIES & RESTRICT in EAPI 8

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -653,13 +653,6 @@ if ! has "$EBUILD_PHASE" clean cleanrm ; then
 			shopt -u failglob
 		fi
 
-		if [[ "${EBUILD_PHASE}" != "depend" ]] ; then
-			PROPERTIES=${PORTAGE_PROPERTIES}
-			RESTRICT=${PORTAGE_RESTRICT}
-			[[ -e $PORTAGE_BUILDDIR/.ebuild_changed ]] && \
-			rm "$PORTAGE_BUILDDIR/.ebuild_changed"
-		fi
-
 		[ "${EAPI+set}" = set ] || EAPI=0
 
 		# export EAPI for helpers (especially since we unset it above)
@@ -687,6 +680,13 @@ if ! has "$EBUILD_PHASE" clean cleanrm ; then
 
 		unset ECLASS E_IUSE E_REQUIRED_USE E_DEPEND E_RDEPEND E_PDEPEND
 		unset E_BDEPEND E_PROPERTIES E_RESTRICT __INHERITED_QA_CACHE
+
+		if [[ "${EBUILD_PHASE}" != "depend" ]] ; then
+			PROPERTIES=${PORTAGE_PROPERTIES}
+			RESTRICT=${PORTAGE_RESTRICT}
+			[[ -e $PORTAGE_BUILDDIR/.ebuild_changed ]] && \
+			rm "$PORTAGE_BUILDDIR/.ebuild_changed"
+		fi
 
 		# alphabetically ordered by $EBUILD_PHASE value
 		case ${EAPI} in


### PR DESCRIPTION
Reorder the code to prevent eclass PROPERTIES & RESTRICT logic from
overriding the processed values gotten from PORTAGE_PROPERTIES
and PORTAGE_RESTRICT.  Otherwise, code in Portage misbehaves due to
unexpected USE-conditionals in PROPERTIES/RESTRICT.

Bug: https://bugs.gentoo.org/796959
Signed-off-by: Michał Górny <mgorny@gentoo.org>