### PR TITLE
Remove dummy threading

### DIFF
--- a/lib/_emerge/PollScheduler.py
+++ b/lib/_emerge/PollScheduler.py
@@ -1,10 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 from portage.util.futures import asyncio
 from portage.util._async.SchedulerInterface import SchedulerInterface

--- a/lib/portage/_emirrordist/MirrorDistTask.py
+++ b/lib/portage/_emirrordist/MirrorDistTask.py
@@ -4,11 +4,7 @@
 import errno
 import logging
 import time
-
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 import portage
 from portage import os

--- a/lib/portage/debug.py
+++ b/lib/portage/debug.py
@@ -1,13 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import os
 import sys
-
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 import portage.const
 from portage.util import writemsg

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -1,6 +1,9 @@
-# portage: Lock management code
-# Copyright 2004-2021 Gentoo Authors
+# Copyright 2004-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+"""
+Portage: Lock management code
+"""
 
 __all__ = [
     "lockdir",

--- a/lib/portage/proxy/lazyimport.py
+++ b/lib/portage/proxy/lazyimport.py
@@ -1,15 +1,11 @@
-# Copyright 2009-2020 Gentoo Authors
+# Copyright 2009-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ["lazyimport"]
 
 import sys
 import types
-
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 from portage.proxy.objectproxy import ObjectProxy
 

--- a/lib/portage/tests/locks/test_asynchronous_lock.py
+++ b/lib/portage/tests/locks/test_asynchronous_lock.py
@@ -1,13 +1,8 @@
-# Copyright 2010-2011 Gentoo Foundation
+# Copyright 2010-2023 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 import signal
 import tempfile
-
-try:
-    import dummy_threading
-except ImportError:
-    dummy_threading = None
 
 from portage import os
 from portage import shutil
@@ -23,20 +18,16 @@ class AsynchronousLockTestCase(TestCase):
         try:
             path = os.path.join(tempdir, "lock_me")
             for force_async in (True, False):
-                for force_dummy in (
-                    (False,) if dummy_threading is None else (True, False)
-                ):
-                    async_lock = AsynchronousLock(
-                        path=path,
-                        scheduler=scheduler,
-                        _force_async=force_async,
-                        _force_thread=True,
-                        _force_dummy=force_dummy,
-                    )
-                    async_lock.start()
-                    self.assertEqual(async_lock.wait(), os.EX_OK)
-                    self.assertEqual(async_lock.returncode, os.EX_OK)
-                    scheduler.run_until_complete(async_lock.async_unlock())
+                async_lock = AsynchronousLock(
+                    path=path,
+                    scheduler=scheduler,
+                    _force_async=force_async,
+                    _force_thread=True,
+                )
+                async_lock.start()
+                self.assertEqual(async_lock.wait(), os.EX_OK)
+                self.assertEqual(async_lock.returncode, os.EX_OK)
+                scheduler.run_until_complete(async_lock.async_unlock())
 
                 async_lock = AsynchronousLock(
                     path=path,

--- a/lib/portage/tests/process/test_PopenProcessBlockingIO.py
+++ b/lib/portage/tests/process/test_PopenProcessBlockingIO.py
@@ -1,13 +1,7 @@
-# Copyright 2012-2022 Gentoo Authors
+# Copyright 2012-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import subprocess
-
-try:
-    import threading
-except ImportError:
-    # dummy_threading will not suffice
-    threading = None
 
 from portage import os
 from portage.tests import TestCase
@@ -58,12 +52,6 @@ class PopenPipeBlockingIOTestCase(TestCase):
         return consumer.getvalue().decode("ascii", "replace")
 
     def testPopenPipeBlockingIO(self):
-        if threading is None:
-            skip_reason = "threading disabled"
-            self.portage_skip = "threading disabled"
-            self.assertFalse(True, skip_reason)
-            return
-
         for x in (1, 2, 5, 6, 7, 8, 2**5, 2**10, 2**12, 2**13, 2**14):
             test_string = x * "a"
             output = self._testPipeReader(test_string)

--- a/lib/portage/tests/util/futures/test_retry.py
+++ b/lib/portage/tests/util/futures/test_retry.py
@@ -1,13 +1,10 @@
-# Copyright 2018-2021 Gentoo Authors
+# Copyright 2018-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from concurrent.futures import Future, ThreadPoolExecutor
 import contextlib
 
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 import weakref
 import time

--- a/lib/portage/util/_async/PipeReaderBlockingIO.py
+++ b/lib/portage/util/_async/PipeReaderBlockingIO.py
@@ -1,11 +1,7 @@
-# Copyright 2012-2022 Gentoo Authors
+# Copyright 2012-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-try:
-    import threading
-except ImportError:
-    # dummy_threading will not suffice
-    threading = None
+import threading
 
 from portage import os
 from _emerge.AbstractPollTask import AbstractPollTask

--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -36,10 +36,7 @@ from asyncio import (
     TimeoutError,
 )
 
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 import portage
 


### PR DESCRIPTION
`dummy_threading` is deprecated since python 3.7 and portage's minimum supported python version is 3.7. So, all code related to `dummy_threading` is removed. 