### PR TITLE
vartree: skip env-update if no updates were merged; avoid lock contention

### DIFF
--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -5148,14 +5148,17 @@ class dblink:
         self._clear_contents_cache()
         contents = self.getcontents()
         destroot_len = len(destroot) - 1
-        self.lockdb()
-        try:
-            for blocker in blockers:
-                self.vartree.dbapi.removeFromContents(
-                    blocker, iter(contents), relative_paths=False
-                )
-        finally:
-            self.unlockdb()
+
+        # Avoid lock contention if we aren't going to do any work.
+        if blockers:
+            self.lockdb()
+            try:
+                for blocker in blockers:
+                    self.vartree.dbapi.removeFromContents(
+                        blocker, iter(contents), relative_paths=False
+                    )
+            finally:
+                self.unlockdb()
 
         plib_registry = self.vartree.dbapi._plib_registry
         if plib_registry:

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -2608,14 +2608,16 @@ class dblink:
         else:
             self.settings.pop("PORTAGE_LOG_FILE", None)
 
-        env_update(
-            target_root=self.settings["ROOT"],
-            prev_mtimes=ldpath_mtimes,
-            contents=contents,
-            env=self.settings,
-            writemsg_level=self._display_merge,
-            vardbapi=self.vartree.dbapi,
-        )
+        # If we didn't unmerge anything, don't bother updating env.
+        if contents:
+            env_update(
+                target_root=self.settings["ROOT"],
+                prev_mtimes=ldpath_mtimes,
+                contents=contents,
+                env=self.settings,
+                writemsg_level=self._display_merge,
+                vardbapi=self.vartree.dbapi,
+            )
 
         unmerge_with_replacement = preserve_paths is not None
         if not unmerge_with_replacement:
@@ -5258,15 +5260,17 @@ class dblink:
                 ],
             )
 
-        # update environment settings, library paths. DO NOT change symlinks.
-        env_update(
-            target_root=self.settings["ROOT"],
-            prev_mtimes=prev_mtimes,
-            contents=contents,
-            env=self.settings,
-            writemsg_level=self._display_merge,
-            vardbapi=self.vartree.dbapi,
-        )
+        # Update environment settings, library paths. DO NOT change symlinks.
+        # Only do this if we actually installed something.
+        if contents:
+            env_update(
+                target_root=self.settings["ROOT"],
+                prev_mtimes=prev_mtimes,
+                contents=contents,
+                env=self.settings,
+                writemsg_level=self._display_merge,
+                vardbapi=self.vartree.dbapi,
+            )
 
         # For gcc upgrades, preserved libs have to be removed after the
         # the library path has been updated.


### PR DESCRIPTION
Two cherry-picks from chromiumos.

```
commit 4b60899631d9a184e4e276af866fe9404f9a706c (HEAD -> cherry-pick-env, sam/cherry-pick-env)
Author: Mike Frysinger <vapier@chromium.org>
Date:   Tue Mar 29 08:12:25 2022 +0100

    vartree: avoid lock contention when there are no blockers

    No sense in grabbing the vdb lock if we aren't going to do any work.
    This avoids contention on the global lock with parallel packages.

    [sam: cherry-picked from chromiumos' third_party/portage_tool repo]
    (cherry picked from commit ea5f6f8c0a5e05d7630f9070992a89fa6907cc14)
    Signed-off-by: Sam James <sam@gentoo.org>

commit cce49d3e4840814a6bf6c6489b8fb53f4d29aa2d
Author: Mike Frysinger <vapier@chromium.org>
Date:   Tue Mar 29 14:56:55 2022 +0100

    vartree: skip env-update if no updates were merged

    This speeds up virtual/ installs by not constantly re-running env-update.

    [sam: cherry-picked from chromiumos' third_party/portage_tool repo]
    (cherry picked from commit 87ac3566ebb7155a57876d345849bd0fd6878c0e)

    Bug: https://bugs.gentoo.org/836375
    Signed-off-by: Sam James <sam@gentoo.org>
```