### PR TITLE
eend: drop QA warning when ebegin was called from another function

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -380,9 +380,6 @@ eend() {
 	if [[ -v EBEGIN_EEND ]] ; then
 		local caller="${FUNCNAME[1]}"
 		local tos="${EBEGIN_EEND[-1]}"
-		if [[ "${caller}" != "${tos}" ]] ; then
-			eqawarn "QA Notice: eend (in ${caller}) improperly matched with ebegin (called in ${tos})"
-		fi
 		unset EBEGIN_EEND[-1]
 		if [[ ${#EBEGIN_EEND[@]} -eq 0 ]] ; then
 			unset EBEGIN_EEND

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -207,7 +207,11 @@ __preprocess_ebuild_env() {
 }
 
 __ebuild_phase() {
+	local __EBEGIN_EEND_COUNT=0
 	declare -F "$1" >/dev/null && __qa_call $1
+	if (( __EBEGIN_EEND_COUNT > 0 )); then
+		eqawarn "QA Notice: ebegin called without eend in $1"
+	fi
 }
 
 __ebuild_phase_with_hooks() {
@@ -1087,12 +1091,6 @@ __ebuild_main() {
 		exit 1
 		;;
 	esac
-
-	if [[ -v EBEGIN_EEND ]] ; then
-		for func in "${EBEGIN_EEND[@]}" ; do
-			eqawarn "QA Notice: ebegin called in ${func} but missing call to eend"
-		done
-	fi
 
 	# Save the env only for relevant phases.
 	if ! has "${1}" clean help info nofetch ; then


### PR DESCRIPTION
check-reqs.eclass does this:

```
_check_reqs_start_phase() {
    ...
    ebegin
    ...
}

_check_reqs_foo() {
    _check_reqs_start_phase
    ...
    eend
}
```

This seems like a valid pattern.

Fixes: 605ad0d675a64eb39144122cf284100192cdfea0