### PR TITLE
data.py: fix PORTAGE_USERNAME default (bug 873088)

### DIFF
--- a/lib/portage/data.py
+++ b/lib/portage/data.py
@@ -259,7 +259,7 @@ def _get_global(k):
         if env_key in os.environ:
             v = os.environ[env_key]
         elif hasattr(portage, "settings"):
-            v = portage.settings.get(env_key)
+            v = portage.settings.get(env_key, v)
         else:
             # The config class has equivalent code, but we also need to
             # do it here if _disable_legacy_globals() has been called.


### PR DESCRIPTION
Fix the PORTAGE_USERNAME default for the case where the portage.settings attribute exists and PORTAGE_USERNAME is unset.

Fixes: 18e5a8170c69aecd10f162918de571d85055ae81
Bug: https://bugs.gentoo.org/873088
Signed-off-by: Zac Medico <zmedico@gentoo.org>