### PR TITLE
repository: config: absorb all exceptions when determining volatility

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,12 +1,19 @@
+portage-3.0.45.3 (UNRELEASED)
+----------------
+
+Bug fixes:
+* repository: config: Handle more error cases when determining repository
+  volatility (bug #900683).
+
 portage-3.0.45.2 (2023-03-04)
---------------
+----------------
 
 Bug fixes:
 * repository: config: Fix initial sync of repositories (bug #899208). Regression
   from portage-3.0.45, but the real bug is from portage-3.0.42.
 
 portage-3.0.45.1 (2023-02-27)
---------------
+----------------
 
 Bug fixes:
 * install-qa-check.d/90config-impl-decl: fix handling of non-ASCII quotes when

--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -361,7 +361,14 @@ class RepoConfig:
                     self.volatile = True
                 else:
                     self.volatile = False
-            except (FileNotFoundError, PermissionError):
+            except Exception:
+                # There's too many conditions here to refine the exception list:
+                # - We lack permissions to poke at the directory (PermissionError)
+                # - Its UID doesn't actually exist and the repository
+                #   won't be synced by the user (KeyError).
+                # - The directory doesn't exist (FileNotFoundError)
+                # - Probably many others.
+                # So, just fail safe.
                 self.volatile = True
 
         self.eapi = None


### PR DESCRIPTION
Not ideal, but we don't have much else of a choice. It's a very small section and trying to granularly specify the relevant exceptions here is clearly a waste of time (see ref'd bugs).

Besides, the consequence is just failing-safe and assuming the repo is volatile anyway.

Bug: https://bugs.gentoo.org/899208
Bug: https://bugs.gentoo.org/900683