### PR TITLE
emerge: Log completion of package installs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ Features:
 
 * install-qa-check.d: 60pkgconfig: add opt-in QA_PKGCONFIG_VERSION check
 
+* emerge: Log completion of package installs.
+
 Bug fixes:
 * gpkg: Handle out-of-space errors (bug #891391).
 

--- a/lib/_emerge/PackageMerge.py
+++ b/lib/_emerge/PackageMerge.py
@@ -9,13 +9,33 @@ from portage.output import colorize
 class PackageMerge(CompositeTask):
     __slots__ = ("merge", "postinst_failure")
 
+    def _should_show_status(self):
+        return (
+            not self.merge.build_opts.fetchonly
+            and not self.merge.build_opts.pretend
+            and not self.merge.build_opts.buildpkgonly
+        )
+
+    def _make_msg(self, pkg, action_desc, preposition, counter_str):
+        pkg_color = "PKG_MERGE"
+        if pkg.type_name == "binary":
+            pkg_color = "PKG_BINARY_MERGE"
+
+        msg = "{} {}{}".format(
+            action_desc,
+            counter_str,
+            colorize(pkg_color, pkg.cpv + _repo_separator + pkg.repo),
+        )
+
+        if pkg.root_config.settings["ROOT"] != "/":
+            msg += f" {preposition} {pkg.root}"
+
+        return msg
+
     def _start(self):
         self.scheduler = self.merge.scheduler
         pkg = self.merge.pkg
         pkg_count = self.merge.pkg_count
-        pkg_color = "PKG_MERGE"
-        if pkg.type_name == "binary":
-            pkg_color = "PKG_BINARY_MERGE"
 
         if pkg.installed:
             action_desc = "Uninstalling"
@@ -29,20 +49,8 @@ class PackageMerge(CompositeTask):
                 colorize("MERGE_LIST_PROGRESS", str(pkg_count.maxval)),
             )
 
-        msg = "{} {}{}".format(
-            action_desc,
-            counter_str,
-            colorize(pkg_color, pkg.cpv + _repo_separator + pkg.repo),
-        )
-
-        if pkg.root_config.settings["ROOT"] != "/":
-            msg += f" {preposition} {pkg.root}"
-
-        if (
-            not self.merge.build_opts.fetchonly
-            and not self.merge.build_opts.pretend
-            and not self.merge.build_opts.buildpkgonly
-        ):
+        if self._should_show_status():
+            msg = self._make_msg(pkg, action_desc, preposition, counter_str)
             self.merge.statusMessage(msg)
 
         task = self.merge.create_install_task()

--- a/lib/_emerge/PackageMerge.py
+++ b/lib/_emerge/PackageMerge.py
@@ -58,5 +58,25 @@ class PackageMerge(CompositeTask):
 
     def _install_exit(self, task):
         self.postinst_failure = getattr(task, "postinst_failure", None)
+
+        pkg = self.merge.pkg
+        pkg_count = self.merge.pkg_count
+
+        if self.postinst_failure:
+            action_desc = "Failed"
+            preposition = "in"
+            counter_str = ""
+        else:
+            action_desc = "Completed"
+            preposition = "to"
+            counter_str = "({} of {}) ".format(
+                colorize("MERGE_LIST_PROGRESS", str(pkg_count.curval)),
+                colorize("MERGE_LIST_PROGRESS", str(pkg_count.maxval)),
+            )
+
+        if self._should_show_status():
+            msg = self._make_msg(pkg, action_desc, preposition, counter_str)
+            self.merge.statusMessage(msg)
+
         self._final_exit(task)
         self.wait()


### PR DESCRIPTION
The log currently shows Emerging/Installing progress messages, but
it doesn't indicate when a package finishes.  Since there can be dozens
of installs in flight at once, this makes it nearly impossible to
determine how long an individual package took.  This adds a similar
"Completed" line when the package merge completes.

Reviewed-by: Mike Frysinger <vapier@chromium.org>
Reviewed-by: Chris McDonald <cjmcdonald@chromium.org>
Signed-off-by: Matt Turner <mattst88@gentoo.org>


@yetamrra: I've found this very useful in ChromeOS. Can I get your Signed-off-by tag so we can upstream it? I split the patch in two for easier review.