### PR TITLE
testSimple: debugging flakey test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,7 @@ jobs:
         printf "[build_ext]\nportage_ext_modules=true" >> setup.cfg
         ./setup.py install --root=/tmp/install-root
     - name: Run tox targets for ${{ matrix.python-version }}
+      # Capture who this runs as before the run starts
       run: |
+        id
         tox -vv

--- a/lib/portage/tests/emerge/test_simple.py
+++ b/lib/portage/tests/emerge/test_simple.py
@@ -692,7 +692,7 @@ move dev-util/git dev-vcs/git
                 # triggered by python -Wd will be visible.
                 stdout = subprocess.PIPE
 
-            for args in test_commands:
+            for idx, args in enumerate(test_commands):
                 if hasattr(args, "__call__"):
                     args()
                     continue
@@ -704,21 +704,22 @@ move dev-util/git dev-vcs/git
                 else:
                     local_env = env
 
-                proc = await asyncio.create_subprocess_exec(
-                    *args, env=local_env, stderr=None, stdout=stdout
-                )
+                with self.subTest(cmd=args, i=idx):
+                    proc = await asyncio.create_subprocess_exec(
+                        *args, env=local_env, stderr=None, stdout=stdout
+                    )
 
-                if debug:
-                    await proc.wait()
-                else:
-                    output, _err = await proc.communicate()
-                    await proc.wait()
-                    if proc.returncode != os.EX_OK:
-                        portage.writemsg(output)
+                    if debug:
+                        await proc.wait()
+                    else:
+                        output, _err = await proc.communicate()
+                        await proc.wait()
+                        if proc.returncode != os.EX_OK:
+                            portage.writemsg(output)
 
-                self.assertEqual(
-                    os.EX_OK, proc.returncode, f"emerge failed with args {args}"
-                )
+                    self.assertEqual(
+                        os.EX_OK, proc.returncode, f"emerge failed with args {args}"
+                    )
         finally:
             binhost_server.__exit__(None, None, None)
             playground.cleanup()


### PR DESCRIPTION
Per IRC, tweaks to make it easier to debug flakey behavior in testSimple.
```
testSimple (portage.tests.emerge.test_simple.SimpleEmergeTestCase.testSimple) ... emerge: superuser access is required
```

This PR should show:
1. What user the tests actually run as
2. Individual parts of `testSimple`, because there are a LOT of them, despite the name.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>