### PR TITLE
Add support for a distinct SYSROOT location and fix definition of ESYSROOT

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ Features:
 
 * cleanups: Drop long-obsolete Jython compatibility code.
 
+* Add support for a distinct SYSROOT location that is not equal to / or ROOT.
+  This is only expected to be used for cross-bootstrapping a new system from
+  scratch using a crossdev environment under /usr/${CHOST}.
+
 Bug fixes:
 * sync: Clobber repositories using sync-type=git to match rsync behavior. This
   helps with issues where git-synced repositories can become confused

--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,11 @@ Bug fixes:
   fatal for now. The number of failures in bug #870412 is too large for the time
   being.
 
+* Fix definition of ESYSROOT to use SYSROOT's prefix. For a given location, we
+  were basing ESYSROOT on the prefix of that location instead of the prefix used
+  by the SYSROOT location. For example, if BROOT=/foo, ROOT=/bar, EPREFIX=/baz,
+  EROOT=/bar/baz, and SYSROOT=/ then ESYSROOT should be /foo, not /baz.
+
 portage-3.0.39 (2022-11-20)
 --------------
 

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -688,12 +688,23 @@ def create_trees(
 
         if depcachedir is not None:
             clean_env["PORTAGE_DEPCACHEDIR"] = depcachedir
-        settings = config(
+        mysettings = config(
             config_root=None, target_root="/", env=clean_env, sysroot="/", eprefix=None
         )
-        settings.lock()
-        trees._running_eroot = settings["EROOT"]
-        myroots.append((settings["EROOT"], settings))
+        mysettings.lock()
+        trees._running_eroot = mysettings["EROOT"]
+        myroots.append((mysettings["EROOT"], mysettings))
+
+        if settings["SYSROOT"] != "/" and settings["SYSROOT"] != settings["ROOT"]:
+            mysettings = config(
+                config_root=settings["SYSROOT"],
+                target_root=settings["SYSROOT"],
+                env=clean_env,
+                sysroot=settings["SYSROOT"],
+                eprefix="",
+            )
+            mysettings.lock()
+            myroots.append((mysettings["EROOT"], mysettings))
 
     for myroot, mysettings in myroots:
         trees[myroot] = portage.util.LazyItemsDict(trees.get(myroot, {}))

--- a/lib/portage/package/ebuild/_config/LocationsManager.py
+++ b/lib/portage/package/ebuild/_config/LocationsManager.py
@@ -389,13 +389,13 @@ class LocationsManager:
             + os.path.sep
         )
 
-        if self.sysroot != "/" and self.sysroot != self.target_root:
+        if self.sysroot != "/" and self.target_root == "/":
             writemsg(
                 _(
                     "!!! Error: SYSROOT (currently %s) must "
-                    "equal / or ROOT (currently %s).\n"
+                    "be set to / when ROOT is /.\n"
                 )
-                % (self.sysroot, self.target_root),
+                % self.sysroot,
                 noiselevel=-1,
             )
             raise InvalidLocation(self.sysroot)

--- a/lib/portage/package/ebuild/_config/LocationsManager.py
+++ b/lib/portage/package/ebuild/_config/LocationsManager.py
@@ -93,8 +93,6 @@ class LocationsManager:
                 + os.sep
             )
 
-        self.esysroot = self.sysroot.rstrip(os.sep) + self.eprefix + os.sep
-
         # TODO: Set this via the constructor using
         # PORTAGE_OVERRIDE_EPREFIX.
         self.broot = portage.const.EPREFIX
@@ -404,6 +402,15 @@ class LocationsManager:
         self._check_var_directory("ROOT", self.target_root)
 
         self.eroot = self.target_root.rstrip(os.sep) + self.eprefix + os.sep
+
+        # In a cross-prefix scenario where SYSROOT=/ and ROOT=/, assume we want
+        # ESYSROOT to point to the target prefix.
+        if self.sysroot == self.target_root:
+            self.esysroot = self.sysroot.rstrip(os.sep) + self.eprefix + os.sep
+        elif self.sysroot == "/":
+            self.esysroot = self.broot + os.sep
+        else:
+            self.esysroot = self.sysroot
 
         self.global_config_path = GLOBAL_CONFIG_PATH
         if portage.const.EPREFIX:

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -424,7 +424,6 @@ class config:
             eprefix = locations_manager.eprefix
             config_root = locations_manager.config_root
             sysroot = locations_manager.sysroot
-            esysroot = locations_manager.esysroot
             broot = locations_manager.broot
             abs_user_config = locations_manager.abs_user_config
             make_conf_paths = [
@@ -467,6 +466,7 @@ class config:
             locations_manager.set_root_override(make_conf.get("ROOT"))
             target_root = locations_manager.target_root
             eroot = locations_manager.eroot
+            esysroot = locations_manager.esysroot
             self.global_config_path = locations_manager.global_config_path
 
             # The expand_map is used for variable substitution


### PR DESCRIPTION
This new `SYSROOT` location cannot be prefix-aware as we don't currently have any variable to represent that. Given that this is intended to be used with crossdev toolchains under `/usr/${CHOST}`, that should not matter. Even if that location is nested within a prefixed system, it does not need to be aware of that as it is not intended for execution.

For a given location, we were basing `ESYSROOT` on the prefix of that location instead of the prefix used by the `SYSROOT` location. For example, if `BROOT=/foo`, `ROOT=/bar`, `EPREFIX=/baz`, `EROOT=/bar/baz`, and `SYSROOT=/` then `ESYSROOT` should be `/foo`, not `/baz`.

As discussed, this should have been done years ago, but the drawn out debate we had about changing the definition of `ESYSROOT` dragged on so long that I forgot to do the follow up. Sorry!

I saw that ChromeOS were patching out the overly restrictive `SYSROOT` check years ago, and I hear they still are. They should not need to following this change.