### PR TITLE
fetch: enable resume for digestgen case

### DIFF
--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -1485,10 +1485,11 @@ def fetch(
                             except EnvironmentError:
                                 pass
                     elif not orig_digests:
-                        # We don't have a digest, but the file exists.  We must
-                        # assume that it is fully downloaded.
+                        # We don't have a digest, and the temporary file exists.
                         if not force:
-                            continue
+                            # Try to resume this download when full
+                            # download has not been explicitly forced.
+                            fetched = 1
                     else:
                         if (
                             mydigests[myfile].get("size") is not None


### PR DESCRIPTION
Enable resume for the digestgen case (no digests available), when
the temporary file exceeds PORTAGE_FETCH_RESUME_MIN_SIZE. This
fixes a case which caused the ebuild digest command to skip the
download and fail with a message like this:
```
!!! File b'/var/cache/distfiles/foo.tar.xz' doesn't exist, can't update Manifest
```
Bug: https://bugs.gentoo.org/821571
Signed-off-by: Zac Medico <zmedico@gentoo.org>