### PR TITLE
Whirlpool use cleanup + warning

### DIFF
--- a/lib/portage/checksum.py
+++ b/lib/portage/checksum.py
@@ -310,10 +310,13 @@ if "STREEBOG256" not in hashfunc_map or "STREEBOG512" not in hashfunc_map:
 _whirlpool_unaccelerated = False
 if "WHIRLPOOL" not in hashfunc_map:
     # Bundled WHIRLPOOL implementation
-    _whirlpool_unaccelerated = True
-    from portage.util.whirlpool import new as _new_whirlpool
+    from portage.util.whirlpool import CWhirlpool, PyWhirlpool
 
-    _generate_hash_function("WHIRLPOOL", _new_whirlpool, origin="bundled")
+    if CWhirlpool.is_available:
+        _generate_hash_function("WHIRLPOOL", CWhirlpool, origin="bundled-c")
+    else:
+        _whirlpool_unaccelerated = True
+        _generate_hash_function("WHIRLPOOL", PyWhirlpool, origin="bundled-py")
 
 
 # There is only one implementation for size

--- a/lib/portage/tests/util/test_whirlpool.py
+++ b/lib/portage/tests/util/test_whirlpool.py
@@ -1,23 +1,27 @@
-# Copyright 2011-2014 Gentoo Foundation
+# Copyright 2011-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import subprocess
-
-import portage
-from portage import os
-from portage.const import PORTAGE_PYM_PATH
 from portage.tests import TestCase
+from portage.util.whirlpool import Whirlpool
 
 
 class WhirlpoolTestCase(TestCase):
     def testBundledWhirlpool(self):
-        # execute the tests bundled with the whirlpool module
-        retval = subprocess.call(
-            [
-                portage._python_interpreter,
-                "-b",
-                "-Wd",
-                os.path.join(PORTAGE_PYM_PATH, "portage/util/whirlpool.py"),
-            ]
+        self.assertEqual(
+            Whirlpool(b"The quick brown fox jumps over the lazy dog").hexdigest(),
+            "b97de512e91e3828b40d2b0fdce9ceb3c4a71f9bea8d88e75c4fa854df36725fd2b52eb6544edcacd6f8beddfea403cb55ae31f03ad62a5ef54e42ee82c3fb35",
         )
-        self.assertEqual(retval, os.EX_OK)
+        self.assertEqual(
+            Whirlpool(b"The quick brown fox jumps over the lazy eog").hexdigest(),
+            "c27ba124205f72e6847f3e19834f925cc666d0974167af915bb462420ed40cc50900d85a1f923219d832357750492d5c143011a76988344c2635e69d06f2d38c",
+        )
+        self.assertEqual(
+            Whirlpool(b"").hexdigest(),
+            "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3",
+        )
+        w = Whirlpool()
+        w.update(b"")
+        self.assertEqual(
+            w.hexdigest(),
+            "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3",
+        )

--- a/lib/portage/tests/util/test_whirlpool.py
+++ b/lib/portage/tests/util/test_whirlpool.py
@@ -2,26 +2,31 @@
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
-from portage.util.whirlpool import Whirlpool
+from portage.util.whirlpool import CWhirlpool, PyWhirlpool
 
 
 class WhirlpoolTestCase(TestCase):
-    def testBundledWhirlpool(self):
+    def testBundledWhirlpool(self, cls=PyWhirlpool):
         self.assertEqual(
-            Whirlpool(b"The quick brown fox jumps over the lazy dog").hexdigest(),
+            cls(b"The quick brown fox jumps over the lazy dog").hexdigest(),
             "b97de512e91e3828b40d2b0fdce9ceb3c4a71f9bea8d88e75c4fa854df36725fd2b52eb6544edcacd6f8beddfea403cb55ae31f03ad62a5ef54e42ee82c3fb35",
         )
         self.assertEqual(
-            Whirlpool(b"The quick brown fox jumps over the lazy eog").hexdigest(),
+            cls(b"The quick brown fox jumps over the lazy eog").hexdigest(),
             "c27ba124205f72e6847f3e19834f925cc666d0974167af915bb462420ed40cc50900d85a1f923219d832357750492d5c143011a76988344c2635e69d06f2d38c",
         )
         self.assertEqual(
-            Whirlpool(b"").hexdigest(),
+            cls(b"").hexdigest(),
             "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3",
         )
-        w = Whirlpool()
+        w = cls()
         w.update(b"")
         self.assertEqual(
             w.hexdigest(),
             "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3",
         )
+
+    def testCWhirlpool(self):
+        if not CWhirlpool.is_available:
+            self.skipTest("C Whirlpool extension is not importable")
+        self.testBundledWhirlpool(CWhirlpool)

--- a/lib/portage/util/whirlpool.py
+++ b/lib/portage/util/whirlpool.py
@@ -83,6 +83,8 @@ class CWhirlpool:
     may be provided; if present, this string will be automatically
     hashed."""
 
+    is_available = WhirlpoolExt is not None
+
     def __init__(self, arg=b""):
         self.obj = WhirlpoolExt()
         self.dig = None

--- a/lib/portage/util/whirlpool.py
+++ b/lib/portage/util/whirlpool.py
@@ -30,6 +30,10 @@
 
 # pylint: disable=mixed-indentation
 
+import warnings
+
+from portage.localization import _
+
 try:
     from ._whirlpool import Whirlpool as WhirlpoolExt
 except ImportError:
@@ -47,6 +51,13 @@ class PyWhirlpool:
     hashed."""
 
     def __init__(self, arg=b""):
+        warnings.warn(
+            _(
+                "The last-resort unaccelerated Whirlpool implementation is "
+                "being used. It is known to be absurdly slow. Please report "
+                "that the Whirlpool hash is deprecated to the repository owner."
+            )
+        )
         self.ctx = WhirlpoolStruct()
         self.update(arg)
 

--- a/lib/portage/util/whirlpool.py
+++ b/lib/portage/util/whirlpool.py
@@ -110,19 +110,6 @@ class CWhirlpool:
         return tempstr
 
 
-if WhirlpoolExt is not None:
-    Whirlpool = CWhirlpool
-else:
-    Whirlpool = PyWhirlpool
-
-
-def new(init=b""):
-    """Return a new Whirlpool object. An optional string argument
-    may be provided; if present, this string will be automatically
-    hashed."""
-    return Whirlpool(init)
-
-
 #
 # Private.
 #

--- a/lib/portage/util/whirlpool.py
+++ b/lib/portage/util/whirlpool.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
 # whirlpool.py - pure Python implementation of the Whirlpool algorithm.
 # Bjorn Edstrom <be@bjrn.se> 16 december 2007.
 ##
@@ -2372,29 +2375,3 @@ def processBuffer(ctx):
     # apply the Miyaguchi-Preneel compression function
     for i in range(8):
         ctx.hash[i] ^= state[i] ^ block[i]
-
-
-#
-# Tests.
-#
-
-
-if __name__ == "__main__":
-    assert (
-        Whirlpool(b"The quick brown fox jumps over the lazy dog").hexdigest()
-        == "b97de512e91e3828b40d2b0fdce9ceb3c4a71f9bea8d88e75c4fa854df36725fd2b52eb6544edcacd6f8beddfea403cb55ae31f03ad62a5ef54e42ee82c3fb35"
-    )
-    assert (
-        Whirlpool(b"The quick brown fox jumps over the lazy eog").hexdigest()
-        == "c27ba124205f72e6847f3e19834f925cc666d0974167af915bb462420ed40cc50900d85a1f923219d832357750492d5c143011a76988344c2635e69d06f2d38c"
-    )
-    assert (
-        Whirlpool(b"").hexdigest()
-        == "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3"
-    )
-    w = Whirlpool()
-    w.update(b"")
-    assert (
-        w.hexdigest()
-        == "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3"
-    )


### PR DESCRIPTION
Bunch of fixes to:

1. Test both C and Python implementations of Whirlpool separately.
2. Consider only the Python implementation to be unaccelerated (i.e. don't skip Whirlpool hashes if we're using the C implementation).
3. Emit a `UserWarning` when the Python implementation is used, to have them expect very slow hashing and help finding the few ebuilds using that hash.