### PR TITLE
xtermTitle: support foot terminal

### DIFF
--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -266,7 +266,7 @@ def nc_len(mystr):
 
 
 _legal_terms_re = re.compile(
-    r"^(xterm|xterm-color|Eterm|aterm|rxvt|screen|kterm|rxvt-unicode|gnome|interix|tmux|st-256color|alacritty|konsole)"
+    r"^(xterm|xterm-color|Eterm|aterm|rxvt|screen|kterm|rxvt-unicode|gnome|interix|tmux|st-256color|alacritty|konsole|foot)"
 )
 _disable_xtermTitle = None
 _max_xtermTitle_len = 253


### PR DESCRIPTION
Foot supports title updates so let's dynamically update the title when using it.

Similar change was done in https://github.com/gentoo/portage/pull/555 though foot is not in ncurses db by default. Not sure that makes a difference - if someone is using TERM=foot/foot-direct (remotely) they should provide their own terminfo or other apps will break too?