### PR TITLE
Add a pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+---
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/pylint
+    rev: v2.15.7
+    hooks:
+      - id: pylint

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ editor integration. Something like this:
 black --check --diff .
 ```
 
+One can also use pre-commit to run the configured pre-commit
+hooks. Utilizing pre-commit has the advantage of running the linter
+over only the changed files, resulting in a much faster pre-commit
+hook. To use, install pre-commit and then install the hook to your
+.git:
+
+```sh
+emerge dev-vcs/pre-commit
+pre-commit install
+```
+
 To ignore commit 1bb64ff452 (and other reformatting commits) which is a
 massive commit that simply formatted the code base using black - you can do
 the following:


### PR DESCRIPTION
Using pre-commit instead of a manually written pre-commit hook will run the linter only over files that have changes, resulting in a much faster linting hook.

Signed-off-by: John Helmert III <ajak@gentoo.org>