### PR TITLE
Add QA check for implicit function declarations in configure logs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,17 @@ Features:
 
 * install-qa-check.d: 60pkgconfig: add opt-in QA_PKGCONFIG_VERSION check
 
+* install-qa-check.d: add 90config-impl-decl to detect -Wimplicit-function-declaration
+  in config.log, CMakeError.log, and meson-log.txt. ebuilds can add functions to
+  the QA_CONFIG_IMPL_DECL_SKIP array to skip false positives.
+
+  The following entries are created in qa.log under the tag 'config.log-impl-decl':
+
+  * 'line' - line number in the config log where the warning is found
+  * 'func' - the function that is implicitly declared
+
+  (bug #892651)
+
 * emerge: Log completion of package installs.
 
 Bug fixes:

--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -1,0 +1,87 @@
+# Check for implicit function declaration warnings in configure logs
+#
+# ebuilds should set the QA_CONFIG_IMPL_DECL_SKIP array to skip known false
+# positives.
+#
+# Some examples of logs to look for:
+# bash: work/bash-5.1/config.log
+#       ^---  easy
+# python: work/Python-3.10.9/config.log
+#         ^---  easy
+# gcc: work/build/config.log
+#      ^---  can be out-of-tree
+# clang: work/x/y/clang-abi_x86_64.amd64/CMakeFiles/CMakeError.log
+#        ^---  can be non-autotools (and very deep)
+# systemd-utils: work/systemd-stable-251.10-abi_x86_64.amd64/meson-logs/meson-log.txt
+#                ^---  can be non-autotools
+#
+# Adapted from macports portconfigure.tcl with love.
+#
+# See also: bug 892651
+
+find_log_targets() {
+	local log_targets=(
+		'config.log'
+		'CMakeError.log'
+		'meson-log.txt'
+	)
+	local find_args=()
+	local log
+
+	# Find config logs. Assume the dirs can have spaces in them, even though
+	# that is hella evil and goes against good filesystem manners!
+	for log in "${log_targets[@]}"; do
+		find_args+=( '-name' "${log}" '-o' )
+	done
+	unset -v 'find_args[-1]'
+	printf '%s\0' "${WORKDIR}" |
+		find -files0-from - -type f \( "${find_args[@]}" \) -print0
+}
+
+config_impl_decl_check() {
+	local files=()
+	local lines=()
+	local funcs=()
+	local l
+	local entry
+	local line
+	local func
+	local re=" function '([[:print:]]+)'"
+
+	# Iterate over every log file found and check for '-Wimplicit-function-declaration'
+	while IFS= read -rd '' l; do
+		while IFS= read -ru3 entry; do
+			# Strip ANSI codes (color and erase in line have been seen at least)
+			entry="$(printf '%s\n' "${entry}" | sed -E -e $'s/\033\[[0-9;]*[A-Za-z]//g')"
+
+			line="${entry%%:*}"
+			# This conditional should always be true unless compiler warnings
+			# get drastically changed
+			if [[ ${entry} =~ ${re} ]]; then
+				func="${BASH_REMATCH[1]}"
+			fi
+
+			has "${func}" "${QA_CONFIG_IMPL_DECL_SKIP[@]}" && continue
+
+			files+=( "${l}" )
+			lines+=( "${line}" )
+			funcs+=( "${func}" )
+		# Using -I to ignore binary files is a GNU extension for grep
+		done 3< <(grep -nEI -e '-Wimplicit-function-declaration' "${l}")
+	done < <(find_log_targets)
+
+	# Drop out early if no impl decls found (all the arrays are the same size)
+	[[ ${#files[@]} -eq 0 ]] && return
+
+	eqawarn 'Found the following implicit function declarations in configure logs:'
+	for l in "${!files[@]}"; do
+		eqawarn "  ${files[l]}:${lines[l]} - ${funcs[l]}"
+		eqatag 'config.log-impl-decl' "line=${lines[l]}" "func=${funcs[l]}" "${files[l]}"
+	done
+	eqawarn 'Check that no features were accidentally disabled.'
+}
+
+config_impl_decl_check
+: # guarantee successful exit
+
+# vim:ft=sh noexpandtab:


### PR DESCRIPTION
Add a script into `install-qa-check.d/` which looks for implicit function declarations in configure logs (currently `config.log`, `CMakeError.log`, and `meson-log.txt`) and warns about a potentially misconfigured program. ebuilds can declare known false positives by adding the function names into the `QA_CONFIG_IMPL_DECL_SKIP` array.

Example `build.log`:
```
... snip ...
>>> Completed installing dev-lang/python-3.10.9-r1 into /var/tmp/portage/dev-lang/python-3.10.9-r1/image

 * Final size of build directory: 130296 KiB (127.2 MiB)
 * Final size of installed tree:  127600 KiB (124.6 MiB)

 * Verifying compiled files for python3.10
 * Found the following implicit function declarations in configure logs:
 *   /var/tmp/portage/dev-lang/python-3.10.9-r1/work/Python-3.10.9/config.log:10419 - chflags
 *   /var/tmp/portage/dev-lang/python-3.10.9-r1/work/Python-3.10.9/config.log:10766 - lchflags
 * Check that no features were accidentally disabled.
strip: x86_64-pc-linux-gnu-strip --strip-unneeded -N __gentoo_check_ldflags__ -R .comment -R .GCC.command.line -R .note.gnu.gold-version
... snip ...
```
and the corresponding `qa.log`:
```
- tag: config.log-impl-decl
  data:
    line: "10419"
    func: "chflags"
  files:
    - "/var/tmp/portage/dev-lang/python-3.10.9-r1/work/Python-3.10.9/config.log"
- tag: config.log-impl-decl
  data:
    line: "10766"
    func: "lchflags"
  files:
    - "/var/tmp/portage/dev-lang/python-3.10.9-r1/work/Python-3.10.9/config.log"
```

Example `build.log` with `QA_CONFIG_IMPL_DECL_SKIP=( 'chflags' )`
```
... snip ...
>>> Completed installing dev-lang/python-3.10.9-r2 into /var/tmp/portage/dev-lang/python-3.10.9-r2/image

 * Final size of build directory: 130296 KiB (127.2 MiB)
 * Final size of installed tree:  127600 KiB (124.6 MiB)

 * Verifying compiled files for python3.10
 * Found the following implicit function declarations in configure logs:
 *   /var/tmp/portage/dev-lang/python-3.10.9-r2/work/Python-3.10.9/config.log:10766 - lchflags
 * Check that no features were accidentally disabled.
strip: x86_64-pc-linux-gnu-strip --strip-unneeded -N __gentoo_check_ldflags__ -R .comment -R .GCC.command.line -R .note.gnu.gold-version
... snip ...
```
and the corresponding `qa.log`:
```
- tag: config.log-impl-decl
  data:
    line: "10766"
    func: "lchflags"
  files:
    - "/var/tmp/portage/dev-lang/python-3.10.9-r2/work/Python-3.10.9/config.log"
```

Example `build.log` with `QA_CONFIG_IMPL_DECL_SKIP=( 'chflags' 'lchflags' )`
```
... snip ...
>>> Completed installing dev-lang/python-3.10.9-r3 into /var/tmp/portage/dev-lang/python-3.10.9-r3/image

 * Final size of build directory: 130296 KiB (127.2 MiB)
 * Final size of installed tree:  127600 KiB (124.6 MiB)

 * Verifying compiled files for python3.10
strip: x86_64-pc-linux-gnu-strip --strip-unneeded -N __gentoo_check_ldflags__ -R .comment -R .GCC.command.line -R .note.gnu.gold-version
... snip ...
```
(no `qa.log` as expected)