### PR TITLE
install-qa-check.d/10large-file-support: issue warnings for 32bit ELF…

### DIFF
--- a/bin/install-qa-check.d/10large-file-support
+++ b/bin/install-qa-check.d/10large-file-support
@@ -5,8 +5,8 @@
 # https://bugs.gentoo.org/471102
 
 # Lists gleaned from headers and this doc:
-# http://people.redhat.com/berrange/notes/largefile.html
-# http://opengroup.org/platform/lfs.html
+# https://people.redhat.com/berrange/notes/largefile.html
+# https://www.opengroup.org/platform/lfs.html
 SYMBOLS=(
 	# aio.h
 	aio_cancel
@@ -103,19 +103,24 @@ SYMBOLS=(
 	truncate
 	__pread_chk
 )
+
 SYMBOLS_REGEX=$(printf '%s|' "${SYMBOLS[@]}")
 # The @@ part is to workaround a limitation in pax-utils w/versioned symbols.
 SYMBOLS_REGEX="^(${SYMBOLS_REGEX%|})(@@.*)?$"
 
 check_lfs() {
-	local files=$(scanelf -F '%s %p' -qyRgs "-${SYMBOLS_REGEX}" "$@")
+	local dir="$@"
+	if [[ ! -d "${dir}" && -n "${ED}" ]] ; then
+		dir="${ED}"
+	fi
+
+	local files=$(scanelf -F '%p:%s' -qyRgs "-${SYMBOLS_REGEX}" "${dir}")
 
 	if [[ -n ${files} ]]; then
-		echo
 		eqawarn "QA Notice: The following files were not built with LFS support:"
-		eqawarn "  Please see https://bugs.gentoo.org/471102 for details."
-		eqawarn "${files}"
-		echo
+		eqawarn " Please see https://bugs.gentoo.org/471102 for details."
+		eqawarn "Affected files:"
+		eqatag -v lfs.missing ${files[@]}
 	fi
 }
 
@@ -127,32 +132,43 @@ filtered_check_lfs() {
 	# Only check glibc & uClibc libraries.  Others are presumed to use LFS by
 	# default (e.g. musl), or it's not relevant (e.g. newlib).
 	case ${CHOST} in
-	*-gnu*|*-uclibc*) ;;
-	*) return ;;
+		*-gnu*|*-uclibc*)
+			;;
+		*)
+			return
+			;;
 	esac
 
 	# Only check on 32-bit systems.  Filtering by $ARCH here isn't perfect, but
 	# it should be good enough for our needs.
 	case ${ARCH} in
-	arm|mips|ppc|sh|x86) ;;
-	*) return ;;
+		arm|mips|ppc|sh|x86)
+			;;
+		*)
+			return
+			;;
 	esac
 
 	# Obviously filter out C libraries themselves :).
 	# The sandbox has to capture all symbols by design.
 	case ${CATEGORY}/${PN} in
-	*/glibc|\
-	*/uclibc|\
-	*/gcc|\
-	sys-apps/sandbox) ;;
-	*) check_lfs "${ED}" ;;
+		*/glibc|*/uclibc|*/gcc|sys-apps/sandbox)
+			;;
+		*)
+			check_lfs "${ED}"
+			;;
 	esac
 }
 
 # Allow for people to run manually for testing/debugging.
 if [[ $# -ne 0 ]]; then
 	eqawarn() { echo " * $*"; }
+	eqatag() { eqawarn "$@";  }
 	check_lfs "$@"
 else
 	filtered_check_lfs
 fi
+
+: # guarantee successful exit
+
+# vim:ft=sh

--- a/bin/install-qa-check.d/10large-file-support
+++ b/bin/install-qa-check.d/10large-file-support
@@ -142,7 +142,20 @@ filtered_check_lfs() {
 	# Only check on 32-bit systems.  Filtering by $ARCH here isn't perfect, but
 	# it should be good enough for our needs.
 	case ${ARCH} in
-		arm|mips|ppc|sh|x86)
+		arm|mips|hppa|m68k|ppc|sh|x86)
+			;;
+		s390)
+			# s390x is 64-bit, but s390 is 32-bit.
+			# We use the same keyword for both.
+			if [[ ${CHOST} == s390x-* ]] ; then
+				return
+			fi
+			;;
+		sparc)
+			# sparc and sparc64 share the same keyword.
+			if [[ ${CHOST} == sparc64* ]] ; then
+				return
+			fi
 			;;
 		*)
 			return

--- a/bin/install-qa-check.d/10large-file-support
+++ b/bin/install-qa-check.d/10large-file-support
@@ -1,0 +1,158 @@
+# Detect 32-bit builds that are using legacy 32-bit file interfaces.
+# https://en.wikipedia.org/wiki/Large_file_support
+#
+# We want to make sure everyone is using the 64-bit interfaces.
+# https://bugs.gentoo.org/471102
+
+# Lists gleaned from headers and this doc:
+# http://people.redhat.com/berrange/notes/largefile.html
+# http://opengroup.org/platform/lfs.html
+SYMBOLS=(
+	# aio.h
+	aio_cancel
+	aio_error
+	aio_fsync
+	aio_read
+	aio_return
+	aio_suspend
+	aio_write
+	lio_listio
+
+	# dirent.h
+	alphasort
+	getdirentries
+	readdir
+	readdir_r
+	scandir
+	scandirat
+	versionsort
+
+	# fcntl.h
+	creat
+	fallocate
+	fopen
+	fopenat
+	freopen
+	open
+	openat
+	posix_fadvise
+	posix_fallocate
+	__open
+	__open_2
+	__openat_2
+
+	# ftw.h
+	ftw
+	nftw
+
+	# glob.h
+	glob
+	globfree
+
+	# stdio.h
+	fgetpos
+	fopen
+	freopen
+	fseeko
+	fsetpos
+	ftello
+	tmpfile
+
+	# stdlib.h
+	mkostemp
+	mkostemps
+	mkstemp
+	mkstemps
+
+	# sys/mman.h
+	mmap
+
+	# sys/resource.h
+	getrlimit
+	prlimit
+	setrlimit
+
+	# sys/sendfile.h
+	sendfile
+
+	# sys/stat.h
+	fstat
+	fstatat
+	lstat
+	stat
+	__fxstat
+	__fxstatat
+	__lxstat
+	__xstat
+
+	# sys/statfs.h
+	fstatfs
+
+	# sys/statvfs.h
+	statvfs
+	fstatvfs
+
+	# unistd.h
+	lockf
+	lseek
+	ftruncate
+	pread
+	preadv
+	pwrite
+	pwritev
+	truncate
+	__pread_chk
+)
+SYMBOLS_REGEX=$(printf '%s|' "${SYMBOLS[@]}")
+# The @@ part is to workaround a limitation in pax-utils w/versioned symbols.
+SYMBOLS_REGEX="^(${SYMBOLS_REGEX%|})(@@.*)?$"
+
+check_lfs() {
+	local files=$(scanelf -F '%s %p' -qyRgs "-${SYMBOLS_REGEX}" "$@")
+
+	if [[ -n ${files} ]]; then
+		echo
+		eqawarn "QA Notice: The following files were not built with LFS support:"
+		eqawarn "  Please see https://bugs.gentoo.org/471102 for details."
+		eqawarn "${files}"
+		echo
+	fi
+}
+
+filtered_check_lfs() {
+	if ! type -P scanelf >/dev/null || has binchecks ${RESTRICT}; then
+		return
+	fi
+
+	# Only check glibc & uClibc libraries.  Others are presumed to use LFS by
+	# default (e.g. musl), or it's not relevant (e.g. newlib).
+	case ${CHOST} in
+	*-gnu*|*-uclibc*) ;;
+	*) return ;;
+	esac
+
+	# Only check on 32-bit systems.  Filtering by $ARCH here isn't perfect, but
+	# it should be good enough for our needs.
+	case ${ARCH} in
+	arm|mips|ppc|sh|x86) ;;
+	*) return ;;
+	esac
+
+	# Obviously filter out C libraries themselves :).
+	# The sandbox has to capture all symbols by design.
+	case ${CATEGORY}/${PN} in
+	*/glibc|\
+	*/uclibc|\
+	*/gcc|\
+	sys-apps/sandbox) ;;
+	*) check_lfs "${ED}" ;;
+	esac
+}
+
+# Allow for people to run manually for testing/debugging.
+if [[ $# -ne 0 ]]; then
+	eqawarn() { echo " * $*"; }
+	check_lfs "$@"
+else
+	filtered_check_lfs
+fi

--- a/bin/install-qa-check.d/10large-file-support
+++ b/bin/install-qa-check.d/10large-file-support
@@ -87,10 +87,17 @@ SYMBOLS=(
 
 	# sys/statfs.h
 	fstatfs
+	statfs
 
 	# sys/statvfs.h
 	statvfs
 	fstatvfs
+
+	# sys/uio.h
+	preadv
+	preadv2
+	pwritev
+	pwritev2
 
 	# unistd.h
 	lockf

--- a/bin/install-qa-check.d/95time64_t
+++ b/bin/install-qa-check.d/95time64_t
@@ -1,0 +1,245 @@
+# Detect 32-bit builds that are using legacy 32-bit time interfaces.
+# This is closely related to "Large File Support" (LFS) but not
+# quite the same.
+#
+# We want to make sure everyone is using the 64-bit interfaces.
+# https://bugs.gentoo.org/471102
+#
+# Lists gleaned from headers, roughly:
+# `grep -rsin "#.*define" /usr/include/ | grep time | grep 64 | grep -v asm | grep -v syscalls | sort -u`
+
+# TODO: check for icky legacy interfaces in pre-built binaries?
+# obviously we can't fix them, but we can warn stuff will break.
+
+# There are various surprising symbols in this list, like recvmsg.
+# * Often, it's either quite hidden through indirection:
+#   e.g. https://github.com/bminor/glibc/commit/4b93a93e407308000ee6a1c3fec3715127c2c4c5
+# * Or it's because there's a relationship with LFS (note that glibc
+#   requires LFS to be enabled for time64), like a symbol had to be fixed
+#   up for LFS, and then it had to be again.
+
+SYMBOLS=(
+	# aio.h
+	aio_suspend
+
+	# bits/time.h
+	clock_adjtime
+
+	# fcntl.h
+	fcntl
+	fcntl64
+
+	# fts.h
+	fts_children
+	fts_close
+	fts_open
+	fts_read
+	fts_set
+
+	# ftw.h
+	ftw
+	nftw64
+	nftw
+	nftw64
+
+	# mqueue.h
+	mq_timedreceive
+	mq_timedsend
+
+	# netdb.h
+	gai_suspend
+
+	# pthread.h
+	pthread_cond_clockwait
+	pthread_clockjoin_np
+	pthread_timedjoin_np
+	pthread_mutex_clocklock
+	pthread_mutex_timedlock
+	pthread_rwlock_clockrdlock
+	pthread_rwlock_clockwrlock
+	pthread_rwlock_timedrdlock
+	pthread_rwlock_timedwrlock
+	pthread_cond_timedwait
+
+	# semaphore.h
+	sem_clockwait
+	sem_timedwait
+
+	# signal.h
+	sigtimedwait
+
+	# utime.h
+	utime
+
+	# sys/epoll.h
+	epoll_pwait2
+
+	# sys/ioctl.h
+	ioctl
+
+	# sys/msg.h
+	msgctl
+
+	# sys/poll.h
+	ppoll
+
+	# sys/sem.h
+	semtimedop
+
+	# sys/shm.h
+	shmctl
+
+	# sys/socket.h
+	recvmmsg
+	sendmmsg
+	getsockopt
+	recvmsg
+	sendmsg
+	setsockopt
+
+	# sys/stat.h
+	stat
+	fstat
+	stat64
+	fstat64
+	fstatat
+	fstatat64
+	lstat
+	utimensat
+	futimens
+
+	# sys/time.h
+	gettimeofday
+	settimeofday
+	adjtime
+	getitimer
+	setitimer
+	utimes
+	lutimes
+	futimes
+	futimesat
+
+	# sys/timerfd.h
+	timerfd_settime
+	timerfd_gettime
+
+	# sys/timex.h
+	adjtimex
+	ntp_adjtime
+	ntp_gettime
+	ntp_gettimex
+
+	# sys/wait.h
+	wait3
+	wait4
+
+	# threads.h
+	mtx_timedlock
+	cnd_timedwait
+
+	# time.h
+	time
+	difftime
+	mktime
+	gmtime
+	localtime
+	gmtime_r
+	ctime
+	ctime_r
+	timegm
+	nanosleep
+	clock_getres
+	clock_gettime
+	clock_settime
+	clock_nanosleep
+	timer_settime
+	timer_gettime
+	timespec_get
+	timespec_getres
+
+	# utime.h
+	utime
+)
+
+SYMBOLS_REGEX=$(printf '%s|' "${SYMBOLS[@]}")
+# _r.* to allow reentrant variants
+# The @@ part is to workaround a limitation in pax-utils w/versioned symbols.
+SYMBOLS_REGEX="^[^_].*(${SYMBOLS_REGEX%|})(_r)?(@@.*)?$"
+
+check_time() {
+	local dir="$@"
+	if [[ ! -d "${dir}" && -n "${ED}" ]] ; then
+		dir="${ED}"
+	fi
+
+	local files=$(scanelf -F '%p:%s' -qyRgs "-${SYMBOLS_REGEX}" "${dir}")
+
+	if [[ -n ${files} ]]; then
+		eqawarn "QA Notice: Some installed files are missing 64-bit time_t support!"
+		eqawarn " Please see https://wiki.gentoo.org/wiki/Project:Toolchain/time64_migration for details."
+		eqawarn "Affected files:"
+		eqatag -v time64.missing ${files[@]}
+	fi
+}
+
+filtered_check_time() {
+        if ! type -P scanelf >/dev/null || has binchecks ${RESTRICT}; then
+                return
+        fi
+
+        # Only check glibc & uClibc libraries.  Others are presumed to use LFS by
+        # default (e.g. musl), or it's not relevant (e.g. newlib).
+        case ${CHOST} in
+                *-gnu*|*-uclibc*)
+                        ;;
+                *)
+                        return
+                        ;;
+        esac
+
+        # Only check on 32-bit systems.  Filtering by $ARCH here isn't perfect, but
+        # it should be good enough for our needs.
+        case ${ARCH} in
+                arm|mips|hppa|m68k|ppc|sh|x86)
+                        ;;
+                s390)
+                        # s390x is 64-bit, but s390 is 32-bit.
+                        # We use the same keyword for both.
+                        if [[ ${CHOST} == s390-* ]] ; then
+                                return
+                        fi
+                        ;;
+                sparc)
+                        # sparc and sparc64 share the same keyword.
+                        if [[ ${CHOST} == sparc64* ]] ; then
+                                return
+                        fi
+                        ;;
+                *)
+                        return
+                        ;;
+        esac
+
+        # Obviously filter out C libraries themselves :).
+        # The sandbox has to capture all symbols by design.
+        case ${CATEGORY}/${PN} in
+                */glibc|*/uclibc|*/gcc|sys-apps/sandbox)
+                        ;;
+                *)
+                        check_time "${ED}"
+                        ;;
+        esac
+}
+
+# Allow for people to run manually for testing/debugging.
+if [[ $# -ne 0 ]]; then
+	eqawarn() { echo " * $*"; }
+	eqatag() { eqawarn "$@";  }
+	check_time "$@"
+else
+	filtered_check_time
+fi
+
+: # guarantee successful exit
+
+# vim:ft=sh


### PR DESCRIPTION
…s not using LFS

Start issuing QA warnings when ELFs are installed using the old 32bit
file interface.  These programs can fail out right:
* working with large files (more than 2GiB) can return EOVERFLOW
* stating files on large filesystems w/64bit inodes can fail too

It also can lead to silent corruption that is hard to debug like when
one library/app is compiled using 64bit structures and tries to work
with another one that uses 32bit (or vice versa).  This is because
the API in the header utilizes off_t's or structs (like stat) that
have off_t's embedded in them.  By default, off_t is defined as an
off32_t, but when the code is compiled with -D_FILE_OFFSET_BITS=64,
it is transparently changed to off64_t.  That means while one side
was compiled (w/out warnings) expecting 32bit structs, the other
was compiled (w/out warnings) expecting 64bit structs.  The ABI is
different, but C does not support type checking, so no one notices.

The only sane way forward is to use LFS everywhere.

Closes: https://bugs.gentoo.org/549092
Signed-off-by: Sam James <sam@gentoo.org>