### PR TITLE
Replace repoman with pkgdev in man

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -570,9 +570,9 @@ ignored because any libraries that have consumers will simply be
 preserved.
 .TP
 .BR \-\-digest
-Prevent corruption from being noticed. The `repoman manifest` command is the
+Prevent corruption from being noticed. The \fBpkgdev manifest\fR command is the
 preferred way to generate manifests and it is capable of doing an entire
-repository or category at once (see \fBrepoman\fR(1)).
+repository or category at once (see \fBpkgdev\fR(1)).
 .TP
 .BR "\-\-dynamic\-deps < y | n >"
 In dependency calculations, substitute the dependencies of installed


### PR DESCRIPTION
Repoman is deprecated by bug [#835013](https://bugs.gentoo.org/835013).

This one just caught my eye during `man emerge`...