### PR TITLE
Improve "An update to portage" message

### DIFF
--- a/lib/portage/emaint/modules/sync/sync.py
+++ b/lib/portage/emaint/modules/sync/sync.py
@@ -334,17 +334,17 @@ class SyncRepos:
             msgs.append("")
             msgs.append(
                 warn(" * ")
-                + bold("An update to portage is available.")
-                + " It is _highly_ recommended"
+                + bold("An update to Portage is available.")
+                + " It is highly recommended"
             )
             msgs.append(
                 warn(" * ")
-                + "that you update portage now, before any other packages are updated."
+                + "that you update Portage now, before any other packages are updated."
             )
             msgs.append("")
             msgs.append(
                 warn(" * ")
-                + "To update portage, run 'emerge --oneshot sys-apps/portage' now."
+                + "To update Portage, run `emerge --oneshot sys-apps/portage` now."
             )
             msgs.append("")
         return msgs


### PR DESCRIPTION
I changed "\_highly\_" to "highly". I am not sure if that was a typo or intentional but it looks weird. Also, the name "Portage" should be capitalized in my opinion. And replace apostrophes with backticks to indicate that it is a command.