### PR TITLE
Add more error handles

### DIFF
--- a/bin/gpkg-helper.py
+++ b/bin/gpkg-helper.py
@@ -8,9 +8,11 @@ import portage
 
 portage._internal_caller = True
 from portage import os
+from portage.output import EOutput
 
 
 def command_compose(args):
+    eout = EOutput()
 
     usage = "usage: compose <package_cpv> <binpkg_path> <metadata_dir> <image_dir>\n"
 
@@ -31,9 +33,13 @@ def command_compose(args):
         sys.stderr.write("Argument 4 is not a directory: '%s'\n" % image_dir)
         return 1
 
-    gpkg_file = portage.gpkg.gpkg(portage.settings, basename, binpkg_path)
-    metadata = gpkg_file._generate_metadata_from_dir(metadata_dir)
-    gpkg_file.compress(image_dir, metadata)
+    try:
+        gpkg_file = portage.gpkg.gpkg(portage.settings, basename, binpkg_path)
+        metadata = gpkg_file._generate_metadata_from_dir(metadata_dir)
+        gpkg_file.compress(image_dir, metadata)
+    except portage.exception.CompressorOperationFailed:
+        eout.eerror("Compressor Operation Failed")
+        exit(1)
     return os.EX_OK
 
 

--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -27,6 +27,7 @@ from portage.dbapi.dep_expand import dep_expand
 from portage.dep import Atom, use_reduce
 from portage.exception import (
     AmbiguousPackageName,
+    CompressorOperationFailed,
     InvalidAtom,
     InvalidData,
     InvalidBinaryPackageFormat,
@@ -203,24 +204,29 @@ def quickpkg_atom(options, infos, arg, eout):
                 )
             else:
                 raise InvalidBinaryPackageFormat(binpkg_format)
+        except CompressorOperationFailed as e:
+            eout.eerror(f"Compressor operation failed")
+            os.remove(binpkg_tmpfile)
+            binpkg_tmpfile = None
         finally:
             if have_lock:
                 dblnk.unlockdb()
-        pkg_info = bintree.inject(cpv, current_pkg_path=binpkg_tmpfile)
-        # The pkg_info value ensures that the following getname call
-        # returns the correct path when FEATURES=binpkg-multi-instance
-        # is enabled, but fallback to cpv in case the inject call
-        # returned None due to some kind of failure.
-        binpkg_path = bintree.getname(pkg_info or cpv)
-        try:
-            s = os.stat(binpkg_path)
-        except OSError:
-            s = None
+        if binpkg_tmpfile is not None:
+            pkg_info = bintree.inject(cpv, current_pkg_path=binpkg_tmpfile)
+            # The pkg_info value ensures that the following getname call
+            # returns the correct path when FEATURES=binpkg-multi-instance
+            # is enabled, but fallback to cpv in case the inject call
+            # returned None due to some kind of failure.
+            binpkg_path = bintree.getname(pkg_info or cpv)
+            try:
+                s = os.stat(binpkg_path)
+            except OSError:
+                s = None
 
-        if s is None or pkg_info is None:
+        if binpkg_tmpfile is None or s is None or pkg_info is None:
             # Sanity check, shouldn't happen normally.
             eout.eend(1)
-            eout.eerror("Failed to create package: '%s'" % binpkg_path)
+            eout.eerror(f"Failed to create package: '{cpv}'")
             retval |= 1
         else:
             eout.eend(0)


### PR DESCRIPTION
And catch process Exception spawned by portage itself. e.g. bad decompress command.

Closes: https://bugs.gentoo.org/871570

Signed-off-by: Sheng Yu <syu.os@protonmail.com>