### PR TITLE
Add emerge hooks

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -104,7 +104,7 @@ def callemergerc(phase='', packages='', opts=''):
     if os.path.isfile(emergerc_script):
         subprocess.run([os.path.join(". /", emergerc_script)],
                        shell=True,
-                       env={"EMERGE_PHASE": phase, "PACKAGES": packages, "OPTS": opts})
+                       env={"EMERGE_PHASE": phase, "PACKAGES": packages, "OPTS": opts, "EMERGE_PID": str(os.getpid())})
 
 def action_build(
     emerge_config,

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -101,7 +101,11 @@ from _emerge.UserQuery import UserQuery
 
 emergerc_script = os.path.join("/", portage.const.USER_CONFIG_PATH, "emergerc")
 def callemergerc(phase):
-    os.system(" [[ -f " + emergerc_script + " ]] && export EMERGE_PHASE=" + phase + " && " + os.path.join(". /", emergerc_script))
+    if os.path.isfile(emergerc_script):
+        subprocess.run([os.path.join(". /", emergerc_script)],
+                       shell=True,
+                       env={"EMERGE_PHASE": phase})
+
 callemergerc('emerge_startup')
 
 def action_build(


### PR DESCRIPTION
Right now Portage has already bashrc to hook into the ebuild process. However, initially this was thought to manipulate environment variables (I think so, hence the name?) for a single package build.
Bashrc is sourced several times DURING the ebuild process. However it is not sourced BEFORE and AFTER the ebuild process.

My proposed feature would be to source emergerc, a script located in /etc/portage as well, several times and change a environment variable (e.g. EMERGE_PHASE) to let the users control which code is called.
A purpose for that for example would be to make a btrfs snapshot every time before emerging an update.

There are several situations that come to mind, where a user could benefit from a source of emergerc. The value that the environment variable $EMERGE_PHASE will have it that situation is written behind those points:
- every time emerge starts (emerge_startup)
- right before the dependencies are calculated (pre_calc_deps)
- after dependencies are successfully calculated (post_calc_deps_success)
- after dependencies and they were not successfully calculated (post_calc_deps_fail)
- after the prompt "Would you like to merge these packages?" (if --ask) right before emerge starts working with the first package (pre_first_emerge)
- before --sync (pre_sync)
- after --sync (although there is postsync.d for that) (post_sync_success) / (post_sync_fail)
- when emerge installed all packages successfully  (post_emerge_success)
- when emerge failed with one package (post_emerge_fail)
- when emerge exits (emerge_exit)
- before and after depclean (pre_depclean) / (post_depclean)
- before and after unmerge (pre_unmerge) / (post_unmerge)

To tell the different phases of emerge apart, one would do the same like in bashrc with environment variables
https://wiki.gentoo.org/wiki//etc/portage/bashrc#Environment_variable
```
if [ "${EMERGE_PHASE}" == "pre_first_emerge" ]
then
  echo "your code here"
fi
```

See also:
Bug: https://bugs.gentoo.org/839777
