### PR TITLE
bin/ecompress: add lz4 command line options

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -75,6 +75,9 @@ Bug fixes:
 * emerge(1): mention --with-bdeps=n behavior for both --usepkg (-k) and
   --usepkgonly (-K) (bug #863422).
 
+* ecompress: add option to lz4 in order to be able to compress multiple
+  files at once (bug #672916).
+
 portage-3.0.34 (2022-07-20)
 --------------
 

--- a/bin/ecompress
+++ b/bin/ecompress
@@ -124,6 +124,12 @@ fi
 if [[ ${PORTAGE_COMPRESS_FLAGS+set} != "set" ]] ; then
 	case ${PORTAGE_COMPRESS} in
 		bzip2|gzip)  PORTAGE_COMPRESS_FLAGS="-9";;
+        # Without setting '-m' lz4 will not compress
+        # multiple files at once.
+        # See: https://bugs.gentoo.org/672916
+        # Setting '--rm' will remove the source files after
+        # a successful compression.
+        lz4)  PORTAGE_COMPRESS_FLAGS="-m --rm";;
 	esac
 fi
 


### PR DESCRIPTION
Calling lz4 with mutliple files results in
warnings of the form:

`Warning : <path>/<file> won't be used !
Do you want multiple input files (-m) ?`

Adding the `-m` option to the lz4 call
resolves this issue.
Additionally, the `--rm` option will remove
the source files after a successful compression.

Bug: https://bugs.gentoo.org/672916
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>