### PR TITLE
portage: drop obsolete fixpackages warning

### DIFF
--- a/lib/portage/_global_updates.py
+++ b/lib/portage/_global_updates.py
@@ -261,13 +261,4 @@ def _do_global_updates(trees, prev_mtimes, quiet=False, if_mtime_changed=True):
         # what follows.
         writemsg_stdout("\n\n")
 
-        if bindb and bindb.cpv_all():
-            writemsg_stdout(
-                _(
-                    " ** Skipping packages. Run 'fixpackages' or set it in FEATURES to fix the tbz2's in the packages directory.\n"
-                )
-            )
-            writemsg_stdout(bold(_("Note: This can take a very long time.")))
-            writemsg_stdout("\n")
-
     return retupd


### PR DESCRIPTION
18e5a8170c69aecd10f162918de571d85055ae81 exposed this but
the support for fixpackages actually got removed
in 7ab4d5722a828167dd1bf946b26cfa80808f59fc.

The "if True" construct was just intended as a way
of stubbing out the old stuff. Let's just drop the
cruft instead.

This fixes giving a completely harmless "fixpackages error"
which is meaningless.

See: https://forums.gentoo.org/viewtopic-t-1152818.html
Signed-off-by: Sam James <sam@gentoo.org>