### PR TITLE
Add script to call pylint on all python files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'

--- a/run-pylint
+++ b/run-pylint
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec pylint "$@" lib/_emerge lib/portage $(grep -Rl '^#!.*python' bin)

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,5 @@ deps =
 setenv =
 	PYTHONPATH={toxinidir}/lib
 commands =
-	pylint: bash -c 'rm -rf build && PYTHONPATH=$PWD/lib pylint bin/* lib/*'
+	pylint: ./run-pylint
 	python -b -Wd setup.py test


### PR DESCRIPTION
This gives us a simple way to call pylint from tox.ini.

Our previous hack would call pylint on non-python files (shell scripts), and only went unnoticed because we have most errors disabled in pylintrc.