### PR TITLE
install-qa-check.d/60openrc: be explicit about OpenRC

### DIFF
--- a/bin/install-qa-check.d/60openrc
+++ b/bin/install-qa-check.d/60openrc
@@ -32,7 +32,7 @@ openrc_check() {
 				[[ -L ${i} ]] && continue
 				f=$("${checkbashisms}" -n -f "${i}" 2>&1)
 				[[ $? != 0 && -n ${f} ]] || continue
-				eqawarn "QA Notice: shell script appears to use non-POSIX feature(s):"
+				eqawarn "QA Notice: OpenRC shell script appears to use non-POSIX feature(s):"
 				while read -r ;
 					do eqawarn "   ${REPLY}"
 				done <<< "${f//${ED}}"


### PR DESCRIPTION
Be explicit that this is not some arbitrary shell script that is checked by the QA check, but an OpenRC runscript.