### PR TITLE
SCHEDULING_POLICY: switch to scheduler policy IDs rather than aliases.

### DIFF
--- a/cnf/make.conf.example
+++ b/cnf/make.conf.example
@@ -292,12 +292,12 @@
 #PORTAGE_IONICE_COMMAND="ionice -c 3 -p \${PID}"
 #
 # PORTAGE_SCHEDULING_POLICY allows changing the current scheduling policy. The
-# supported options are 'other', 'batch', 'idle', 'fifo' and 'round-robin'. When
-# unset, the scheduling policy remains unchanged, by default Linux uses 'other'
-# policy. Users that wish to minimize the Portage's impact on system
-# responsiveness should set scheduling policy to 'idle' which significantly
-# reduces the disruption to the rest of the system by scheduling Portage as
-# extremely low priority processes.
+# supported options are 'other', 'batch', 'idle', 'fifo', 'round-robin' and
+# 'deadline'. When unset, the scheduling policy remains unchanged, by default
+# Linux uses 'other' policy. Users that wish to minimize the Portage's impact
+# on system responsiveness should set scheduling policy to 'idle' which
+# significantly reduces the disruption to the rest of the system by scheduling
+# Portage as extremely low priority processes.
 #
 #PORTAGE_SCHEDULING_POLICY="idle"
 #

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -3117,12 +3117,14 @@ def set_scheduling_policy(settings):
     if platform.system() != "Linux" or not scheduling_policy:
         return os.EX_OK
 
+    # IDs sourced from linux/sched.h kernel's header.
     policies = {
-        "other": os.SCHED_OTHER,
-        "batch": os.SCHED_BATCH,
-        "idle": os.SCHED_IDLE,
-        "fifo": os.SCHED_FIFO,
-        "round-robin": os.SCHED_RR,
+        "other": 0,
+        "fifo": 1,
+        "round-robin": 2,
+        "batch": 3,
+        "idle": 5,
+        "deadline": 6,
     }
 
     out = portage.output.EOutput()

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1101,14 +1101,14 @@ will set idle io priority. For more information about ionice, see
 Portage will also set the autogroup-nice value (see fBsched\fR(7))), if
 FEATURES="pid\-sandbox" is enabled.
 .TP
-\fBPORTAGE_SCHEDULING_POLICY\fR = \fI[policy name]\fR
-Allows changing the current scheduling policy. The supported options are
-\fBother\fR, \fBbatch\fR, \fBidle\fR, \fBfifo\fR, and \fBround-robin\fR. When
-unset, the scheduling policy remains unchanged, by default Linux uses 'other'
-policy. Users that wish to minimize the Portage's impact on system
-responsiveness should set scheduling policy to \fBidle\fR, which significantly
-reduces the disruption to the rest of the system by scheduling Portage as
-extremely low priority processes. see \fBsched\fR(7) for more information.
+\fBPORTAGE_SCHEDULING_POLICY\fR = \fI[policy name]\fR Allows changing the
+current scheduling policy. The supported options are \fBother\fR, \fBbatch\fR,
+\fBidle\fR, \fBfifo\fR, \fBround-robin\fR and \fBdeadline\fR. When unset, the
+scheduling policy remains unchanged, by default Linux uses 'other' policy.
+Users that wish to minimize the Portage's impact on system responsiveness
+should set scheduling policy to \fBidle\fR, which significantly reduces the
+disruption to the rest of the system by scheduling Portage as extremely low
+priority processes. see \fBsched\fR(7) for more information.
 .TP
 \fBPORTAGE_SCHEDULING_PRIORITY\fR = \fI[priority]\fR
 Allows changing the priority (1-99) of the current scheduling policy, only


### PR DESCRIPTION
The os.SCHED_* aliases are not reliable enough, the mainline Python lacks deadline, and the pypy lacks them all together. The IDs are not going to change, at most new would arrive, so it is safe to use it as is.

By extension, the deadline policy was also added, since those originally were not present in aliases.

Closes: https://bugs.gentoo.org/867031
Signed-off-by: KARBOWSKI Piotr <slashbeast@gentoo.org>