### PR TITLE
sync: git: report error if volatile repository

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,9 @@ Bug fixes:
 
 * tests: news: significantly improved test coverage (bug #889330).
 
+* git: also report sync errors for volatile repos. Portage would previously simply
+  report success if an volatile repository failed to sync
+
 portage-3.0.44 (2023-01-15)
 --------------
 

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -376,15 +376,16 @@ class GitSync(NewBase):
             **self.spawn_kwargs,
         )
 
-        if exitcode != os.EX_OK and not self.repo.volatile:
-            # HACK - sometimes merging results in a tree diverged from
-            # upstream, so try to hack around it
-            # https://stackoverflow.com/questions/41075972/how-to-update-a-git-shallow-clone/41081908#41081908
-            exitcode = portage.process.spawn(
-                f"{self.bin_command} reset --hard refs/remotes/{remote_branch}",
-                cwd=portage._unicode_encode(self.repo.location),
-                **self.spawn_kwargs,
-            )
+        if exitcode != os.EX_OK:
+            if not self.repo.volatile:
+                # HACK - sometimes merging results in a tree diverged from
+                # upstream, so try to hack around it
+                # https://stackoverflow.com/questions/41075972/how-to-update-a-git-shallow-clone/41081908#41081908
+                exitcode = portage.process.spawn(
+                    f"{self.bin_command} reset --hard refs/remotes/{remote_branch}",
+                    cwd=portage._unicode_encode(self.repo.location),
+                    **self.spawn_kwargs,
+                )
 
             if exitcode != os.EX_OK:
                 msg = f"!!! git merge error in {self.repo.location}"


### PR DESCRIPTION
Previously portage would not report a merge_cmd error if the repository was volatile. This could potentially be the cause of bug #895526, however if it unclear, at the time of writing this, if the repository in the bug is a volatile one.