### PR TITLE
depgraph: Do not allow slotted deps to be satisfied by wrong slots

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -4041,6 +4041,16 @@ class depgraph:
                         inst_pkg, modified_use=self._pkg_use_enabled(inst_pkg)
                     )
                 ]
+                # Do not allow slotted deps to be satisfied by wrong slots.
+                # Otherwise, slot-operator-dependent packages may rebuild
+                # before the slotted package they are dependent on.
+                if child and atom.slot_operator == "=":
+                    inst_pkgs = [
+                        inst_pkg
+                        for inst_pkg in inst_pkgs
+                        if inst_pkg.slot == child.slot
+                        and inst_pkg.sub_slot == child.sub_slot
+                    ]
                 if inst_pkgs:
                     for inst_pkg in inst_pkgs:
                         if self._pkg_visibility_check(inst_pkg):
@@ -4160,6 +4170,14 @@ class depgraph:
                             inst_pkg, modified_use=self._pkg_use_enabled(inst_pkg)
                         )
                     ]
+                    # Do not allow slotted deps to be satisfied by wrong slots.
+                    if child and atom.slot_operator == "=":
+                        inst_pkgs = [
+                            inst_pkg
+                            for inst_pkg in inst_pkgs
+                            if inst_pkg.slot == child.slot
+                            and inst_pkg.sub_slot == child.sub_slot
+                        ]
                     if inst_pkgs:
                         for inst_pkg in inst_pkgs:
                             if self._pkg_visibility_check(inst_pkg):

--- a/lib/portage/tests/resolver/test_perl_rebuild_bug.py
+++ b/lib/portage/tests/resolver/test_perl_rebuild_bug.py
@@ -1,0 +1,121 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class PerlRebuildBugTestCase(TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def testPerlRebuildBug(self):
+        """
+        The infamous Perl rebuild bug.
+
+        A non-slotted build-time dependency cycle is created by:
+        dev-lang/perl -> sys-libs/zlib -> sys-devel/automake -> dev-lang/perl
+        Everything else depends on this cycle.
+
+        Bug in solving for smallest cycle causes slot in RDEPEND of
+        dev-perl/Locale-gettext to be ignored, so all dependencies other than
+        perl's >=sys-libs/zlib-1.2.12 are satisfied by already-installed
+        packages. dev-perl/Locale-gettext and sys-devel/automake become leaves
+        of the depgraph after satisfied packages are ignored. They become
+        emerged first. This causes an issue because dev-perl/Locale-gettext is
+        now built before the slot upgrade of dev-lang/perl.
+        """
+        ebuilds = {
+            "dev-lang/perl-5.36.0-r2": {
+                "EAPI": "5",
+                "DEPEND": ">=sys-libs/zlib-1.2.12",
+                "RDEPEND": ">=sys-libs/zlib-1.2.12",
+                "SLOT": "0/5.36",
+            },
+            "dev-perl/Locale-gettext-1.70.0-r1": {
+                "EAPI": "5",
+                "DEPEND": "dev-lang/perl",
+                "RDEPEND": "dev-lang/perl:=",
+            },
+            "sys-apps/help2man-1.49.3": {
+                "EAPI": "5",
+                "DEPEND": "dev-lang/perl dev-perl/Locale-gettext",
+                "RDEPEND": "dev-lang/perl dev-perl/Locale-gettext",
+            },
+            "sys-devel/automake-1.16.5": {
+                "EAPI": "5",
+                "DEPEND": "dev-lang/perl",
+                "RDEPEND": "dev-lang/perl",
+            },
+            "sys-libs/zlib-1.2.13-r1": {
+                "EAPI": "5",
+                "DEPEND": "sys-devel/automake",
+            },
+        }
+
+        installed = {
+            "dev-lang/perl-5.34.0-r3": {
+                "EAPI": "5",
+                "DEPEND": "sys-libs/zlib",
+                "RDEPEND": "sys-libs/zlib",
+                "SLOT": "0/5.34",
+            },
+            "dev-perl/Locale-gettext-1.70.0-r1": {
+                "EAPI": "5",
+                "DEPEND": "dev-lang/perl",
+                "RDEPEND": "dev-lang/perl:0/5.34=",
+            },
+            "sys-apps/help2man-1.48.5": {
+                "EAPI": "5",
+                "DEPEND": "dev-lang/perl dev-perl/Locale-gettext",
+                "RDEPEND": "dev-lang/perl dev-perl/Locale-gettext",
+            },
+            "sys-devel/automake-1.16.4": {
+                "EAPI": "5",
+                "DEPEND": "dev-lang/perl",
+                "RDEPEND": "dev-lang/perl",
+            },
+            "sys-libs/zlib-1.2.11-r4": {
+                "EAPI": "5",
+                "DEPEND": "sys-devel/automake",
+            },
+        }
+
+        world = ["sys-apps/help2man"]
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["@world"],
+                options={"--deep": True, "--update": True, "--verbose": True},
+                success=True,
+                ambiguous_merge_order=True,
+                merge_order_assertions=(
+                    (
+                        "dev-perl/Locale-gettext-1.70.0-r1",
+                        "dev-lang/perl-5.36.0-r2",
+                    ),
+                ),
+                mergelist=[
+                    "dev-perl/Locale-gettext-1.70.0-r1",
+                    "sys-devel/automake-1.16.5",
+                    "sys-libs/zlib-1.2.13-r1",
+                    "dev-lang/perl-5.36.0-r2",
+                    "sys-apps/help2man-1.49.3",
+                ],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=installed,
+            world=world,
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_perl_rebuild_bug.py
+++ b/lib/portage/tests/resolver/test_perl_rebuild_bug.py
@@ -94,15 +94,15 @@ class PerlRebuildBugTestCase(TestCase):
                 ambiguous_merge_order=True,
                 merge_order_assertions=(
                     (
-                        "dev-perl/Locale-gettext-1.70.0-r1",
                         "dev-lang/perl-5.36.0-r2",
+                        "dev-perl/Locale-gettext-1.70.0-r1",
                     ),
                 ),
                 mergelist=[
-                    "dev-perl/Locale-gettext-1.70.0-r1",
                     "sys-devel/automake-1.16.5",
                     "sys-libs/zlib-1.2.13-r1",
                     "dev-lang/perl-5.36.0-r2",
+                    "dev-perl/Locale-gettext-1.70.0-r1",
                     "sys-apps/help2man-1.49.3",
                 ],
             ),


### PR DESCRIPTION
This may be part of what caused the "perl rebuild bug". The "priority" of perl, when seen by perl modules, may have "satisfied" set to an installed perl of a wrong slot. Compounding this factor with [bug #756199](https://bugs.gentoo.org/756199) where `find_smallest_cycle` would select a single node, in this case because the dependency of perl is satisfied and the priority then gets ignored, the "cycle" becomes a perl module alone and gets rebuilt early.

I also updated the test from the previous patch to account for this change. No other tests seems affected.

For a larger scale test, I reproduced this initially with a stage3 chroot from a Jan 1 2022 stage3 snapshot, and testing in an equivalent dockerfile would work too:

```dockerfile
FROM gentoo/stage3:amd64-openrc-20220101
RUN emerge-webrsync
COPY . /portage
```

Before this patch (USE flags omitted):

```
# cd /portage && bin/emerge -puDN @world 2>&1 | grep -i perl
[ebuild     U  ] app-admin/perl-cleaner-2.30-r1 [2.30]
[ebuild  rR    ] virtual/perl-File-Temp-0.231.100
[ebuild  rR    ] dev-perl/Locale-gettext-1.70.0-r1
[ebuild  rR    ] dev-perl/MIME-Charset-1.12.2-r1
[ebuild  rR    ] dev-perl/Module-Build-0.423.100
[ebuild  rR    ] dev-perl/Text-CharWidth-0.40.0-r2
[ebuild     U  ] dev-lang/perl-5.36.0-r2 [5.34.0-r3]
[ebuild  N     ] virtual/perl-CPAN-2.330.0
[ebuild     U  ] virtual/perl-ExtUtils-MakeMaker-7.640.0 [7.620.0]
[ebuild     U  ] virtual/perl-File-Spec-3.840.0 [3.800.0]
[...]
```

After this patch:

```
# cd /portage && bin/emerge -puDN @world 2>&1 | grep -i perl
[ebuild     U  ] app-admin/perl-cleaner-2.30-r1 [2.30]
[ebuild     U  ] dev-lang/perl-5.36.0-r2:0/5.36 [5.34.0-r3:0/5.34]
[ebuild  N     ] virtual/perl-CPAN-2.330.0
[ebuild     U  ] virtual/perl-ExtUtils-MakeMaker-7.640.0 [7.620.0]
[ebuild     U  ] virtual/perl-Data-Dumper-2.184.0 [2.179.0]
[ebuild     U  ] virtual/perl-File-Spec-3.840.0 [3.800.0]
[ebuild     U  ] virtual/perl-Test-Harness-3.440.0-r1 [3.430.0]
[ebuild  rR    ] dev-perl/Pod-Parser-1.630.0-r1
[ebuild  rR    ] dev-perl/Text-CharWidth-0.40.0-r2
[ebuild  rR    ] dev-perl/Text-WrapI18N-0.60.0-r2
[...]
```

Bug: https://bugs.gentoo.org/463976
Bug: https://bugs.gentoo.org/592880
Bug: https://bugs.gentoo.org/596664
Bug: https://bugs.gentoo.org/631490
Bug: https://bugs.gentoo.org/764365
Bug: https://bugs.gentoo.org/793992
Signed-off-by: YiFei Zhu <zhuyifei1999@gmail.com>