### PR TITLE
bin/install-qa-check.d/05prefix: prefixify init-script shebangs.

### DIFF
--- a/bin/install-qa-check.d/05prefix
+++ b/bin/install-qa-check.d/05prefix
@@ -76,8 +76,8 @@ install_qa_check_prefix() {
 			fi
 			continue
 		fi
-		# unprefixed shebang, is the script directly in ${PATH}?
-		if [[ ":${PATH}:" == *":${fp}:"* ]] ; then
+		# unprefixed shebang, is the script directly in ${PATH} or an init script?
+		if [[ ":${PATH}:${EPREFIX}/etc/init.d:" == *":${fp}:"* ]] ; then
 			if [[ -e ${EROOT}${line[0]} || -e ${ED}${line[0]} ]] ; then
 				# is it unprefixed, but we can just fix it because a
 				# prefixed variant exists


### PR DESCRIPTION
Init scripts in /etc/init.d have OpenRC shebangs "#!/sbin/openrc-run". They should be prefixified like a executable script in a Prefix.


Closes: https://bugs.gentoo.org/640658