### PR TITLE
glsa.py: raise exception on invalid GLSA range type

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Bug fixes:
 * Adjust write tests for DISTDIR and PORTAGE_TMPDIR to work with automount
   directories (bug #485100, bug #890812).
 
+* glsa-check: appropriately handle more error cases with invalid GLSAs
+  (bug #905660)
+
 portage-3.0.48.1 (2023-06-06)
 ----------------
 

--- a/lib/portage/glsa.py
+++ b/lib/portage/glsa.py
@@ -268,7 +268,13 @@ def makeAtom(pkgname, versionNode):
     @rtype:		String
     @return:	the portage atom
     """
-    op = opMapping[versionNode.getAttribute("range")]
+    rangetype = versionNode.getAttribute("range")
+    if rangetype in opMapping:
+        op = opMapping[rangetype]
+    else:
+        raise GlsaFormatException(
+            _(f"Invalid range found for '{pkgname}': {rangetype}")
+        )
     version = getText(versionNode, format="strip")
     rValue = f"{op}{pkgname}-{version}"
     try:
@@ -292,7 +298,11 @@ def makeVersion(versionNode):
     @rtype:		String
     @return:	the version string
     """
-    op = opMapping[versionNode.getAttribute("range")]
+    rangetype = versionNode.getAttribute("range")
+    if rangetype in opMapping:
+        op = opMapping[rangetype]
+    else:
+        raise GlsaFormatException(_(f"Invalid range found: {rangetype}"))
     version = getText(versionNode, format="strip")
     rValue = f"{op}{version}"
     try:

--- a/lib/portage/tests/glsa/test_security_set.py
+++ b/lib/portage/tests/glsa/test_security_set.py
@@ -30,8 +30,8 @@ class SecuritySetTestCase(TestCase):
   <access>remote</access>
   <affected>
     <package name="%(cp)s" auto="yes" arch="%(arch)s">
-      <unaffected range="ge">%(unaffected_version)s</unaffected>
-      <vulnerable range="lt">%(unaffected_version)s</vulnerable>
+      <unaffected range="%(unaffected_range)s">%(unaffected_version)s</unaffected>
+      <vulnerable range="%(affected_range)s">%(affected_version)s</vulnerable>
     </package>
   </affected>
   <background>
@@ -96,21 +96,30 @@ class SecuritySetTestCase(TestCase):
                 "glsa_id": "201301-01",
                 "pkgname": "A-vulnerable",
                 "cp": "cat/A-vulnerable",
+                "unaffected_range": "ge",
+                "affected_range": "lt",
                 "unaffected_version": "2.2",
+                "affected_version": "2.2",
                 "arch": "*",
             },
             {
                 "glsa_id": "201301-02",
                 "pkgname": "B-not-vulnerable",
                 "cp": "cat/B-not-vulnerable",
+                "unaffected_range": "ge",
+                "affected_range": "lt",
                 "unaffected_version": "4.4",
+                "affected_version": "4.4",
                 "arch": "*",
             },
             {
                 "glsa_id": "201301-03",
                 "pkgname": "NotInstalled",
                 "cp": "cat/NotInstalled",
+                "unaffected_range": "ge",
+                "affected_range": "lt",
                 "unaffected_version": "3.5",
+                "affected_version": "3.5",
                 "arch": "*",
             },
         )
@@ -171,7 +180,10 @@ class SecuritySetTestCase(TestCase):
                 "glsa_id": "201301-04",
                 "pkgname": "A-vulnerable",
                 "cp": "cat/A-vulnerable",
+                "unaffected_range": "ge",
+                "affected_range": "lt",
                 "unaffected_version": "2.2",
+                "affected_version": "2.2",
                 # Use an invalid delimiter (comma)
                 "arch": "amd64,sparc",
             },
@@ -179,7 +191,10 @@ class SecuritySetTestCase(TestCase):
                 "glsa_id": "201301-05",
                 "pkgname": "A-vulnerable",
                 "cp": "cat/A-vulnerable",
+                "unaffected_range": "ge",
+                "affected_range": "lt",
                 "unaffected_version": "2.2",
+                "affected_version": "2.2",
                 # Use an invalid arch (~arch)
                 "arch": "~amd64",
             },
@@ -187,7 +202,10 @@ class SecuritySetTestCase(TestCase):
                 "glsa_id": "201301-06",
                 "pkgname": "A-vulnerable",
                 "cp": "cat/A-vulnerable",
+                "unaffected_range": "ge",
+                "affected_range": "lt",
                 "unaffected_version": "2.2",
+                "affected_version": "2.2",
                 # Two valid arches followed by an invalid one
                 "arch": "amd64 sparc $$$$",
             },

--- a/lib/portage/tests/glsa/test_security_set.py
+++ b/lib/portage/tests/glsa/test_security_set.py
@@ -209,6 +209,16 @@ class SecuritySetTestCase(TestCase):
                 # Two valid arches followed by an invalid one
                 "arch": "amd64 sparc $$$$",
             },
+            {
+                "glsa_id": "201301-07",
+                "pkgname": "A-vulnerable",
+                "cp": "cat/A-vulnerable",
+                "unaffected_range": "None",
+                "affected_range": "lt",
+                "unaffected_version": "2.2",
+                "affected_version": "2.2",
+                "arch": "*",
+            },
         )
 
         world = ["cat/A"]


### PR DESCRIPTION
This will indeed make `glsa-check` fail softer:

```
$ GLSA_DIR=$(pwd) ~/gentoo/portage/bin/glsa-check --list 202306-01
[A] means this GLSA was marked as applied (injected),
[U] means the system is not affected and
[N] indicates that the system might be affected.

invalid GLSA: 202306-01 (error message was: Invalid range found: None)
$ GLSA_DIR=$(pwd) glsa-check --list 202306-01
[A] means this GLSA was marked as applied (injected),
[U] means the system is not affected and
[N] indicates that the system might be affected.

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.11/glsa-check", line 310, in <module>
    sys.exit(summarylist(glsalist))
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python-exec/python3.11/glsa-check", line 247, in summarylist
    myglsa = Glsa(myid, portage.settings, vardb, portdb)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/portage/glsa.py", line 521, in __init__
    self.read()
  File "/usr/lib/python3.11/site-packages/portage/glsa.py", line 542, in read
    self.parse(f)
  File "/usr/lib/python3.11/site-packages/portage/glsa.py", line 656, in parse
    tmp["vul_vers"] = [
                      ^
  File "/usr/lib/python3.11/site-packages/portage/glsa.py", line 657, in <listcomp>
    makeVersion(v) for v in p.getElementsByTagName("vulnerable")
    ^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/portage/glsa.py", line 295, in makeVersion
    op = opMapping[versionNode.getAttribute("range")]
         ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'None'
```