### PR TITLE
portage: sets: VariableSet: parse *DEPEND in includes/excludes

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -110,8 +110,8 @@ class = portage.sets.dbapi.UnavailableBinaries
 [changed-deps]
 class = portage.sets.dbapi.ChangedDepsSet
 
-# Installed packages that inherit from known go related eclasses.
+# Installed packages for which vdb *DEPEND includes dev-lang/go.
 [golang-rebuild]
 class = portage.sets.dbapi.VariableSet
-variable = INHERITED
-includes = golang-base golang-build golang-vcs golang-vcs-snapshot go-module
+variable = BDEPEND
+includes = dev-lang/go

--- a/lib/portage/_sets/dbapi.py
+++ b/lib/portage/_sets/dbapi.py
@@ -168,14 +168,32 @@ class VariableSet(EverythingSet):
             return False
         (values,) = self._metadatadb.aux_get(ebuild, [self._variable])
         values = values.split()
+
+        if "DEPEND" in self._variable:
+            include_atoms = []
+            for include in self._includes:
+                include_atoms.append(Atom(include))
+
+            for x in use_reduce(values, token_class=Atom):
+                if not isinstance(x, Atom):
+                    continue
+
+                for include_atom in include_atoms:
+                    print(f" Checking if {x=} intersects with {include_atom=}")
+                    if include_atom.match(x):
+                        return True
+
+            return False
+
         if self._includes and not self._includes.intersection(values):
             return False
+
         if self._excludes and self._excludes.intersection(values):
             return False
+
         return True
 
     def singleBuilder(cls, options, settings, trees):
-
         variable = options.get("variable")
         if variable is None:
             raise SetConfigError(_("missing required attribute: 'variable'"))


### PR DESCRIPTION
VariableSet takes a metadata variable and checks
its contents based on 'includes' or 'excludes'
from the set definition.

Unfortunately, until now, it didn't parse/expand the chosen variable
and would only match it literally (it'd also not check effective
metadata, just what's listed in the ebuild -- no *DEPEND
from an eclass, for example).

If variable is *DEPEND, actually parse includes/excludes
so we can effecitvely match say, includes="dev-lang/go"
against ">=dev-lang/go-1.18" in an ebuild.

Bug: https://bugs.gentoo.org/827974
Bug: https://bugs.gentoo.org/865115
Signed-off-by: Sam James <sam@gentoo.org>