### PR TITLE
doebuild.py: PVR includes -r0 if explicitly specified

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ Bug fixes:
 * All _E_*DESTTREE_ variables to renamed to __E_*DESTTREE, in order to move
   them to the __* namespace which is reserved for the package manager.
 
+* The PVR variable includes -r0 if explicitly specified (bug #875362).
+
 portage-3.0.46 (2023-04-07)
 ---------------
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2021 Gentoo Authors
+# Copyright 2010-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ["doebuild", "doebuild_environment", "spawn", "spawnebuild"]
@@ -443,14 +443,10 @@ def doebuild_environment(
     mysettings["PN"] = mysplit[0]
     mysettings["PV"] = mysplit[1]
     mysettings["PR"] = mysplit[2]
+    mysettings["PVR"] = mypv[len(mysplit[0]) + 1 :]
 
     if noiselimit < 0:
         mysettings["PORTAGE_QUIET"] = "1"
-
-    if mysplit[2] == "r0":
-        mysettings["PVR"] = mysplit[1]
-    else:
-        mysettings["PVR"] = mysplit[1] + "-" + mysplit[2]
 
     # All temporary directories should be subdirectories of
     # $PORTAGE_TMPDIR/portage, since it's common for /tmp and /var/tmp

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -371,7 +371,7 @@ Contains the revision number or 'r0' if no revision number exists.
 .fi
 .TP
 .B PVR
-Contains the version number with the revision (if non-zero).
+Contains the version number with the revision (if any).
 
 \fBExample\fR:
 .nf


### PR DESCRIPTION
PMS says that PVR is "Package version and revision (if any)". https://projects.gentoo.org/pms/8/pms.html#x1-109001r1

Bug: https://bugs.gentoo.org/875362