### PR TITLE
update Actions versions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Collect stragglers that Black misses"
         id: stragglers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies


### PR DESCRIPTION
We've started getting warnings about the versions of our Actions [1]:

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2

[1] https://github.com/gentoo/portage/actions/runs/3595151962

Signed-off-by: John Helmert III <ajak@gentoo.org>