### PR TITLE
Scheduling policy switching

### DIFF
--- a/cnf/make.conf.example
+++ b/cnf/make.conf.example
@@ -291,6 +291,23 @@
 #     unset.
 #PORTAGE_IONICE_COMMAND="ionice -c 3 -p \${PID}"
 #
+# PORTAGE_SCHEDULING_POLICY allows changing the current scheduling policy. The
+# supported options are 'other', 'batch', 'idle', 'fifo' and 'round-robin'. When
+# unset, the scheduling policy remains unchanged, by default Linux uses 'other'
+# policy. Users that wish to minimize the Portage's impact on system
+# responsiveness should set scheduling policy to 'idle' which significantly
+# reduces the disruption to the rest of the system by scheduling Portage as
+# extremely low priority processes.
+#
+#PORTAGE_SCHEDULING_POLICY="idle"
+#
+# PORTAGE_SCHEDULING_PRIORITY allows changing the priority (1-99) of the current
+# scheduling policy, only applies if PORTAGE_SCHEDULING_POLICY is set to 'fifo'
+# or 'round-robin', for others the only supported priority is 0, If unset,
+# defaults to lowest priority of the selected scheduling policy.
+#
+#PORTAGE_SCHEDULING_PRIORITY="99"
+#
 # AUTOCLEAN enables portage to automatically clean out older or overlapping
 #     packages from the system after every successful merge. This is the
 #     same as running 'emerge -c' after every merge. Set with: "yes" or "no".

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1080,6 +1080,22 @@ will set idle io priority. For more information about ionice, see
 Portage will also set the autogroup-nice value (see fBsched\fR(7))), if
 FEATURES="pid\-sandbox" is enabled.
 .TP
+\fBPORTAGE_SCHEDULING_POLICY\fR = \fI[policy name]\fR
+Allows changing the current scheduling policy. The supported options are
+\fBother\fR, \fBbatch\fR, \fBidle\fR, \fBfifo\fR, and \fBround-robin\fR. When
+unset, the scheduling policy remains unchanged, by default Linux uses 'other'
+policy. Users that wish to minimize the Portage's impact on system
+responsiveness should set scheduling policy to \fBidle\fR, which significantly
+reduces the disruption to the rest of the system by scheduling Portage as
+extremely low priority processes. see \fBsched\fR(7) for more information.
+.TP
+\fBPORTAGE_SCHEDULING_PRIORITY\fR = \fI[priority]\fR
+Allows changing the priority (1-99) of the current scheduling policy, only
+applies if PORTAGE _SCHEDULING_POLICY is set to 'fifo' or 'round-robin',
+for others the only supported priority is 0, If unset, defaults to lowest
+priority of the selected scheduling policy. For more information about
+scheduler, see \fBsched\fR(7). This variable is unset by default.
+.TP
 .B PORTAGE_LOG_FILTER_FILE_CMD
 This variable specifies a command that filters build log output to a
 log file. In order to filter ANSI escape codes from build logs,


### PR DESCRIPTION
Adds ability to control the scheduler policy that is used for emerge and
all child processes. Mainly to interface the ability to switch to
SCHED_IDLE as the solution to keep interactive tasks unaffected by
building process happening in the background.

On a test sample N=1 with AMD Ryzen 5950x and 64 GB of ram building
sys-devel/gcc with lto enabled significantly reduces responsiveness of
the system, even with CONFIG_SCHED_AUTOGROUP and PREEMPT enabled. Using
a web browser result in visible lags, video playback in web browser,
when using CPU decoding, also suffers greatly.

Switching Portage to SCHED_IDLE (PORTAGE_SCHEDULING_POLICY="idle")
results in no visible slowdowns and responsiveness is as if nothing in
the background was happening.

This is especially worthy feature when running on powerful CPUs, where
users often opt in to build not only with parallel build jobs, but also
with multiple packages at once. Anyone running with PORTAGE_NICENESS="19"
will undoubtedly want to use this feature to force SCHED_IDLE policy.

Signed-off-by: KARBOWSKI Piotr <slashbeast@gentoo.org>