### PR TITLE
bin: ebuild.sh: drop QA interceptors

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -480,9 +480,6 @@ __try_source() {
 export SANDBOX_ON="1"
 export S=${WORKDIR}/${P}
 
-# Turn off extended glob matching so that g++ doesn't get incorrectly matched.
-shopt -u extglob
-
 # Subshell/helper die support (must export for the die helper).
 export EBUILD_MASTER_PID=${BASHPID:-$(__bashpid)}
 trap 'exit 1' SIGTERM

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -82,6 +82,8 @@ else
 	# note: we can't use empty because it implies current directory
 	_PORTAGE_ORIG_PATH=${PATH}
 	export PATH=/dev/null
+	# invoked internally by bash on PATH search failure, see the bash man
+	# page section on command execution for details
 	command_not_found_handle() {
 		die "External commands disallowed while sourcing ebuild: ${*}"
 	}

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -481,56 +481,6 @@ export S=${WORKDIR}/${P}
 # Turn off extended glob matching so that g++ doesn't get incorrectly matched.
 shopt -u extglob
 
-if [[ ${EBUILD_PHASE} == depend ]] ; then
-	QA_INTERCEPTORS="awk bash cc egrep equery fgrep g++
-		gawk gcc grep javac java-config nawk perl
-		pkg-config python python-config sed"
-elif [[ ${EBUILD_PHASE} == clean* ]] ; then
-	unset QA_INTERCEPTORS
-else
-	QA_INTERCEPTORS="autoconf automake aclocal libtoolize"
-fi
-
-# Level the QA interceptors if we're in depend
-if [[ -n ${QA_INTERCEPTORS} ]] ; then
-	for BIN in ${QA_INTERCEPTORS}; do
-		BIN_PATH=$(type -Pf ${BIN})
-		if [[ "$?" != "0" ]]; then
-			BODY="echo \"*** missing command: ${BIN}\" >&2; return 127"
-		else
-			BODY="${BIN_PATH} \"\$@\"; return \$?"
-		fi
-		if [[ ${EBUILD_PHASE} == depend ]] ; then
-			FUNC_SRC="${BIN}() {
-				if [[ \${ECLASS_DEPTH} -gt 0 ]]; then
-					eqawarn \"QA Notice: '${BIN}' called in global scope: eclass \${ECLASS}\"
-				else
-					eqawarn \"QA Notice: '${BIN}' called in global scope: \${CATEGORY}/\${PF}\"
-				fi
-			${BODY}
-			}"
-		elif has ${BIN} autoconf automake aclocal libtoolize ; then
-			FUNC_SRC="${BIN}() {
-				if ! has \${FUNCNAME[1]} eautoreconf eaclocal _elibtoolize \\
-					eautoheader eautoconf eautomake autotools_run_tool \\
-					autotools_check_macro autotools_get_subdirs \\
-					autotools_get_auxdir ; then
-					eqawarn \"QA Notice: '${BIN}' called by \${FUNCNAME[1]}: \${CATEGORY}/\${PF}\"
-					eqawarn \"Use autotools.eclass instead of calling '${BIN}' directly.\"
-				fi
-			${BODY}
-			}"
-		else
-			FUNC_SRC="${BIN}() {
-				eqawarn \"QA Notice: '${BIN}' called by \${FUNCNAME[1]}: \${CATEGORY}/\${PF}\"
-			${BODY}
-			}"
-		fi
-		eval "${FUNC_SRC}" || echo "error creating QA interceptor ${BIN}" >&2
-	done
-	unset BIN_PATH BIN BODY FUNC_SRC
-fi
-
 # Subshell/helper die support (must export for the die helper).
 export EBUILD_MASTER_PID=${BASHPID:-$(__bashpid)}
 trap 'exit 1' SIGTERM

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -132,12 +132,6 @@ die() {
 	fi
 
 	set +e
-	if [[ -n "${QA_INTERCEPTORS}" ]]; then
-		# die was called from inside inherit. We need to clean up
-		# QA_INTERCEPTORS since sed is called below.
-		unset -f ${QA_INTERCEPTORS}
-		unset QA_INTERCEPTORS
-	fi
 	local n filespacing=0 linespacing=0
 	# setup spacing to make output easier to read
 	(( n = ${#FUNCNAME[@]} - 1 ))

--- a/bin/save-ebuild-env.sh
+++ b/bin/save-ebuild-env.sh
@@ -77,8 +77,7 @@ __save_ebuild_env() {
 		__unpack_tar __unset_colors \
 		__source_env_files __try_source __check_bash_version \
 		__bashpid __start_distcc \
-		__eqaquote __eqatag \
-		${QA_INTERCEPTORS}
+		__eqaquote __eqatag
 
 	___eapi_has_usex && unset -f usex
 
@@ -107,7 +106,6 @@ __save_ebuild_env() {
 		PORTAGE_SANDBOX_DENY PORTAGE_SANDBOX_PREDICT \
 		PORTAGE_SANDBOX_READ PORTAGE_SANDBOX_WRITE \
 		PORTAGE_SOCKS5_PROXY PREROOTPATH \
-		QA_INTERCEPTORS \
 		RC_DEFAULT_INDENT RC_DOT_PATTERN RC_ENDCOL RC_INDENTATION  \
 		ROOT ROOTPATH RPMDIR TEMP TMP TMPDIR USE_EXPAND \
 		XARGS _RC_GET_KV_CACHE


### PR DESCRIPTION
Long-obsolete since fb2459330cf226ee34d3875a1143531bd109aaf2
and 40da7ee19c4c195da35083bf2d2fcbd852ad3846.

Indeed, pkgcore dropped QA interceptors for the same
reason after its analogue of those commits.

Arfrever notably pointed out that for the binaries
listed, it'd actually be a downgrade in severity
from fatal -> warning, as it overrides the
command not found abort.

Signed-off-by: Sam James <sam@gentoo.org>