### PR TITLE
EbuildPhase: print SLOT along other build metadata

### DIFF
--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -135,7 +135,9 @@ class EbuildPhase(CompositeTask):
                     maint_str = "<invalid metadata.xml>"
 
             msg = []
-            msg.append("Package:    %s" % self.settings.mycpv)
+            msg.append(
+                "Package:    %s:%s" % (self.settings.mycpv, self.settings["SLOT"])
+            )
             if self.settings.get("PORTAGE_REPO_NAME"):
                 msg.append("Repository: %s" % self.settings["PORTAGE_REPO_NAME"])
             if maint_str:


### PR DESCRIPTION
Requested as a useful part in the output from tinderbox runs.

Closes: https://bugs.gentoo.org/864382
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>