### PR TITLE
xml.metadata.py: Fix gentoolkit traceback in _Useflag class

### DIFF
--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -106,7 +106,7 @@ class _Useflag:
         _desc = ""
         if node.text:
             _desc = node.text
-        for child in node.getchildren():
+        for child in node.iter():
             _desc += child.text if child.text else ""
             _desc += child.tail if child.tail else ""
         # This takes care of tabs and newlines left from the file


### PR DESCRIPTION
brian@storm ~/Dev/git/gentoolkit $ equery u smartmontools
Traceback (most recent call last):
  File "/home/brian/Dev/git/gentoolkit/bin/equery", line 44, in <module>
    equery.main(sys.argv)
  File "/home/brian/Dev/git/gentoolkit/pym/gentoolkit/equery/__init__.py", line 359, in main
    loaded_module.main(module_args)
  File "/home/brian/Dev/git/gentoolkit/pym/gentoolkit/equery/uses.py", line 341, in main
    output = get_output_descriptions(pkg, global_usedesc)
  File "/home/brian/Dev/git/gentoolkit/pym/gentoolkit/equery/uses.py", line 201, in get_output_descriptions
    local_usedesc = pkg.metadata.use()
  File "/usr/lib/python3.10/site-packages/portage/xml/metadata.py", line 337, in use
    self._useflags = tuple(_Useflag(node) for node in iterate("flag"))
  File "/usr/lib/python3.10/site-packages/portage/xml/metadata.py", line 337, in <genexpr>
    self._useflags = tuple(_Useflag(node) for node in iterate("flag"))
  File "/usr/lib/python3.10/site-packages/portage/xml/metadata.py", line 109, in __init__
    for child in node.getchildren():
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'

Reported by: IRC user kurly

gentoolkit original class used node.iter()
Wrap the relevant code block in a try: except pair to prevent the error

Signed-off-by: Brian Dolbec <dolsen@gentoo.org>