### PR TITLE
phase-functions.sh: do not "addpredict /" for src_test

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -501,8 +501,6 @@ __dyn_test() {
 	elif [[ ${EBUILD_FORCE_TEST} != 1 ]] && ! has test ${FEATURES} ; then
 		__vecho ">>> Test phase [not enabled]: ${CATEGORY}/${PF}"
 	else
-		local save_sp=${SANDBOX_PREDICT}
-		addpredict /
 		__ebuild_phase pre_src_test
 
 		__vecho ">>> Test phase: ${CATEGORY}/${PF}"
@@ -512,7 +510,6 @@ __dyn_test() {
 		>> "$PORTAGE_BUILDDIR/.tested" || \
 			die "Failed to create $PORTAGE_BUILDDIR/.tested"
 		__ebuild_phase post_src_test
-		SANDBOX_PREDICT=${save_sp}
 	fi
 
 	trap - SIGINT SIGQUIT


### PR DESCRIPTION
Silencing the sandbox by default makes it more difficult to track down
file access problems that may effect tests.

Removing this will likely cause an increased number of test failures
until affected ebuilds can be adjusted.

Bug: https://bugs.gentoo.org/836671