### PR TITLE
git.py: fix "is-shallow-repository" check by stripping \n

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ Bug fixes:
   Whirlpool is considered deprecated within Portage and we recommend that
   repository maintainers remove it from `metadata/layout.conf`!
 
+* Fix "is shallow git repository" check.
+
 portage-3.0.42 (2022-12-26)
 --------------
 

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -237,7 +237,7 @@ class GitSync(NewBase):
                         is_shallow_cmd,
                         cwd=portage._unicode_encode(self.repo.location),
                     )
-                )
+                ).rstrip("\n")
                 if is_shallow_res == "false":
                     sync_depth = 0
             else:


### PR DESCRIPTION
The output of git commands has a trailing newline character which we usually strip.

Fixes: 92f8d27e0345 ("sync: git: only clobber changes if repository is marked as non-volatile")
Signed-off-by: Florian Schmaus <flow@gentoo.org>