### PR TITLE
change --digest warning msg about repoman to pkgdev

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -271,9 +271,9 @@ def action_build(
             msg = "The FEATURES=digest setting"
 
         msg += (
-            " can prevent corruption from being"
-            + " noticed. The `repoman manifest` command is the preferred"
-            + " way to generate manifests and it is capable of doing an"
+            " can prevent corruption from being noticed."
+            + " `pkgdev` is the preferred way to generate"
+            + " manifests and it is capable of doing an"
             + " entire repository or category at once."
         )
         prefix = bad(" * ")


### PR DESCRIPTION
This one was a user facing message.
There are also still references elsewhere, repoman is still mentioned in the codebase, usually comments.
Also the man page. (that maybe were missed during the bulk deletion during #819 )