### PR TITLE
GitSync.update: default to "--depth 1" (bug 824782 comment 17)

### DIFF
--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -84,9 +84,6 @@ class GitSync(NewBase):
         if self.repo.clone_depth is not None:
             if self.repo.clone_depth != 0:
                 git_cmd_opts += " --depth %d" % self.repo.clone_depth
-        elif self.repo.sync_depth is not None:
-            if self.repo.sync_depth != 0:
-                git_cmd_opts += " --depth %d" % self.repo.sync_depth
         else:
             # default
             git_cmd_opts += " --depth 1"
@@ -147,6 +144,13 @@ class GitSync(NewBase):
 
         if self.settings.get("PORTAGE_QUIET") == "1":
             git_cmd_opts += " --quiet"
+        if self.repo.sync_depth is not None:
+            if self.repo.sync_depth != 0:
+                git_cmd_opts += " --depth %d" % self.repo.sync_depth
+        else:
+            # default
+            git_cmd_opts += " --depth 1"
+
         if self.repo.module_specific_options.get("sync-git-pull-extra-opts"):
             git_cmd_opts += (
                 " %s" % self.repo.module_specific_options["sync-git-pull-extra-opts"]
@@ -171,10 +175,8 @@ class GitSync(NewBase):
             writemsg_level(msg + "\n", level=logging.ERROR, noiselevel=-1)
             return (e.returncode, False)
 
-        shallow = self.repo.sync_depth is not None and self.repo.sync_depth != 0
+        shallow = self.repo.sync_depth is None or self.repo.sync_depth != 0
         if shallow:
-            git_cmd_opts += " --depth %d" % self.repo.sync_depth
-
             # For shallow fetch, unreachable objects may need to be pruned
             # manually, in order to prevent automatic git gc calls from
             # eventually failing (see bug 599008).

--- a/man/portage.5
+++ b/man/portage.5
@@ -981,7 +981,8 @@ yes, true.
 .TP
 .B clone\-depth
 Specifies clone depth to use for DVCS repositories. Defaults to 1 (only
-the newest commit). If set to 0, the depth is unlimited.
+the newest commit). If set to 0, the depth is unlimited, because Git is
+not executed with "--depth #".
 .TP
 .B eclass\-overrides
 Makes given repository inherit eclasses from specified repositories.
@@ -1036,8 +1037,9 @@ overlay filesystems. Defaults to yes, true.
 Specifies CVS repository.
 .TP
 .B sync\-depth
-Specifies sync depth to use for DVCS repositories. If set to 0, the
-depth is unlimited. Defaults to 0.
+Specifies sync depth to use for DVCS repositories. Defaults to 1 (only
+the newest commit). If set to 0, the depth is unlimited, because Git is
+not executed with "--depth #".
 .TP
 .B sync\-git\-clone\-env
 Set environment variables for git when cloning repository (git clone).


### PR DESCRIPTION
Enforce the use of "--depth" in both GitSync.new and GitSync.update following the same logic.

Each function gets its own designated portage option of "clone-depth" and "sync-depth". This means that portage option "sync-depth" is not taken into consideration anymore in GitSync.new.

Portage option "clone-depth" and "sync-depth" lead to following behaviour with a value of:
0: The use of "--depth <value>" is disabled causing the retrieval of the whole Git history.
ℕ (positive integer): "--depth <value>" is used.
Unset portage option: "--depth 1" is used.