### PR TITLE
Delete remnants of CONF_LIBDIR

### DIFF
--- a/bin/ebuild-helpers/dolib
+++ b/bin/ebuild-helpers/dolib
@@ -22,15 +22,13 @@ else
 fi
 
 # Setup ABI cruft
-LIBDIR_VAR="LIBDIR_${ABI}"
-if [[ -n ${ABI} && -n ${!LIBDIR_VAR} ]] ; then
-	CONF_LIBDIR=${!LIBDIR_VAR}
+libdir="lib"
+libdir_var="LIBDIR_${ABI}"
+if [[ -n ${ABI} && -n ${!libdir_var} ]] ; then
+	libdir=${!libdir_var}
 fi
-unset LIBDIR_VAR
 
-# We need this to default to lib so that things dont break
-CONF_LIBDIR=${CONF_LIBDIR:-lib}
-libdir="${ED%/}/${__E_DESTTREE#/}/${CONF_LIBDIR}"
+libdir="${ED%/}/${__E_DESTTREE#/}/${libdir}"
 
 if [[ $# -lt 1 ]] ; then
 	__helpers_die "${0##*/}: at least one argument needed"

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -681,13 +681,13 @@ econf() {
 		fi
 
 		# If the profile defines a location to install libs to aside from default, pass it on.
-		# If the ebuild passes in --libdir, they're responsible for the conf_libdir fun.
-		local CONF_LIBDIR LIBDIR_VAR="LIBDIR_${ABI}"
-		if [[ -n ${ABI} && -n ${!LIBDIR_VAR} ]] ; then
-			CONF_LIBDIR=${!LIBDIR_VAR}
+		# If the ebuild passes in --libdir, they're responsible for the libdir fun.
+		local libdir libdir_var="LIBDIR_${ABI}"
+		if [[ -n ${ABI} && -n ${!libdir_var} ]] ; then
+			libdir=${!libdir_var}
 		fi
 
-		if [[ -n ${CONF_LIBDIR} ]] && ! __hasgq --libdir=\* "$@" ; then
+		if [[ -n ${libdir} ]] && ! __hasgq --libdir=\* "$@" ; then
 			export CONF_PREFIX=$(__hasg --exec-prefix=\* "$@")
 			[[ -z ${CONF_PREFIX} ]] && CONF_PREFIX=$(__hasg --prefix=\* "$@")
 
@@ -695,10 +695,10 @@ econf() {
 			CONF_PREFIX=${CONF_PREFIX#*=}
 
 			[[ ${CONF_PREFIX} != /* ]] && CONF_PREFIX="/${CONF_PREFIX}"
-			[[ ${CONF_LIBDIR} != /* ]] && CONF_LIBDIR="/${CONF_LIBDIR}"
+			[[ ${libdir} != /* ]] && libdir="/${libdir}"
 
 			conf_args+=(
-				--libdir="$(__strip_duplicate_slashes "${CONF_PREFIX}${CONF_LIBDIR}")"
+				--libdir="$(__strip_duplicate_slashes "${CONF_PREFIX}${libdir}")"
 			)
 		fi
 
@@ -751,14 +751,13 @@ einstall() {
 		local ED=${D}
 	fi
 
-	LIBDIR_VAR="LIBDIR_${ABI}"
-	if [[ -n "${ABI}" && -n "${!LIBDIR_VAR}" ]]; then
-		CONF_LIBDIR="${!LIBDIR_VAR}"
+	local libdir libdir_var="LIBDIR_${ABI}"
+	if [[ -n "${ABI}" && -n "${!libdir_var}" ]]; then
+		libdir="${!libdir_var}"
 	fi
-	unset LIBDIR_VAR
 
-	if [[ -n "${CONF_LIBDIR}" && "${CONF_PREFIX:+set}" = set ]]; then
-		EI_DESTLIBDIR="${D%/}/${CONF_PREFIX}/${CONF_LIBDIR}"
+	if [[ -n "${libdir}" && "${CONF_PREFIX:+set}" = set ]]; then
+		EI_DESTLIBDIR="${D%/}/${CONF_PREFIX}/${libdir}"
 		EI_DESTLIBDIR="$(__strip_duplicate_slashes "${EI_DESTLIBDIR}")"
 		LOCAL_EXTRA_EINSTALL="libdir=${EI_DESTLIBDIR} ${LOCAL_EXTRA_EINSTALL}"
 		unset EI_DESTLIBDIR

--- a/lib/portage/tests/bin/test_filter_bash_env.py
+++ b/lib/portage/tests/bin/test_filter_bash_env.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Gentoo Foundation
+# Copyright 2018-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import difflib
@@ -33,12 +33,10 @@ declare -- _EUTILS_ECLASS="1"
 declare -- f
 get_libdir ()
 {
-    local CONF_LIBDIR;
-    if [ -n "${CONF_LIBDIR_OVERRIDE}" ]; then
-        echo ${CONF_LIBDIR_OVERRIDE};
-    else
-        get_abi_LIBDIR;
-    fi
+    local libdir_var="LIBDIR_${ABI}";
+    local libdir="lib";
+    [[ -n ${ABI} && -n ${!libdir_var} ]] && libdir=${!libdir_var};
+    echo "${libdir}"
 }
 make_wrapper ()
 {
@@ -65,12 +63,10 @@ declare -- _EUTILS_ECLASS="1"
 declare -- f
 get_libdir ()
 {
-    local CONF_LIBDIR;
-    if [ -n "${CONF_LIBDIR_OVERRIDE}" ]; then
-        echo ${CONF_LIBDIR_OVERRIDE};
-    else
-        get_abi_LIBDIR;
-    fi
+    local libdir_var="LIBDIR_${ABI}";
+    local libdir="lib";
+    [[ -n ${ABI} && -n ${!libdir_var} ]] && libdir=${!libdir_var};
+    echo "${libdir}"
 }
 make_wrapper ()
 {


### PR DESCRIPTION
Support for CONF_LIBDIR was initially added on 2004-08-16 in:
https://gitweb.gentoo.org/archive/proj/portage-cvs.git/commit/?id=ecc2faaa00b1e6250129267ba873bedd2121eac5

Support for LIBDIR_${ABI} was initially added on 2005-02-26 in:
https://gitweb.gentoo.org/archive/proj/portage-cvs.git/commit/?id=64779fdecc8e4ec7d2cb9a6fa70066694f78231d

Since then, CONF_LIBDIR was not used if ABI and LIBDIR_${ABI} were set.

CONF_LIBDIR was set only in 2004.3 profiles:
https://gitweb.gentoo.org/archive/repo/gentoo-2.git/commit/?id=1482b856ad2a301c8eb2245a7c7265350af2691d

LIBDIR_${ABI} was set in profiles starting with 2005.0 profiles:
https://gitweb.gentoo.org/archive/repo/gentoo-2.git/commit/?id=054e484d8717a18622615e019e7cd62495365192 https://gitweb.gentoo.org/archive/repo/gentoo-2.git/commit/?id=a1f9392206c050c2b952c3e1281b731f1c969bc9

Bug: https://bugs.gentoo.org/75420
Bug: https://bugs.gentoo.org/267159