### PR TITLE
portage(5): list volatile option as a separate entry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ portage-3.0.45 (UNRELEASED)
 Bug fixes:
 * gpkg: Handle out-of-space errors (bug #891391).
 
+* portage(5): List volatile option as a separate entry (bug #888585).
+
 portage-3.0.44 (2023-01-15)
 --------------
 

--- a/man/portage.5
+++ b/man/portage.5
@@ -1260,7 +1260,8 @@ Keep snapshots in \fBDISTDIR\fR (do not delete). Defaults to no, false.
 Require the detached tarball signature to contain a good OpenPGP
 signature. This uses the OpenPGP key(ring) specified by the
 sync\-openpgp\-key\-path setting. Defaults to no, false.
-.B volatile
+.TP
+.B volatile = yes|no|true|false
 Specifies whether a repository is volatile.  Volatile repositories
 are assumed to contain changes made outside of Portage.  This prohibits
 optimizations from occurring by assuming the integrity of the repository


### PR DESCRIPTION
The volatile option was hidden in the sync-webrsync-verify-signature entry. Add a separate entry for volatile, specifying its possible values in the portage(5) man page.

Closes: https://bugs.gentoo.org/888585
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>