### PR TITLE
ebuild/doebuild.py: add -Oline to default MAKEOPTS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ portage-3.0.45 (UNRELEASED)
 Features:
 * Support new ELF machine code: AMDGPU
 
+* ebuild: Set GNUMAKEFLAGS="--output-sync=line" to ensure build logs are written
+  to synchronously when running GNU make in parallel. This option is only set if
+  MAKEOPTS and GNUMAKEFLAGS are left unset by the user.
+
 Bug fixes:
 * gpkg: Handle out-of-space errors (bug #891391).
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -592,6 +592,8 @@ def doebuild_environment(
             nproc = get_cpu_count()
             if nproc:
                 mysettings["MAKEOPTS"] = "-j%d" % (nproc)
+            if "GNUMAKEFLAGS" not in mysettings:
+                mysettings["GNUMAKEFLAGS"] = "--output-sync=line"
 
         if not eapi_exports_KV(eapi):
             # Discard KV for EAPIs that don't support it. Cached KV is restored


### PR DESCRIPTION
Add `-Oline` to ensure proper synchronization of output when doing parallel builds.

Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>