### PR TITLE
Add test case for VariableSets

### DIFF
--- a/lib/portage/tests/sets/base/testVariableSet.py
+++ b/lib/portage/tests/sets/base/testVariableSet.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Gentoo Foundation
+# Distributed under the terms of the GNU General public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class VariableSetTestCase(TestCase):
+    def testVariableSetEmerge(self):
+        ebuilds = {
+            "dev-go/go-pkg-1": {"BDEPEND": "dev-lang/go"},
+        }
+        installed = ebuilds
+        playground = ResolverPlayground(ebuilds=ebuilds, installed=installed)
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["@golang-rebuild"],
+                mergelist=["dev-go/go-pkg-1"],
+                success=True,
+            ),
+        )
+
+        try:
+            for test_case in test_cases:
+                # Create an artificial VariableSet to test against
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
This follows up on 38c479d46dc91be66877d857a3682534eb1b5f12 to add a test for VariableSets using the new @golang-rebuild set.

Signed-off-by: John Helmert III <ajak@gentoo.org>