### PR TITLE
install-qa-check.d/60pkgconfig: fix eapi_has_version_functions call

### DIFF
--- a/bin/install-qa-check.d/60pkgconfig
+++ b/bin/install-qa-check.d/60pkgconfig
@@ -1,7 +1,7 @@
 # Check for pkg-config file issues
 
 # Ensure that ver_test is available.
-if ! __eapi_has_version_functions; then
+if ! ___eapi_has_version_functions; then
 	source "${PORTAGE_BIN_PATH}/eapi7-ver-funcs.sh" || exit 1
 fi
 


### PR DESCRIPTION
The function is prefixed with three three underscores, not two.

Fixes: https://github.com/gentoo/portage/commit/f0d4e696f82d989371360d7e4d8df6e2ff1f6bd2 ("install-qa-check.d/60pkgconfig: conditionally source eapi7-ver-funcs.sh")