### PR TITLE
emerge-webrsync: create a new temporary dir for legacy gpg verification

### DIFF
--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -574,7 +574,7 @@ do_latest_snapshot() {
 	# Daily snapshots are created at 00:45 and are not
 	# available until after 01:00. Don't waste time trying
 	# to fetch a snapshot before it's been created.
-	if [[ ${start_hour} -lt 1 ]] ; then
+	if [[ ${start_hour#0} -lt 1 ]] ; then
 		(( start_time -= 86400 ))
 	fi
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -314,7 +314,26 @@ check_file_signature_gpg_unwrapped() {
 	local file="$2"
 
 	if type -P gpg > /dev/null; then
-		if gnupg_status=$(gpg --homedir "${PORTAGE_GPG_DIR}" --batch \
+		if [[ -n ${PORTAGE_GPG_KEY} ]] ; then
+			local key="${PORTAGE_GPG_KEY}"
+		else
+			local key="${EPREFIX:-/}"/usr/share/openpgp-keys/gentoo-release.asc
+		fi
+
+		local gpgdir="${PORTAGE_GPG_DIR}"
+		if [[ -z ${gpgdir} ]] ; then
+			gpgdir=$(mktemp -d "${PORTAGE_TMPDIR}/portage/webrsync-XXXXXX")
+			if [[ ! -w ${gpgdir} ]] ; then
+				die "gpgdir is not writable: ${gpgdir}"
+			fi
+
+			# If we're created our own temporary directory, it's okay for us
+			# to import the keyring by ourselves. But we'll avoid doing it
+			# if the user has set PORTAGE_GPG_DIR by themselves.
+			gpg --no-default-keyring --homedir "${gpgdir}" --batch --import "${key}"
+		fi
+
+		if gnupg_status=$(gpg --no-default-keyring --homedir "${gpgdir}" --batch \
 			--status-fd 1 --verify "${signature}" "${file}"); then
 			while read -r line; do
 				if [[ ${line} == "[GNUPG:] GOODSIG"* ]]; then


### PR DESCRIPTION
It's possible that we can't read /root/.gnupg and we shouldn't
be poking around in there anyway.

If PORTAGE_GPG_DIR is unset, make a tmpdir w/ mktemp.

Bug: https://bugs.gentoo.org/905868
Signed-off-by: Sam James <sam@gentoo.org>