### PR TITLE
WIP: add support for parallel lzip (plzip)

### DIFF
--- a/lib/portage/util/compression_probe.py
+++ b/lib/portage/util/compression_probe.py
@@ -9,6 +9,15 @@ import re
 from portage import _encodings, _unicode_encode
 from portage.exception import FileNotFound, PermissionDenied
 
+parallel_lzip = True
+
+if parallel_lzip:
+    lzip_cmd = "plzip -n {JOBS}"
+    lzip_pkg = "app-arch/plzip"
+else:
+    lzip_cmd = "lzip"
+    lzip_pkg = "app-arch/lzip"
+
 _compressors = {
     "bzip2": {
         "compress": "${PORTAGE_BZIP2_COMMAND} ${BINPKG_COMPRESS_FLAGS}",
@@ -27,9 +36,9 @@ _compressors = {
         "package": "app-arch/lz4",
     },
     "lzip": {
-        "compress": "lzip ${BINPKG_COMPRESS_FLAGS}",
-        "decompress": "lzip -d",
-        "package": "app-arch/lzip",
+        "compress": f"{lzip_cmd} ${{BINPKG_COMPRESS_FLAGS}}",
+        "decompress": f"{lzip_cmd} -d",
+        "package": lzip_pkg,
     },
     "lzop": {
         "compress": "lzop ${BINPKG_COMPRESS_FLAGS}",


### PR DESCRIPTION
Using `plzip` (parallel lzip) over `lzip` provides a significant speed improvement, especially on machines with many cores.

However, due the design of portage's `_compressor` map it is not straight forward to make the decision between lzip and plzip configurable. This is because the map assumes that there can only be one compressor/decompressor for every format. And lzip appears to be the only format known in the map where the parallel (de)compressor is actually a different binary.

Potential design options include:
- simply always use plzip instead of lzip
- add a FEATURE parallel-zip. but the existence of this feature may not be easily determinable with the current code design?
- make it configurable via an environment variable (and default to plzip?)

Personally, I am leaning towards simply using plzip instead of lzip.  But I am happy about any other suggestions how to make portage plzip.