### PR TITLE
lib/portage/process.py: warn on process spawn with large environment

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+* New portage FEATURE warn-on-large-env, to emit a warning if portage
+  executes an ebuild-related child process with a large environment.
+
 portage-3.0.45.2 (2023-03-04)
 --------------
 

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -213,6 +213,7 @@ SUPPORTED_FEATURES = frozenset(
         "userpriv",
         "usersandbox",
         "usersync",
+        "warn-on-large-env",
         "webrsync-gpg",
         "xattr",
     )

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -209,6 +209,7 @@ def _doebuild_spawn(phase, settings, actionmap=None, **kwargs):
     kwargs["pidns"] = (
         "pid-sandbox" in settings.features and phase not in _global_pid_phases
     )
+    kwargs["warn_on_large_env"] = "warn-on-large-env" in settings.features
 
     if phase == "depend":
         kwargs["droppriv"] = "userpriv" in settings.features

--- a/lib/portage/tests/process/test_spawn_warn_large_env.py
+++ b/lib/portage/tests/process/test_spawn_warn_large_env.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import platform
+import tempfile
+
+from pathlib import Path
+
+import portage.process
+
+from portage import shutil
+from portage.tests import TestCase
+
+
+class SpawnWarnLargeEnvTestCase(TestCase):
+    def testSpawnWarnLargeEnv(self):
+        if platform.system() != "Linux":
+            self.skipTest("not Linux")
+
+        env = dict()
+        env["LARGE_ENV_VAR"] = "X" * 1024 * 96
+
+        tmpdir = tempfile.mkdtemp()
+        previous_env_too_large_warnings = portage.process.env_too_large_warnings
+        try:
+            logfile = tmpdir / Path("logfile")
+            echo_output = "This is an echo process with a large env"
+            retval = portage.process.spawn(
+                ["echo", echo_output],
+                env=env,
+                logfile=logfile,
+                warn_on_large_env=True,
+            )
+
+            with open(logfile) as f:
+                logfile_content = f.read()
+                self.assertIn(
+                    echo_output,
+                    logfile_content,
+                )
+            self.assertTrue(
+                portage.process.env_too_large_warnings > previous_env_too_large_warnings
+            )
+            self.assertEqual(retval, 0)
+        finally:
+            shutil.rmtree(tmpdir)

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -813,6 +813,9 @@ It is the user's responsibility to ensure correct ownership, since otherwise
 Portage would have to waste time validating ownership for each and every sync
 operation.
 .TP
+.B warn-on-large-env
+Warn if portage is about to execute a child process with a large environment.
+.TP
 .B webrsync-gpg
 Enable GPG verification when using \fIemerge\-webrsync\fR. This feature is
 deprecated and has been replaced by the \fBrepos.conf\fR


### PR DESCRIPTION
We have discussed that such a warning may be sensible to make people aware of the "large environment" issue. This is a first shot at it. I wonder if emitting the warning unconditionally, as opposed to only if an ebuild bash is spawned, is sensible, or if it may cause to much noise. Then again, first tests shows that most environments are far smaller than 96 KiB, and if you above the 96 KiB warning limit, then some proactive action may be necessary anway.