### PR TITLE
sync: rsync, git: respect --debug for gemato

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+portage-3.0.51 (UNRELEASED)
+--------------
+
+Features:
+* emerge: Set up logging immediately and respect --debug for log level.
+
+* sync: git, rsync: now respects --debug for better output from gemato. This is
+  especially useful for debugging hangs during the 'Refreshing keys' stage.
+
 portage-3.0.50 (2023-08-09)
 --------------
 

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -1191,6 +1191,10 @@ def emerge_main(args: Optional[list[str]] = None):
     myaction, myopts, myfiles = parse_opts(args, silent=True)
     if "--debug" in myopts:
         os.environ["PORTAGE_DEBUG"] = "1"
+        portage.util.initialize_logger(logging.DEBUG)
+    else:
+        portage.util.initialize_logger()
+
     if "--config-root" in myopts:
         os.environ["PORTAGE_CONFIGROOT"] = myopts["--config-root"]
     if "--sysroot" in myopts:

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -1,4 +1,4 @@
-# Copyright 2005-2022 Gentoo Authors
+# Copyright 2005-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
@@ -416,7 +416,16 @@ class GitSync(NewBase):
             )
             return False
 
-        openpgp_env = self._get_openpgp_env(self.repo.sync_openpgp_key_path)
+        opts = self.options.get("emerge_config").opts
+        debug = "--debug" in opts
+
+        openpgp_env = self._get_openpgp_env(self.repo.sync_openpgp_key_path, debug)
+        logging.getLogger("gemato").setLevel(logging.DEBUG)
+
+        if debug:
+            old_level = logging.getLogger().getEffectiveLevel()
+            logging.getLogger().setLevel(logging.DEBUG)
+            logging.getLogger("gemato").setLevel(logging.DEBUG)
 
         try:
             out = EOutput()
@@ -475,6 +484,8 @@ class GitSync(NewBase):
         finally:
             if openpgp_env is not None:
                 openpgp_env.close()
+            if debug:
+                logging.getLogger().setLevel(old_level)
 
     def retrieve_head(self, **kwargs) -> tuple[int, bool]:
         """Get information about the head commit"""

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -480,6 +480,14 @@ class GitSync(NewBase):
             else:
                 expl = "unknown issue"
             out.eerror(f"No valid signature found: {expl}")
+
+            if debug:
+                writemsg_level(
+                    f"!!! Got following output from gpg: {status}\n",
+                    level=logging.DEBUG,
+                    noiselevel=-1,
+                )
+
             return False
         finally:
             if openpgp_env is not None:

--- a/lib/portage/sync/modules/rsync/rsync.py
+++ b/lib/portage/sync/modules/rsync/rsync.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import datetime
@@ -147,11 +147,16 @@ class RsyncSync(NewBase):
         else:
             self.max_age = 0
 
+        debug = "--debug" in opts
+        if debug:
+            old_level = logging.getLogger().getEffectiveLevel()
+            logging.getLogger().setLevel(logging.DEBUG)
+
         openpgp_env = None
         if self.verify_metamanifest and gemato is not None:
             # Use isolated environment if key is specified,
             # system environment otherwise
-            openpgp_env = self._get_openpgp_env(self.repo.sync_openpgp_key_path)
+            openpgp_env = self._get_openpgp_env(self.repo.sync_openpgp_key_path, debug)
 
         try:
             # Load and update the keyring early. If it fails, then verification
@@ -484,6 +489,8 @@ class RsyncSync(NewBase):
                 self.repo_storage.abort_update()
             if openpgp_env is not None:
                 openpgp_env.close()
+            if debug:
+                logging.getLogger().setLevel(old_level)
 
     def _process_exitcode(self, exitcode, syncuri, out, maxretries):
         if exitcode == 0:

--- a/lib/portage/sync/syncbase.py
+++ b/lib/portage/sync/syncbase.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 Gentoo Authors
+# Copyright 2014-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """
@@ -328,7 +328,7 @@ class SyncBase:
                 loop.run_until_complete(decorated_func())
         out.eend(0)
 
-    def _get_openpgp_env(self, openpgp_key_path=None):
+    def _get_openpgp_env(self, openpgp_key_path=None, debug=False):
         if gemato is not None:
             # Override global proxy setting with one provided in emerge configuration
             if "http_proxy" in self.spawn_kwargs["env"]:
@@ -337,9 +337,13 @@ class SyncBase:
                 proxy = None
 
             if openpgp_key_path:
-                openpgp_env = gemato.openpgp.OpenPGPEnvironment(proxy=proxy)
+                openpgp_env = gemato.openpgp.OpenPGPEnvironment(
+                    proxy=proxy, debug=debug
+                )
             else:
-                openpgp_env = gemato.openpgp.OpenPGPSystemEnvironment(proxy=proxy)
+                openpgp_env = gemato.openpgp.OpenPGPSystemEnvironment(
+                    proxy=proxy, debug=debug
+                )
 
             return openpgp_env
 


### PR DESCRIPTION
Respect --debug and pass it down to gemato so we get nice debugging output
when e.g. 'refreshing keys' is stuck.

Bug: https://bugs.gentoo.org/646194
Bug: https://bugs.gentoo.org/647696
Bug: https://bugs.gentoo.org/691666
Bug: https://bugs.gentoo.org/779766
Bug: https://bugs.gentoo.org/873133
Bug: https://bugs.gentoo.org/906875
Signed-off-by: Sam James <sam@gentoo.org>