### PR TITLE
tests: fix util/test_shelve.py

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,7 +56,8 @@ Features:
   for a time for compatibility.
 
 Bug fixes:
-* TODO
+* tests: util/test_shelve: fix test failure if the backend for the shelve module
+  does not create the shelve db using the literal filename.
 
 portage-3.0.45.3 (2023-03-19)
 ----------------

--- a/lib/portage/tests/util/test_shelve.py
+++ b/lib/portage/tests/util/test_shelve.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Gentoo Authors
+# Copyright 2020-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
@@ -44,7 +44,6 @@ class ShelveUtilsTestCase(TestCase):
                 db.close()
                 dump(dump_args)
 
-                os.unlink(dump_args.src)
                 restore_args = argparse.Namespace(
                     dest=dump_args.src,
                     src=dump_args.dest,


### PR DESCRIPTION
Remove the `os.unlink()` call which can fail if the backend lib, eg, adds a suffix to the filename. When debugging this failed run [1], the `shelve_file` was being created as `shelve_file.db`.

From the Python docs:

    The filename parameter is the base filename for the underlying
    database.  As a side-effect, an extension may be added to the
    filename and more than one file may be created.

[1]: https://builds.sr.ht/~xxc3nsoredxx/job/966549