### PR TITLE
getbinpkg: fix command list with --getbinpkgonly

### DIFF
--- a/lib/portage/getbinpkg.py
+++ b/lib/portage/getbinpkg.py
@@ -529,7 +529,7 @@ def file_get(
     from portage.util import varexpand
     from portage.process import spawn
 
-    myfetch = (varexpand(x, mydict=variables) for x in portage.util.shlex_split(fcmd))
+    myfetch = [varexpand(x, mydict=variables) for x in portage.util.shlex_split(fcmd)]
     fd_pipes = {
         0: portage._get_stdin().fileno(),
         1: sys.__stdout__.fileno(),


### PR DESCRIPTION
Observable with say, PORTAGE_BINHOST="rsync://../" set.

Bug: https://bugs.gentoo.org/866197
Fixes: 13740f43bcc38e787153d9efeabc4f5d878e7af0
Thanks-to: Sheng Yu <syu.os@protonmail.com>
Signed-off-by: Sam James <sam@gentoo.org>