### PR TITLE
cnf/make.globals: use https for default mirror

### DIFF
--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -21,7 +21,7 @@ FCFLAGS=""
 
 # Default distfiles mirrors. This rotation has multiple hosts and is reliable.
 # Approved by the mirror-admin team.
-GENTOO_MIRRORS="http://distfiles.gentoo.org"
+GENTOO_MIRRORS="https://distfiles.gentoo.org"
 
 ACCEPT_PROPERTIES="*"
 ACCEPT_RESTRICT="*"


### PR DESCRIPTION
Signed-off-by: John Helmert III <ajak@gentoo.org>