### PR TITLE
repoman: make file.size-fatal non-fatal for non-::gentoo (overlays)

### DIFF
--- a/repoman/lib/repoman/modules/scan/fetch/fetches.py
+++ b/repoman/lib/repoman/modules/scan/fetch/fetches.py
@@ -126,10 +126,16 @@ class FetchChecks(ScanBase):
                 # Current policy is no files over 20 KiB, these are the checks.
                 # File size over 20 KiB causes an error.
                 elif mystat.st_size > 20480:
-                    self.qatracker.add_error(
-                        "file.size",
-                        "(%d KiB) %s/files/%s" % (mystat.st_size // 1024, xpkg, y),
-                    )
+                    if self.repo_settings.repo_config.name == "gentoo":
+                        self.qatracker.add_error(
+                            "file.size",
+                            "(%d KiB) %s/files/%s" % (mystat.st_size // 1024, xpkg, y),
+                        )
+                    else:
+                        self.qatracker.add_warning(
+                            "file.size",
+                            "(%d KiB) %s/files/%s" % (mystat.st_size // 1024, xpkg, y),
+                        )
                 elif mystat.st_size == 0:
                     self.qatracker.add_error("file.empty", "%s/files/%s" % (xpkg, y))
 


### PR DESCRIPTION
In #gentoo-dev-help, we've had a nummber of overlay users ask about
splitting patches. This defeats the purpose of the check:

in ::gentoo, we really want people to upload them to a separate location
& download them in SRC_URI. I don't think it's necessary for overlay
users to do this as long as they're aware it's a possible issue.

This downgrades file.size-fatal to a warning for repositories
other than ::gentoo.

Signed-off-by: Sam James <sam@gentoo.org>