### PR TITLE
emerge: add --onlydeps-with-ideps=<y|n> option (bug 890777)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ Features:
 * ebuild: Set GNUMAKEFLAGS="--output-sync=line" to ensure build logs are written
   to synchronously when running GNU make in parallel. This option is only set if
   MAKEOPTS and GNUMAKEFLAGS are left unset by the user.
+* emerge: add --onlydeps-with-ideps=<y|n> option.
 
 Bug fixes:
 * gpkg: Handle out-of-space errors (bug #891391).

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -3718,7 +3718,8 @@ class depgraph:
         ):
             edepend["RDEPEND"] = ""
             edepend["PDEPEND"] = ""
-            edepend["IDEPEND"] = ""
+            if self._frozen_config.myopts.get("--onlydeps-with-ideps") in ("n", None):
+                edepend["IDEPEND"] = ""
 
         ignore_build_time_deps = False
         if pkg.built and not removal_action:

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -162,6 +162,7 @@ def insert_optional_args(args):
         "--jobs": valid_integers,
         "--keep-going": y_or_n,
         "--load-average": valid_floats,
+        "--onlydeps-with-ideps": y_or_n,
         "--onlydeps-with-rdeps": y_or_n,
         "--package-moves": y_or_n,
         "--quiet": y_or_n,
@@ -573,8 +574,12 @@ def parse_opts(tmpcmdline, silent=False):
             + "Emerge will ignore matching binary packages. ",
             "action": "append",
         },
+        "--onlydeps-with-ideps": {
+            "help": "modify interpretation of dependencies to include IDEPEND",
+            "choices": true_y_or_n,
+        },
         "--onlydeps-with-rdeps": {
-            "help": "modify interpretation of depedencies",
+            "help": "modify interpretation of dependencies",
             "choices": true_y_or_n,
         },
         "--rebuild-exclude": {
@@ -671,7 +676,7 @@ def parse_opts(tmpcmdline, silent=False):
             "action": "store",
         },
         "--root-deps": {
-            "help": "modify interpretation of depedencies",
+            "help": "modify interpretation of dependencies",
             "choices": ("True", "rdeps"),
         },
         "--search-index": {

--- a/lib/portage/tests/resolver/test_onlydeps_ideps.py
+++ b/lib/portage/tests/resolver/test_onlydeps_ideps.py
@@ -1,0 +1,172 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class OnlydepsIdepsTestCase(TestCase):
+    def testOnlydepsIdepsEAPI7(self):
+        ebuilds = {
+            "dev-libs/A-1": {
+                "EAPI": "7",
+                "DEPEND": "dev-libs/B",
+                "RDEPEND": "dev-libs/C",
+                "PDEPEND": "dev-libs/D",
+                "IDEPEND": "dev-libs/E",
+            },
+            "dev-libs/B-1": {},
+            "dev-libs/C-1": {},
+            "dev-libs/D-1": {},
+            "dev-libs/E-1": {},
+        }
+        ebuilds["dev-libs/F-1"] = ebuilds["dev-libs/A-1"]
+        installed = {}
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                all_permutations=True,
+                success=True,
+                options={"--onlydeps": True, "--onlydeps-with-rdeps": "y"},
+                ambiguous_merge_order=True,
+                mergelist=[("dev-libs/B-1", "dev-libs/C-1", "dev-libs/D-1")],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                all_permutations=True,
+                success=True,
+                options={"--onlydeps": True, "--onlydeps-with-rdeps": "n"},
+                mergelist=["dev-libs/B-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": "y",
+                },
+                ambiguous_merge_order=True,
+                mergelist=[("dev-libs/B-1")],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": True,
+                },
+                ambiguous_merge_order=True,
+                mergelist=[("dev-libs/B-1")],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": "n",
+                },
+                mergelist=["dev-libs/B-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, debug=False
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testOnlydepsIdepsEAPI8(self):
+        ebuilds = {
+            "dev-libs/A-1": {
+                "EAPI": "8",
+                "DEPEND": "dev-libs/B",
+                "RDEPEND": "dev-libs/C",
+                "PDEPEND": "dev-libs/D",
+                "IDEPEND": "dev-libs/E",
+            },
+            "dev-libs/B-1": {},
+            "dev-libs/C-1": {},
+            "dev-libs/D-1": {},
+            "dev-libs/E-1": {},
+        }
+        ebuilds["dev-libs/F-1"] = ebuilds["dev-libs/A-1"]
+        installed = {}
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                all_permutations=True,
+                success=True,
+                options={"--onlydeps": True, "--onlydeps-with-rdeps": "y"},
+                ambiguous_merge_order=True,
+                mergelist=[
+                    ("dev-libs/B-1", "dev-libs/C-1", "dev-libs/D-1", "dev-libs/E-1")
+                ],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                all_permutations=True,
+                success=True,
+                options={"--onlydeps": True, "--onlydeps-with-rdeps": "n"},
+                mergelist=["dev-libs/B-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": "y",
+                },
+                ambiguous_merge_order=True,
+                mergelist=[("dev-libs/B-1", "dev-libs/E-1")],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": True,
+                },
+                ambiguous_merge_order=True,
+                mergelist=[("dev-libs/B-1", "dev-libs/E-1")],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": "n",
+                },
+                mergelist=["dev-libs/B-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, debug=False
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_onlydeps_minimal.py
+++ b/lib/portage/tests/resolver/test_onlydeps_minimal.py
@@ -15,10 +15,12 @@ class OnlydepsMinimalTestCase(TestCase):
                 "DEPEND": "dev-libs/B",
                 "RDEPEND": "dev-libs/C",
                 "PDEPEND": "dev-libs/D",
+                "IDEPEND": "dev-libs/E",
             },
             "dev-libs/B-1": {},
             "dev-libs/C-1": {},
             "dev-libs/D-1": {},
+            "dev-libs/E-1": {},
         }
         installed = {}
 
@@ -36,6 +38,29 @@ class OnlydepsMinimalTestCase(TestCase):
                 all_permutations=True,
                 success=True,
                 options={"--onlydeps": True, "--onlydeps-with-rdeps": "n"},
+                mergelist=["dev-libs/B-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": "y",
+                },
+                ambiguous_merge_order=True,
+                mergelist=[("dev-libs/B-1",)],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                all_permutations=True,
+                success=True,
+                options={
+                    "--onlydeps": True,
+                    "--onlydeps-with-rdeps": "n",
+                    "--onlydeps-with-ideps": "n",
+                },
                 mergelist=["dev-libs/B-1"],
             ),
         )

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -800,6 +800,11 @@ Include run time dependencies when \fB\-\-onlydeps\fR is specified.
 When this is disabled only build time dependencies are included. This
 option is enabled by default.
 .TP
+.BR "\-\-onlydeps\-with\-ideps < y | n >"
+Include install time dependencies when \fB\-\-onlydeps\fR and
+\fB\-\-onlydeps\-with\-rdeps=n\fR are both specified. This option is
+disabled by default.
+.TP
 .BR "\-\-package\-moves [ y | n ]"
 Perform package moves when necessary. This option is enabled
 by default. Package moves are typically applied immediately


### PR DESCRIPTION
Add --onlydeps-with-ideps option in order to include install-time dependencies with --onlydeps and --onlydeps-with-rdeps=n. The dependencies that get pulled in are those that are necessary for emerge --nodeps to succeed when run after the equivalent --onlydeps. The default --onlydeps --onlydeps-with-rdeps=n behavior is unchanged.

Bug: https://bugs.gentoo.org/890777