### PR TITLE
sync: git: Fix sync printing local repo path

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,8 @@ Bug fixes:
 * emerge(1), make.conf(5), xpak(5): document BINPKG_FORMAT and the gpkg binary
   packate format further.
 
+* sync: git: Fix sync printing local repo path (bug #875812)
+
 portage-3.0.38.1 (2022-10-04)
 --------------
 

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -362,7 +362,8 @@ class GitSync(NewBase):
                 "--get",
                 "safe.directory",
                 f"^{location_escaped}$",
-            ]
+            ],
+            stdout=subprocess.DEVNULL,
         )
         if result.returncode == 1:
             result = subprocess.run(
@@ -373,6 +374,7 @@ class GitSync(NewBase):
                     "--add",
                     "safe.directory",
                     self.repo.location,
-                ]
+                ],
+                stdout=subprocess.DEVNULL,
             )
         return result.returncode == 0


### PR DESCRIPTION
I was able to reproduce this [bug](https://bugs.gentoo.org/875812).

Using `python -m trace -t ./bin/emerge --sync --quiet` I identified `add_safe_directory(self)` to be the issue.
The subprocess `git config --get safe.directory <repo_location>` prints the path to the local repo.
Directing the subprocess output to `DEVNULL` fixes the issue.

The output gets redirected regardless of whether `--quiet` is set or not, because it seems to me that the
output is rather unnecessary in the emerge output.  