### PR TITLE
dbapi: avoid iterating porttrees twice in _set_porttrees()

### DIFF
--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -367,14 +367,14 @@ class portdbapi(dbapi):
                 repo priority
         @type porttrees: list
         """
+        self._porttrees = tuple(porttrees)
         self._porttrees_repos = portage.OrderedDict(
             (repo.name, repo)
             for repo in (
                 self.repositories.get_repo_for_location(location)
-                for location in porttrees
+                for location in self._porttrees
             )
         )
-        self._porttrees = tuple(porttrees)
 
     def _get_porttrees(self):
         return self._porttrees


### PR DESCRIPTION
If porttrees is a generator object, the second pass will fail.

Bug: https://bugs.gentoo.org/865635
Fixes: 9e24d0143450628f334cdb62e579efafd1bfd2ba
Signed-off-by: Mike Gilbert <floppym@gentoo.org>