### PR TITLE
Make EAPI 8 `--disable-static` logic libtool-specific

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -46,6 +46,10 @@ Bug fixes:
   in different ways, but one example was a rebuild in / causing the same package
   to be added to ROOT, even when it had no other reason to be.
 
+* --disable-static is only passed for libtool-enabled configure scripts in EAPI 8.
+  This avoids annoying warnings when a configure script has a flag such as
+  --disable-static_link that would then trigger a QA warning (bug #814380).
+
 portage-3.0.39 (2022-11-20)
 --------------
 

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -655,8 +655,8 @@ econf() {
 			fi
 
 			if ___eapi_econf_passes_--disable-static; then
-				if [[ ${conf_help} == *--disable-static* || \
-						${conf_help} == *--enable-static* ]]; then
+				if [[ ${conf_help} == *--enable-shared[^A-Za-z0-9+_.-]* &&
+						${conf_help} == *--enable-static[^A-Za-z0-9+_.-]* ]]; then
 					conf_args+=( --disable-static )
 				fi
 			fi


### PR DESCRIPTION
* The intention has always been to only target `configure` scripts that use libtool, not just any script with a `--disable-static*` option.

* libtool has been using the same `configure` format for at least the past 15 years (going back to libtool 1.5.22):

  1. shared and static libraries enabled (the main use case): --enable-shared[=PKGS]  build shared libraries [default=yes] --enable-static[=PKGS]  build static libraries [default=yes]

  2. shared libraries enabled and static libraries disabled: --enable-static[=PKGS]  build static libraries [default=no] --enable-shared[=PKGS]  build shared libraries [default=yes]

  3. shared libraries disabled and static libraries enabled: --enable-shared[=PKGS]  build shared libraries [default=no] --enable-static[=PKGS]  build static libraries [default=yes]

Bug: https://bugs.gentoo.org/814380