### PR TITLE
Use PORTAGE_PROPERTIES and PORTAGE_RESTRICT internally

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -737,7 +737,7 @@ if ! has "$EBUILD_PHASE" clean cleanrm ; then
 	fi
 fi
 
-if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT}
+if has nostrip ${FEATURES} ${PORTAGE_RESTRICT} || has strip ${PORTAGE_RESTRICT}
 then
 	export DEBUGBUILD=1
 fi

--- a/bin/estrip
+++ b/bin/estrip
@@ -16,7 +16,7 @@ exp_tf() {
 	done
 }
 exp_tf FEATURES compressdebug installsources nostrip splitdebug xattr
-exp_tf RESTRICT binchecks installsources splitdebug strip
+exp_tf PORTAGE_RESTRICT binchecks installsources splitdebug strip
 
 if ! ___eapi_has_prefix_variables; then
 	EPREFIX= ED=${D}
@@ -24,7 +24,7 @@ fi
 
 banner=false
 SKIP_STRIP=false
-if ${RESTRICT_strip} || ${FEATURES_nostrip} ; then
+if ${PORTAGE_RESTRICT_strip} || ${FEATURES_nostrip} ; then
 	SKIP_STRIP=true
 	banner=true
 	${FEATURES_installsources} || exit 0
@@ -167,7 +167,7 @@ mkdir -p "${tmpdir}"/{inodes,splitdebug,sources}
 # Usage: save_elf_sources <elf>
 save_elf_sources() {
 	${FEATURES_installsources} || return 0
-	${RESTRICT_installsources} && return 0
+	${PORTAGE_RESTRICT_installsources} && return 0
 	if ! ${debugedit_found} ; then
 		if ! ${debugedit_warned} ; then
 			debugedit_warned=true
@@ -192,7 +192,7 @@ save_elf_sources() {
 # Usage: save_elf_debug <elf> [splitdebug file]
 save_elf_debug() {
 	${FEATURES_splitdebug} || return 0
-	${RESTRICT_splitdebug} && return 0
+	${PORTAGE_RESTRICT_splitdebug} && return 0
 
 	# NOTE: Debug files must be installed in
 	# ${EPREFIX}/usr/lib/debug/${EPREFIX} (note that ${EPREFIX} occurs
@@ -318,7 +318,7 @@ process_ar() {
 		# There is no concept of splitdebug for objects not yet
 		# linked in (only for finally linked ELFs), so we have to
 		# retain the debug info in the archive itself.
-		if ! ${FEATURES_splitdebug} || ${RESTRICT_splitdebug} ; then
+		if ! ${FEATURES_splitdebug} || ${PORTAGE_RESTRICT_splitdebug} ; then
 			${STRIP} -g "${x}" && ${RANLIB} "${x}"
 		fi
 	fi
@@ -327,7 +327,7 @@ process_ar() {
 # The existance of the section .symtab tells us that a binary is stripped.
 # We want to log already stripped binaries, as this may be a QA violation.
 # They prevent us from getting the splitdebug data.
-if ! ${RESTRICT_binchecks} ; then
+if ! ${PORTAGE_RESTRICT_binchecks} ; then
 	# We need to do the non-stripped scan serially first before we turn around
 	# and start stripping the files ourselves.  The log parsing can be done in
 	# parallel though.
@@ -459,7 +459,7 @@ __multijob_finish
 cd "${tmpdir}"/sources/ && cat * > "${tmpdir}/debug.sources" 2>/dev/null
 if [[ -s ${tmpdir}/debug.sources ]] && \
    ${FEATURES_installsources} && \
-   ! ${RESTRICT_installsources} && \
+   ! ${PORTAGE_RESTRICT_installsources} && \
    ${debugedit_found}
 then
 	__vecho "installsources: rsyncing source files"

--- a/bin/install-qa-check.d/10executable-issues
+++ b/bin/install-qa-check.d/10executable-issues
@@ -2,7 +2,7 @@
 # text relocations, executable stacks
 
 elf_check() {
-	if ! type -P scanelf >/dev/null || has binchecks ${RESTRICT}; then
+	if ! type -P scanelf >/dev/null || has binchecks ${PORTAGE_RESTRICT}; then
 		return
 	fi
 

--- a/bin/install-qa-check.d/10ignored-flags
+++ b/bin/install-qa-check.d/10ignored-flags
@@ -2,7 +2,7 @@
 
 ignored_flag_check() {
 	type -P scanelf > /dev/null || return
-	has binchecks ${RESTRICT} && return
+	has binchecks ${PORTAGE_RESTRICT} && return
 
 	local qa_var="QA_FLAGS_IGNORED_${ARCH/-/_}"
 	eval "[[ -n \${!qa_var} ]] && QA_FLAGS_IGNORED=(\"\${${qa_var}[@]}\")"
@@ -65,7 +65,7 @@ ignored_flag_check() {
 
 	# Check for files built without respecting LDFLAGS
 	if [[ "${LDFLAGS}" == *,--defsym=__gentoo_check_ldflags__* ]] && \
-		! has binchecks ${RESTRICT} ; then
+		! has binchecks ${PORTAGE_RESTRICT} ; then
 		f=$(LC_ALL=C comm -2 -3 <(scanelf -qyRF '#k%p' -k .dynsym "${ED%/}/" | LC_ALL=C sort) \
 			<(scanelf -qyRF '#s%p' -s __gentoo_check_ldflags__ "${ED%/}/" | LC_ALL=C sort))
 		if [[ -n ${f} ]] ; then

--- a/bin/install-qa-check.d/80libraries
+++ b/bin/install-qa-check.d/80libraries
@@ -92,7 +92,7 @@ scanelf_lib_check() {
 lib_check() {
 	local f x i j
 
-	if type -P scanelf >/dev/null && ! has binchecks ${RESTRICT}; then
+	if type -P scanelf >/dev/null && ! has binchecks ${PORTAGE_RESTRICT}; then
 		scanelf_lib_check
 	fi
 

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -206,7 +206,7 @@ install_qa_check() {
 				eqawarn "QA Notice: <stabilize-allarches/> found on package installing ELF files"
 			fi
 
-			if has binchecks ${RESTRICT}; then
+			if has binchecks ${PORTAGE_RESTRICT}; then
 				eqawarn "QA Notice: RESTRICT=binchecks prevented checks on these ELF files:"
 				eqawarn "$(while read -r x; do x=${x#*;} ; x=${x%%;*} ; echo "${x#${EPREFIX}}" ; done < "${PORTAGE_BUILDDIR}"/build-info/NEEDED.ELF.2)"
 			fi

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -490,8 +490,8 @@ __dyn_test() {
 		die "The source directory '${S}' doesn't exist"
 	fi
 
-	if has test ${RESTRICT} && ! has all ${ALLOW_TEST} &&
-			! { has test_network ${PROPERTIES} && has network ${ALLOW_TEST}; }
+	if has test ${PORTAGE_RESTRICT} && ! has all ${ALLOW_TEST} &&
+			! { has test_network ${PORTAGE_PROPERTIES} && has network ${ALLOW_TEST}; }
 	then
 		einfo "Skipping make test/check due to ebuild restriction."
 		__vecho ">>> Test phase [disabled because of RESTRICT=test]: ${CATEGORY}/${PF}"
@@ -704,7 +704,7 @@ __dyn_install() {
 
 	cp "${EBUILD}" "${PF}.ebuild"
 	[ -n "${PORTAGE_REPO_NAME}" ]  && echo "${PORTAGE_REPO_NAME}" > repository
-	if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT}
+	if has nostrip ${FEATURES} ${PORTAGE_RESTRICT} || has strip ${PORTAGE_RESTRICT}
 	then
 		>> DEBUGBUILD
 	fi
@@ -759,7 +759,7 @@ __dyn_help() {
 	echo "  c++ flags   : ${CXXFLAGS}"
 	echo "  make flags  : ${MAKEOPTS}"
 	echo -n "  build mode  : "
-	if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT} ;
+	if has nostrip ${FEATURES} ${PORTAGE_RESTRICT} || has strip ${PORTAGE_RESTRICT}
 	then
 		echo "debug (large)"
 	else

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -21,7 +21,7 @@ export PORTAGE_DOCOMPRESS_SIZE_LIMIT="128"
 declare -a PORTAGE_DOCOMPRESS=( /usr/share/{doc,info,man} )
 declare -a PORTAGE_DOCOMPRESS_SKIP=( /usr/share/doc/${PF}/html )
 declare -a PORTAGE_DOSTRIP=( / )
-has strip ${RESTRICT} && PORTAGE_DOSTRIP=()
+has strip ${PORTAGE_RESTRICT} && PORTAGE_DOSTRIP=()
 declare -a PORTAGE_DOSTRIP_SKIP=()
 
 into() {


### PR DESCRIPTION
Use PORTAGE_PROPERTIES and PORTAGE_RESTRICT directly for internal
purposes rather than relying on PROPERTIES and RESTRICT having
the flattened values.

Signed-off-by: Michał Górny <mgorny@gentoo.org>