### PR TITLE
mergeme: Don't overwrite files if the content matches

### DIFF
--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -159,6 +159,7 @@ SUPPORTED_FEATURES = frozenset(
         "getbinpkg",
         "gpg-keepalive",
         "icecream",
+        "ignore-mtime",
         "installsources",
         "ipc-sandbox",
         "keeptemp",

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -6267,9 +6267,10 @@ class dblink:
         if mydmode is None or not stat.S_ISREG(mydmode) or mymode != mydmode:
             return True
 
-        excluded_xattrs = self.settings.get("PORTAGE_XATTR_EXCLUDE", "")
-        if not _cmpxattr(mysrc, mydest, exclude=excluded_xattrs):
-            return True
+        if "xattr" in self.settings.features:
+            excluded_xattrs = self.settings.get("PORTAGE_XATTR_EXCLUDE", "")
+            if not _cmpxattr(mysrc, mydest, exclude=excluded_xattrs):
+                return True
 
         return not filecmp.cmp(mysrc, mydest, shallow=False)
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -5544,6 +5544,8 @@ class dblink:
                     destmd5,
                     mydest_link,
                 )
+                if protected and moveme:
+                    mydmode = None
 
             zing = "!!!"
             if not moveme:
@@ -5584,6 +5586,7 @@ class dblink:
                         msg.append("")
                         self._eerror("preinst", msg)
                         mydest = newdest
+                        mydmode = None
 
                 # if secondhand is None it means we're operating in "force" mode and should not create a second hand.
                 if (secondhand is not None) and (not os.path.exists(myrealto)):
@@ -5797,6 +5800,7 @@ class dblink:
                     msg.append("")
                     self._eerror("preinst", msg)
                     mydest = newdest
+                    mydmode = None
 
                 # whether config protection or not, we merge the new file the
                 # same way.  Unless moveme=0 (blocking directory)
@@ -6260,10 +6264,7 @@ class dblink:
         Takes file mode and extended attributes into account.
         Should only be used for regular files.
         """
-        if not os.path.exists(mydest):
-            return True
-
-        if mymode != mydmode:
+        if mydmode is None or not stat.S_ISREG(mydmode) or mymode != mydmode:
             return True
 
         excluded_xattrs = self.settings.get("PORTAGE_XATTR_EXCLUDE", "")

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -5422,6 +5422,7 @@ class dblink:
         srcroot = normalize_path(srcroot).rstrip(sep) + sep
         destroot = normalize_path(destroot).rstrip(sep) + sep
         calc_prelink = "prelink-checksums" in self.settings.features
+        ignore_mtime = "ignore-mtime" in self.settings.features
 
         protect_if_modified = (
             "config-protect-if-modified" in self.settings.features
@@ -5830,6 +5831,13 @@ class dblink:
                         hardlink_candidates.append(mydest)
                         zing = ">>>"
                     else:
+                        if not ignore_mtime:
+                            mymtime = thismtime if thismtime is not None else mymtime
+                            try:
+                                os.utime(mydest, ns=(mymtime, mymtime))
+                            except OSError:
+                                # utime can fail here with EPERM
+                                pass
                         zing = "==="
 
                     try:

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -533,6 +533,12 @@ If your GPG is auto unlocked on login, you do not need this.
 .B icecream
 Enable portage support for the icecream package.
 .TP
+.B ignore\-mtime
+Do not update mtime if the target file is equal. This can be useful on some
+filesystems to better utilize features like snapshots and data deduplication,
+however this violates the preservation of file modification times as stipulated
+in the PMS.
+.TP
 .B installsources
 Install source code into /usr/src/debug/${CATEGORY}/${PF} (also see
 \fBsplitdebug\fR). This feature works only if debugedit is installed, CFLAGS


### PR DESCRIPTION
Uses `filecmp.cmp(..., shallow=False)` to compare file contents and doesn't replace them if they are equal. This results in less disk churn and helps to keep filesystem snapshots as small as possible.

Closes: https://bugs.gentoo.org/722270

Below are some benchmarks on btrfs with CoW enabled. I will do some more benchmarks with ext4 over the next days, so until then this is a draft get some comments and suggestions.

There seems to be no regression for CoW file systems, but a small performance improvement, especially for large files.


#### 1) Large files with PORTAGE_TMPDIR on tmpfs
To get a more realistic use case I first emerged an older version of linux-firmware and timed the update.

**portage-3.0.44:**

```
# export PORTAGE_TMPDIR="/tmp"
# emerge -1v =sys-kernel/linux-firmware-20220310 && time emerge -1v =sys-kernel/linux-firmware-20230210
...
real    0m55.446s
user    1m16.033s
sys     0m26.503s
```

**mergeme-filecmp branch:**

```
# export PORTAGE_TMPDIR="/tmp"
# bin/emerge -1v =sys-kernel/linux-firmware-20220310 && time bin/emerge -1v =sys-kernel/linux-firmware-20230210
...
real    0m44.532s
user    1m11.348s
sys     0m17.755s
```

#### 2) Large files with PORTAGE_TMPDIR on the same disk

**portage-3.0.44:**

```
# export PORTAGE_TMPDIR="/var/tmp"
# emerge -1v =sys-kernel/linux-firmware-20220310 && time emerge -1v =sys-kernel/linux-firmware-20230210
...
real    0m55.697s
user    1m14.798s
sys     0m26.915s
```

**mergeme-filecmp branch:**

```
# export PORTAGE_TMPDIR="/var/tmp"
# bin/emerge -1v =sys-kernel/linux-firmware-20220310 && time bin/emerge -1v =sys-kernel/linux-firmware-20230210
...
real    0m47.278s
user    1m15.744s
sys     0m18.229s
```

#### 3) Lots of small files with PORTAGE_TMPDIR on tmpfs
papirus-icon-theme provides a lot of small files which might be useful as benchmark to represent most use cases.


**portage-3.0.44:**

```
# export PORTAGE_TMPDIR="/tmp"
# time emerge -1v =x11-themes/papirus-icon-theme-20230104
...
real    2m1.555s
user    1m35.551s
sys     0m55.645s
```

**mergeme-filecmp branch:**

```
# export PORTAGE_TMPDIR="/tmp"
# time bin/emerge -1v =x11-themes/papirus-icon-theme-20230104
...
real    1m57.153s
user    1m34.715s
sys     0m50.894s
```

#### 4) Lots of small files with PORTAGE_TMPDIR on the same disk


**portage-3.0.44:**

```
# export PORTAGE_TMPDIR="/var/tmp"
# time emerge -1v =x11-themes/papirus-icon-theme-20230104
...
real    2m7.899s
user    1m33.625s
sys     1m1.591s
```

**mergeme-filecmp branch:**

```
# export PORTAGE_TMPDIR="/var/tmp"
# time bin/emerge -1v =x11-themes/papirus-icon-theme-20230104
...
real    2m3.284s
user    1m33.874s
sys     0m58.363s
```