### PR TITLE
emerge-webrsync: tidy up 'webrsync-gpg' case

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,10 +3,8 @@ portage-3.0.48 (UNRELEASED)
 Bug fixes:
 * fowners, fperms: Fix handling of relative pathnames (bug #905223).
 
-* emerge-webrsync: Be less alarmist when a user is syncing with Portage
-  (not calling emerge-webrsync directly) with sync-type='webrsync'. We
-  were emitting a misleading warning about the validation method in use
-  which might in fact encourage people to use the older method.
+* emerge-webrsync: Switch Portage to use gemato for when it shells out
+  to emerge-webrsync for repositories configured with sync-type=webrsync.
 
 Cleanups:
 * Convert printf-style %-formats into fstrings.

--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,12 @@ Bug fixes:
 * fowners, fperms: Fix handling of relative pathnames (bug #905223).
 
 * emerge-webrsync: Switch Portage to use gemato for when it shells out
-  to emerge-webrsync for repositories configured with sync-type=webrsync.
+  to emerge-webrsync for repositories configured with sync-type=webrsync
+  (bug #905358).
+
+  This unifies some of the logic between Portage and emerge-webrsync:
+  both of them now use the same main path for PGP verification (i.e.
+  gemato).
 
 Cleanups:
 * Convert printf-style %-formats into fstrings.

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ portage-3.0.48 (UNRELEASED)
 Bug fixes:
 * fowners, fperms: Fix handling of relative pathnames (bug #905223).
 
+* emerge-webrsync: Be less alarmist when a user is syncing with Portage
+  (not calling emerge-webrsync directly) with sync-type='webrsync'. We
+  were emitting a misleading warning about the validation method in use
+  which might in fact encourage people to use the older method.
+
 Cleanups:
 * Convert printf-style %-formats into fstrings.
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -290,10 +290,6 @@ check_file_signature_gemato() {
 		)
 
 		[[ -n ${PORTAGE_GPG_KEY_SERVER} ]] && gemato_args+=( --keyserver "${PORTAGE_GPG_KEY_SERVER}" )
-		# Portage is calling us so it'll handle refreshing if configured to do so.
-		# Don't repeat its work.
-		[[ -n ${PORTAGE_TEMP_GPG_DIR} ]] && gemato_args+=( --no-refresh-keys --no-wkd )
-
 		[[ ${PORTAGE_QUIET} == 1 ]] && gemato_args+=( --quiet )
 		[[ ${do_debug} == 1 ]] && gemato_args+=( --debug )
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -272,9 +272,15 @@ check_file_signature_gemato() {
 	local r=1
 
 	if type -P gemato > /dev/null; then
+		if [[ -n ${PORTAGE_GPG_KEY} ]] ; then
+			local key="${PORTAGE_GPG_KEY}"
+		else
+			local key="${EPREFIX:-/}"/usr/share/openpgp-keys/gentoo-release.asc
+		fi
+
 		local gemato_args=(
 			openpgp-verify-detached
-			-K "${EPREFIX:-/}"/usr/share/openpgp-keys/gentoo-release.asc
+			-K "${key}"
 		)
 
 		[[ ${PORTAGE_QUIET} == 1 ]] && gemato_args+=( --quiet )

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -274,7 +274,7 @@ check_file_signature_gemato() {
 	if type -P gemato > /dev/null; then
 		local gemato_args=(
 			openpgp-verify-detached
-			-K /usr/share/openpgp-keys/gentoo-release.asc
+			-K "${EPREFIX:-/}"/usr/share/openpgp-keys/gentoo-release.asc
 		)
 
 		[[ ${PORTAGE_QUIET} == 1 ]] && gemato_args+=( --quiet )

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -283,6 +283,10 @@ check_file_signature_gemato() {
 			-K "${key}"
 		)
 
+		# Portage is calling us so it'll handle refreshing if configured to do so.
+		# Don't repeat its work.
+		[[ -n ${PORTAGE_TEMP_GPG_DIR} ]] && gemato_args+=( --no-refresh-keys --no-wkd )
+
 		[[ ${PORTAGE_QUIET} == 1 ]] && gemato_args+=( --quiet )
 		[[ ${do_debug} == 1 ]] && gemato_args+=( --debug )
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -279,11 +279,17 @@ check_file_signature_gemato() {
 			local key="${EPREFIX:-/}"/usr/share/openpgp-keys/gentoo-release.asc
 		fi
 
+		local keyserver
+		if [[ -n ${PORTAGE_GPG_KEY_SERVER} ]] ; then
+			keyserver="--keyserver ${PORTAGE_GPG_KEY_SERVER}"
+		fi
+
 		local gemato_args=(
 			openpgp-verify-detached
 			-K "${key}"
 		)
 
+		[[ -n ${PORTAGE_GPG_KEY_SERVER} ]] && gemato_args+=( --keyserver "${PORTAGE_GPG_KEY_SERVER}" )
 		# Portage is calling us so it'll handle refreshing if configured to do so.
 		# Don't repeat its work.
 		[[ -n ${PORTAGE_TEMP_GPG_DIR} ]] && gemato_args+=( --no-refresh-keys --no-wkd )
@@ -291,7 +297,7 @@ check_file_signature_gemato() {
 		[[ ${PORTAGE_QUIET} == 1 ]] && gemato_args+=( --quiet )
 		[[ ${do_debug} == 1 ]] && gemato_args+=( --debug )
 
-		gemato "${gemato_args[@]}" "${signature}" "${file}"
+		gemato "${gemato_args[@]}" -- "${signature}" "${file}"
 		r=$?
 
 		if [[ ${r} -ne 0 ]]; then

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -109,20 +109,16 @@ do_debug=0
 keep=false
 
 handle_pgp_setup() {
-	has webrsync-gpg ${FEATURES} && webrsync_gpg=1 || webrsync_gpg=0
-
-	if [[ ${webrsync_gpg} -eq 1 ]]; then
-		ewarn "FEATURES=webrsync-gpg is deprecated, see the make.conf(5) man page."
-	fi
-
-	repo_has_webrsync_verify=$(
-		has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature	| LC_ALL=C tr '[:upper:]' '[:lower:]') true yes
-	)
-
 	# WEBRSYNC_VERIFY_SIGNATURE=0: disable PGP verification
 	# WEBRSYNC_VERIFY_SIGNATURE=1: use gemato for verification, fallback to regular gpg
 	# WEBRSYNC_VERIFY_SIGNATURE=2: use legacy FEATURES="webrsync-gpg"
 	WEBRSYNC_VERIFY_SIGNATURE=1
+
+	has webrsync-gpg ${FEATURES} && webrsync_gpg=1 || webrsync_gpg=0
+
+	repo_has_webrsync_verify=$(
+		has $(__repo_attr "${repo_name}" sync-webrsync-verify-signature	| LC_ALL=C tr '[:upper:]' '[:lower:]') true yes
+	)
 
 	if [[ -n ${PORTAGE_TEMP_GPG_DIR} ]] || [[ ${repo_has_webrsync_verify} -eq 1 ]]; then
 		# If FEATURES=webrsync-gpg is enabled then allow direct emerge-webrsync
@@ -134,10 +130,18 @@ handle_pgp_setup() {
 		fi
 
 		WEBRSYNC_VERIFY_SIGNATURE=2
-	elif has webrsync-gpg ${FEATURES}; then
+	elif [[ ${webrsync_gpg} -eq 1 ]] then
+		# We only warn if FEATURES="webrsync-gpg" is in make.conf, not if
+		# Portage is calling us for 'type=webrsync' with verification.
+		# TODO: Change the Portage path to fully use gemato and unify the lot.
+		ewarn "FEATURES=webrsync-gpg is deprecated, see the make.conf(5) man page."
 		WEBRSYNC_VERIFY_SIGNATURE=2
 	elif [[ -n ${no_pgp_verify} ]]; then
 		WEBRSYNC_VERIFY_SIGNATURE=0
+	else
+		# The default at the beginning of handle_pgp_setup is WEBRSYNC_VERIFY_SIGNATURE=1
+		# i.e. gemato.
+		:;
 	fi
 
 	case "${WEBRSYNC_VERIFY_SIGNATURE}" in
@@ -148,7 +152,7 @@ handle_pgp_setup() {
 			[[ ${PORTAGE_QUIET} -eq 1 ]] || einfo "PGP verification method: gemato"
 			;;
 		2)
-			ewarn "PGP verification method: legacy FEATURES=webrsync-gpg"
+			[[ ${PORTAGE_QUIET} -eq 1 ]] || ewarn "PGP verification method: legacy gpg path"
 			;;
 		*)
 			die "Unknown WEBRSYNC_VERIFY_SIGNATURE state: \${WEBRSYNC_VERIFY_SIGNATURE}=${WEBRSYNC_VERIFY_SIGNATURE}"

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -129,11 +129,12 @@ handle_pgp_setup() {
 			die "Do not call ${argv0##*/} directly, instead call emerge --sync or emaint sync."
 		fi
 
-		WEBRSYNC_VERIFY_SIGNATURE=2
-	elif [[ ${webrsync_gpg} -eq 1 ]] then
+		# Use gemato for the standard Portage-calling-us case w/ sync-type='webrsync'.
+		WEBRSYNC_VERIFY_SIGNATURE=1
+	elif [[ ${webrsync_gpg} -eq 1 ]]; then
 		# We only warn if FEATURES="webrsync-gpg" is in make.conf, not if
-		# Portage is calling us for 'type=webrsync' with verification.
-		# TODO: Change the Portage path to fully use gemato and unify the lot.
+		# Portage is calling us for 'sync-type=webrsync' with verification, because
+		# that path uses gemato now (plus the user can't help it, obviously).
 		ewarn "FEATURES=webrsync-gpg is deprecated, see the make.conf(5) man page."
 		WEBRSYNC_VERIFY_SIGNATURE=2
 	elif [[ -n ${no_pgp_verify} ]]; then
@@ -152,7 +153,7 @@ handle_pgp_setup() {
 			[[ ${PORTAGE_QUIET} -eq 1 ]] || einfo "PGP verification method: gemato"
 			;;
 		2)
-			[[ ${PORTAGE_QUIET} -eq 1 ]] || ewarn "PGP verification method: legacy gpg path"
+			ewarn "PGP verification method: legacy gpg path"
 			;;
 		*)
 			die "Unknown WEBRSYNC_VERIFY_SIGNATURE state: \${WEBRSYNC_VERIFY_SIGNATURE}=${WEBRSYNC_VERIFY_SIGNATURE}"

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -112,6 +112,9 @@ class WebRsync(SyncBase):
                     self.spawn_kwargs["env"][
                         "PORTAGE_GPG_KEY"
                     ] = self.repo.sync_openpgp_key_path
+                    self.spawn_kwargs["env"][
+                        "PORTAGE_GPG_KEY_SERVER"
+                    ] = self.repo.sync_openpgp_key_server
                 except (GematoException, asyncio.TimeoutError) as e:
                     writemsg_level(
                         f"!!! Verification impossible due to keyring problem:\n{e}\n",

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -5,7 +5,6 @@ import logging
 import portage
 from portage import os
 from portage.util import writemsg_level
-from portage.util.futures import asyncio
 from portage.output import create_color_func
 from portage.sync.syncbase import SyncBase
 
@@ -14,7 +13,6 @@ bad = create_color_func("BAD")
 warn = create_color_func("WARN")
 
 try:
-    from gemato.exceptions import GematoException
     import gemato.openpgp
 except ImportError:
     gemato = None
@@ -99,29 +97,13 @@ class WebRsync(SyncBase):
                     )
                     return (1, False)
 
-                openpgp_env = self._get_openpgp_env(self.repo.sync_openpgp_key_path)
-
-                out = portage.output.EOutput(quiet=quiet)
-                try:
-                    out.einfo(f"Using keys from {self.repo.sync_openpgp_key_path}")
-                    with open(self.repo.sync_openpgp_key_path, "rb") as f:
-                        openpgp_env.import_key(f)
-                    self._refresh_keys(openpgp_env)
-                    self.spawn_kwargs["env"]["PORTAGE_GPG_DIR"] = openpgp_env.home
-                    self.spawn_kwargs["env"]["PORTAGE_TEMP_GPG_DIR"] = openpgp_env.home
-                    self.spawn_kwargs["env"][
-                        "PORTAGE_GPG_KEY"
-                    ] = self.repo.sync_openpgp_key_path
-                    self.spawn_kwargs["env"][
-                        "PORTAGE_GPG_KEY_SERVER"
-                    ] = self.repo.sync_openpgp_key_server
-                except (GematoException, asyncio.TimeoutError) as e:
-                    writemsg_level(
-                        f"!!! Verification impossible due to keyring problem:\n{e}\n",
-                        level=logging.ERROR,
-                        noiselevel=-1,
-                    )
-                    return (1, False)
+                self.spawn_kwargs["env"]["PORTAGE_SYNC_WEBRSYNC_GPG"] = True
+                self.spawn_kwargs["env"][
+                    "PORTAGE_GPG_KEY"
+                ] = self.repo.sync_openpgp_key_path
+                self.spawn_kwargs["env"][
+                    "PORTAGE_GPG_KEY_SERVER"
+                ] = self.repo.sync_openpgp_key_server
 
             webrsync_cmd = [self.bin_command]
             if verbose:

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -109,6 +109,9 @@ class WebRsync(SyncBase):
                     self._refresh_keys(openpgp_env)
                     self.spawn_kwargs["env"]["PORTAGE_GPG_DIR"] = openpgp_env.home
                     self.spawn_kwargs["env"]["PORTAGE_TEMP_GPG_DIR"] = openpgp_env.home
+                    self.spawn_kwargs["env"][
+                        "PORTAGE_GPG_KEY"
+                    ] = self.repo.sync_openpgp_key_path
                 except (GematoException, asyncio.TimeoutError) as e:
                     writemsg_level(
                         f"!!! Verification impossible due to keyring problem:\n{e}\n",


### PR DESCRIPTION
webrsync-gpg is actually two distinct cases:
1. A user has FEATURES="webrsync-gpg" in make.conf and is calling
   'emerge-webrsync'. This is deprecated.

2. A user has 'sync-type=webrsync', is using emaint/emerge to sync,
   and Portage is shelling out to emerge-webrsync. This is what
   users are encouraged to do, but it currently uses the legacy
   webrsync-gpg path.

For the benefit of case #2 and to clarify things, don't mention
FEATURES="webrsync-gpg" if the user hasn't set it - this is to avoid
users *starting to set it* because it sounds like something they may
want.

We also silence the (new) 'gpg legacy path' phrasing for now with
--quiet given this is expected with case #2.

Consolidate some logic while at it.

The next step is, of course, to shift everything to the gemato path.

Signed-off-by: Sam James <sam@gentoo.org>