### PR TITLE
Revert FEATURES=ignore-mtime

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,10 +9,6 @@ Features:
   contents have changed. This is particularly beneficial on CoW filesystems
   with snapshots. This is always enabled. See bug #722270.
 
-  This also adds an additional optional optimization to overwrite only if
-  the hashes have changed, via FEATURES="ignore-mtime". Note that this violates
-  a condition in PMS so should not be relied upon. It is off by default.
-
 Bug fixes:
 * fowners, fperms: Fix handling of relative pathnames (bug #905223).
 

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -159,7 +159,6 @@ SUPPORTED_FEATURES = frozenset(
         "getbinpkg",
         "gpg-keepalive",
         "icecream",
-        "ignore-mtime",
         "installsources",
         "ipc-sandbox",
         "keeptemp",

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -5422,7 +5422,6 @@ class dblink:
         srcroot = normalize_path(srcroot).rstrip(sep) + sep
         destroot = normalize_path(destroot).rstrip(sep) + sep
         calc_prelink = "prelink-checksums" in self.settings.features
-        ignore_mtime = "ignore-mtime" in self.settings.features
 
         protect_if_modified = (
             "config-protect-if-modified" in self.settings.features
@@ -5831,13 +5830,12 @@ class dblink:
                         hardlink_candidates.append(mydest)
                         zing = ">>>"
                     else:
-                        if not ignore_mtime:
-                            mymtime = thismtime if thismtime is not None else mymtime
-                            try:
-                                os.utime(mydest, ns=(mymtime, mymtime))
-                            except OSError:
-                                # utime can fail here with EPERM
-                                pass
+                        mymtime = thismtime if thismtime is not None else mymtime
+                        try:
+                            os.utime(mydest, ns=(mymtime, mymtime))
+                        except OSError:
+                            # utime can fail here with EPERM
+                            pass
                         zing = "==="
 
                     try:

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -533,12 +533,6 @@ If your GPG is auto unlocked on login, you do not need this.
 .B icecream
 Enable portage support for the icecream package.
 .TP
-.B ignore\-mtime
-Do not update mtime if the target file is equal. This can be useful on some
-filesystems to better utilize features like snapshots and data deduplication,
-however this violates the preservation of file modification times as stipulated
-in the PMS.
-.TP
 .B installsources
 Install source code into /usr/src/debug/${CATEGORY}/${PF} (also see
 \fBsplitdebug\fR). This feature works only if debugedit is installed, CFLAGS


### PR DESCRIPTION
The ignore-mtime feature violates PMS:
https://projects.gentoo.org/pms/8/pms.html#x1-14500013.3.2

Allowing the package manager to arbitrarily modify timestamps of installed files will lead to problems with several languages:

- Lisp (*.fasl must be newer than corresponding *.lisp)
- Emacs (*.elc must not be older than *.el)
- ghdl/VHDL (libraries check their mtimes)
- Python (*.pyc vs *.py, not sure if this one is still an issue)

If the PM does not preserve timestamps, there is no reasonable way to work around this on the ebuild level. (Some horrible hacks existed in the past, see for example impl-*-timestamp-hack in previous versions of common-lisp-common*.eclass which used to overwrite its installed files in pkg_postinst.)

This partially reverts commit 89703c688868c9eb8cd6115cb42ff92f0b9668b8.

Closes: https://bugs.gentoo.org/906978
See-also: https://bugs.gentoo.org/264130
Signed-off-by: Ulrich Müller <ulm@gentoo.org>
