### PR TITLE
gcc-warning QA checks -Wincompatible-pointer-types and -Wclobbered

### DIFF
--- a/bin/install-qa-check.d/90gcc-warnings
+++ b/bin/install-qa-check.d/90gcc-warnings
@@ -58,6 +58,11 @@ gcc_warn_check() {
 			'warning: .*\[-Wsizeof-pointer-memaccess\]'
 			# iteration invokes undefined behavior
 			'warning: .*\[-Waggressive-loop-optimizations\]'
+			# conversion between pointers that have incompatible types
+			'warning: .*\[-Wincompatible-pointer-types\]'
+			# clobbered: Warn for variables that might be changed by longjmp or vfork
+			# (This warning is also enabled by -Wextra.)
+			'warning: .*\[-Wclobbered\]'
 
 			# this may be valid code :/
 			#': warning: multi-character character constant'


### PR DESCRIPTION
Discussed these 2 potential additions to the portage GCC warning checklist, during a code review session with sam:
```
[-Wincompatible-pointer-types]
[-Wclobbered]
```
They appear rarely enough that the additional noise should not be too much of a concern for QA,
but of enough importance that it should be investigated and dealt with.
Only a couple (~2) packages were flagged during inspecting my past build logs to test this commit.

We are also open to discussing or adding more:
<sam_> we flag some as QA notices and say you should report them upstream
<sam_> we could expand the list i think
<sam_> (and i think we should expand the list)
<sam_> the problem with [-Wmaybe-uninitialized] is that we tell people to report these things upstream
<sam_> and i think that might be regarded as a nuisance with a high FP [false positive] rate

So it needs a balanced approach. We stopped short of adding more. Request for comments.