### PR TITLE
logging: Write logs under BROOT, not EPREFIX

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ Bug fixes:
 * make.conf(5): Note the various file suffixes / file extensions used
   for binary packages.
 
+* logging: Write logs under BROOT, not EPREFIX.
+
 portage-3.0.41 (2022-11-04)
 --------------
 

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -3799,7 +3799,10 @@ def run_action(emerge_config):
 
     emerge_log_dir = emerge_config.target_config.settings.get("EMERGE_LOG_DIR")
     default_log_dir = os.path.join(
-        os.sep, portage.const.EPREFIX.lstrip(os.sep), "var", "log"
+        os.sep,
+        emerge_config.target_config.settings["BROOT"].lstrip(os.sep),
+        "var",
+        "log",
     )
     for x in ("--pretend", "--fetchonly", "--fetch-all-uri"):
         if x in emerge_config.opts:

--- a/lib/portage/elog/mod_save.py
+++ b/lib/portage/elog/mod_save.py
@@ -20,7 +20,7 @@ def process(mysettings, key, logentries, fulltext):
         logdir = normalize_path(mysettings["PORTAGE_LOGDIR"])
     else:
         logdir = os.path.join(
-            os.sep, mysettings["EPREFIX"].lstrip(os.sep), "var", "log", "portage"
+            os.sep, mysettings["BROOT"].lstrip(os.sep), "var", "log", "portage"
         )
 
     if not os.path.isdir(logdir):

--- a/lib/portage/elog/mod_save_summary.py
+++ b/lib/portage/elog/mod_save_summary.py
@@ -20,7 +20,7 @@ def process(mysettings, key, logentries, fulltext):
         logdir = normalize_path(mysettings["PORTAGE_LOGDIR"])
     else:
         logdir = os.path.join(
-            os.sep, mysettings["EPREFIX"].lstrip(os.sep), "var", "log", "portage"
+            os.sep, mysettings["BROOT"].lstrip(os.sep), "var", "log", "portage"
         )
 
     if not os.path.isdir(logdir):


### PR DESCRIPTION
Logs should be written to the build system, not the host system. When building for a prefixed system under `ROOT`, logs were being written under `/${EPREFIX}` even though that directory did not exist at all.