### PR TITLE
emerge --keep-going: deduplicate atoms in 'dropped' message

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -2164,7 +2164,7 @@ class Scheduler(PollScheduler):
             if not atoms:
                 msg += " dropped because it is masked or unavailable"
             else:
-                msg += " dropped because it requires %s" % ", ".join(atoms)
+                msg += " dropped because it requires %s" % ", ".join(set(atoms))
             for line in textwrap.wrap(msg, msg_width):
                 eerror(line, phase="other", key=pkg.cpv)
             settings = self.pkgsettings[pkg.root]


### PR DESCRIPTION
The --keep-going 'dropped' message sometimes contains duplicate atoms:

 * emerge --keep-going: app-containers/podman-4.0.2 dropped because it
 * requires app-containers/catatonit, app-containers/catatonit

This patch deduplicates the atoms printed in that message:

 * emerge --keep-going: app-containers/podman-4.0.2 dropped because it
 * requires app-containers/catatonit

Signed-off-by: John Helmert III <ajak@gentoo.org>