### PR TITLE
news: fix isRelevant check

### DIFF
--- a/lib/portage/news.py
+++ b/lib/portage/news.py
@@ -281,10 +281,9 @@ class NewsItem:
         kwargs = {"vardb": vardb, "config": config, "profile": profile}
 
         all_match = all(
-            True
+            restriction.checkRestriction(**kwargs)
             for values in self.restrictions.values()
             for restriction in values
-            if restriction.checkRestriction(**kwargs)
         )
 
         return all_match


### PR DESCRIPTION
Manifested as all news items being shown, even if
(very) irrelevant to the running system (e.g.
different arch, packages not installed, ...).

I think the distinction here is that with the previous state,
we'd end up with _only_ Trues, or nothing (an element
would be omitted), whereas this commit means we end
up considering a possible mixed sequence.

Fixes: 9e24d0143450628f334cdb62e579efafd1bfd2ba
Reported-by: kurly
Signed-off-by: Sam James <sam@gentoo.org>