### PR TITLE
bin/install-qa-check.d/95empty-dirs: update message for EAPI 8

### DIFF
--- a/bin/install-qa-check.d/95empty-dirs
+++ b/bin/install-qa-check.d/95empty-dirs
@@ -33,7 +33,7 @@ find_empty_dirs() {
 		done
 		eqawarn
 		eqawarn "If those directories need to be preserved, please make sure to create"
-		eqawarn "or mark them for keeping using 'keepdir'. Future versions of Portage"
+		eqawarn "or mark them for keeping using 'keepdir'. Portage for >= EAPI 8 ebuilds"
 		eqawarn "will strip empty directories from installation image."
 	fi
 }


### PR DESCRIPTION
Portage changed the default for >= EAPI 8 ("newer EAPIs" at the time, not
actually specific to 8) in bfda0d2bd4ba03a4e77f488ec3fd4f9c6c351662 to
enable FEATURES="strict-keepdir".

Signed-off-by: Sam James <sam@gentoo.org>