### PR TITLE
Copy files/* into the work tree instead of symlinking it

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -296,7 +296,7 @@ __dyn_clean() {
 
 		rm -rf "${PORTAGE_BUILDDIR}/build-info"
 		rm -rf "${WORKDIR}"
-		rm -f "${PORTAGE_BUILDDIR}/files"
+		rm -rf "${PORTAGE_BUILDDIR}/files"
 	fi
 
 	if [ -f "${PORTAGE_BUILDDIR}/.unpacked" ]; then


### PR DESCRIPTION
Symlinking FILESDIR into the work tree has the unintended consequence
of preserving all original file metadata, including system-specific ACLs
and so on.  When these files are installed, this could lead to
unintentionally copying this metadata to the system and/or binary
packages.

Let's copy all files instead and drop metadata in the process.  Since
FILESDIR is expected to be small by design, this shouldn't cause any
major trouble.  It is also easier and less likely to cause regressions
than making sure stuff is not preserved when installing.

Unfortunately, a similar problem applies to DISTDIR.  However,
installing files from DISTDIR is rarer than from FILESDIR, so I guess
we'll cross that bridge when we get to it.

Bug: https://bugs.gentoo.org/814857
Signed-off-by: Michał Górny <mgorny@gentoo.org>