### PR TITLE
bintree: Fix breaking GPKG structure on updates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,9 @@ Features:
   by using ewarn rather than eerror.
 
 Bug fixes:
-* TODO
+* Fixed possible corruption of GPKG multi-instance binary packages on upgrade.
+  Bug #877271.
+
 
 portage-3.0.40 (2022-12-01)
 --------------

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -244,7 +244,6 @@ class bindbapi(fakedbapi):
     def aux_update(self, cpv, values):
         if not self.bintree.populated:
             self.bintree.populate()
-        build_id = None
         try:
             build_id = cpv.build_id
         except AttributeError:
@@ -257,6 +256,10 @@ class bindbapi(fakedbapi):
                 cpv = self._instance_key(cpv, support_string=True)[0]
                 build_id = cpv.build_id
 
+        cpv_str = str(cpv)
+        if build_id is not None:
+            cpv_str += f"-{build_id}"
+
         binpkg_path = self.bintree.getname(cpv)
         if not os.path.exists(binpkg_path):
             raise KeyError(cpv)
@@ -267,7 +270,7 @@ class bindbapi(fakedbapi):
             mydata = mytbz2.get_data()
             encoding_key = True
         elif binpkg_format == "gpkg":
-            mybinpkg = portage.gpkg.gpkg(self.settings, cpv, binpkg_path)
+            mybinpkg = portage.gpkg.gpkg(self.settings, cpv_str, binpkg_path)
             mydata = mybinpkg.get_metadata()
             encoding_key = False
         else:

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -1150,7 +1150,8 @@ class gpkg:
             prefix = os.path.commonpath(container.getnames())
             if not prefix:
                 raise InvalidBinaryPackageFormat(
-                    f"gpkg file structure mismatch in {self.gpkg_file}"
+                    f"gpkg file structure mismatch in {self.gpkg_file}; files: "
+                    f"{container.getnames()}"
                 )
 
         shutil.move(tmp_gpkg_file_name, self.gpkg_file)


### PR DESCRIPTION
Fix passing the wrong basename to the gpkg initializer when performing package updates.  This caused newly written files to be missing build_id and therefore causing a structure mismatch.

Closes: https://bugs.gentoo.org/877271
Signed-off-by: Michał Górny <mgorny@gentoo.org>