### PR TITLE
bin/quickpkg: loosen default umask

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -6,6 +6,7 @@ import argparse
 import errno
 import math
 import signal
+import stat
 import subprocess
 import sys
 
@@ -406,8 +407,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(usage=usage)
     parser.add_argument(
         "--umask",
-        default="0077",
-        help="umask used during package creation (default is 0077)",
+        default="0022",
+        help="umask used during package creation (default is 0022)",
     )
     parser.add_argument(
         "--ignore-default-opts",
@@ -441,6 +442,16 @@ if __name__ == "__main__":
     # We need to ensure a sane umask for the packages that will be created.
     old_umask = os.umask(umask)
     eout = portage.output.EOutput()
+
+    if (
+        options.include_unmodified_config == "n"
+        and options.include_config == "y"
+        and int(options.umask) & stat.S_IROTH
+    ):
+        eout.ewarn(
+            "Creating world-readable binpkgs with system's config files, "
+            "this might leak secrets into binary packages!"
+        )
 
     def sigwinch_handler(signum, frame):
         lines, eout.term_columns = portage.output.get_term_size()


### PR DESCRIPTION
This default was originally changed in bug #182428 to prevent config files with secrets being leaked into binary packages that were readable by everyone, but given the default is to not include configs, it is safe to use a less restrictive umask by default. Also, warn the user if there is a possibility that secrets end up in a world-readable binpkg.

Bug: https://bugs.gentoo.org/182428
Bug: https://bugs.gentoo.org/890823
Signed-off-by: John Helmert III <ajak@gentoo.org>