### PR TITLE
file_copy: handle zero bytes copied by copy_file_range (bug 828844)

### DIFF
--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -261,13 +261,14 @@ _reflink_linux_file_copy(PyObject *self, PyObject *args)
                                         &offset_out,
                                         len);
 
-                if (copyfunc_ret < 0) {
+                if (copyfunc_ret <= 0) {
                     error = errno;
-                    if ((errno == EXDEV || errno == ENOSYS || errno == EOPNOTSUPP) &&
+                    if ((errno == EXDEV || errno == ENOSYS || errno == EOPNOTSUPP || copyfunc_ret == 0) &&
                         copyfunc == cfr_wrapper) {
                         /* Use sendfile instead of copy_file_range for
                          * cross-device copies, or when the copy_file_range
-                         * syscall is not available (less than Linux 4.5).
+                         * syscall is not available (less than Linux 4.5),
+                         * or when copy_file_range copies zero bytes.
                          */
                         error = 0;
                         copyfunc = sf_wrapper;


### PR DESCRIPTION
When copy_file_range copied zero bytes, fall back to sendfile,
so that we don't call copy_file_range in an infinite loop.

Bug: https://bugs.gentoo.org/828844
Tested-by: John Helmert III <ajak@gentoo.org>
Signed-off-by: Zac Medico <zmedico@gentoo.org>