### PR TITLE
install-qa-check.d/90gcc-warnings: add more LTO warnings (-Wodr, -Wlt…

### DIFF
--- a/bin/install-qa-check.d/90gcc-warnings
+++ b/bin/install-qa-check.d/90gcc-warnings
@@ -1,5 +1,6 @@
 # Check for important gcc warnings
 # TODO: adapt for clang?
+# TODO: add -Wformat-security
 
 gcc_warn_check() {
 	local f

--- a/bin/install-qa-check.d/90gcc-warnings
+++ b/bin/install-qa-check.d/90gcc-warnings
@@ -1,4 +1,5 @@
-# Check for important gcc warning
+# Check for important gcc warnings
+# TODO: adapt for clang?
 
 gcc_warn_check() {
 	local f

--- a/bin/install-qa-check.d/90gcc-warnings
+++ b/bin/install-qa-check.d/90gcc-warnings
@@ -63,6 +63,10 @@ gcc_warn_check() {
 			# clobbered: Warn for variables that might be changed by longjmp or vfork
 			# (This warning is also enabled by -Wextra.)
 			'warning: .*\[-Wclobbered\]'
+			# LTO type mismatch (https://wiki.gentoo.org/wiki/Project:Toolchain/LTO)
+			'warning: .*\[-Wlto-type-mismatch\]'
+			# ODR (https://wiki.gentoo.org/wiki/Project:Toolchain/LTO)
+			'warning: .*\[-Wodr\]'
 
 			# this may be valid code :/
 			#': warning: multi-character character constant'


### PR DESCRIPTION
…o-type-mismatch)

Bug: https://bugs.gentoo.org/618550
Signed-off-by: Sam James <sam@gentoo.org>