### PR TITLE
Simplify signal handling in entry point scripts

### DIFF
--- a/bin/ebuild
+++ b/bin/ebuild
@@ -7,22 +7,11 @@ import signal
 import sys
 import textwrap
 
-# This block ensures that ^C interrupts are handled quietly.
-try:
+# This ensures that ^C interrupts are handled quietly.
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    def exithandler(signum, _frame):
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        sys.exit(128 + signum)
-
-    signal.signal(signal.SIGINT, exithandler)
-    signal.signal(signal.SIGTERM, exithandler)
-    # Prevent "[Errno 32] Broken pipe" exceptions when
-    # writing to a pipe.
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
-except KeyboardInterrupt:
-    sys.exit(128 + signal.SIGINT)
+# Prevent "[Errno 32] Broken pipe" exceptions when writing to a pipe.
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 
 def debug_signal(_signum, _frame):

--- a/bin/ebuild-ipc.py
+++ b/bin/ebuild-ipc.py
@@ -5,21 +5,14 @@
 # This is a helper which ebuild processes can use
 # to communicate with portage's main python process.
 
-# This block ensures that ^C interrupts are handled quietly.
-try:
-    import os
-    import signal
+import os
+import signal
 
-    def exithandler(signum, _frame):
-        signal.signal(signum, signal.SIG_DFL)
-        os.kill(os.getpid(), signum)
+# This ensures that ^C interrupts are handled quietly.
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    signal.signal(signal.SIGINT, exithandler)
-    signal.signal(signal.SIGTERM, exithandler)
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
-except KeyboardInterrupt:
-    raise SystemExit(130)
+# Prevent "[Errno 32] Broken pipe" exceptions when writing to a pipe.
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 import errno
 import logging

--- a/bin/egencache
+++ b/bin/egencache
@@ -7,19 +7,11 @@ import signal
 import stat
 import sys
 
-# This block ensures that ^C interrupts are handled quietly.
-try:
+# This ensures that ^C interrupts are handled quietly.
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    def exithandler(signum, _frame):
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        sys.exit(128 + signum)
-
-    signal.signal(signal.SIGINT, exithandler)
-    signal.signal(signal.SIGTERM, exithandler)
-
-except KeyboardInterrupt:
-    sys.exit(128 + signal.SIGINT)
+# Prevent "[Errno 32] Broken pipe" exceptions when writing to a pipe.
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 
 def debug_signal(_signum, _frame):

--- a/bin/emaint
+++ b/bin/emaint
@@ -7,22 +7,13 @@
 
 import sys
 import errno
+import signal
 
-# This block ensures that ^C interrupts are handled quietly.
-try:
-    import signal
+# This ensures that ^C interrupts are handled quietly.
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    def exithandler(signum, _frame):
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        sys.exit(128 + signum)
-
-    signal.signal(signal.SIGINT, exithandler)
-    signal.signal(signal.SIGTERM, exithandler)
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
-except KeyboardInterrupt:
-    sys.exit(1)
+# Prevent "[Errno 32] Broken pipe" exceptions when writing to a pipe.
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 from os import path as osp
 

--- a/bin/emerge
+++ b/bin/emerge
@@ -2,6 +2,7 @@
 # Copyright 2006-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import os
 import signal
 import sys
 
@@ -13,13 +14,7 @@ import sys
 global_event_loop = None
 try:
 
-    def exithandler(signum, _frame):
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        sys.exit(128 + signum)
-
-    signal.signal(signal.SIGTERM, exithandler)
-    # Prevent "[Errno 32] Broken pipe" exceptions when
-    # writing to a pipe.
+    # Prevent "[Errno 32] Broken pipe" exceptions when writing to a pipe.
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     def debug_signal(_signum, _frame):
@@ -82,7 +77,8 @@ try:
 except KeyboardInterrupt:
     sys.stderr.write("\n\nExiting on signal {signal}\n".format(signal=signal.SIGINT))
     sys.stderr.flush()
-    sys.exit(128 + signal.SIGINT)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    os.kill(os.getpid(), signal.SIGINT)
 finally:
     if global_event_loop is not None:
         global_event_loop().close()

--- a/bin/portageq
+++ b/bin/portageq
@@ -6,19 +6,11 @@ import argparse
 import signal
 import sys
 
-# This block ensures that ^C interrupts are handled quietly.
-try:
+# This ensures that ^C interrupts are handled quietly.
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    def exithandler(signum, _frame):
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        sys.exit(128 + signum)
-
-    signal.signal(signal.SIGINT, exithandler)
-    signal.signal(signal.SIGTERM, exithandler)
-
-except KeyboardInterrupt:
-    sys.exit(128 + signal.SIGINT)
+# Prevent "[Errno 32] Broken pipe" exceptions when writing to a pipe.
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 import os
 import types


### PR DESCRIPTION
These scripts have some boiler-plate code to install a stub handler for SIGINT, SIGTERM, and SIGPIPE to prevent errors from being displayed to the user.

For SIGINT, Python installs a handler that raises KeyboardInterrupt. We reset the handler to SIG_DFL to avoid this.

For SIGTERM, we don't actually need to do anything: Python doesn't handle SIGTERM, and the process will be terminated silently.

For SIGPIPE, Python ignores this by default, and a BrokenPipeError is raised if we attempt to write to a broken pipe. We reset the handler to SIG_DFL to avoid this.

Bug: https://bugs.gentoo.org/887817