### PR TITLE
bin/save-ebuild-env.sh: deal with compgen possibly not being available

### DIFF
--- a/bin/save-ebuild-env.sh
+++ b/bin/save-ebuild-env.sh
@@ -82,9 +82,12 @@ __save_ebuild_env() {
 
 	___eapi_has_usex && unset -f usex
 
-	# Clear out the triple underscore namespace as it is reserved by the PM.
-	unset -f $(compgen -A function ___)
-	unset ${!___*}
+	# avoid errors, compgen is not compiled in bash during bootstrap
+	if type compgen &>/dev/null ; then
+		# Clear out the triple underscore namespace as it is reserved by the PM.
+		unset -f $(compgen -A function ___)
+		unset ${!___*}
+	fi
 
 	# portage config variables and variables set directly by portage
 	unset ACCEPT_LICENSE BUILD_PREFIX COLS \


### PR DESCRIPTION
During bootstrap, the bash being used is without readline support, which
means no compgen is available.

Signed-off-by: Fabian Groffen <grobian@gentoo.org>