### PR TITLE
sync: git: also print merge_cmd

### DIFF
--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -169,7 +169,7 @@ class GitSync(NewBase):
             }
             self.spawn_kwargs["env"].update(pull_env)
 
-        if self.settings.get("PORTAGE_QUIET") == "1":
+        if quiet:
             git_cmd_opts += " --quiet"
 
         # The logic here is a bit delicate. We need to balance two things:

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -301,7 +301,8 @@ class GitSync(NewBase):
             git_cmd_opts,
         )
 
-        writemsg_level(git_cmd + "\n")
+        if not quiet:
+            writemsg_level(git_cmd + "\n")
 
         rev_cmd = [self.bin_command, "rev-list", "--max-count=1", "HEAD"]
         previous_rev = subprocess.check_output(

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -370,6 +370,9 @@ class GitSync(NewBase):
         if quiet:
             merge_cmd.append("--quiet")
 
+        if not quiet:
+            writemsg_level(' '.join(merge_cmd) + "\n")
+
         exitcode = portage.process.spawn(
             merge_cmd,
             cwd=portage._unicode_encode(self.repo.location),


### PR DESCRIPTION
It felt strange that the sync operation would print the "git fetch" command, but not the command used to merge the remote's changes into the local working tree.