### PR TITLE
Changed default action for emaint target sync to 'auto'.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Bug fixes:
 
 * portage(5): List volatile option as a separate entry (bug #888585).
 
+* emaint: Changed default action for emaint target sync to 'auto'.
+
 portage-3.0.44 (2023-01-15)
 --------------
 

--- a/lib/portage/emaint/main.py
+++ b/lib/portage/emaint/main.py
@@ -210,10 +210,16 @@ def emaint_main(myargv):
             long_action = opt.long.lstrip("-")
 
     if long_action is None:
-        # print("DEBUG: long_action is None: setting to 'check'")
-        long_action = "check"
-        func = check_opt.func
-        status = check_opt.status
+        if args[0] == "sync":
+            # print("DEBUG: long_action is None: setting to 'auto'")
+            long_action = "auto"
+            func = "auto_sync"
+            status = "Syncing %s"
+        else:
+            # print("DEBUG: long_action is None: setting to 'check'")
+            long_action = "check"
+            func = check_opt.func
+            status = check_opt.status
 
     if args[0] == "all":
         tasks = []


### PR DESCRIPTION
When using 'sync' module of emaint the default option is '--check' when none is provided which spits out an ERROR about '--check' not being an option for module 'sync'.
```
terminal ~ # emaint sync

ERROR: module 'sync' does not have option '--check'

sync module options:
-A, --allrepos (sync module only): -A, --allrepos  Sync all repos that have a sync-url defined
-a, --auto    (sync module only): -a, --auto  Sync auto-sync enabled repos only
-r, --repo    (sync module only): -r, --repo  Sync the specified repo
```

My idea was to change the default action for the 'sync' module to '--auto'. To me '--auto' seems to be the most useful default option for the 'sync' module since I would imagine that is the most common use case and presumably most users typing 'emaint sync' would be looking for this outcome. 

I'm not sure if I missed something but if defaulting to '--auto' is not good for some reason then perhaps changing the error message to something roughly along the lines of "please use an option" when using the 'sync' module without an option would be a good idea. 

This is my first time creating a pull request so by all means feel free to critique any mistakes. I've already tried to correct a few.