### PR TITLE
-Oline fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+portage-3.0.51 (UNRELEASED)
+--------------
+
+Bug fixes:
+* doebuild: gate -Oline behind MAKEFLAGS check.
+
 portage-3.0.50 (2023-08-09)
 --------------
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -589,7 +589,7 @@ def doebuild_environment(
             nproc = get_cpu_count()
             if nproc:
                 mysettings["MAKEOPTS"] = "-j%d" % (nproc)
-            if "GNUMAKEFLAGS" not in mysettings:
+            if "GNUMAKEFLAGS" not in mysettings and "MAKEFLAGS" not in mysettings:
                 mysettings["GNUMAKEFLAGS"] = "--output-sync=line"
 
         if not eapi_exports_KV(eapi):


### PR DESCRIPTION
Add a check to see if MAKEFLAGS is set (alongside the existing MAKEOPTS
and GNUMAKEFLAGS checks) before enabling output synchronization.

This is only tangentially related to the bug below via being a (likely
rare) case of MAKEFLAGS being set in the wild.

Bug: https://bugs.gentoo.org/909009