### PR TITLE
install-qa-check.d/60pkgconfig: fix ver_test type check

### DIFF
--- a/bin/install-qa-check.d/60pkgconfig
+++ b/bin/install-qa-check.d/60pkgconfig
@@ -109,7 +109,7 @@ pkgconfig_check() {
 		local is_pms_ver=false
 		if [[ ${QA_PKGCONFIG_VERSION} =~ ${pms_ver_re} ]] ; then
 			# Ensure that ver_test is available.
-			[[ $(type -f ver_test) == function ]] || inherit eapi7-ver
+			[[ $(type -t ver_test) == function ]] || inherit eapi7-ver
 			is_pms_ver=true
 		fi
 


### PR DESCRIPTION
Somehow, this ended up using the wrong argument to bash's 'type'
builtin. :/ It must be '-t', which prints the type of the queried
name.

Fixes: f46b89282ff5 ("install-qa-check.d/60pkgconfig: use ver_test to compare versions")
Signed-off-by: Florian Schmaus <flow@gentoo.org>