### PR TITLE
dispatch-conf: add a warning about changing the use-rcs setting

### DIFF
--- a/cnf/dispatch-conf.conf
+++ b/cnf/dispatch-conf.conf
@@ -15,6 +15,9 @@ archive-dir=${EPREFIX}/etc/config-archive
 # the ci(1) man page, users can control access to RCS files by setting
 # the permissions of the directory containing the files (see
 # archive-dir above).
+# WARNING: When changing this setting, you should ensure that
+# archive-dir is empty by removing or renaming any existing directory.
+# Otherwise, conflicts may occur (bug 837533).
 # (yes or no)
 use-rcs=no
 


### PR DESCRIPTION
If there are existing files in the archive directory, this may cause
conflicts with the files/directories managed using rcs.

Bug: https://bugs.gentoo.org/837533