### PR TITLE
depgraph: Print dependency resolution time

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import stat
 import textwrap
+import time
 import warnings
 import collections
 from collections import deque, OrderedDict
@@ -11514,6 +11515,7 @@ def _spinner_start(spinner, myopts):
 
     if show_spinner:
         portage.writemsg_stdout("Calculating dependencies  ")
+    spinner.start_time = time.time()
 
 
 def _spinner_stop(spinner):
@@ -11526,6 +11528,10 @@ def _spinner_stop(spinner):
         portage.writemsg_stdout("\b\b")
 
     portage.writemsg_stdout("... done!\n")
+
+    stop_time = time.time()
+    time_fmt = f"{stop_time - spinner.start_time:.2f}"
+    portage.writemsg_stdout(f"Dependency resolution took {darkgreen(time_fmt)} s.\n\n")
 
 
 def backtrack_depgraph(settings, trees, myopts, myparams, myaction, myfiles, spinner):

--- a/lib/_emerge/stdout_spinner.py
+++ b/lib/_emerge/stdout_spinner.py
@@ -39,6 +39,7 @@ class stdout_spinner:
         ]
         self.last_update = 0
         self.min_display_latency = 0.05
+        self.start_time = None
 
     def _return_early(self):
         """


### PR DESCRIPTION
Print the wall clock time it took emerge to calculate the dependency graph if spinner is used (i.e. we're in verbose mode).

![Screenshot_2023-01-05_16-28-19](https://user-images.githubusercontent.com/110765/210816939-3fe99ab9-4bce-4df6-9872-8cc0cd36894f.png)
