### PR TITLE
emerge-webrsync: handle https_proxy too

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,12 @@ Features:
   especially useful for debugging hangs during the 'Refreshing keys' stage.
 
 Bug fixes:
+* sync (inc. emerge-webrsync): Handle https_proxy to help users who only have it set
+  - the expectation is to have http_proxy set (bug #691434, bug #835927, bug #911629)
+
+* emerge-webrsync: Explicitly pass http_proxy or https_proxy into gemato
+  via --proxy (bug #911629).
+
 * misc/emerge-delta-webrsync: Fix PGP logic which prevented syncing for this
   rarely-used tool (bug #911335).
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -83,8 +83,8 @@ eval "$("${portageq}" envvar -v DISTDIR EPREFIX FEATURES \
 	PORTAGE_BIN_PATH PORTAGE_CONFIGROOT PORTAGE_GPG_DIR \
 	PORTAGE_NICENESS PORTAGE_REPOSITORIES PORTAGE_RSYNC_EXTRA_OPTS \
 	PORTAGE_RSYNC_OPTS PORTAGE_TEMP_GPG_DIR PORTAGE_TMPDIR \
-	USERLAND http_proxy ftp_proxy)"
-export http_proxy ftp_proxy
+	USERLAND http_proxy https_proxy ftp_proxy)"
+export http_proxy https_proxy ftp_proxy
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -290,6 +290,13 @@ check_file_signature_gemato() {
 			-K "${key}"
 		)
 
+
+		if [[ -n ${http_proxy} || -n ${https_proxy} ]] ; then
+			gemato_args+=(
+				--proxy "${http_proxy:-${https_proxy}}"
+			)
+		fi
+
 		[[ -n ${PORTAGE_GPG_KEY_SERVER} ]] && gemato_args+=( --keyserver "${PORTAGE_GPG_KEY_SERVER}" )
 		[[ ${PORTAGE_QUIET} == 1 ]] && gemato_args+=( --quiet )
 		[[ ${do_debug} == 1 ]] && gemato_args+=( --debug )

--- a/bin/save-ebuild-env.sh
+++ b/bin/save-ebuild-env.sh
@@ -28,7 +28,7 @@ __save_ebuild_env() {
 
 	# misc variables inherited from the calling environment
 	unset COLORTERM DISPLAY EDITOR LESS LESSOPEN LOGNAME LS_COLORS PAGER \
-		TERM TERMCAP USER ftp_proxy http_proxy no_proxy
+		TERM TERMCAP USER ftp_proxy http_proxy https_proxy no_proxy
 
 	# other variables inherited from the calling environment
 	unset CVS_RSH ECHANGELOG_USER GPG_AGENT_INFO \

--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -215,6 +215,7 @@ environ_whitelist = frozenset(
         "USER",
         "ftp_proxy",
         "http_proxy",
+        "https_proxy",
         "no_proxy",
         # tempdir settings
         "TMPDIR",

--- a/lib/portage/sync/syncbase.py
+++ b/lib/portage/sync/syncbase.py
@@ -333,6 +333,8 @@ class SyncBase:
             # Override global proxy setting with one provided in emerge configuration
             if "http_proxy" in self.spawn_kwargs["env"]:
                 proxy = self.spawn_kwargs["env"]["http_proxy"]
+            elif "https_proxy" in self.spawn_kwargs["env"]:
+                proxy = self.spawn_kwargs["env"]["https_proxy"]
             else:
                 proxy = None
 


### PR DESCRIPTION
If `https_proxy` is also set in make.conf, pick that up so it's passed down to
wget.

Bug: https://bugs.gentoo.org/911629
Signed-off-by: Sam James <sam@gentoo.org>