### PR TITLE
Enable automated tests on sourcehut builds

### DIFF
--- a/.builds/ci.yml
+++ b/.builds/ci.yml
@@ -1,0 +1,39 @@
+# Maintainer: Oskari Pirhonen <xxc3ncoredxx@gmail.com>
+
+image: ubuntu/jammy
+shell: true
+repositories:
+  # For more versions than just the default python3
+  deadsnakes: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main "BA6932366A755776"
+  # Because Ubuntu have yet to fix: https://foss.hetapod.net/pypy/pypy/-/issues/3741
+  # pypy: https://ppa.launchpadcontent.net/pypy/ppa/ubuntu jammy main "251104D968854915"
+environment:
+  PYTHON_VERSIONS:
+    - '3.7'
+    - '3.8'
+    - '3.9'
+    - '3.10'
+    - '3.11'
+    # Testing PyPy is currently broken, see bug #903709
+    # - 'pypy3'
+tasks:
+  - setup-python: |
+      portage/.builds/setup-python.sh "${PYTHON_VERSIONS[@]}"
+
+  - test-install: |
+      for py in "${PYTHON_VERSIONS[@]}"; do
+        source ".venv-$py/bin/activate"
+        pushd portage
+          time ./setup.py clean install
+        popd
+        deactivate
+      done
+
+  - test-portage: |
+      for py in "${PYTHON_VERSIONS[@]}"; do
+        source ".venv-$py/bin/activate"
+        pushd portage
+          ./setup.py clean test
+        popd
+        deactivate
+      done

--- a/.builds/lint.yml
+++ b/.builds/lint.yml
@@ -21,11 +21,27 @@ tasks:
       pip install black
       deactivate
 
+  - setup-pylint: |
+      for py in "${PYTHON_VERSIONS[@]}"; do
+        source ".venv-$py/bin/activate"
+        pip install pylint
+        deactivate
+      done
+
   - black: |
       source .venv/bin/activate
       cd portage
       STRAGGLERS="$(find bin runtests -type f -not -name '*.py' -not -name '*.sh' | \
           xargs grep -l '#!/usr/bin/env python' | \
           tr '\n' ' ')"
-      black --check --diff --color . $STRAGGLERS
+      time black --check --diff --color . $STRAGGLERS
       deactivate
+
+  - pylint: |
+      for py in "${PYTHON_VERSIONS[@]}"; do
+        source ".venv-$py/bin/activate"
+        pushd portage
+          time ./run-pylint
+        popd
+        deactivate
+      done

--- a/.builds/lint.yml
+++ b/.builds/lint.yml
@@ -1,15 +1,25 @@
 # Maintainer: Oskari Pirhonen <xxc3ncoredxx@gmail.com>
 
-image: ubuntu/lts
+image: ubuntu/jammy
 shell: true
+repositories:
+  # For more versions than just the default python3
+  deadsnakes: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main "BA6932366A755776"
+environment:
+  PYTHON_VERSIONS:
+    - '3.7'
+    - '3.8'
+    - '3.9'
+    - '3.10'
+    - '3.11'
 tasks:
-  - setup-lint-env: |
-      sudo apt-get update
-      sudo apt-get install -y --no-install-recommends python-is-python3 python3-venv
-      python -m venv .venv
+  - setup-python: |
+      portage/.builds/setup-python.sh "${PYTHON_VERSIONS[@]}"
+
+  - setup-black: |
       source .venv/bin/activate
-      pip install --upgrade pip
       pip install black
+      deactivate
 
   - black: |
       source .venv/bin/activate
@@ -18,3 +28,4 @@ tasks:
           xargs grep -l '#!/usr/bin/env python' | \
           tr '\n' ' ')"
       black --check --diff --color . $STRAGGLERS
+      deactivate

--- a/.builds/lint.yml
+++ b/.builds/lint.yml
@@ -1,0 +1,20 @@
+# Maintainer: Oskari Pirhonen <xxc3ncoredxx@gmail.com>
+
+image: ubuntu/lts
+shell: true
+tasks:
+  - setup-lint-env: |
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends python-is-python3 python3-venv
+      python -m venv .venv
+      source .venv/bin/activate
+      pip install --upgrade pip
+      pip install black
+
+  - black: |
+      source .venv/bin/activate
+      cd portage
+      STRAGGLERS="$(find bin runtests -type f -not -name '*.py' -not -name '*.sh' | \
+          xargs grep -l '#!/usr/bin/env python' | \
+          tr '\n' ' ')"
+      black --check --diff --color . $STRAGGLERS

--- a/.builds/setup-python.sh
+++ b/.builds/setup-python.sh
@@ -4,17 +4,24 @@
 set -ex
 
 install_versions=( "${@/#/python}" )
+# Fix any pypy versions
+install_versions=( "${install_versions[@]/#pythonpypy/pypy}" )
 
 sudo apt-get install -y --no-install-recommends \
-    python-is-python3 \
-    "${install_versions[@]}" \
-    "${install_versions[@]/%/-venv}"
+        python-is-python3 \
+        python3-venv \
+        "${install_versions[@]}" \
+        "${install_versions[@]/%/-venv}"
 
-for py in "${@}"; do
-  "python$py" -m venv ".venv-$py"
-  source ".venv-$py/bin/activate"
-  pip install --upgrade pip
-  deactivate
+for py in "$@"; do
+    if [[ "$py" != pypy* ]]; then
+        "python$py" -m venv ".venv-$py"
+    else
+        "$py" -m venv ".venv-$py"
+    fi
+    source ".venv-$py/bin/activate"
+    pip install --upgrade pip
+    deactivate
 done
 
 python -m venv .venv

--- a/.builds/setup-python.sh
+++ b/.builds/setup-python.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Maintainer: Oskari Pirhonen <xxc3ncoredxx@gmail.com>
+
+set -ex
+
+install_versions=( "${@/#/python}" )
+
+sudo apt-get install -y --no-install-recommends \
+    python-is-python3 \
+    "${install_versions[@]}" \
+    "${install_versions[@]/%/-venv}"
+
+for py in "${@}"; do
+  "python$py" -m venv ".venv-$py"
+  source ".venv-$py/bin/activate"
+  pip install --upgrade pip
+  deactivate
+done
+
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+deactivate

--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,25 @@ Features:
   See bug #898224. Portage previously used NOCOLOR. It continues to support NOCOLOR
   for a time for compatibility.
 
+* ci: enable running Portage tests on sourcehut builds
+
+  The build manifests and supporting files can be found in .builds/
+
+  Current limitations compared to GitHub actions:
+
+  - Does not test with PyPy (see bug #903709)
+  - Runs all all tests on each push (unless pushed with `-o skip-ci` which skips
+    all tests)
+  - Runs lint and ci jobs concurrently, but each Python version within those is
+    tested sequentially. This means tests will take longer to complete, unless
+    the run fails partway through (~1h vs ~15-20m).
+
+  Benefits compared to GitHub actions:
+
+  - Can monitor test progress over SSH
+  - Can investigate failed tests over SSH
+  - ... not GitHub ;)
+
 Bug fixes:
 * tests: util/test_shelve: fix test failure if the backend for the shelve module
   does not create the shelve db using the literal filename.


### PR DESCRIPTION
Run tests on push for Portage clones hosted on sourcehut. Currently skips testing on PyPy.

Example run: https://builds.sr.ht/~xxc3nsoredxx/job/967249