### PR TITLE
estrip: avoid calling scanelf twice

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -410,8 +410,9 @@ while read -r x ; do
 done < <(
 	# Use sort -u to eliminate duplicates for bug #445336.
 	(
-		scanelf -yqRBF '#k%F' -k '.symtab' "$@"
 		find "$@" -type f ! -type l -name '*.a'
+		cut -d ' ' -f1 < "${PORTAGE_BUILDDIR}"/build-info/NEEDED \
+			| sed -e "s:^:${ED}:"
 	) | LC_ALL=C sort -u
 )
 else

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -151,20 +151,6 @@ install_qa_check() {
 		"${PORTAGE_BIN_PATH}"/ecompress --dequeue
 	fi
 
-	# If binpkg-dostrip is enabled, apply stripping before creating
-	# the binary package.
-	# Note: disabling it won't help with packages calling prepstrip directly.
-	if has binpkg-dostrip ${FEATURES}; then
-		export STRIP_MASK
-		if ___eapi_has_dostrip; then
-			"${PORTAGE_BIN_PATH}"/estrip --queue "${PORTAGE_DOSTRIP[@]}"
-			"${PORTAGE_BIN_PATH}"/estrip --ignore "${PORTAGE_DOSTRIP_SKIP[@]}"
-			"${PORTAGE_BIN_PATH}"/estrip --dequeue
-		else
-			prepallstrip
-		fi
-	fi
-
 	if has chflags $FEATURES ; then
 		# Restore all the file flags that were saved earlier on.
 		mtree -U -e -p "${ED}" -k flags < "${T}/bsdflags.mtree" &> /dev/null
@@ -246,6 +232,21 @@ install_qa_check() {
 				eqawarn "QA Notice: RESTRICT=binchecks prevented checks on these ELF files:"
 				eqawarn "$(while read -r x; do x=${x#*;} ; x=${x%%;*} ; echo "${x#${EPREFIX}}" ; done < "${PORTAGE_BUILDDIR}"/build-info/NEEDED.ELF.2)"
 			fi
+		fi
+	fi
+
+	# If binpkg-dostrip is enabled, apply stripping before creating
+	# the binary package.
+	# Note: disabling it won't help with packages calling prepstrip directly.
+	# We do this after the scanelf bits so that we can reuse the data. bug #749624.
+	if has binpkg-dostrip ${FEATURES}; then
+		export STRIP_MASK
+		if ___eapi_has_dostrip; then
+			"${PORTAGE_BIN_PATH}"/estrip --queue "${PORTAGE_DOSTRIP[@]}"
+			"${PORTAGE_BIN_PATH}"/estrip --ignore "${PORTAGE_DOSTRIP_SKIP[@]}"
+			"${PORTAGE_BIN_PATH}"/estrip --dequeue
+		else
+			prepallstrip
 		fi
 	fi
 


### PR DESCRIPTION
We can use the previous scanelf data to not call it again to find
all of the dynamically linked executables/libraries which need stripping.

Bug: https://bugs.gentoo.org/749624
Signed-off-by: Sam James <sam@gentoo.org>