### PR TITLE
emerge-webrsync: fall back correctly to manual gpg if no gemato

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ Bug fixes:
   both of them now use the same main path for PGP verification (i.e.
   gemato).
 
+* emerge-webrsync: Fall back correctly to manual gpg (rather than aborting
+  entirely) if gemato is not installed (bug #905868).
+
 Cleanups:
 * Convert printf-style %-formats into fstrings.
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -302,6 +302,8 @@ check_file_signature_gemato() {
 			# a keyring problem).
 			die "signature verification failed"
 		fi
+	else
+		return 127
 	fi
 
 	return "${r}"
@@ -346,6 +348,13 @@ check_file_signature() {
 			1)
 				check_file_signature_gemato "${signature}" "${file}"
 				r=$?
+
+				if [[ ${r} -eq 127 ]] ; then
+					ewarn "Falling back to gpg as gemato is not installed"
+					check_file_signature_gpg_unwrapped "${signature}" "${file}"
+					r=$?
+				fi
+
 				;;
 			2)
 				check_file_signature_gpg_unwrapped "${signature}" "${file}"

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -361,6 +361,11 @@ check_file_signature() {
 				r=$?
 				;;
 		esac
+
+		if [[ ${r} != 0 ]] ; then
+			eerror "Error occurred in check_file_signature: ${r}. Aborting."
+			die "Verification error occured."
+		fi
 	else
 		r=0
 	fi


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/905868