### PR TITLE
emerge: Default enable soname dependencies (bug 687956)

### DIFF
--- a/lib/_emerge/create_depgraph_params.py
+++ b/lib/_emerge/create_depgraph_params.py
@@ -104,7 +104,7 @@ def create_depgraph_params(myopts, myaction):
     if ignore_built_slot_operator_deps is not None:
         myparams["ignore_built_slot_operator_deps"] = ignore_built_slot_operator_deps
 
-    myparams["ignore_soname_deps"] = myopts.get("--ignore-soname-deps", "y")
+    myparams["ignore_soname_deps"] = myopts.get("--ignore-soname-deps", "n")
 
     dynamic_deps = myopts.get("--dynamic-deps", "y") != "n" and "--nodeps" not in myopts
     if dynamic_deps:

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -639,9 +639,10 @@ supported beginning with \fBEAPI 5\fR.
 .TP
 .BR "\-\-ignore\-soname\-deps < y | n >"
 Ignore the soname dependencies of binary and installed packages. This
-option is enabled by default, since soname dependencies are relatively
-new, and the required metadata is not guaranteed to exist for binary and
-installed packages built with older versions of portage. Also, soname
+option may be useful when working with binary or installed packages
+that lack appropriate soname dependency metadata because they were built
+with a package manager that does not support soname dependencies (perhaps
+an older version of portage). Soname
 dependencies will be automatically ignored for dependency calculations
 that can pull unbuilt ebuilds into the dependency graph, since unbuilt
 ebuilds do not have any soname dependency metadata, making it impossible


### PR DESCRIPTION
Default emerge --ignore-soname-deps=n, in order to enable
soname dependencies by default. As always, soname dependencies
remain inapplicable in the absence of the --usepkgonly option
(or --getbinpkgonly). Therefore, this change only affects
commands that specify --usepkgonly or --getbinpkgonly.

Bug: https://bugs.gentoo.org/687956
Signed-off-by: Zac Medico <zmedico@gentoo.org>