### PR TITLE
ebuild.5: update for dolib, libopts being banned in EAPI 7

### DIFF
--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -1314,7 +1314,8 @@ make \\
 .fi
 Please do \fBnot\fR use this in place of 'emake install DESTDIR=${D}'.
 That is the preferred way of installing make\-based packages.  Also, do
-not utilize the \fIEXTRA_EINSTALL\fR variable since it is for users.
+not utilize the \fIEXTRA_EINSTALL\fR variable since it is for users.  Banned
+since \fBEAPI 6\fR.
 
 .TP
 .B docompress\fR \fI[\-x] <path> [list of more paths]


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>