### PR TITLE
dbapi: fix logic in bintree.binarytree._parse_build_id()

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1877,11 +1877,10 @@ class binarytree:
         suffixlen = len(".xpak")
         hyphen = filename.rfind("-", 0, -(suffixlen + 1))
         if hyphen != -1:
-            build_id = filename[hyphen + 1 : -suffixlen]
-        try:
-            build_id = int(build_id)
-        except ValueError:
-            pass
+            try:
+                build_id = int(filename[hyphen + 1 : -suffixlen])
+            except ValueError:
+                pass
         return build_id
 
     def isremote(self, pkgname):


### PR DESCRIPTION
Resolves an error when improperly named xpak files exist in PKGDIR.

Bug: https://bugs.gentoo.org/818886