### PR TITLE
WIP: install-qa-check.d/20perl-directories: add new QA check

### DIFF
--- a/bin/install-qa-check.d/20perl-directories
+++ b/bin/install-qa-check.d/20perl-directories
@@ -1,0 +1,28 @@
+# Check for perl modules installed in invalid directories.
+
+perl_dir_check() {
+	local invalid_dirs=(
+		usr/share/perl5
+	)
+	if [[ ${PN} != dev-lang/perl ]]; then
+		invalid_dirs+=( usr/lib64/perl5/5.* )
+	fi
+
+	# See, for example, bug #876757
+	local dir detected_invalid_dirs=()
+	for dir in "${invalid_dirs[@]}" ; do
+		if [[ -d ${ED}/${dir} ]]; then
+		   detected_invalid_dirs+=( "${x}" )
+		fi
+	done
+	if [[ ${#detected_invalid_dirs[@]} -gt 0 ]] ; then
+		eqawarn "QA Notice: This ebuild installs perl modules into invalid directories."
+		eqawarn " Maybe PERLDIR is not set accordingly in the ebuild?"
+		eqatag -erl.invalid-module-directory -v "${detected_invalid_dirs[@]}"
+	fi
+}
+
+perl_dir_check
+: # guarantee successful exit
+
+# vim:ft=sh


### PR DESCRIPTION
@akhuettel: @sam [asked me for such a check](https://github.com/gentoo/gentoo/pull/28222#issuecomment-1311528464), does this go into the right direction? As of now, this is untested WIP.

Check for perl modules installed into invalid directories.

Bug: https://bugs.gentoo.org/876757
Signed-off-by: Florian Schmaus <flow@gentoo.org>