### PR TITLE
.github: add pypy3.8, pypy3.9 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         - '3.9'
         - '3.10'
         - 'pypy-3.7'
+        - 'pypy-3.8'
+        - 'pypy-3.9'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>