### PR TITLE
BROOT is defined in pkg_* phases only when the EAPI has IDEPEND

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Bug fixes:
+* Define BROOT in pkg_* phases only when the EAPI has IDEPEND.
+
 portage-3.0.50 (2023-08-09)
 --------------
 

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -3338,7 +3338,7 @@ class config:
         if not (src_like_phase and eapi_attrs.sysroot):
             mydict.pop("ESYSROOT", None)
 
-        if not eapi_attrs.broot:
+        if not ((src_like_phase or eapi_attrs.idepend) and eapi_attrs.broot):
             mydict.pop("BROOT", None)
 
         if phase == "depend" or (


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/911797#c13