### PR TITLE
man/make.conf.5: Document default MAKEOPTS behaviour

### DIFF
--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -923,6 +923,7 @@ between \fICPUs+1\fR and \fI2*CPUs+1\fR. In order to avoid
 excess load, the \fB\-\-load\-average\fR option is recommended.
 For more information, see \fBmake\fR(1). Also see \fBemerge\fR(1) for
 information about analogous \fB\-\-jobs\fR and \fB\-\-load\-average\fR options.
+Defaults to the number of processors if left unset.
 .TP
 \fBNOCOLOR\fR = \fI["true" | "false"]\fR
 Defines if color should be disabled by default.


### PR DESCRIPTION
After commits 5a1e6c9 and 6c054da, if `MAKEOPTS` is left unset, it will default to the number of processors.