### PR TITLE
sync: webrsync: fix keyserver variable typo

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+portage-3.0.48.1 (2023-06-06)
+----------------
+
+Bug fixes:
+* sync: webrsync: Fix syncing with keyserver explicitly specified (bug #907816).
+
 portage-3.0.48 (2023-06-01)
 --------------
 Breaking changes:

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -97,7 +97,7 @@ class WebRsync(SyncBase):
                     )
                     return (1, False)
 
-                self.spawn_kwargs["env"]["PORTAGE_SYNC_WEBRSYNC_GPG"] = True
+                self.spawn_kwargs["env"]["PORTAGE_SYNC_WEBRSYNC_GPG"] = "1"
                 self.spawn_kwargs["env"][
                     "PORTAGE_GPG_KEY"
                 ] = self.repo.sync_openpgp_key_path

--- a/lib/portage/sync/modules/webrsync/webrsync.py
+++ b/lib/portage/sync/modules/webrsync/webrsync.py
@@ -103,7 +103,7 @@ class WebRsync(SyncBase):
                 ] = self.repo.sync_openpgp_key_path
                 self.spawn_kwargs["env"][
                     "PORTAGE_GPG_KEY_SERVER"
-                ] = self.repo.sync_openpgp_key_server
+                ] = self.repo.sync_openpgp_keyserver
 
             webrsync_cmd = [self.bin_command]
             if verbose:


### PR DESCRIPTION
Much like with the news item issues, I think we need some full end-to-end tests for sync.

Bug: https://bugs.gentoo.org/907816