### PR TITLE
fowners, fperms: Fix handling of relative pathnames

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Bug fixes:
+* fowners, fperms: Fix handling of relative pathnames (bug #905223).
+
 portage-3.0.47 (2023-04-30)
 ---------------
 

--- a/bin/ebuild-helpers/fowners
+++ b/bin/ebuild-helpers/fowners
@@ -5,7 +5,7 @@
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
 if ! ___eapi_has_prefix_variables; then
-	EPREFIX= ED=${D}
+	ED=${D}
 fi
 
 args=()

--- a/bin/ebuild-helpers/fowners
+++ b/bin/ebuild-helpers/fowners
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
@@ -8,27 +8,21 @@ if ! ___eapi_has_prefix_variables; then
 	EPREFIX= ED=${D}
 fi
 
+args=()
 got_owner=
 for arg; do
-	[[ ${arg} == -* ]] && continue
-
-	if [[ ! ${got_owner} ]]; then
+	if [[ ${arg} == -* ]]; then
+		args+=( "${arg}" )
+	elif [[ ! ${got_owner} ]]; then
+		# the first non-option is the owner and must not be prefixed
 		got_owner=1
-		continue
-	fi
-
-	if [[ ${arg} != /* ]]; then
-		eqawarn "Relative path passed to '${0##*/}': ${arg}"
-		eqawarn "This is unsupported. Please use 'chown' when you need to work on files"
-		eqawarn "outside the installation image (\${ED})."
+		args+=( "${arg}" )
+	else
+		args+=( "${ED%/}/${arg#/}" )
 	fi
 done
 
-
-# we can't prefix all arguments because
-# chown takes random options
-slash="/"
-chown "${@/#${slash}/${ED%/}${slash}}"
+chown "${args[@]}"
 ret=$?
 
 [[ ${ret} -ne 0 ]] && __helpers_die "${0##*/} failed"

--- a/bin/ebuild-helpers/fowners
+++ b/bin/ebuild-helpers/fowners
@@ -19,6 +19,12 @@ for arg; do
 		args+=( "${arg}" )
 	else
 		args+=( "${ED%/}/${arg#/}" )
+		# remove the QA warning after 2024-12-31
+		if [[ ${arg:0:1} != / ]]; then
+			eqawarn "${0##*/}: Path '${arg}' does not start with '/'."
+			eqawarn "This is unsupported. Add a slash for a path in \${ED},"
+			eqawarn "or use 'chown' for a path relative to the working dir."
+		fi
 	fi
 done
 

--- a/bin/ebuild-helpers/fperms
+++ b/bin/ebuild-helpers/fperms
@@ -20,6 +20,12 @@ for arg; do
 		args+=( "${arg}" )
 	else
 		args+=( "${ED%/}/${arg#/}" )
+		# remove the QA warning after 2024-12-31
+		if [[ ${arg:0:1} != / ]]; then
+			eqawarn "${0##*/}: Path '${arg}' does not start with '/'."
+			eqawarn "This is unsupported. Add a slash for a path in \${ED},"
+			eqawarn "or use 'chmod' for a path relative to the working dir."
+		fi
 	fi
 done
 

--- a/bin/ebuild-helpers/fperms
+++ b/bin/ebuild-helpers/fperms
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
@@ -8,27 +8,22 @@ if ! ___eapi_has_prefix_variables; then
 	ED=${D}
 fi
 
+args=()
 got_mode=
 for arg; do
 	# - can either be an option or a mode string
-	[[ ${arg} == -* && ${arg} != -[ugorwxXst] ]] && continue
-
-	if [[ ! ${got_mode} ]]; then
+	if [[ ${arg} == -* && ${arg} != -[ugorwxXst] ]]; then
+		args+=( "${arg}" )
+	elif [[ ! ${got_mode} ]]; then
+		# the first non-option is the mode and must not be prefixed
 		got_mode=1
-		continue
-	fi
-
-	if [[ ${arg} != /* ]]; then
-		eqawarn "Relative path passed to '${0##*/}': ${arg}"
-		eqawarn "This is unsupported. Please use 'chmod' when you need to work on files"
-		eqawarn "outside the installation image (\${ED})."
+		args+=( "${arg}" )
+	else
+		args+=( "${ED%/}/${arg#/}" )
 	fi
 done
 
-# we can't prefix all arguments because
-# chmod takes random options
-slash="/"
-chmod "${@/#${slash}/${ED%/}${slash}}"
+chmod "${args[@]}"
 ret=$?
 [[ ${ret} -ne 0 ]] && __helpers_die "${0##*/} failed"
 exit ${ret}


### PR DESCRIPTION
PMS section 12.3.9 specifies that fowners and fperms "[take] paths relative to the image directory."

Currently, these helpers interpret any pathnames not beginning with a slash as relative to the current working directory (after printing a QA warning). This contradicts the spec.

It is also inconsistent with other helpers like insinto or dostrip, which expand their pathnames relative to ${ED}.

Closes: https://bugs.gentoo.org/905223