### PR TITLE
bin/ebuild-helpers/doins: fix D check, add EPREFIX check

### DIFF
--- a/bin/ebuild-helpers/doins
+++ b/bin/ebuild-helpers/doins
@@ -42,12 +42,22 @@ if ! ___eapi_has_prefix_variables; then
 	export ED="${D}"
 fi
 
-if [[ ${_E_INSDESTTREE_#${ED}} != "${_E_INSDESTTREE_}" ]]; then
+if [[ ${_E_INSDESTTREE_#${D}} != "${_E_INSDESTTREE_}" ]]; then
 	__vecho "-------------------------------------------------------" 1>&2
 	__vecho "You should not use \${D} or \${ED} with helpers." 1>&2
 	__vecho "  --> ${_E_INSDESTTREE_}" 1>&2
 	__vecho "-------------------------------------------------------" 1>&2
 	__helpers_die "${helper} used with \${D} or \${ED}"
+	exit 1
+fi
+if [[ -n ${EPREFIX} && \
+		${_E_INSDESTTREE_#${EPREFIX}} != "${_E_INSDESTTREE_}" ]]
+then
+	__vecho "-------------------------------------------------------" 1>&2
+	__vecho "You should not use \${EPREFIX} with helpers." 1>&2
+	__vecho "  --> ${_E_INSDESTTREE_}" 1>&2
+	__vecho "-------------------------------------------------------" 1>&2
+	__helpers_die "${helper} used with \${EPREFIX}"
 	exit 1
 fi
 


### PR DESCRIPTION
ED = D/EPREFIX, so checking for ED includes EPREFIX, which when this is
absent fails to check for D.  Simply check for D instead, which catches
both the case for D and ED.

Add check for usage of EPREFIX, like for using D with helpers.

Signed-off-by: Fabian Groffen <grobian@gentoo.org>