### PR TITLE
Drop -b from shebangs

### DIFF
--- a/bin/archive-conf
+++ b/bin/archive-conf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/binhost-snapshot
+++ b/bin/binhost-snapshot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2010-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/check-implicit-pointer-usage.py
+++ b/bin/check-implicit-pointer-usage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 
 # Ripped from HP and updated from Debian
 # Update by Gentoo to support unicode output

--- a/bin/chmod-lite.py
+++ b/bin/chmod-lite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/chpathtool.py
+++ b/bin/chpathtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2011-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/clean_locks
+++ b/bin/clean_locks
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/dohtml.py
+++ b/bin/dohtml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/doins.py
+++ b/bin/doins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2017-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 #

--- a/bin/ebuild
+++ b/bin/ebuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/ebuild-ipc.py
+++ b/bin/ebuild-ipc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2010-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 #

--- a/bin/egencache
+++ b/bin/egencache
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2009-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/emaint
+++ b/bin/emaint
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2005-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/emerge
+++ b/bin/emerge
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2006-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/emirrordist
+++ b/bin/emirrordist
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2013-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/env-update
+++ b/bin/env-update
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/filter-bash-environment.py
+++ b/bin/filter-bash-environment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/fixpackages
+++ b/bin/fixpackages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/glsa-check
+++ b/bin/glsa-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/gpkg-helper.py
+++ b/bin/gpkg-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/install.py
+++ b/bin/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2013-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/lock-helper.py
+++ b/bin/lock-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2010-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/portageq
+++ b/bin/portageq
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/regenworld
+++ b/bin/regenworld
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/shelve-utils
+++ b/bin/shelve-utils
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/xattr-helper.py
+++ b/bin/xattr-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2012-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/bin/xpak-helper.py
+++ b/bin/xpak-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2009-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 

--- a/lib/portage/tests/runTests.py
+++ b/lib/portage/tests/runTests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -bWd
+#!/usr/bin/env python -Wd
 # runTests.py -- Portage Unit Test Functionality
 # Copyright 2006-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

--- a/lib/portage/util/changelog.py
+++ b/lib/portage/util/changelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -b
+#!/usr/bin/env python
 # Copyright 2009-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 


### PR DESCRIPTION
The switch to using '/usr/bin/env python' shebangs doesn't naively
work with arguments after 'python', so the shebangs were broken. '-b'
is of dubious necessity anyway, so let's just drop it.

Fixes: 41f4f6d25019c4f944b8d9576d96482f92231fda
Signed-off-by: John Helmert III <ajak@gentoo.org>