### PR TITLE
[RFC] install-qa-check.d/90config-impl-decl: Add infrastructure for skipping functions globally

### DIFF
--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -19,6 +19,18 @@
 #
 # See also: bug 892651
 
+# Same as the "has" function, but allows wildcards in the array
+is_in() {
+	local needle=$1
+	shift
+
+	local x
+	for x in "$@"; do
+		[[ "${needle}" = ${x} ]] && return 0
+	done
+	return 1
+}
+
 find_log_targets() {
 	local log_targets=(
 		'config.log'
@@ -80,7 +92,7 @@ config_impl_decl_check() {
 				continue
 			fi
 
-			has "${func}" "${QA_CONFIG_IMPL_DECL_SKIP[@]}" && continue
+			is_in "${func}" "${QA_CONFIG_IMPL_DECL_SKIP[@]}" && continue
 
 			files+=( "${l}" )
 			lines+=( "${line}" )

--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -40,6 +40,11 @@ add_default_skips() {
 		# https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
 		"__atomic_*"
 	)
+
+	# Functions not available on Linux
+	[[ ${CHOST} == *linux* ]] && QA_CONFIG_IMPL_DECL_SKIP+=(
+		res_ndestroy
+	)
 }
 
 find_log_targets() {

--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -43,6 +43,7 @@ add_default_skips() {
 
 	# Functions not available on Linux
 	[[ ${CHOST} == *linux* ]] && QA_CONFIG_IMPL_DECL_SKIP+=(
+		res_getservers
 		res_ndestroy
 	)
 }

--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -43,8 +43,10 @@ add_default_skips() {
 
 	# Functions not available on Linux
 	[[ ${CHOST} == *linux* ]] && QA_CONFIG_IMPL_DECL_SKIP+=(
+		acl
 		res_getservers
 		res_ndestroy
+		statacl
 	)
 }
 

--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -31,6 +31,17 @@ is_in() {
 	return 1
 }
 
+add_default_skips() {
+	# Skip built-in functions provided by the compiler
+	QA_CONFIG_IMPL_DECL_SKIP+=(
+		"__builtin_*"
+		# https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html
+		"__sync_*"
+		# https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
+		"__atomic_*"
+	)
+}
+
 find_log_targets() {
 	local log_targets=(
 		'config.log'
@@ -67,6 +78,8 @@ config_impl_decl_check() {
 	local re_uni
 	local re_asc
 	local is_utf8
+
+	add_default_skips
 
 	# Given the UTF-8 character type, both gcc and clang may enclose the
 	# function name between the LEFT SINGLE QUOTATION MARK and RIGHT SINGLE

--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -44,6 +44,7 @@ add_default_skips() {
 	# Functions not available on Linux
 	[[ ${CHOST} == *linux* ]] && QA_CONFIG_IMPL_DECL_SKIP+=(
 		acl
+		acl_get_perm_np
 		res_getservers
 		res_ndestroy
 		statacl


### PR DESCRIPTION
The first patch makes it possible to specify wildcards in `QA_CONFIG_IMPL_DECL_SKIP`. The next patch ignores `__builtin_*`, `__sync_*`, and `__atomic_*` built-ins globally. The subsequent patches add functions that are not present on Linux as examples.

This series aims to provide a single location to list functions

1. whose availability might differ per-platform (e.g. listing `acl` in `app-editors/vim` unconditionally is wrong for Solaris).
2. that are never available on a platform (i.e., it makes little sense to list `res_getservers` in many separate ebuilds when it is never present on Linux)