### PR TITLE
portage/util/_dyn_libs/dyn_libs.py: fix symlink recursion issue

### DIFF
--- a/lib/portage/util/_dyn_libs/dyn_libs.py
+++ b/lib/portage/util/_dyn_libs/dyn_libs.py
@@ -1,7 +1,15 @@
 # Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import glob
+import os
+
+
+def installed_dynlibs(directory):
+    for _dirpath, _dirnames, filenames in os.walk(directory):
+        for filename in filenames:
+            if filename.endswith(".so"):
+                return True
+    return False
 
 
 def check_dyn_libs_inconsistent(directory, provides):
@@ -17,5 +25,4 @@ def check_dyn_libs_inconsistent(directory, provides):
     # but this doesn't gain us anything. We're interested in failure
     # to properly parse the installed files at all, which should really
     # be a global problem (e.g. bug #811462)
-    installed_dynlibs = glob.glob(directory + "/**/*.so", recursive=True)
-    return installed_dynlibs and not provides
+    return not provides and installed_dynlibs(directory)


### PR DESCRIPTION
Python's glob.glob() function follows symlinks recursively. Use
os.walk() instead.

Also re-order the operands to short-circuit the directory walk when
PROVIDES is not empty.

Bug: https://bugs.gentoo.org/826982
Fixes: cba2156dba89a22f2858238013469b4d80208854