### PR TITLE
ebuild/doebuild.py: also set --load-average in GNUMAKEFLAGS default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Features:
+* GNUMAKEFLAGS: also specifiy "-l $(nproc)", that is, limit by load average,
+  per default.
+
 portage-3.0.52 (2023-10-03)
 --------------
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -590,7 +590,9 @@ def doebuild_environment(
             if nproc:
                 mysettings["MAKEOPTS"] = "-j%d" % (nproc)
             if "GNUMAKEFLAGS" not in mysettings and "MAKEFLAGS" not in mysettings:
-                mysettings["GNUMAKEFLAGS"] = "--output-sync=line"
+                mysettings[
+                    "GNUMAKEFLAGS"
+                ] = f"--load-average {nproc} --output-sync=line"
 
         if not eapi_exports_KV(eapi):
             # Discard KV for EAPIs that don't support it. Cached KV is restored

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -933,7 +933,8 @@ between \fICPUs+1\fR and \fI2*CPUs+1\fR. In order to avoid
 excess load, the \fB\-\-load\-average\fR option is recommended.
 For more information, see \fBmake\fR(1). Also see \fBemerge\fR(1) for
 information about analogous \fB\-\-jobs\fR and \fB\-\-load\-average\fR options.
-Defaults to the number of processors if left unset.
+If unset, defaults to using the number of processors to limit jobs (and
+load average via GNUMAKEFLAGS).
 .TP
 \fBNO_COLOR\fR = \fI[any string]\fR
 Set to any nonempty string (e.g. "1") to disable color by default.


### PR DESCRIPTION
In the presence of multiple parallel emerge jobs, i.e., emerge -j<num>, it is good to limit the overall parallelism in the system via its load average. This avoids overprovisioning the system with tasks and losing performance due to an increased number of context switches.

note: untested