### PR TITLE
depgraph: Don't ignore downgrades as missed_updates 

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -1284,9 +1284,7 @@ class depgraph:
                 pkg.root, pkg.slot_atom
             ):
                 any_selected = True
-                if chosen_pkg > pkg or (
-                    not chosen_pkg.installed and chosen_pkg.version == pkg.version
-                ):
+                if not chosen_pkg.installed and chosen_pkg.version == pkg.version:
                     missed_update = False
                     break
             if any_selected and missed_update:

--- a/lib/portage/tests/resolver/test_slot_conflict_blocked_prune.py
+++ b/lib/portage/tests/resolver/test_slot_conflict_blocked_prune.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class SlotConflictBlockedPruneTestCase(TestCase):
+    def testSlotConflictBlockedPrune(self):
+        """
+        Bug 622270
+        Downgrading package (as openssl here) due to un-accepting unstable.
+        Dependent package (as rustup here) cannot be rebuilt due to missing
+        keyword, so dependee downgrade is cancelled, but other dependents
+        (such as xwayland here) are rebuilt nevertheless. This should not
+        happen and the rebuilds should be pruned.
+        """
+        ebuilds = {
+            "x11-base/xwayland-23.1.1": {
+                "EAPI": "5",
+                "RDEPEND": "dev-libs/openssl:=",
+            },
+            "dev-util/rustup-1.25.2": {
+                "EAPI": "5",
+                "RDEPEND": "dev-libs/openssl:0=",
+                "KEYWORDS": "~x86",
+            },
+            "dev-libs/openssl-1.1.1u": {
+                "EAPI": "5",
+                "SLOT": "0/1.1",
+            },
+            "dev-libs/openssl-3.1.1": {
+                "EAPI": "5",
+                "SLOT": "0/3",
+                "KEYWORDS": "~x86",
+            },
+        }
+
+        installed = {
+            "x11-base/xwayland-23.1.1": {
+                "EAPI": "5",
+                "RDEPEND": "dev-libs/openssl:0/3=",
+            },
+            "dev-util/rustup-1.25.2": {
+                "EAPI": "5",
+                "RDEPEND": "dev-libs/openssl:0/3=",
+                "KEYWORDS": "~x86",
+            },
+            "dev-libs/openssl-3.1.1": {
+                "EAPI": "5",
+                "SLOT": "0/3",
+                "KEYWORDS": "~x86",
+            },
+        }
+
+        world = ["x11-base/xwayland", "dev-util/rustup"]
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["@world"],
+                options={"--deep": True, "--update": True, "--verbose": True},
+                success=True,
+                mergelist=["x11-base/xwayland-23.1.1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, world=world
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_slot_conflict_blocked_prune.py
+++ b/lib/portage/tests/resolver/test_slot_conflict_blocked_prune.py
@@ -63,7 +63,7 @@ class SlotConflictBlockedPruneTestCase(TestCase):
                 ["@world"],
                 options={"--deep": True, "--update": True, "--verbose": True},
                 success=True,
-                mergelist=["x11-base/xwayland-23.1.1"],
+                mergelist=[],
             ),
         )
 


### PR DESCRIPTION
Missed updates can also come in the form of package downgrades,
when, for example, there are keyword changes. They can cause
rebuilds, and these rebuilds may be not possible due to reasons such
as keywords or masks. In this case, prior to this patch, portage
would cancel the downgrade, but the rebuilds would be requested
endlessly, because [bug 439688](https://bugs.gentoo.org/439688)'s backtrack code does not trigger.

To reproduce, on an `ACCEPT_KEYWORDS=~amd64` machine, emerge
`=dev-libs/openssl=3.0.9`, `dev-util/rustup`, and something else that
depends on openssl. Then un-accept ~amd64 for openssl and rustup.
Prior to this patch, a `@world` upgrade would cause:

```
These are the packages that would be merged, in order:

Calculating dependencies... done!

[ebuild  rR    ] dev-libs/libevent-2.1.12-r1:0/2.1-7::gentoo
[ebuild  rR    ] net-misc/rsync-3.2.7-r2::gentoo
[...]

Total: 71 packages (71 reinstalls), Size of downloads: 0 KiB
```

There are no packages marked "R", only "rR". There are no section
labeled "The following packages are causing rebuilds:" either.

After this patch, we have:

```
These are the packages that would be merged, in order:

Calculating dependencies... done!

Total: 0 packages, Size of downloads: 0 KiB

WARNING: One or more updates/rebuilds have been skipped due to a dependency conflict:

dev-libs/openssl:0

  (dev-libs/openssl-1.1.1u:0/1.1::gentoo, ebuild scheduled for merge)
    dev-libs/openssl:0/3= required by (dev-util/rustup-1.25.2:0/0::gentoo, installed)
```

I also added a test to test this change. No other tests seems affected.

Bug: https://bugs.gentoo.org/622270
Signed-off-by: YiFei Zhu <zhuyifei1999@gmail.com>