### PR TITLE
cnf: sets: add @rust-rebuild set

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -115,3 +115,9 @@ class = portage.sets.dbapi.ChangedDepsSet
 class = portage.sets.dbapi.VariableSet
 variable = BDEPEND
 includes = dev-lang/go
+
+# Installed packages for which vdb *DEPEND includes virtual/rust
+[rust-rebuild]
+class = portage.sets.dbapi.VariableSet
+variable = BDEPEND
+includes = virtual/rust


### PR DESCRIPTION
Rust is statically linked like Go and this is useful for us to mention in GLSAs (and possibly dev-lang/rust{,-bin}'s pkg_postinst).

Bug: https://bugs.gentoo.org/827974
Bug: https://bugs.gentoo.org/865115
Signed-off-by: Sam James <sam@gentoo.org>