### PR TITLE
sync: git: fix code comment regarding clobbering the repository

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -125,8 +125,14 @@ Breaking changes:
     to work.
 
   The default value of 'volatile' is determined as follows:
-  - If unset and the repository is under /var/db/repos and the repository
-    exists and it's owned by either 'portage' or 'root', set to yes.
+  - If the repository is under /var/db/repos or if it is owned by either
+    'portage' or 'root', then it defaults to 'no'. That is, portage
+    assumes full control over the repository, potentially performing
+    destructive changes to the repository.
+  - If the repository is not under /var/db/repos or owned by a different
+    user than 'portage' or 'root', then it defaults to 'yes'. That is,
+    portage assumes the repository is user owned and does *not* perform
+    any destructive changes.
 
 Features:
 * cnf: make.conf.example.loong: add for the loong arch (bug #884135).

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -194,13 +194,14 @@ class GitSync(NewBase):
         # 1. sync-type=git
         # 2.
         #   - volatile=no (explicitly set to no), OR
-        #   - volatile is unset AND the repository owner is neither root or portage
+        #   - volatile is unset AND the repository owner is either root or portage
         # 3. Portage is syncing the respository (rather than e.g. auto-sync=no
         # and never running 'emaint sync -r foo')
         #
         # Portage will not clobber if:
         # 1. volatile=yes (explicitly set in the config), OR
-        # 2. volatile is unset and the repository owner is root or portage.
+        # 2. volatile is unset and the repository owner is neither root nor
+        #    portage.
         #
         # 'volatile' refers to whether the repository is volatile and may
         # only be safely changed by Portage itself, i.e. whether Portage


### PR DESCRIPTION
The logic the comment stated was simply inverted. The actual implementation is correct.