### PR TITLE
install-qa-check.d/60pkgconfig: remove PCRE

### DIFF
--- a/bin/install-qa-check.d/60pkgconfig
+++ b/bin/install-qa-check.d/60pkgconfig
@@ -77,7 +77,7 @@ pkgconfig_check() {
 			fi
 		elif [[ ${f} == *lib64/pkgconfig* ]] ; then
 			# We want to match /lib/, /lib/foo/, but not e.g. /lib64 or /lib64/, or libfoo
-			if grep -qP '=(/usr)?/lib\b' ${f} ; then
+			if grep -E -q '=(/usr)?/lib\b' ${f} ; then
 				bad_libdir+=( "${f//${D}}" )
 			fi
 		fi


### PR DESCRIPTION
The pattern in question works with both `grep -P` and `grep -E`, prefer the latter to avoid having to check if grep is built with PCRE support.

    '=(/usr)?/lib\b'

Bug: https://bugs.gentoo.org/884285
Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>