### PR TITLE
Revert changes to portage.checksum._apply_hash_filter

### DIFF
--- a/lib/portage/checksum.py
+++ b/lib/portage/checksum.py
@@ -442,10 +442,10 @@ def _apply_hash_filter(digests, hash_filter):
     """
 
     verifiable_hash_types = set(digests).intersection(hashfunc_keys)
+    verifiable_hash_types.discard("size")
     modified = False
     if len(verifiable_hash_types) > 1:
-        verifiable_hash_types.discard("size")
-        for k in verifiable_hash_types:
+        for k in list(verifiable_hash_types):
             if not hash_filter(k):
                 modified = True
                 verifiable_hash_types.remove(k)
@@ -453,7 +453,11 @@ def _apply_hash_filter(digests, hash_filter):
                     break
 
     if modified:
-        digests = {k: v for k, v in digests.items() if k in verifiable_hash_types}
+        digests = {
+            k: v
+            for k, v in digests.items()
+            if k == "size" or k in verifiable_hash_types
+        }
 
     return digests
 

--- a/lib/portage/tests/util/test_checksum.py
+++ b/lib/portage/tests/util/test_checksum.py
@@ -1,9 +1,9 @@
-# Copyright 2011-2017 Gentoo Foundation
+# Copyright 2011-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
 
-from portage.checksum import checksum_str
+from portage.checksum import checksum_str, _apply_hash_filter
 from portage.exception import DigestException
 
 
@@ -146,3 +146,26 @@ class ChecksumTestCase(TestCase):
             )
         except DigestException:
             self.skipTest("STREEBOG512 implementation not available")
+
+
+class ApplyHashFilterTestCase(TestCase):
+    def test_apply_hash_filter(self):
+        indict = {"MD5": "", "SHA1": "", "SHA256": "", "size": ""}
+
+        self.assertEqual(
+            sorted(_apply_hash_filter(indict, lambda x: True)),
+            ["MD5", "SHA1", "SHA256", "size"],
+        )
+        self.assertEqual(
+            sorted(_apply_hash_filter(indict, lambda x: x == "MD5")), ["MD5", "size"]
+        )
+        self.assertEqual(
+            sorted(_apply_hash_filter(indict, lambda x: x != "MD5")),
+            ["SHA1", "SHA256", "size"],
+        )
+        self.assertEqual(
+            sorted(_apply_hash_filter(indict, lambda x: x == "SHA256")),
+            ["SHA256", "size"],
+        )
+        # this should return size + one of the hashes
+        self.assertEqual(len(list(_apply_hash_filter(indict, lambda x: False))), 2)


### PR DESCRIPTION
The modified code may discard the file size from the output, which is never desired.

Also, it calls remove on the object being iterated over, which is problematic.

Reverts: 18e5a8170c69aecd10f162918de571d85055ae81
Reported-by: Marek Behún