### PR TITLE
Exclude binary pkg installation for live ebuilds

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7303,6 +7303,7 @@ class depgraph:
         rebuilt_binaries = "rebuilt_binaries" in self._dynamic_config.myparams
         usepkg = "--usepkg" in self._frozen_config.myopts
         usepkgonly = "--usepkgonly" in self._frozen_config.myopts
+        usepkg_exclude_live = "--usepkg-exclude-live" in self._frozen_config.myopts
         empty = "empty" in self._dynamic_config.myparams
         selective = "selective" in self._dynamic_config.myparams
         reinstall = False
@@ -7370,11 +7371,23 @@ class depgraph:
                     ):
                         continue
 
+                    # We can choose not to install a live package from using binary
+                    # cache by disabling it with option --usepkg-exclude-live in the
+                    # emerge call.
+
+                    live_ebuild = False
+
+                    if "live" in pkg._metadata.get("PROPERTIES", "").split():
+                        live_ebuild = True
+
                     if (
                         built
                         and not installed
-                        and usepkg_exclude.findAtomForPackage(
-                            pkg, modified_use=self._pkg_use_enabled(pkg)
+                        and (
+                            usepkg_exclude.findAtomForPackage(
+                                pkg, modified_use=self._pkg_use_enabled(pkg)
+                            )
+                            or (usepkg_exclude_live and live_ebuild)
                         )
                     ):
                         break

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -179,6 +179,7 @@ def insert_optional_args(args):
         "--use-ebuild-visibility": y_or_n,
         "--usepkg": y_or_n,
         "--usepkgonly": y_or_n,
+        "--usepkg-exclude-live": y_or_n,
         "--verbose": y_or_n,
         "--verbose-slot-rebuilds": y_or_n,
         "--with-test-deps": y_or_n,
@@ -720,6 +721,10 @@ def parse_opts(tmpcmdline, silent=False):
             "help": "use only binary packages",
             "choices": true_y_or_n,
         },
+        "--usepkg-exclude-live": {
+            "help": "do not install from binary packages for live ebuilds",
+            "choices": true_y_or_n,
+        },
         "--verbose": {
             "shortopt": "-v",
             "help": "verbose output",
@@ -1114,6 +1119,11 @@ def parse_opts(tmpcmdline, silent=False):
         myoptions.usepkgonly = True
     else:
         myoptions.usepkgonly = None
+
+    if myoptions.usepkg_exclude_live in true_y:
+        myoptions.usepkg_exclude_live = True
+    else:
+        myoptions.usepkg_exclude_live = None
 
     if myoptions.verbose in true_y:
         myoptions.verbose = True

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1064,6 +1064,9 @@ packages must be available at the time of dependency calculation or emerge
 will simply abort.  Portage does not use ebuild repositories when calculating
 dependency information so all masking information is ignored.
 .TP
+.BR "\-\-usepkg\-exclude\-live [ y | n ]"
+Tells emerge to not install from binary packages for live ebuilds.
+.TP
 .BR "\-\-verbose [ y | n ]" ", " \-v
 Tell emerge to run in verbose mode.  Currently this flag causes emerge to print
 out GNU info errors, if any, and to show the USE flags that will be used for


### PR DESCRIPTION
This commit introduces a new option "--usepkg-exclude-live" for emerge.
Passing this option with the emerge call, will disable binary pkgs from
being installed for live ebuilds. So it is no longer necessary to pass
a list of live packages to --usepkg-exclude.

Before this commit, when an emerge is called with the option
'--usepkg', the corresponding package is installed from the binary cache
under /var/cache/binpkgs.

With this commit, even if we explicitly use the options, '--usepkg'
for the packages with live ebuilds, no binary package will not be
installed for live ebuilds (given we disable it calling emerge with
"--usepkg-exclude-live" in the emerge).

Motivation: We no longer need to maintain a separate list for VCS based
pkgs (eg., git pkgs), from being installed from the binary cache, and
then pass it to --usepkg-exclude. This reduces some redundancy.

Signed-off-by: Madhu Priya Murugan <madhu.murugan@rohde-schwarz.com>