### PR TITLE
sr.ht ci: install pytest

### DIFF
--- a/.builds/ci.yml
+++ b/.builds/ci.yml
@@ -20,6 +20,13 @@ tasks:
   - setup-python: |
       portage/.builds/setup-python.sh "${PYTHON_VERSIONS[@]}"
 
+  - setup-tests: |
+      for py in "${PYTHON_VERSIONS[@]}"; do
+        source ".venv-$py/bin/activate"
+        pip install pytest
+        deactivate
+      done
+
   - test-install: |
       for py in "${PYTHON_VERSIONS[@]}"; do
         source ".venv-$py/bin/activate"


### PR DESCRIPTION
Ensure pytest exists on sourcehut builds before running Portage test suite.