### PR TITLE
ebegin: Output QA warning if call to eend is missing

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -339,6 +339,9 @@ ebegin() {
 	[[ ${RC_ENDCOL} == "yes" ]] && echo >&2
 	LAST_E_LEN=$(( 3 + ${#RC_INDENTATION} + ${#msg} ))
 	LAST_E_CMD="ebegin"
+	if [[ -v EBEGIN_EEND ]] ; then
+		eqawarn "QA Notice: ebegin called, but missing call to eend (phase: ${EBUILD_PHASE})"
+	fi
 	EBEGIN_EEND=1
 	return 0
 }

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -1088,6 +1088,10 @@ __ebuild_main() {
 		;;
 	esac
 
+	if [[ -v EBEGIN_EEND ]] ; then
+		eqawarn "QA Notice: ebegin called, but missing call to eend (phase: ${1})"
+	fi
+
 	# Save the env only for relevant phases.
 	if ! has "${1}" clean help info nofetch ; then
 		umask 002


### PR DESCRIPTION
The idea here is to check if EBEGIN_EEND is set after the phase has been
executed. If so, then a call to eend is probably missing. This is under
the assumption that ebegin-eend invocations should be properly paired
within the same phase.

In ebegin, the EBEGIN_EEND variable is also checked, and, if set,
indicates that ebegin has been called and is missing the closing call to
eend.

I doubt that this check is perfect, but it seems to work in what little
testing I've done.

Closes: https://bugs.gentoo.org/835823
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>