### PR TITLE
RFC: extract tar archives with -k / --keep-old-files

### DIFF
--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -368,7 +368,7 @@ unpack() {
 						"secondary suffix '${y}' which is unofficially" \
 						"supported with EAPI '${EAPI}'. Instead use 'tar'."
 				fi
-				$1 -c -- "${srcdir}${x}" | tar xof -
+				$1 -c -- "${srcdir}${x}" | tar xokf -
 				__assert_sigpipe_ok "${myfail}"
 			else
 				local cwd_dest=${x##*/}
@@ -386,7 +386,7 @@ unpack() {
 						"suffix '${suffix}' which is unofficially supported" \
 						"with EAPI '${EAPI}'. Instead use 'tar'."
 				fi
-				tar xof "${srcdir}${x}" || die "${myfail}"
+				tar xokf "${srcdir}${x}" || die "${myfail}"
 				;;
 			tgz)
 				if ___eapi_unpack_is_case_sensitive && \
@@ -404,7 +404,7 @@ unpack() {
 						"suffix '${suffix}' which is unofficially supported" \
 						"with EAPI '${EAPI}'. Instead use 'tbz' or 'tbz2'."
 				fi
-				${PORTAGE_BUNZIP2_COMMAND:-${PORTAGE_BZIP2_COMMAND} -d} -c -- "${srcdir}${x}" | tar xof -
+				${PORTAGE_BUNZIP2_COMMAND:-${PORTAGE_BZIP2_COMMAND} -d} -c -- "${srcdir}${x}" | tar xokf -
 				__assert_sigpipe_ok "${myfail}"
 				;;
 			zip|jar)
@@ -557,7 +557,7 @@ unpack() {
 						"with EAPI '${EAPI}'. Instead use 'txz'."
 				fi
 				if ___eapi_unpack_supports_txz; then
-					XZ_OPT="-T$(___makeopts_jobs)" tar xof "${srcdir}${x}" || die "${myfail}"
+					XZ_OPT="-T$(___makeopts_jobs)" tar xokf "${srcdir}${x}" || die "${myfail}"
 				else
 					__vecho "unpack ${x}: file format not recognized. Ignoring."
 				fi


### PR DESCRIPTION
Tar's default behavior is to override existing files upon extraction. This may be sensible when restoring a backup, but it is probably a security issue for ebuilds.

Consider a Go package using a dependency tarball. Such packages typically have two archives in SRC_URI: upstream's tarball and a (often user created) dependency tarball. If malicious dependency tarballs is able to override go.sum of upstream's tarball, then it is able to pass "go mod verify" performed by the go-modules.eclass [1].

Invoking tar with -k / --keep-old-files makes tar error out when extracting an archive would override a file.

See app-misc/archives-override-content-experiment (found in ::flow[2]) for a simple ebuild to verify the current and proposed behavior.

This is a RFC. It is not clear to  me yet if the current behavior is also considered a feature. PMS does not seem to specify the behavior if an archive would override a file upon extraction (at least, I couldn't find anything).

Furthermore, this currently only changes the behavior when extracting tarballs. For consistency reasons, it would be desirable that the behavior is equal across all archives types. This could mean that we may end up with a design where we extract all archives into dedicated target directories, and portage later merges those into WORKDIR checking for collisions.

1: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=733b4944c1a061269f96219cc96530f89d8f439e
2: https://gitlab.com/Flow/flow-s-ebuilds/-/commit/af3f5c99758b8316e672ad91320df51f734b30d6