### PR TITLE
make.globals: default-on FEATURES=pkgdir-index-trusted

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 portage-3.0.52 (UNRELEASED)
 --------------
 
+Breaking changes:
+* FEATURES=pkgdir-index-trusted is now on by default.
+
 Features:
 * bintree: Add new API member (invalid_paths) to allow gentoolkit to later
   clean up invalid binpkgs (bug #900224).

--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -78,7 +78,7 @@ FEATURES="assume-digests binpkg-docompress binpkg-dostrip binpkg-logs
           binpkg-multi-instance buildpkg-live
           config-protect-if-modified distlocks ebuild-locks
           fixlafiles ipc-sandbox merge-sync multilib-strict
-          network-sandbox news parallel-fetch pid-sandbox
+          network-sandbox news parallel-fetch pkgdir-index-trusted pid-sandbox
           preserve-libs protect-owned qa-unresolved-soname-deps
           sandbox sfperms strict
           unknown-features-warn unmerge-logs unmerge-orphans userfetch

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -803,7 +803,13 @@ class binarytree:
             except PortageException:
                 pass
 
-    def populate(self, getbinpkgs=False, getbinpkg_refresh=False, add_repos=()):
+    def populate(
+        self,
+        getbinpkgs=False,
+        getbinpkg_refresh=False,
+        add_repos=(),
+        force_reindex=False,
+    ):
         """
         Populates the binarytree with package metadata.
 
@@ -833,6 +839,7 @@ class binarytree:
         try:
             update_pkgindex = self._populate_local(
                 reindex="pkgdir-index-trusted" not in self.settings.features
+                or force_reindex
             )
 
             if update_pkgindex and self.dbapi.writable:

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -17,6 +17,7 @@ from portage.const import (
 )
 from portage.process import find_binary
 from portage.dep import Atom, _repo_separator
+from portage.dbapi.bintree import binarytree
 from portage.package.ebuild.config import config
 from portage.package.ebuild.digestgen import digestgen
 from portage._sets import load_default_config
@@ -396,6 +397,9 @@ class ResolverPlayground:
                 t.compress(os.path.dirname(binpkg_path), metadata)
             else:
                 raise InvalidBinaryPackageFormat(binpkg_format)
+
+            bintree = binarytree(pkgdir=self.pkgdir, settings=self.settings)
+            bintree.populate(force_reindex=True)
 
     def _create_installed(self, installed):
         for cpv in installed:


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/889300
Signed-off-by: John Helmert III <ajak@gentoo.org>