### PR TITLE
runTests.py: fix shebang

### DIFF
--- a/lib/portage/tests/runTests.py
+++ b/lib/portage/tests/runTests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -Wd
+#!/usr/bin/env python
 # runTests.py -- Portage Unit Test Functionality
 # Copyright 2006-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2


### PR DESCRIPTION
Fixes: 41f4f6d25 ("Use '/usr/bin/env python' shebangs")
Signed-off-by: John Helmert III <ajak@gentoo.org>