### PR TITLE
portage.5: document restrict-allowed, properties-allowed

### DIFF
--- a/man/portage.5
+++ b/man/portage.5
@@ -1,4 +1,4 @@
-.TH "PORTAGE" "5" "Apr 2021" "Portage VERSION" "Portage"
+.TH "PORTAGE" "5" "July 2022" "Portage VERSION" "Portage"
 .SH NAME
 portage \- the heart of Gentoo
 .SH "DESCRIPTION"
@@ -1454,6 +1454,14 @@ listed toward the left of the list.
 .TP
 .BR repo\-name " = <value of profiles/repo_name>"
 The name of this repository (overrides profiles/repo_name if it exists).
+.TP
+.BR properties\-allowed
+List of PROPERTIES tokens which are allowed for ebuilds within
+the repo.  If unset, all tokens are allowed.
+.TP
+.BR restrict\-allowed
+List of RESTRICT tokens which are allowed for ebuilds within
+the repo.  If unset, all tokens are allowed.
 .TP
 .BR sign\-commits " = [true|" false "]"
 Boolean value whether we should sign commits in this repo.


### PR DESCRIPTION
Note that Portage doesn't really do anything with these
right now AFAICT but it may in future (not planned though) decide
to ignore non-acceptable tokens, etc.

Bug: https://bugs.gentoo.org/861659
Signed-off-by: Sam James <sam@gentoo.org>