### PR TITLE
Fix installation issue related to black formatting and regex

### DIFF
--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -60,9 +60,9 @@ GLOBAL_CONFIG_PATH = "/usr/share/portage/config"
 # NOTE: Use realpath(__file__) so that python module symlinks in site-packages
 # are followed back to the real location of the whole portage installation.
 # NOTE: Please keep PORTAGE_BASE_PATH in one line to help substitutions.
-PORTAGE_BASE_PATH = os.path.join(
-    os.sep, os.sep.join(os.path.realpath(__file__.rstrip("co")).split(os.sep)[:-3])
-)
+# fmt:off
+PORTAGE_BASE_PATH = os.path.join( os.sep, os.sep.join(os.path.realpath(__file__.rstrip("co")).split(os.sep)[:-3]))
+# fmt:on
 PORTAGE_BIN_PATH = PORTAGE_BASE_PATH + "/bin"
 PORTAGE_PYM_PATH = os.path.realpath(os.path.join(__file__, "../.."))
 LOCALE_DATA_PATH = PORTAGE_BASE_PATH + "/locale"  # FIXME: not used


### PR DESCRIPTION
I grepped through the repo for any other instances of the phrase "one line", since it turns out there _was_ a helpful comment related to this problem.

I didn't get any hits except for what is already covered in this PR.

Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>
