### PR TITLE
lib/portage: drop obsolete Python version checks (mainly 2.x)

### DIFF
--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import os
-import sys
 
 # ===========================================================================
 # START OF CONSTANTS -- START OF CONSTANTS -- START OF CONSTANTS -- START OF
@@ -262,10 +261,7 @@ LIVE_ECLASSES = frozenset(
 
 SUPPORTED_BINPKG_FORMATS = ("tar", "rpm")
 
-if sys.version_info.major < 3:
-    SUPPORTED_GENTOO_BINPKG_FORMATS = ("xpak",)
-else:
-    SUPPORTED_GENTOO_BINPKG_FORMATS = ("xpak", "gpkg")
+SUPPORTED_GENTOO_BINPKG_FORMATS = ("xpak", "gpkg")
 
 SUPPORTED_XPAK_EXTENSIONS = (".tbz2", ".xpak")
 SUPPORTED_GPKG_EXTENSIONS = (".gpkg.tar",)

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -770,8 +770,6 @@ class gpkg:
         base_name is the package basename.
         gpkg_file should be exists file path for read or will create.
         """
-        if sys.version_info.major < 3:
-            raise InvalidBinaryPackageFormat("GPKG not support Python 2")
         self.settings = settings
         self.gpkg_version = "gpkg-1"
         if gpkg_file is None:

--- a/lib/portage/tests/gpkg/test_gpkg_checksum.py
+++ b/lib/portage/tests/gpkg/test_gpkg_checksum.py
@@ -2,7 +2,6 @@
 # Portage Unit Testing Functionality
 
 import io
-import sys
 import tarfile
 import tempfile
 from os import urandom
@@ -21,9 +20,6 @@ from portage.exception import (
 
 class test_gpkg_checksum_case(TestCase):
     def test_gpkg_missing_header(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -66,9 +62,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_missing_manifest(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -109,9 +102,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_missing_files(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -156,9 +146,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_extra_files(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -203,9 +190,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_incorrect_checksum(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -253,9 +237,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_duplicate_files(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -298,9 +279,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_manifest_duplicate_files(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -351,9 +329,6 @@ class test_gpkg_checksum_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_different_size_file(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (

--- a/lib/portage/tests/gpkg/test_gpkg_gpg.py
+++ b/lib/portage/tests/gpkg/test_gpkg_gpg.py
@@ -2,7 +2,6 @@
 # Portage Unit Testing Functionality
 
 import io
-import sys
 import tarfile
 import tempfile
 from os import urandom
@@ -18,9 +17,6 @@ from portage.exception import MissingSignature, InvalidSignature
 
 class test_gpkg_gpg_case(TestCase):
     def test_gpkg_missing_manifest_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -76,9 +72,6 @@ class test_gpkg_gpg_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_missing_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -123,9 +116,6 @@ class test_gpkg_gpg_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_ignore_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -167,9 +157,6 @@ class test_gpkg_gpg_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_auto_use_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -214,9 +201,6 @@ class test_gpkg_gpg_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_invalid_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -286,9 +270,6 @@ qGAN3VUF+8EsdcsV781H0F86PANhyBgEYTGDrnItTGe3/vAPjCo=
             playground.cleanup()
 
     def test_gpkg_untrusted_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         gpg_test_path = os.environ["PORTAGE_GNUPGHOME"]
 
         playground = ResolverPlayground(
@@ -331,9 +312,6 @@ qGAN3VUF+8EsdcsV781H0F86PANhyBgEYTGDrnItTGe3/vAPjCo=
             playground.cleanup()
 
     def test_gpkg_unknown_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (

--- a/lib/portage/tests/gpkg/test_gpkg_metadata_update.py
+++ b/lib/portage/tests/gpkg/test_gpkg_metadata_update.py
@@ -2,7 +2,6 @@
 # Portage Unit Testing Functionality
 
 import tempfile
-import sys
 from os import urandom
 
 from portage import os
@@ -15,8 +14,6 @@ from portage.gpkg import gpkg
 
 class test_gpkg_metadata_case(TestCase):
     def test_gpkg_update_metadata(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="gzip"',),

--- a/lib/portage/tests/gpkg/test_gpkg_metadata_url.py
+++ b/lib/portage/tests/gpkg/test_gpkg_metadata_url.py
@@ -3,7 +3,6 @@
 
 import io
 import random
-import sys
 import tarfile
 import tempfile
 from functools import partial
@@ -44,12 +43,6 @@ class test_gpkg_metadata_url_case(TestCase):
         return server
 
     def test_gpkg_get_metadata_url(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
-        if sys.version_info.major == 3 and sys.version_info.minor <= 6:
-            self.skipTest("http server not support change root dir")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (
@@ -96,12 +89,6 @@ class test_gpkg_metadata_url_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_get_metadata_url_unknown_signature(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
-        if sys.version_info.major == 3 and sys.version_info.minor <= 6:
-            self.skipTest("http server not support change root dir")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": (

--- a/lib/portage/tests/gpkg/test_gpkg_path.py
+++ b/lib/portage/tests/gpkg/test_gpkg_path.py
@@ -5,7 +5,6 @@
 import tempfile
 import tarfile
 import io
-import sys
 from os import urandom
 
 from portage import os
@@ -18,9 +17,6 @@ from portage.gpkg import gpkg
 
 class test_gpkg_path_case(TestCase):
     def test_gpkg_short_path(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="none"',),
@@ -77,9 +73,6 @@ class test_gpkg_path_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_long_path(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="none"',),
@@ -141,9 +134,6 @@ class test_gpkg_path_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_non_ascii_path(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="none"',),
@@ -198,9 +188,6 @@ class test_gpkg_path_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_symlink_path(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="none"',),
@@ -258,9 +245,6 @@ class test_gpkg_path_case(TestCase):
             playground.cleanup()
 
     def test_gpkg_long_hardlink_path(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="none"',),
@@ -327,9 +311,6 @@ class test_gpkg_path_case(TestCase):
             shutil.rmtree(tmpdir)
 
     def test_gpkg_long_filename(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="none"',),

--- a/lib/portage/tests/gpkg/test_gpkg_size.py
+++ b/lib/portage/tests/gpkg/test_gpkg_size.py
@@ -3,7 +3,6 @@
 
 import tempfile
 import tarfile
-import sys
 
 from portage import os, shutil
 from portage.tests import TestCase
@@ -13,9 +12,6 @@ from portage.gpkg import gpkg
 
 class test_gpkg_large_size_case(TestCase):
     def test_gpkg_large_size(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         playground = ResolverPlayground(
             user_config={
                 "make.conf": ('BINPKG_COMPRESS="gzip"',),

--- a/lib/portage/tests/gpkg/test_gpkg_stream.py
+++ b/lib/portage/tests/gpkg/test_gpkg_stream.py
@@ -1,7 +1,6 @@
 # Copright Gentoo Foundation 2006-2020
 # Portage Unit Testing Functionality
 
-import sys
 import tempfile
 import io
 import tarfile
@@ -16,9 +15,6 @@ from portage.exception import CompressorOperationFailed
 
 class test_gpkg_stream_case(TestCase):
     def test_gpkg_stream_reader(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         data = urandom(1048576)
         data_io = io.BytesIO(data)
         data_io.seek(0)
@@ -28,9 +24,6 @@ class test_gpkg_stream_case(TestCase):
         self.assertEqual(data, data2)
 
     def test_gpkg_stream_reader_without_cmd(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         data = urandom(1048576)
         data_io = io.BytesIO(data)
         data_io.seek(0)
@@ -40,9 +33,6 @@ class test_gpkg_stream_case(TestCase):
         self.assertEqual(data, data2)
 
     def test_gpkg_stream_reader_kill(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         data = urandom(1048576)
         data_io = io.BytesIO(data)
         data_io.seek(0)
@@ -55,9 +45,6 @@ class test_gpkg_stream_case(TestCase):
         self.assertNotEqual(test_reader.proc.poll(), None)
 
     def test_gpkg_stream_reader_kill_without_cmd(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         data = urandom(1048576)
         data_io = io.BytesIO(data)
         data_io.seek(0)
@@ -67,9 +54,6 @@ class test_gpkg_stream_case(TestCase):
         self.assertEqual(test_reader.proc, None)
 
     def test_gpkg_stream_writer(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         tmpdir = tempfile.mkdtemp()
         try:
             gpkg_file_loc = os.path.join(tmpdir, "test.gpkg.tar")
@@ -89,9 +73,6 @@ class test_gpkg_stream_case(TestCase):
             shutil.rmtree(tmpdir)
 
     def test_gpkg_stream_writer_without_cmd(self):
-        if sys.version_info.major < 3:
-            self.skipTest("Not support Python 2")
-
         tmpdir = tempfile.mkdtemp()
 
         try:

--- a/lib/portage/util/futures/executor/fork.py
+++ b/lib/portage/util/futures/executor/fork.py
@@ -6,7 +6,6 @@ __all__ = ("ForkExecutor",)
 import collections
 import functools
 import os
-import sys
 import traceback
 
 from portage.util._async.AsyncFunction import AsyncFunction
@@ -140,9 +139,3 @@ class _RemoteTraceback(Exception):
 def _rebuild_exc(exc, tb):
     exc.__cause__ = _RemoteTraceback(tb)
     return exc
-
-
-if sys.version_info < (3,):
-    # Python 2 does not support exception chaining, so
-    # don't bother to preserve the traceback.
-    _ExceptionWithTraceback = lambda exc: exc


### PR DESCRIPTION
As for the single <= Python 3.6 check, we already require >= Python 3.7.

Signed-off-by: Sam James <sam@gentoo.org>