### PR TITLE
ebegin/eend: accept properly nested calls in different functions

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -1089,7 +1089,9 @@ __ebuild_main() {
 	esac
 
 	if [[ -v EBEGIN_EEND ]] ; then
-		eqawarn "QA Notice: ebegin called, but missing call to eend (phase: ${1})"
+		for func in "${EBEGIN_EEND[@]}" ; do
+			eqawarn "QA Notice: ebegin called in ${func} but missing call to eend"
+		done
 	fi
 
 	# Save the env only for relevant phases.


### PR DESCRIPTION
Turn the EBEGIN_EEND variable into a stack that tracks which function
called ebegin. Calls to ebegin may be stacked and do not generate a QA
warning if the callers are different functions. Calls to eend then check
that the function name at the top of the stack matches the caller's
function name.

Bug: https://bugs.gentoo.org/839585
Bug: https://bugs.gentoo.org/839588
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>