### PR TITLE
Add 'volatile' configuration option

### DIFF
--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -210,7 +210,7 @@ class Package(Task):
     @property
     def invalid(self):
         if self._invalid is None:
-            self._validate_deps()
+            self._validate_deps(True)
             if self._invalid is None:
                 self._invalid = False
         return self._invalid
@@ -235,7 +235,7 @@ class Package(Task):
         atoms left unevaluated.
         """
         if self._validated_atoms is None:
-            self._validate_deps()
+            self._validate_deps(True)
         return self._validated_atoms
 
     @property
@@ -305,7 +305,7 @@ class Package(Task):
 
         return tuple(elements)
 
-    def _validate_deps(self):
+    def _validate_deps(self, force=False):
         """
         Validate deps. This does not trigger USE calculation since that
         is expensive for ebuilds and therefore we want to avoid doing
@@ -314,6 +314,10 @@ class Package(Task):
         eapi = self.eapi
         dep_eapi = eapi
         dep_valid_flag = self.iuse.is_valid_flag
+
+        if not force and not self.root_config.settings.repositories[self.repo].volatile:
+            return
+
         if self.installed:
             # Ignore EAPI.incompatible and conditionals missing
             # from IUSE for installed packages since these issues


### PR DESCRIPTION
config: Add 'volatile' configuration option

This introduces a 'volatile' configuration option for repos.conf.

* If a repository is marked as volatile (volatile=true), then Portage
  will assume the repository may be changed at any time, and that
  it may contain e.g. local changes.

  Portage will not perform optimizations based on assuming its integrity.

  It will also not perform destructive operations if it is a git repository
  (it will not prioritise being able to continue to sync).

* If a repository is marked as non-volatile (volatile=false), then Portage
  will assume that only Portage changes the repository and that it will not
  be modified otherwise.

  Portage will perform optimizations based on assuming this, like not
  needing to verify the metadata cache for ebuilds & eclasses.

  Portage will prioritise the repository continuing to work and may
  e.g. 'git reset --hard' or 'git clean -fdx' in order to keep git repositories
  working for sync purposes. (If you do not like this, please set 'volatile=true').

See: https://github.com/gentoo/portage/pull/801
See: https://github.com/gentoo/portage/pull/931
See: https://github.com/gentoo/portage/pull/939
See: https://github.com/gentoo/portage/pull/960
Signed-off-by: Sam James <sam@gentoo.org>
