### PR TITLE
repository: config: fix initial sync of (git) repositories

### DIFF
--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -343,24 +343,26 @@ class RepoConfig:
             # If it's unset, we default to no (i.e. the repository is not volatile),
             # but with a heuristic for when a repository is not likely to be suitable
             # (likely to contain custom user changes).
-
-            # If the repository doesn't exist, we can't check its ownership,
-            # so err on the safe side.
-            if missing or not self.location:
+            try:
+                # If the repository doesn't exist, we can't check its ownership,
+                # so err on the safe side.
+                if missing or not self.location:
+                    self.volatile = True
+                # On Prefix, you can't rely on the ownership as a proxy for user
+                # owned because the user typically owns everything.
+                # But we can't access if we're on Prefix here, so use whether
+                # we're under /var/db/repos instead.
+                elif not self.location.startswith("/var/db/repos"):
+                    self.volatile = True
+                # If the owner of the repository isn't root or Portage, it's
+                # an indication the user may expect to be able to safely make
+                # changes in the directory, so default to volatile.
+                elif Path(self.location).owner() not in ("root", "portage"):
+                    self.volatile = True
+                else:
+                    self.volatile = False
+            except (FileNotFoundError, PermissionError):
                 self.volatile = True
-            # On Prefix, you can't rely on the ownership as a proxy for user
-            # owned because the user typically owns everything.
-            # But we can't access if we're on Prefix here, so use whether
-            # we're under /var/db/repos instead.
-            elif not self.location.startswith("/var/db/repos"):
-                self.volatile = True
-            # If the owner of the repository isn't root or Portage, it's
-            # an indication the user may expect to be able to safely make
-            # changes in the directory, so default to volatile.
-            elif Path(self.location).owner() not in ("root", "portage"):
-                self.volatile = True
-            else:
-                self.volatile = False
 
         self.eapi = None
         self.missing_repo_name = missing


### PR DESCRIPTION
After bd8f9f6c590dca750285e296a6c3d530f1053d89, we started to actually dereference the Path object on the (new) repository location. If it doesn't exist yet, it has no owner, and a FileNotFoundError is thrown:
```
[...]
  File "/usr/lib/python3.10/site-packages/portage/repository/config.py", line 794, in _parse
    repo = RepoConfig(sname, optdict, local_config=local_config)
  File "/usr/lib/python3.10/site-packages/portage/repository/config.py", line 360, in __init__
    elif Path(self.location).owner() not in ("root", "portage"):
  File "/usr/lib/python3.10/pathlib.py", line 1103, in owner
    return self._accessor.owner(self)
  File "/usr/lib/python3.10/pathlib.py", line 343, in owner
    return pwd.getpwuid(self.stat(path).st_uid).pw_name
FileNotFoundError: [Errno 2] No such file or directory: '/var/db/repos/foo'
```

It's fine if the repository doesn't exist yet, the intention in ef123a214708c85f9802f2a649b93137fd2ee3be was to default to non-volatile for such cases, so let's honour that by catching FileNotFoundError and PermissionError.

Note that this was exposed by bd8f9f6c590dca750285e296a6c3d530f1053d89 and the real issue was in ef123a214708c85f9802f2a649b93137fd2ee3be, but it's worth having Fixes: tags for both as it becomes easier to understand when it was exposed and when it was actually an issue.

Bug: https://bugs.gentoo.org/899208
Fixes: bd8f9f6c590dca750285e296a6c3d530f1053d89 ("repository: config: fix volatile detection, add missing () operator")
Fixes: ef123a214708c85f9802f2a649b93137fd2ee3be ("config: Add 'volatile' configuration option")