### PR TITLE
estrip: fix double slash for < EAPI 7

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -412,7 +412,7 @@ done < <(
 	(
 		find "$@" -type f ! -type l -name '*.a'
 		cut -d ' ' -f1 < "${PORTAGE_BUILDDIR}"/build-info/NEEDED \
-			| sed -e "s:^:${D}:"
+			| sed -e "s:^:${D%/}:"
 	) | LC_ALL=C sort -u
 )
 else


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/862600
Fixes: bb88e766897f5e7e0b0a10c48cf99a04edb73a40
Signed-off-by: Sam James <sam@gentoo.org>