### PR TITLE
Add per format compression flags for binpkg

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -153,6 +153,18 @@ def quickpkg_atom(options, infos, arg, eout):
                         "compress": "cat",
                         "package": "sys-apps/coreutils",
                     }
+
+                if (
+                    settings.get(
+                        f"BINPKG_COMPRESS_FLAGS_{binpkg_compression.upper()}", None
+                    )
+                    is not None
+                ):
+                    compression["compress"] = compression["compress"].replace(
+                        "${BINPKG_COMPRESS_FLAGS}",
+                        f"${{BINPKG_COMPRESS_FLAGS_{binpkg_compression.upper()}}}",
+                    )
+
                 try:
                     compression_binary = shlex_split(
                         varexpand(compression["compress"], mydict=settings)

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -1788,8 +1788,16 @@ class gpkg:
         if mode not in compressor:
             raise InvalidCompressionMethod("{}: {}".format(compression, mode))
 
-        cmd = compressor[mode]
-        cmd = cmd.replace(
+        if mode == "compress" and (
+            self.settings.get(f"BINPKG_COMPRESS_FLAGS_{compression.upper()}", None)
+            is not None
+        ):
+            compressor["compress"] = compressor["compress"].replace(
+                "${BINPKG_COMPRESS_FLAGS}",
+                f"${{BINPKG_COMPRESS_FLAGS_{compression.upper()}}}",
+            )
+
+        cmd = compressor[mode].replace(
             "{JOBS}", str(makeopts_to_job_count(self.settings.get("MAKEOPTS", "1")))
         )
         cmd = shlex_split(varexpand(cmd, mydict=self.settings))

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1573,6 +1573,17 @@ class config:
                     noiselevel=-1,
                 )
             else:
+                if (
+                    self.get(
+                        f"BINPKG_COMPRESS_FLAGS_{binpkg_compression.upper()}", None
+                    )
+                    is not None
+                ):
+                    compression["compress"] = compression["compress"].replace(
+                        "${BINPKG_COMPRESS_FLAGS}",
+                        f"${{BINPKG_COMPRESS_FLAGS_{binpkg_compression.upper()}}}",
+                    )
+
                 try:
                     compression_binary = shlex_split(
                         portage.util.varexpand(compression["compress"], mydict=self)

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -255,7 +255,7 @@ def _spawn_phase(
             actionmap=actionmap,
             returnpid=returnpid,
             logfile=logfile,
-            **kwargs
+            **kwargs,
         )
 
     # The logfile argument is unused here, since EbuildPhase uses
@@ -266,7 +266,7 @@ def _spawn_phase(
         phase=phase,
         scheduler=SchedulerInterface(asyncio._safe_loop()),
         settings=settings,
-        **kwargs
+        **kwargs,
     )
 
     ebuild_phase.start()
@@ -666,6 +666,17 @@ def doebuild_environment(
                 # Empty BINPKG_COMPRESS disables compression.
                 mysettings["PORTAGE_COMPRESSION_COMMAND"] = "cat"
         else:
+            if (
+                settings.get(
+                    f"BINPKG_COMPRESS_FLAGS_{binpkg_compression.upper()}", None
+                )
+                is not None
+            ):
+                compression["compress"] = compression["compress"].replace(
+                    "${BINPKG_COMPRESS_FLAGS}",
+                    f"${{BINPKG_COMPRESS_FLAGS_{binpkg_compression.upper()}}}",
+                )
+
             try:
                 compression_binary = compression["compress"].replace(
                     "{JOBS}",
@@ -1908,7 +1919,7 @@ def spawn(
     ipc=True,
     mountns=False,
     pidns=False,
-    **keywords
+    **keywords,
 ):
     """
     Spawn a subprocess with extra portage-specific options.
@@ -2116,7 +2127,7 @@ def spawn(
             scheduler=SchedulerInterface(asyncio._safe_loop()),
             spawn_func=spawn_func,
             settings=mysettings,
-            **keywords
+            **keywords,
         )
 
         proc.start()

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -141,6 +141,18 @@ Defaults to "".
 BINPKG_COMPRESS_FLAGS="-9"
 .fi
 .TP
+\fBBINPKG_COMPRESS_FLAGS_[format]\fR = \fI"arguments for [format] compression \
+command"\fR
+This variable is used to add additional arguments only for the specified \
+[format] compression command selected by \fBBINPKG_COMPRESS\fR.
+\fBBINPKG_COMPRESS_FLAGS\fR will be ignored when using [format] compression.
+.br
+.I Example:
+.nf
+# Set only zstd to use compression level 9:
+BINPKG_COMPRESS_FLAGS_ZSTD="-9"
+.fi
+.TP
 \fBBINPKG_GPG_SIGNING_BASE_COMMAND\fR = \fI"GPG command and arguments \
 [PORTAGE_CONFIG]"\fR
 The base command will be used for all signing operations.


### PR DESCRIPTION
This added new config BINPKG_COMPRESS_FLAGS_[format] to be used
for different compression method. General BINPKG_COMPRESS_FLAGS
will be ignored if current method had specified BINPKG_COMPRESS_FLAGS_[format]

e.g. BINPKG_COMPRESS_FLAGS_ZSTD="-9"

Closes: https://bugs.gentoo.org/871573

Signed-off-by: Sheng Yu <syu.os@protonmail.com>