### PR TITLE
misc-functions.sh: Don't call the prepallstrip helper

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/helper-functions.sh || exit 1
@@ -115,6 +115,11 @@ while [[ $# -gt 0 ]] ; do
 		;;
 	--dequeue)
 		[[ -n ${2} ]] && die "${0##*/}: --dequeue takes no additional arguments"
+		break
+		;;
+	--prepallstrip)
+		[[ $# -eq 1 ]] || die "${0##*/}: $1 takes no additional arguments"
+		prepstrip=true
 		break
 		;;
 	*)

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -265,7 +265,7 @@ install_qa_check() {
 			"${PORTAGE_BIN_PATH}"/estrip --ignore "${PORTAGE_DOSTRIP_SKIP[@]}"
 			"${PORTAGE_BIN_PATH}"/estrip --dequeue
 		else
-			prepallstrip
+			"${PORTAGE_BIN_PATH}"/estrip --prepallstrip
 		fi
 	fi
 }
@@ -302,7 +302,7 @@ __dyn_instprep() {
 			"${PORTAGE_BIN_PATH}"/estrip --ignore "${PORTAGE_DOSTRIP_SKIP[@]}"
 			"${PORTAGE_BIN_PATH}"/estrip --dequeue
 		else
-			prepallstrip
+			"${PORTAGE_BIN_PATH}"/estrip --prepallstrip
 		fi
 	fi
 


### PR DESCRIPTION
Otherwise it will output a deprecation warning. Instead, call estrip directly with the new --prepallstrip option.

This affects only EAPI 6 and earlier and does not change functionality.

Fixes: 63d6f2e8985de480c21a5c2f09bba1547c7de6b8