### PR TITLE
estrip: avoid spurious NEEDED warning when no ELF installed; apply optimisation to EAPI 7+ too

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -419,9 +419,10 @@ while read -r x ; do
 done < <(
 	# NEEDED may not exist for some packages (bug #862606)
 	if [[ -f "${PORTAGE_BUILDDIR}"/build-info/NEEDED ]] ; then
-		needed_contents=$(cat "${PORTAGE_BUILDDIR}"/build-info/NEEDED | cut -d ' ' -f1 | sed -e "s:^:${D%/}:")
-	else
-		needed_contents=""
+		while IFS= read -r needed_entry ; do
+			needed_entry="${needed_entry% *}"
+			needed_contents+=( "${D%/}${needed_entry}" )
+		done < "${PORTAGE_BUILDDIR}"/build-info/NEEDED
 	fi
 
 	# Use sort -u to eliminate duplicates (bug #445336).
@@ -429,8 +430,6 @@ done < <(
 		[[ -n ${needed_contents[@]} ]] && printf "%s\n" "${needed_contents[@]}"
 		find "$@" -type f ! -type l -name '*.a'
 	) | LC_ALL=C sort -u
-
-	unset needed_contents
 )
 else
 while IFS= read -d '' -r x ; do

--- a/bin/estrip
+++ b/bin/estrip
@@ -64,12 +64,51 @@ while [[ $# -gt 0 ]] ; do
 		done
 
 		if [[ ${find_paths[@]} ]]; then
+			# We can avoid scanelf calls for binaries we already
+			# checked in install_qa_check (where we generate
+			# NEEDED for everything installed).
+			#
+			# EAPI 7+ has controlled stripping (dostrip) though
+			# which is why estrip has the queue/dequeue logic,
+			# so we need to take the intersection of:
+			# 1. files scanned earlier (all ELF installed)
+			#    (note that this should be a superset of 2., so we don't
+			#    need to worry about unknown files appearing)
+			#
+			# 2. the files we're interested in right now
+			scanelf_results=()
+			if [[ -f "${PORTAGE_BUILDDIR}"/build-info/NEEDED ]] ; then
+				# The arguments may not be exact files (probably aren't), but search paths/directories
+				# which should then be searched recursively.
+				while IFS= read -r needed_entry ; do
+					for find_path in "${find_paths[@]}" ; do
+						# NEEDED has a bunch of entries like:
+						# /usr/lib64/libfoo.so libc.so
+						#
+						# find_path entries may be exact paths (like /usr/lib64/libfoo.so)
+						# or instead /usr/lib64, or ${ED}/usr, etc.
+						#
+						# We check if the beginning (i.e. first entry) of the NEEDED line
+						# matches the path given
+						# e.g. find_path="/usr/lib64" will match needed_entry="/usr/lib64/libfoo.so libc.so".
+						needed_entry_file="${needed_entry% *}"
+						if [[ "${needed_entry_file}" =~ ^${find_path##${D}} ]] ; then
+							scanelf_results+=( "${D}${needed_entry_file}" )
+						fi
+					done
+				done < "${PORTAGE_BUILDDIR}"/build-info/NEEDED
+			else
+				scanelf_results=$(scanelf -yqRBF '#k%F' -k '.symtab' "${find_paths[@]}")
+			fi
+
 			while IFS= read -r path; do
 				>> "${path}.estrip" || die
 			done < <(
-				scanelf -yqRBF '#k%F' -k '.symtab' "${find_paths[@]}"
+				printf "%s\n" "${scanelf_results[@]}"
 				find "${find_paths[@]}" -type f ! -type l -name '*.a'
 			)
+
+			unset scanelf_results needed_entry needed_entry_file find_path
 		fi
 
 		exit 0

--- a/bin/estrip
+++ b/bin/estrip
@@ -417,12 +417,20 @@ while read -r x ; do
 	inode_link=$(get_inode_number "${x}") || die "stat failed unexpectedly"
 	echo "${x}" >> "${inode_link}" || die "echo failed unexpectedly"
 done < <(
-	# Use sort -u to eliminate duplicates for bug #445336.
+	# NEEDED may not exist for some packages (bug #862606)
+	if [[ -f "${PORTAGE_BUILDDIR}"/build-info/NEEDED ]] ; then
+		needed_contents=$(cat "${PORTAGE_BUILDDIR}"/build-info/NEEDED | cut -d ' ' -f1 | sed -e "s:^:${D%/}:")
+	else
+		needed_contents=""
+	fi
+
+	# Use sort -u to eliminate duplicates (bug #445336).
 	(
+		[[ -n ${needed_contents[@]} ]] && printf "%s\n" "${needed_contents[@]}"
 		find "$@" -type f ! -type l -name '*.a'
-		cut -d ' ' -f1 < "${PORTAGE_BUILDDIR}"/build-info/NEEDED \
-			| sed -e "s:^:${D%/}:"
 	) | LC_ALL=C sort -u
+
+	unset needed_contents
 )
 else
 while IFS= read -d '' -r x ; do


### PR DESCRIPTION
```
commit 26c292b0794c72bf4a52499f6bf3366f61181780
Author: Sam James <sam@gentoo.org>
Date:   Mon Aug 1 01:56:51 2022 +0100

    estrip: apply scanelf optimisation to EAPI 7+ / dostrip

    See: bb88e766897f5e7e0b0a10c48cf99a04edb73a40
    Bug: https://bugs.gentoo.org/749624
    Bug: https://bugs.gentoo.org/862606
    Signed-off-by: Sam James <sam@gentoo.org>
```

```
commit 2980e0325e826f5cff7d12fb1fc9fea3c543f08b
Author: Sam James <sam@gentoo.org>
Date:   Mon Aug 1 01:05:47 2022 +0100

    estrip: avoid spurious NEEDED warning when no ELF installed

    If no ELF files are installed, then we're obviously
    not going to have a NEEDED file.

    The reason this didn't get hit sooner is because
    apparently very few of us are actually testing
    EAPI 6 actively - which figures.

    We only take this path for < EAPI 7 (non-dostrip)
    which means we're actually missing the estrip
    optimisation in bug #749624 for newer EAPIs!

    (Will be fixed in a followup).

    Bug: https://bugs.gentoo.org/749624
    Bug: https://bugs.gentoo.org/862606
    Fixes: bb88e766897f5e7e0b0a10c48cf99a04edb73a40
    Signed-off-by: Sam James <sam@gentoo.org>
```