### PR TITLE
install-qa-check.d: 60pkgconfig: only verify defined variables in EPR…

### DIFF
--- a/bin/install-qa-check.d/60pkgconfig
+++ b/bin/install-qa-check.d/60pkgconfig
@@ -38,6 +38,9 @@ pkgconfig_check() {
 		for f in "${files[@]}" ; do
 			local key
 			for key in prefix exec_prefix libdir includedir ; do
+				# Check if the variable is even in there (bug #860825)
+				grep -E -q "^${key}" "${f}" || continue
+
 				local value=$(pkg-config --variable="${key}" "${f}")
 
 				if [[ ${value} != "${EPREFIX}"* ]] ; then

--- a/bin/install-qa-check.d/60pkgconfig
+++ b/bin/install-qa-check.d/60pkgconfig
@@ -27,7 +27,7 @@ pkgconfig_check() {
 	# seems like f.d.o, OpenBSD, and of course pkgconf do though.
 	# Need --maximum-traverse-depth=1 to avoid checking deps and giving
 	# unrelated warnings/errors.
-	if ! pkg-config --maximum-traverse-depth=1 --validate "${files[@]}" ; then
+	if ! pkg-config --maximum-traverse-depth=1 --with-path="${ED}"/usr/{lib*,share}/pkgconfig --validate "${files[@]}" ; then
 		eqawarn "QA Notice: pkg-config files which fail validation found!"
 		eqawarn "Run 'pkg-config --validate ...' for more information"
 	fi


### PR DESCRIPTION
…EFIX check

e.g. 'exec_prefix' might not even appear in the pkg-config file.

Bug: https://bugs.gentoo.org/860825
Signed-off-by: Sam James <sam@gentoo.org>