### PR TITLE
sync: git: only perform shallow updates if the repository is shallow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ portage-3.0.42 (UNRELEASED)
 Features:
 * cnf: make.conf.example.loong: add for the loong arch (bug #884135).
 
+* git: only perform shallow updates if the repository is a shallow one
+
 Bug fixes:
 * glsa: Abort if a GLSA's arch list doesn't match the expected format (bug #882797).
 


### PR DESCRIPTION
With the new default of shallow cloning/updating git repositories, added with f2207e41792d ("GitSync.update: default to "--depth 1" (bug 824782 comment 17)"), existing *non-shallow* repositories would become shallow after a "emerge --sync".

This adds a check to see if the repository is already shallow, and only in this case performs a shallow clone.