### PR TITLE
Exclude binary cache build for live ebuilds

### DIFF
--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -54,7 +54,7 @@ FETCHCOMMAND_SFTP="bash -c \"x=\\\${2#sftp://} ; host=\\\${x%%/*} ; port=\\\${ho
 
 # Default user options
 FEATURES="assume-digests binpkg-docompress binpkg-dostrip binpkg-logs
-          binpkg-multi-instance
+          binpkg-multi-instance buildpkg-live
           config-protect-if-modified distlocks ebuild-locks
           fixlafiles ipc-sandbox merge-sync multilib-strict
           network-sandbox news parallel-fetch pid-sandbox

--- a/lib/_emerge/EbuildBuild.py
+++ b/lib/_emerge/EbuildBuild.py
@@ -343,9 +343,32 @@ class EbuildBuild(CompositeTask):
             and opts.buildpkg != "n"
         )
 
+        # Do not build binary cache for packages from volatile sources.
+        # For volatile sources (eg., git), the PROPERTIES parameter in
+        # the ebuild is set to 'live'.
+
+        # The default behavior is to build binary cache for all pkgs.
+        # "buildpkg-live" is a FEATURE that is enabled by default.
+        # To not build binary cache for live pkgs, we disable it by
+        # specifying FEATURES="-buildpkg-live"
+
+        buildpkg_live = True
+
+        if not "buildpkg-live" in features:
+            buildpkg_live = False
+
+        live_ebuild = False
+
+        if "live" in self.settings.get("PROPERTIES", "").split():
+            live_ebuild = True
+
+        binpkg_live_disabled = live_ebuild and not buildpkg_live
+
         if (
-            "buildpkg" in features or self._issyspkg
-        ) and not self.opts.buildpkg_exclude.findAtomForPackage(pkg):
+            ("buildpkg" in features or self._issyspkg)
+            and not binpkg_live_disabled
+            and not self.opts.buildpkg_exclude.findAtomForPackage(pkg)
+        ):
 
             self._buildpkg = True
 

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -131,6 +131,7 @@ SUPPORTED_FEATURES = frozenset(
         "binpkg-logs",
         "binpkg-multi-instance",
         "buildpkg",
+        "buildpkg-live",
         "buildsyspkg",
         "candy",
         "case-insensitive-fs",

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -323,6 +323,11 @@ Binary packages will be created for all packages that are merged. Also see
 \fBquickpkg\fR(1) and \fBemerge\fR(1) \fB\-\-buildpkg\fR and
 \fB\-\-buildpkgonly\fR options.
 .TP
+.B buildpkg\-live
+This option is enabled (the default), to exhibit the default behavior of 
+building binary cache for all packages. When it is disabled, binary packages
+will not be created for live ebuilds. 
+.TP
 .B buildsyspkg
 Build binary packages for just packages in the system set.
 .TP


### PR DESCRIPTION
This commit introduces a new value "buildpkg-live" for FEATURES, which
is enabled by default (so the default behavior of building binary cache
for all packages is retained). When it is disabled by calling emerge
with FEATURES="-buildpkg-live", binary caches will not be built live
ebuilds even if we specify --buildpkg. So that it is no longer necessary
to pass a list of packages with live ebuilds to --buildpkg-exclude.

Before this commit, when an emerge is called with the option
'--buildpkg', a binary cache for the package is created under
/var/cache/binpkgs. For example, when we do a, 'emerge --ask
--verbose --buildpkg some-gitpkg/abc', a binary cache abc-1.1.1.tbz2
is created under /var/cache/binpkgs/some-gitpkg.

With this commit, even if we explicitly use the options, '--buildpkg'
for the packages with live ebuilds, no binary cache will be created
(given we disable it calling emerge with FEATURES="-buildpkg-live").

Motivation: Since binary caches are created for all packages, including
packages with live ebuilds, a separate list of (for eg.,) git packages
needs to be maintained. And this is then passed to the options
'--buildpkg-exclude' via, EMERGE_DEFAULT_OPTS. So the motivation behind
this patch was to reduce redundancy, while we can simply disable binary
cache for live ebuilds with this option.

Signed-off-by: Madhu Priya Murugan <madhu.murugan@rohde-schwarz.com>