### PR TITLE
glsa: abort on incorrect arch delimiter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,8 +5,10 @@ Features:
 * TODO
 
 Bug fixes:
-* etc-update: Apply defences for patsub_replacement being default on in Bash 5.2.
-  bug #881383.
+* glsa: Abort if a GLSA's arch list doesn't match the expected format (bug #882797).
+
+* etc-update: Apply defences for patsub_replacement being default on in Bash 5.2
+  (bug #881383).
 
 portage-3.0.41 (2022-11-04)
 --------------

--- a/lib/portage/tests/glsa/test_security_set.py
+++ b/lib/portage/tests/glsa/test_security_set.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Gentoo Foundation
+# Copyright 2013-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 
@@ -9,6 +9,8 @@ from portage.tests.resolver.ResolverPlayground import (
     ResolverPlayground,
     ResolverPlaygroundTestCase,
 )
+
+from portage.glsa import GlsaFormatException
 
 
 class SecuritySetTestCase(TestCase):
@@ -28,7 +30,7 @@ class SecuritySetTestCase(TestCase):
   <bug>55555</bug>
   <access>remote</access>
   <affected>
-    <package name="%(cp)s" auto="yes" arch="*">
+    <package name="%(cp)s" auto="yes" arch="%(arch)s">
       <unaffected range="ge">%(unaffected_version)s</unaffected>
       <vulnerable range="lt">%(unaffected_version)s</vulnerable>
     </package>
@@ -65,8 +67,15 @@ class SecuritySetTestCase(TestCase):
         except (AttributeError, ImportError):
             return "python is missing xml support"
 
-    def testSecuritySet(self):
+    def write_glsa_test_case(self, glsa_dir, glsa):
+        with open(
+            os.path.join(glsa_dir, "glsa-" + glsa["glsa_id"] + ".xml"),
+            encoding=_encodings["repo.content"],
+            mode="w",
+        ) as f:
+            f.write(self.glsa_template % glsa)
 
+    def testSecuritySet(self):
         skip_reason = self._must_skip()
         if skip_reason:
             self.portage_skip = skip_reason
@@ -89,18 +98,21 @@ class SecuritySetTestCase(TestCase):
                 "pkgname": "A-vulnerable",
                 "cp": "cat/A-vulnerable",
                 "unaffected_version": "2.2",
+                "arch": "*",
             },
             {
                 "glsa_id": "201301-02",
                 "pkgname": "B-not-vulnerable",
                 "cp": "cat/B-not-vulnerable",
                 "unaffected_version": "4.4",
+                "arch": "*",
             },
             {
                 "glsa_id": "201301-03",
                 "pkgname": "NotInstalled",
                 "cp": "cat/NotInstalled",
                 "unaffected_version": "3.5",
+                "arch": "*",
             },
         )
 
@@ -120,22 +132,95 @@ class SecuritySetTestCase(TestCase):
         )
 
         try:
-
             portdb = playground.trees[playground.eroot]["porttree"].dbapi
             glsa_dir = os.path.join(
                 portdb.repositories["test_repo"].location, "metadata", "glsa"
             )
             portage.util.ensure_dirs(glsa_dir)
             for glsa in glsas:
-                with open(
-                    os.path.join(glsa_dir, "glsa-" + glsa["glsa_id"] + ".xml"),
-                    encoding=_encodings["repo.content"],
-                    mode="w",
-                ) as f:
-                    f.write(self.glsa_template % glsa)
+                self.write_glsa_test_case(glsa_dir, glsa)
 
             for test_case in test_cases:
                 playground.run_TestCase(test_case)
                 self.assertEqual(test_case.test_success, True, test_case.fail_msg)
         finally:
             playground.cleanup()
+
+    def testStatelessSecuritySet(self):
+        # Tests which don't rely on the GLSA being fixed. This allows
+        # testing the format parsing with a bit more flexibility (no
+        # need to keep inventing packages).
+
+        skip_reason = self._must_skip()
+        if skip_reason:
+            self.portage_skip = skip_reason
+            self.assertFalse(True, skip_reason)
+            return
+
+        ebuilds = {
+            "cat/A-vulnerable-2.2": {"KEYWORDS": "x86"},
+            "cat/B-not-vulnerable-4.5": {"KEYWORDS": "x86"},
+        }
+
+        installed = {
+            "cat/A-vulnerable-2.1": {"KEYWORDS": "x86"},
+            "cat/B-not-vulnerable-4.4": {"KEYWORDS": "x86"},
+        }
+
+        glsas = (
+            {
+                "glsa_id": "201301-04",
+                "pkgname": "A-vulnerable",
+                "cp": "cat/A-vulnerable",
+                "unaffected_version": "2.2",
+                # Use an invalid delimiter (comma)
+                "arch": "amd64,sparc",
+            },
+            {
+                "glsa_id": "201301-05",
+                "pkgname": "A-vulnerable",
+                "cp": "cat/A-vulnerable",
+                "unaffected_version": "2.2",
+                # Use an invalid arch (~arch)
+                "arch": "~amd64",
+            },
+            {
+                "glsa_id": "201301-06",
+                "pkgname": "A-vulnerable",
+                "cp": "cat/A-vulnerable",
+                "unaffected_version": "2.2",
+                # Two valid arches followed by an invalid one
+                "arch": "amd64 sparc $$$$",
+            },
+        )
+
+        world = ["cat/A"]
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["@security"],
+                success=True,
+                mergelist=["cat/A-vulnerable-2.2"],
+            ),
+        )
+
+        # Give each GLSA a clean slate
+        for glsa in glsas:
+            playground = ResolverPlayground(
+                ebuilds=ebuilds, installed=installed, world=world, debug=True
+            )
+
+            try:
+                portdb = playground.trees[playground.eroot]["porttree"].dbapi
+                glsa_dir = os.path.join(
+                    portdb.repositories["test_repo"].location, "metadata", "glsa"
+                )
+                portage.util.ensure_dirs(glsa_dir)
+
+                self.write_glsa_test_case(glsa_dir, glsa)
+
+                with self.assertRaises(GlsaFormatException):
+                    for test_case in test_cases:
+                        playground.run_TestCase(test_case)
+            finally:
+                playground.cleanup()


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/882797
Signed-off-by: Sam James <sam@gentoo.org>