### PR TITLE
depgraph.py: fix "no ebuilds/binpkgs" message

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -6456,7 +6456,7 @@ class depgraph:
                     cp_exists = True
                     break
 
-            if self._frozen_config.myopts.get("--usepkgonly", "y"):
+            if self._frozen_config.myopts.get("--usepkgonly", False):
                 writemsg(
                     f"\nemerge: there are no binary packages to satisfy {green(xinfo)}.\n",
                     noiselevel=-1,


### PR DESCRIPTION
The "there are no binary packages to satisfy" was being unconditionally output for packages that could not be found. Fix the logic for choosing between the "binary packages" and "ebuilds" form of the message.

This is a temporary stopgap as alluded to by me in the bug, but the tl;dr is that some entries in the `myopts` dict have "y"/"n" values whereas some are True/unset, and this discrepancy should be sorted out.

Bug: https://bugs.gentoo.org/909853