### PR TITLE
bin/install-qa-check.d/90world-writable: include EPREFIX in reports

### DIFF
--- a/bin/install-qa-check.d/90world-writable
+++ b/bin/install-qa-check.d/90world-writable
@@ -2,7 +2,7 @@
 
 world_writable_check() {
 	# Now we look for all world writable files.
-	local unsafe_files=$(find "${ED}" -type f -perm -2 | sed -e "s:^${ED}:/:")
+	local unsafe_files=$(find "${ED}" -type f -perm -2 | sed -e "s:^${D}:/:")
 	local OLDIFS x prev_shopts=$-
 
 	OLDIFS=$IFS
@@ -19,7 +19,7 @@ world_writable_check() {
 		eqawarn
 	fi
 
-	local unsafe_files=$(find "${ED}" -type f '(' -perm -2002 -o -perm -4002 ')' | sed -e "s:^${ED}:/:")
+	local unsafe_files=$(find "${ED}" -type f '(' -perm -2002 -o -perm -4002 ')' | sed -e "s:^${D}:/:")
 	if [[ -n ${unsafe_files} ]] ; then
 		eqawarn "QA Notice: Unsafe files detected (set*id and world writable)"
 


### PR DESCRIPTION
It is much less confusing and consistent to report full paths including
the leading EPREFIX.

Signed-off-by: Fabian Groffen <grobian@gentoo.org>