### PR TITLE
Remove Jython compat

### DIFF
--- a/bin/ebuild
+++ b/bin/ebuild
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
-import platform
 import signal
 import sys
 import textwrap
@@ -32,12 +31,7 @@ def debug_signal(_signum, _frame):
     pdb.set_trace()
 
 
-if platform.python_implementation() == "Jython":
-    debug_signum = signal.SIGUSR2  # bug #424259
-else:
-    debug_signum = signal.SIGUSR1
-
-signal.signal(debug_signum, debug_signal)
+signal.signal(signal.SIGUSR1, debug_signal)
 
 import io
 import os

--- a/bin/ebuild-ipc.py
+++ b/bin/ebuild-ipc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2010-2021 Gentoo Authors
+# Copyright 2010-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 #
 # This is a helper which ebuild processes can use
@@ -24,7 +24,6 @@ except KeyboardInterrupt:
 import errno
 import logging
 import pickle
-import platform
 import sys
 import time
 
@@ -35,12 +34,7 @@ def debug_signal(signum, frame):
     pdb.set_trace()
 
 
-if platform.python_implementation() == "Jython":
-    debug_signum = signal.SIGUSR2  # bug #424259
-else:
-    debug_signum = signal.SIGUSR1
-
-signal.signal(debug_signum, debug_signal)
+signal.signal(signal.SIGUSR1, debug_signal)
 
 if os.path.isfile(
     os.path.join(

--- a/bin/egencache
+++ b/bin/egencache
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-# Copyright 2009-2021 Gentoo Authors
+# Copyright 2009-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
-import platform
 import signal
 import stat
 import sys
@@ -29,12 +28,7 @@ def debug_signal(_signum, _frame):
     pdb.set_trace()
 
 
-if platform.python_implementation() == "Jython":
-    debug_signum = signal.SIGUSR2  # bug #424259
-else:
-    debug_signum = signal.SIGUSR1
-
-signal.signal(debug_signum, debug_signal)
+signal.signal(signal.SIGUSR1, debug_signal)
 
 import functools
 import io

--- a/bin/emerge
+++ b/bin/emerge
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-# Copyright 2006-2021 Gentoo Authors
+# Copyright 2006-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import platform
 import signal
 import sys
 
@@ -28,12 +27,7 @@ try:
 
         pdb.set_trace()
 
-    if platform.python_implementation() == "Jython":
-        debug_signum = signal.SIGUSR2  # bug #424259
-    else:
-        debug_signum = signal.SIGUSR1
-
-    signal.signal(debug_signum, debug_signal)
+    signal.signal(signal.SIGUSR1, debug_signal)
 
     from os import path as osp
 

--- a/lib/portage/tests/process/test_PopenProcess.py
+++ b/lib/portage/tests/process/test_PopenProcess.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2013 Gentoo Foundation
+# Copyright 2012-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
@@ -14,8 +14,11 @@ from _emerge.PipeReader import PipeReader
 
 class PopenPipeTestCase(TestCase):
     """
-    Test PopenProcess, which can be useful for Jython support, since it
-    uses the subprocess.Popen instead of os.fork().
+    Test PopenProcess, which is historically useful for Jython support,
+    since it uses the subprocess.Popen instead of os.fork().
+
+    Portage does not currently support Jython, but re-introducing support
+    in The Future (TM) may be possible.
     """
 
     _echo_cmd = "echo -n '%s'"

--- a/lib/portage/tests/process/test_PopenProcessBlockingIO.py
+++ b/lib/portage/tests/process/test_PopenProcessBlockingIO.py
@@ -1,4 +1,4 @@
-# Copyright 2012 Gentoo Foundation
+# Copyright 2012-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
@@ -18,10 +18,13 @@ from portage.util._async.PipeReaderBlockingIO import PipeReaderBlockingIO
 
 class PopenPipeBlockingIOTestCase(TestCase):
     """
-    Test PopenProcess, which can be useful for Jython support:
+    Test PopenProcess, which is historically useful for Jython support:
             * use subprocess.Popen since Jython does not support os.fork()
             * use blocking IO with threads, since Jython does not support
               fcntl non-blocking IO)
+
+    Portage does not currently support Jython, but re-introducing support
+    in The Future (TM) may be possible.
     """
 
     _echo_cmd = "echo -n '%s'"

--- a/lib/portage/tests/runTests.py
+++ b/lib/portage/tests/runTests.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # runTests.py -- Portage Unit Test Functionality
-# Copyright 2006-2020 Gentoo Authors
+# Copyright 2006-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import grp
 import os
 import os.path as osp
-import platform
 import pwd
 import signal
 import tempfile
@@ -21,12 +20,7 @@ def debug_signal(signum, frame):
     pdb.set_trace()
 
 
-if platform.python_implementation() == "Jython":
-    debug_signum = signal.SIGUSR2  # bug #424259
-else:
-    debug_signum = signal.SIGUSR1
-
-signal.signal(debug_signum, debug_signal)
+signal.signal(signal.SIGUSR1, debug_signal)
 
 # Pretend that the current user's uid/gid are the 'portage' uid/gid,
 # so things go smoothly regardless of the current user and global

--- a/lib/portage/util/_async/PipeReaderBlockingIO.py
+++ b/lib/portage/util/_async/PipeReaderBlockingIO.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 Gentoo Foundation
+# Copyright 2012-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 try:
@@ -15,10 +15,13 @@ class PipeReaderBlockingIO(AbstractPollTask):
     """
     Reads output from one or more files and saves it in memory, for
     retrieval via the getvalue() method. This is driven by a thread
-    for each input file, in order to support blocking IO.  This may
-    be useful for using threads to handle blocking IO with Jython,
-    since Jython lacks the fcntl module which is needed for
+    for each input file, in order to support blocking IO.  This is
+    historically useful for using threads to handle blocking IO with
+    Jython, since Jython lacks the fcntl module which is needed for
     non-blocking IO (see http://bugs.jython.org/issue1074).
+
+    Portage does not currently support Jython, but re-introducing
+    support in The Future (TM) may be possible.
     """
 
     __slots__ = ("input_files", "_read_data", "_terminate", "_threads", "_thread_rlock")
@@ -38,11 +41,7 @@ class PipeReaderBlockingIO(AbstractPollTask):
                 self._threads[f] = t
 
     def _reader_thread(self, f):
-        try:
-            terminated = self._terminate.is_set
-        except AttributeError:
-            # Jython 2.7.0a2
-            terminated = self._terminate.isSet
+        terminated = self._terminate.is_set
         bufsize = self._bufsize
         while not terminated():
             buf = f.read(bufsize)


### PR DESCRIPTION
Jython is stuck in Python 2-land. Remove Jython compatibility code and references to Jython.

Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>