### PR TITLE
portage.eapi: remove debug logging statement

### DIFF
--- a/lib/portage/eapi.py
+++ b/lib/portage/eapi.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
-import logging
 from functools import lru_cache
 from typing import Optional
 
@@ -219,7 +218,6 @@ def _get_eapi_attrs(eapi_str: Optional[str]) -> _eapi_attrs:
     be helpful for handling of corrupt EAPI metadata in essential functions
     such as pkgsplit.
     """
-    logging.info("cache info: {}".format(_get_eapi_attrs.cache_info()))
     if eapi_str is None or not eapi_is_supported(eapi_str):
         return _eapi_attrs(
             allows_package_provided=True,


### PR DESCRIPTION
This ensures we don't accidentally break portage API consumers that fail
to configure the root logger before calling the portage API.

Bug: https://bugs.gentoo.org/838406