### PR TITLE
portageq-wrapper: New wrapper script

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ Breaking changes:
 * Output deprecation warnings for portageq, prepstrip and prepallstrip
   when they are called from an ebuild (bug #906129, bug #906156).
 
+Cleanups:
+* Move the internal portageq wrapper script out of the ebuild-helpers
+  directory.
+
 portage-3.0.48 (UNRELEASED)
 --------------
 Bug fixes:

--- a/bin/ebuild-helpers/portageq
+++ b/bin/ebuild-helpers/portageq
@@ -2,29 +2,7 @@
 # Copyright 2009-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-scriptpath=${BASH_SOURCE[0]}
-scriptname=${scriptpath##*/}
-
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
 eqawarn "QA Notice: '${0##*/}' is not allowed in ebuild scope"
-
-# Use safe cwd, avoiding unsafe import for bug #469338.
-cd "${PORTAGE_PYM_PATH}" || exit 1
-
-IFS=':'
-set -f # in case ${PATH} contains any shell glob characters
-
-for path in ${PATH}; do
-	[[ -x ${path}/${scriptname} ]] || continue
-	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
-	[[ ${path}/${scriptname} -ef ${scriptpath} ]] && continue
-
-	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
-		exec "${PORTAGE_PYTHON:-/usr/bin/python}" \
-			"${path}/${scriptname}" "$@"
-done
-
-unset IFS
-echo "${scriptname}: command not found" 1>&2
-exit 127
+exec "${PORTAGE_BIN_PATH}"/portageq-wrapper "$@"

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -963,7 +963,7 @@ ___best_version_and_has_version_common() {
 	if [[ -n ${PORTAGE_IPC_DAEMON} ]] ; then
 		cmd+=("${PORTAGE_BIN_PATH}"/ebuild-ipc "${FUNCNAME[1]}" "${root}" "${atom}")
 	else
-		cmd+=("${PORTAGE_BIN_PATH}"/ebuild-helpers/portageq "${FUNCNAME[1]}" "${root}" "${atom}")
+		cmd+=("${PORTAGE_BIN_PATH}"/portageq-wrapper "${FUNCNAME[1]}" "${root}" "${atom}")
 	fi
 
 	"${cmd[@]}"

--- a/bin/portageq-wrapper
+++ b/bin/portageq-wrapper
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2009-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Use safe cwd, avoiding unsafe import for bug #469338.
+cd "${PORTAGE_PYM_PATH}" || exit 1
+
+IFS=":"
+set -f # in case ${PATH} contains any shell glob characters
+
+for path in ${PATH}; do
+	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
+	[[ -x ${path}/portageq ]] || continue
+	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
+		exec "${PORTAGE_PYTHON:-/usr/bin/python}" "${path}/portageq" "$@"
+done
+
+echo "portageq: command not found" >&2
+exit 127

--- a/bin/portageq-wrapper
+++ b/bin/portageq-wrapper
@@ -8,7 +8,7 @@ cd "${PORTAGE_PYM_PATH}" || exit 1
 IFS=":"
 set -f # in case ${PATH} contains any shell glob characters
 
-for path in ${PATH}; do
+for path in "${PORTAGE_BIN_PATH}" ${PATH}; do
 	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
 	[[ -x ${path}/portageq ]] || continue
 	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \


### PR DESCRIPTION
Move the internal portageq wrapper script out of the ebuild-helpers directory. Call the new script from best_version and has_version in the case when IPC is disabled.

The goal is to ban portageq from the ebuild environment after some transition time.