### PR TITLE
install-qa-check.d/60pkgconfig: add QA_PKGCONFIG_VERSION

### DIFF
--- a/bin/install-qa-check.d/60pkgconfig
+++ b/bin/install-qa-check.d/60pkgconfig
@@ -92,25 +92,34 @@ pkgconfig_check() {
 	# about, while avoiding any pathological cases e.g. multiple libraries
 	# with different versioning within one package.
 	# Example bugs: bug #833895, bug #833887.
-	local all_bad=yes
-	# Record the last bad file matched
-	local bad_file
-	for f in "${files[@]}" ; do
-		if [[ ${PV} == $(pkg-config --modversion "${f}") ]] ; then
-			all_bad=no
-			break
+
+	# Default to PV if QA_PKGCONFIG_VERSION is unset.
+	if [[ -z ${QA_PKGCONFIG_VERSION+set} ]]; then
+		local QA_PKGCONFIG_VERSION=${PV}
+	fi
+
+	# Skip the check if QA_PKGCONFIG_VERSION is set to empty string.
+	if [[ -n ${QA_PKGCONFIG_VERSION} ]]; then
+		local all_bad=yes
+		# Record the last bad file matched
+		local bad_file
+		for f in "${files[@]}" ; do
+			if [[ ${QA_PKGCONFIG_VERSION} == $(pkg-config --modversion "${f}") ]] ; then
+				all_bad=no
+				break
+			fi
+
+			bad_file="${f//${D}}"
+		done
+
+		# Skip result reporting if *_p* because for both _pN and _preN, we
+		# don't generally expect the versions to be exactly accurate, and
+		# we want to avoid false positives.
+		if [[ ${all_bad} == "yes" && ${PV} != *_p* ]] && ! has live ${PROPERTIES} ; then
+			eqawarn "QA Notice: pkg-config files with mismatched Version found!"
+			eqawarn "At least ${bad_file}'s Version field does not match ${PV}"
+			eqawarn "Please check all .pc files installed by this package."
 		fi
-
-		bad_file="${f//${D}}"
-	done
-
-	# Skip result reporting if *_p* because for both _pN and _preN, we
-	# don't generally expect the versions to be exactly accurate, and
-	# we want to avoid false positives.
-	if [[ ${all_bad} == "yes" && ${PV} != *_p* ]] && ! has live ${PROPERTIES} ; then
-		eqawarn "QA Notice: pkg-config files with mismatched Version found!"
-		eqawarn "At least ${bad_file}'s Version field does not match ${PV}"
-		eqawarn "Please check all .pc files installed by this package."
 	fi
 }
 


### PR DESCRIPTION
This allows ebuild maintainers to override the expected version in the .pc file when it differs from ${PV}.