### PR TITLE
Use pkg_allocated_path in Scheduler

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -975,7 +975,11 @@ class Scheduler(PollScheduler):
                         continue
 
                     if fetched:
-                        bintree.inject(x.cpv, current_pkg_path=fetched)
+                        bintree.inject(
+                            x.cpv,
+                            current_pkg_path=fetched,
+                            allocated_pkg_path=fetcher.pkg_allocated_path,
+                        )
 
                     infloc = os.path.join(build_dir_path, "build-info")
                     ensure_dirs(infloc)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/872392

Signed-off-by: Sheng Yu <syu.os@protonmail.com>