### PR TITLE
Allow nested ebegin

### DIFF
--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -339,10 +339,7 @@ ebegin() {
 	[[ ${RC_ENDCOL} == "yes" ]] && echo >&2
 	LAST_E_LEN=$(( 3 + ${#RC_INDENTATION} + ${#msg} ))
 	LAST_E_CMD="ebegin"
-	if [[ -v EBEGIN_EEND ]] ; then
-		eqawarn "QA Notice: ebegin called, but missing call to eend (phase: ${EBUILD_PHASE})"
-	fi
-	EBEGIN_EEND=1
+	let ++__EBEGIN_EEND_COUNT
 	return 0
 }
 
@@ -371,10 +368,9 @@ __eend() {
 
 eend() {
 	[[ -n $1 ]] || eqawarn "QA Notice: eend called without first argument"
-	if [[ -v EBEGIN_EEND ]] ; then
-		unset EBEGIN_EEND
-	else
-		eqawarn "QA Notice: eend called without preceding ebegin (phase: ${EBUILD_PHASE})"
+	if (( --__EBEGIN_EEND_COUNT < 0 )); then
+		__EBEGIN_EEND_COUNT=0
+		eqawarn "QA Notice: eend called without preceding ebegin in ${FUNCNAME[1]}"
 	fi
 	local retval=${1:-0}
 	shift

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -207,7 +207,11 @@ __preprocess_ebuild_env() {
 }
 
 __ebuild_phase() {
+	local __EBEGIN_EEND_COUNT=0
 	declare -F "$1" >/dev/null && __qa_call $1
+	if (( __EBEGIN_EEND_COUNT > 0 )); then
+		eqawarn "QA Notice: ebegin called without eend in $1"
+	fi
 }
 
 __ebuild_phase_with_hooks() {
@@ -1087,10 +1091,6 @@ __ebuild_main() {
 		exit 1
 		;;
 	esac
-
-	if [[ -v EBEGIN_EEND ]] ; then
-		eqawarn "QA Notice: ebegin called, but missing call to eend (phase: ${1})"
-	fi
 
 	# Save the env only for relevant phases.
 	if ! has "${1}" clean help info nofetch ; then


### PR DESCRIPTION
I got some push back on gentoo-dev re: banning nested ebegin calls. This PR re-adds support for nested ebegin using a count variable.