### PR TITLE
src: use designated initialiser syntax for PyModuleDef

### DIFF
--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -16,25 +16,20 @@ static PyObject * _reflink_linux_file_copy(PyObject *, PyObject *);
 
 static PyMethodDef reflink_linuxMethods[] = {
     {
-            "file_copy",
-            _reflink_linux_file_copy,
-            METH_VARARGS,
-            "Copy between two file descriptors, "
-            "with reflink and sparse file support."
+            .ml_name = "file_copy",
+            .ml_meth = _reflink_linux_file_copy,
+            .ml_flags = METH_VARARGS,
+            .ml_doc = "Copy between two file descriptors with reflink and sparse file support."
     },
     {NULL, NULL, 0, NULL}
 };
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "reflink_linux",                                /* m_name */
-    "Module for reflink_linux copy operations",     /* m_doc */
-    -1,                                             /* m_size */
-    reflink_linuxMethods,                           /* m_methods */
-    NULL,                                           /* m_reload */
-    NULL,                                           /* m_traverse */
-    NULL,                                           /* m_clear */
-    NULL,                                           /* m_free */
+    .m_name = "reflink_linux",
+    .m_doc = "Module for reflink_linux copy operations",
+    .m_size = -1,
+    .m_methods = reflink_linuxMethods,
 };
 
 PyMODINIT_FUNC

--- a/src/portage_util_libc.c
+++ b/src/portage_util_libc.c
@@ -10,21 +10,28 @@ static PyObject * _libc_tolower(PyObject *, PyObject *);
 static PyObject * _libc_toupper(PyObject *, PyObject *);
 
 static PyMethodDef LibcMethods[] = {
-	{"tolower", _libc_tolower, METH_VARARGS, "Convert to lower case using system locale."},
-	{"toupper", _libc_toupper, METH_VARARGS, "Convert to upper case using system locale."},
+	{
+		.ml_name = "tolower",
+		.ml_meth = _libc_tolower,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "Convert to lower case using system locale."
+
+	},
+	{
+		.ml_name = "toupper",
+		.ml_meth = _libc_toupper,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = "Convert to upper case using system locale."
+	},
 	{NULL, NULL, 0, NULL}
 };
 
 static struct PyModuleDef moduledef = {
 	PyModuleDef_HEAD_INIT,
-	"libc",								/* m_name */
-	"Module for converting case using the system locale",		/* m_doc */
-	-1,								/* m_size */
-	LibcMethods,							/* m_methods */
-	NULL,								/* m_reload */
-	NULL,								/* m_traverse */
-	NULL,								/* m_clear */
-	NULL,								/* m_free */
+	.m_name = "libc",
+	.m_doc = "Module for converting case using the system locale",
+	.m_size = -1,
+	.m_methods = LibcMethods,
 };
 
 PyMODINIT_FUNC


### PR DESCRIPTION
It's far easier to keep track of the arguments this way.