### PR TITLE
_reflink_linux_file_copy: initialize error to 0

### DIFF
--- a/src/portage_util_file_copy_reflink_linux.c
+++ b/src/portage_util_file_copy_reflink_linux.c
@@ -214,6 +214,7 @@ _reflink_linux_file_copy(PyObject *self, PyObject *args)
         return NULL;
 
     eintr_retry = 1;
+    error = 0;
     offset_out = 0;
     stat_in_acquired = 0;
     stat_out_acquired = 0;


### PR DESCRIPTION
Avoids a compiler warning:
```
../src/portage_util_file_copy_reflink_linux.c: In function ‘_reflink_linux_file_copy’:
../src/portage_util_file_copy_reflink_linux.c:379:12: warning: ‘error’ may be used uninitialized [-Wmaybe-uninitialized]
  379 |         if (!error && ftruncate(fd_out, offset_out) < 0)
      |            ^
../src/portage_util_file_copy_reflink_linux.c:205:22: note: ‘error’ was declared here
  205 |     int eintr_retry, error, fd_in, fd_out, stat_in_acquired, stat_out_acquired;
      |                      ^~~~~
```