### PR TITLE
_global_updates.py: fix syntax error

### DIFF
--- a/lib/portage/_global_updates.py
+++ b/lib/portage/_global_updates.py
@@ -105,7 +105,7 @@ def _do_global_updates(trees, prev_mtimes, quiet=False, if_mtime_changed=True):
                                     f"{bold('#')}='/var/db update'",
                                     f"{bold('@')}='/var/db move'\n",
                                     f"{bold('s')}='/var/db SLOT move'",
-                                    f"{bold('%')}='binary move'"
+                                    f"{bold('%')}='binary move'",
                                     f"{bold('S')}='binary SLOT move'\n",
                                     f"{bold('p')}='update /etc/portage/package.*'\n",
                                 )


### PR DESCRIPTION
Due to missed comma operator, indentation between
%='binary move' and S='binary SLOT move' is gone.

Signed-off-by: Vitaliy Perekhovy <feriman@gmail.com>