### PR TITLE
emerge: Do not resolve ambiguous package names via installed pkgs

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -4806,21 +4806,6 @@ class depgraph:
                     if len(non_virtual_cps) == 1:
                         installed_cp_set = non_virtual_cps
 
-                if len(expanded_atoms) > 1 and len(installed_cp_set) == 1:
-                    installed_cp = next(iter(installed_cp_set))
-                    for atom in expanded_atoms:
-                        if atom.cp == installed_cp:
-                            available = False
-                            for pkg in self._iter_match_pkgs_any(
-                                root_config, atom.without_use, onlydeps=onlydeps
-                            ):
-                                if not pkg.installed:
-                                    available = True
-                                    break
-                            if available:
-                                expanded_atoms = [atom]
-                                break
-
                 # If a non-virtual package and one or more virtual packages
                 # are in expanded_atoms, use the non-virtual package.
                 if len(expanded_atoms) > 1:


### PR DESCRIPTION
When dealing with ambiguous package names on command-line, do not use
installed packages to resolve them.  This is counterintuitive
in the best case, and probably the wrong answer most of the time.

After all, if a user calls emerge with a specific package name, it is
quite likely that he intends to install a missing package rather than
rebuild or upgrade an individual package (though the latter can also
happen).  Rather than making assumptions that can go wrong, just display
the ambiguity message as usual.

Signed-off-by: Michał Górny <mgorny@gentoo.org>