### PR TITLE
Add caching to _slot_operator_check_reverse_dependencies

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -2240,6 +2240,7 @@ class depgraph:
 
         return None
 
+    @functools.lru_cache(maxsize=100)
     def _slot_operator_check_reverse_dependencies(
         self, existing_pkg, candidate_pkg, replacement_parent=None
     ):


### PR DESCRIPTION
Add lru_cache to speed up the running time of "Calculating
dependencies".

In a ChromeOS use case, this patch decreases the running time from
311s to 197s with almost no memory usage increase.

Bug: https://bugs.gentoo.org/883071
Signed-off-by: Pin-yen Lin <treapking@chromium.org>
