### PR TITLE
Check MD5 hashes of all packages installed on your system.

### DIFF
--- a/bin/verify_all_hashes.sh
+++ b/bin/verify_all_hashes.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright 2022 Daniel Dwek
+#
+# This file is part of Portage.
+#
+# Portage is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# Portage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Portage; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+#
+# Let's browse recursively the installed packages on the system
+# and check MD5 message digests for each object file listed on
+# "CONTENTS" files, in order to verify right integrities.
+# Please note that we use inverted back references with the "sed"
+# command because we need to add an extra blank space between
+# the hash sum and the filename processed.
+#
+# This script is intended to be used by Gentoo Authors or maintainers before
+# either releasing new or updated ebuilds. It prevents missing files from
+# being added to the list of redistributed ones when actually they have no
+# counterpart on the filesystem.
+#
+# Such a list can be found in "everything.sums.gentoo" file, which will
+# tell to us whether an entry is OK, failed to open or read it
+# (i.e., "FAILED") or hash computing did NOT match as expected. This way
+# you can ensure that there will not be differences across source and
+# binary releases.
+#
+
+# Change working directory to user home directory
+cd ~
+rm -f checksums.gentoo
+rm -f checksums.txt.gentoo
+rm -f everything.sums.gentoo
+
+for category in `ls -1 /var/db/pkg/`; do
+	for package in `ls -1 /var/db/pkg/$category`; do
+		echo -e "\033[01;36m/var/db/pkg/$category/$package:\033[00m"
+		grep "^obj" /var/db/pkg/$category/$package/CONTENTS | cut -d ' ' -f 2,3 >> checksums.gentoo
+		cat checksums.gentoo | sed -e 's,\(^/.*\)* \([0-9a-f]*$\),\2  \1,g' >> checksums.txt.gentoo
+		md5sum -c checksums.txt.gentoo 2>&1 >> everything.sums.gentoo
+		rm checksums.gentoo checksums.txt.gentoo
+	done
+done

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ x_scripts = {
         "bin/etc-update",
         "bin/fixpackages",
         "bin/regenworld",
+        "bin/verify_all_hashes.sh",
     ],
 }
 


### PR DESCRIPTION
Although it's primarily designed for Gentoo Authors and maintainers, this short and simple script can be used for developers or any users too who want to verify existence and integrity of each file on the filesystem.

P.S.: I really love Gentoo, it's my favorite Linux distro, ever! I think on Portage is the most perfect package management, but very often I had to download over an over again entire packs with missing files such as headers and libraries. That was the reason why I wrote this shell script. I believe that it's useful for you and many people, but if you have to modify it in somehow just do so. Last but not least, if you think this script is not suitable to your needs and decide drop the branch, do that, but don't go breaking my heart :-(