### PR TITLE
Revert "env-update: skip PATH in systemd user environment definition"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,9 @@ Bug fixes:
   in different ways, but one example was a rebuild in / causing the same package
   to be added to ROOT, even when it had no other reason to be.
 
+* env-update: Also generate PATH definition in systemd user environment file
+  /etc/environment.d/10-gentoo-env.conf
+
 portage-3.0.39 (2022-11-20)
 --------------
 

--- a/lib/portage/util/env_update.py
+++ b/lib/portage/util/env_update.py
@@ -417,11 +417,6 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env, writemsg_lev
         systemd_gentoo_env.write(senvnotice)
 
         for env_key in env_keys:
-            # Skip PATH since this makes it impossible to use
-            # "systemctl --user import-environment PATH".
-            if env_key == "PATH":
-                continue
-
             env_key_value = env[env_key]
 
             # Skip variables with the empty string


### PR DESCRIPTION
This reverts commit 21739ea1e0a793e207b7ae28d524e45582d9b2ca, as it was appearantly not necessary. Not sure what drove me into believing that this was needed…

Thanks to Arsen for pointing this out.

Closes: https://bugs.gentoo.org/883307
Reported-by: Arsen Arsenović <arsen@aarsen.me>
Signed-off-by: Florian Schmaus <flow@gentoo.org>