### PR TITLE
_doebuild_path: simplify logic used to set PATH

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+portage-3.0.44 (?)
+
+Bug fixes:
+* ebuild: the PATH variable exported to ebuilds has been changed:
+  The PATH setting from /etc/profile.env is appended to portage-internal
+  paths, and ROOTPATH is no longer included (bug #607696, #693308, #888543).
+
 portage-3.0.43 (2023-01-02)
 --------------
 

--- a/bin/egencache
+++ b/bin/egencache
@@ -1130,6 +1130,10 @@ try:
         # completely controlled by commandline arguments.
         env = {}
 
+        # Pass through PATH to allow testing with an empty profile.env.
+        if "PATH" in os.environ:
+            env["PATH"] = os.environ["PATH"]
+
         if not sys.stdout.isatty() or os.environ.get("NOCOLOR", "").lower() in (
             "yes",
             "true",

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -686,6 +686,7 @@ class ResolverPlayground:
             create_trees_kwargs["target_root"] = self.target_root
 
         env = {
+            "PATH": os.environ["PATH"],
             "PORTAGE_REPOSITORIES": "\n".join(
                 "[%s]\n%s"
                 % (
@@ -693,7 +694,7 @@ class ResolverPlayground:
                     "\n".join("{} = {}".format(k, v) for k, v in repo_config.items()),
                 )
                 for repo_name, repo_config in self._repositories.items()
-            )
+            ),
         }
 
         if self.debug:


### PR DESCRIPTION
Remove logic to incoporate PREROOTPATH and ROOTPATH. I'm not sure where PREROOTPATH was ever used, and ROOTPATH has been deprecated in baselayout for a while.

Remove logic to add hard-coded directories like
${EPREFIX}/{,usr{,/local}/{sbin,bin}. Adding these paths is unnecessary if env.d or the calling environment have a valid PATH setting.

Add logic to ignore PATH from the calling environment if PATH is set in env.d. This ensures that packages can update PATH by installing files in /etc/env.d and this will work without having to restart Portage with an updated environment.

Bug: https://bugs.gentoo.org/607696
Bug: https://bugs.gentoo.org/693308
Bug: https://bugs.gentoo.org/888543