### PR TITLE
Allow building of pure Python wheel by setting "pure" appropriately

### DIFF
--- a/DEVELOPING
+++ b/DEVELOPING
@@ -238,7 +238,8 @@ and commit.
 	- python -m venv .venv
 	- . .venv/bin/activate
 	- pip install build twine
-	- python -m build
+	- python -m build # build the sdist and arch/Python-specific wheel
+	- python -m build --wheel -Csetup-args="-Dnative-extensions=false" # build the pure wheel
 	- twine upload dist/<filenames>
 
 7. Bugzilla wrangling:

--- a/lib/_emerge/meson.build
+++ b/lib/_emerge/meson.build
@@ -95,7 +95,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : '_emerge',
-    pure : false
+    pure : true
 )
 
 subdir('resolver')

--- a/lib/_emerge/resolver/meson.build
+++ b/lib/_emerge/resolver/meson.build
@@ -10,5 +10,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : '_emerge/resolver',
-    pure : false
+    pure : true
 )

--- a/lib/portage/_compat_upgrade/meson.build
+++ b/lib/portage/_compat_upgrade/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/_compat_upgrade',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/_emirrordist/meson.build
+++ b/lib/portage/_emirrordist/meson.build
@@ -11,5 +11,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/_emirrordist',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/_sets/meson.build
+++ b/lib/portage/_sets/meson.build
@@ -11,5 +11,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/_sets',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/binrepo/meson.build
+++ b/lib/portage/binrepo/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/binrepo',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/cache/index/meson.build
+++ b/lib/portage/cache/index/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/cache/index',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/cache/meson.build
+++ b/lib/portage/cache/meson.build
@@ -14,7 +14,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/cache',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('index')

--- a/lib/portage/dbapi/meson.build
+++ b/lib/portage/dbapi/meson.build
@@ -18,5 +18,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/dbapi',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/dep/meson.build
+++ b/lib/portage/dep/meson.build
@@ -6,7 +6,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/dep',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('soname')

--- a/lib/portage/dep/soname/meson.build
+++ b/lib/portage/dep/soname/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/dep/soname',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/elog/meson.build
+++ b/lib/portage/elog/meson.build
@@ -12,5 +12,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/elog',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/meson.build
+++ b/lib/portage/emaint/meson.build
@@ -5,7 +5,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('modules')

--- a/lib/portage/emaint/modules/binhost/meson.build
+++ b/lib/portage/emaint/modules/binhost/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/binhost',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/config/meson.build
+++ b/lib/portage/emaint/modules/config/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/config',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/logs/meson.build
+++ b/lib/portage/emaint/modules/logs/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/logs',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/merges/meson.build
+++ b/lib/portage/emaint/modules/merges/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/merges',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/meson.build
+++ b/lib/portage/emaint/modules/meson.build
@@ -3,7 +3,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('binhost')

--- a/lib/portage/emaint/modules/move/meson.build
+++ b/lib/portage/emaint/modules/move/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/move',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/resume/meson.build
+++ b/lib/portage/emaint/modules/resume/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/resume',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/sync/meson.build
+++ b/lib/portage/emaint/modules/sync/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/sync',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/emaint/modules/world/meson.build
+++ b/lib/portage/emaint/modules/world/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/emaint/modules/world',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/env/meson.build
+++ b/lib/portage/env/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/env',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/meson.build
+++ b/lib/portage/meson.build
@@ -52,7 +52,7 @@ py.install_sources(
         __init__py,
     ],
     subdir : 'portage',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('binrepo')

--- a/lib/portage/package/ebuild/_config/meson.build
+++ b/lib/portage/package/ebuild/_config/meson.build
@@ -13,5 +13,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/package/ebuild/_config',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/package/ebuild/_ipc/meson.build
+++ b/lib/portage/package/ebuild/_ipc/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/package/ebuild/_ipc',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/package/ebuild/_parallel_manifest/meson.build
+++ b/lib/portage/package/ebuild/_parallel_manifest/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/package/ebuild/_parallel_manifest',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/package/ebuild/meson.build
+++ b/lib/portage/package/ebuild/meson.build
@@ -15,7 +15,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/package/ebuild',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('_config')

--- a/lib/portage/package/meson.build
+++ b/lib/portage/package/meson.build
@@ -3,7 +3,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/package',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('ebuild')

--- a/lib/portage/proxy/meson.build
+++ b/lib/portage/proxy/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/proxy',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/repository/meson.build
+++ b/lib/portage/repository/meson.build
@@ -4,7 +4,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/repository',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('storage')

--- a/lib/portage/repository/storage/meson.build
+++ b/lib/portage/repository/storage/meson.build
@@ -7,5 +7,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/repository/storage',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/sync/meson.build
+++ b/lib/portage/sync/meson.build
@@ -8,7 +8,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('modules')

--- a/lib/portage/sync/modules/cvs/meson.build
+++ b/lib/portage/sync/modules/cvs/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules/cvs',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/sync/modules/git/meson.build
+++ b/lib/portage/sync/modules/git/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules/git',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/sync/modules/mercurial/meson.build
+++ b/lib/portage/sync/modules/mercurial/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules/mercurial',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/sync/modules/meson.build
+++ b/lib/portage/sync/modules/meson.build
@@ -3,7 +3,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('cvs')

--- a/lib/portage/sync/modules/rsync/meson.build
+++ b/lib/portage/sync/modules/rsync/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules/rsync',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/sync/modules/svn/meson.build
+++ b/lib/portage/sync/modules/svn/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules/svn',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/sync/modules/webrsync/meson.build
+++ b/lib/portage/sync/modules/webrsync/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/sync/modules/webrsync',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/bin/meson.build
+++ b/lib/portage/tests/bin/meson.build
@@ -10,5 +10,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/bin',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/dbapi/meson.build
+++ b/lib/portage/tests/dbapi/meson.build
@@ -8,5 +8,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/dbapi',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/dep/meson.build
+++ b/lib/portage/tests/dep/meson.build
@@ -24,5 +24,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/dep',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/ebuild/meson.build
+++ b/lib/portage/tests/ebuild/meson.build
@@ -13,5 +13,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/ebuild',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/emerge/meson.build
+++ b/lib/portage/tests/emerge/meson.build
@@ -10,5 +10,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/emerge',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/env/config/meson.build
+++ b/lib/portage/tests/env/config/meson.build
@@ -8,5 +8,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/env/config',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/env/meson.build
+++ b/lib/portage/tests/env/meson.build
@@ -4,7 +4,7 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/env',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('config')

--- a/lib/portage/tests/glsa/meson.build
+++ b/lib/portage/tests/glsa/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/glsa',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/gpkg/meson.build
+++ b/lib/portage/tests/gpkg/meson.build
@@ -11,5 +11,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/gpkg',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/lafilefixer/meson.build
+++ b/lib/portage/tests/lafilefixer/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/lafilefixer',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/lazyimport/meson.build
+++ b/lib/portage/tests/lazyimport/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/lazyimport',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/lint/meson.build
+++ b/lib/portage/tests/lint/meson.build
@@ -8,5 +8,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/lint',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/locks/meson.build
+++ b/lib/portage/tests/locks/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/locks',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/meson.build
+++ b/lib/portage/tests/meson.build
@@ -4,7 +4,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/tests',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('bin')

--- a/lib/portage/tests/news/meson.build
+++ b/lib/portage/tests/news/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/news',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/process/meson.build
+++ b/lib/portage/tests/process/meson.build
@@ -12,5 +12,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/process',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/resolver/binpkg_multi_instance/meson.build
+++ b/lib/portage/tests/resolver/binpkg_multi_instance/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/resolver/binpkg_multi_instance',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -89,7 +89,7 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/resolver',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('binpkg_multi_instance')

--- a/lib/portage/tests/resolver/soname/meson.build
+++ b/lib/portage/tests/resolver/soname/meson.build
@@ -15,5 +15,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/resolver/soname',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/sets/base/meson.build
+++ b/lib/portage/tests/sets/base/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/sets/base',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/sets/files/meson.build
+++ b/lib/portage/tests/sets/files/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/sets/files',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/sets/meson.build
+++ b/lib/portage/tests/sets/meson.build
@@ -4,7 +4,7 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/sets',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('base')

--- a/lib/portage/tests/sets/shell/meson.build
+++ b/lib/portage/tests/sets/shell/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/sets/shell',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/sync/meson.build
+++ b/lib/portage/tests/sync/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/sync',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/unicode/meson.build
+++ b/lib/portage/tests/unicode/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/unicode',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/update/meson.build
+++ b/lib/portage/tests/update/meson.build
@@ -7,5 +7,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/update',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/util/dyn_libs/meson.build
+++ b/lib/portage/tests/util/dyn_libs/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/util/dyn_libs',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/util/eventloop/meson.build
+++ b/lib/portage/tests/util/eventloop/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/util/eventloop',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/util/file_copy/meson.build
+++ b/lib/portage/tests/util/file_copy/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/util/file_copy',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/util/futures/asyncio/meson.build
+++ b/lib/portage/tests/util/futures/asyncio/meson.build
@@ -11,5 +11,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/util/futures/asyncio',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/util/futures/meson.build
+++ b/lib/portage/tests/util/futures/meson.build
@@ -9,7 +9,7 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/util/futures',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('asyncio')

--- a/lib/portage/tests/util/meson.build
+++ b/lib/portage/tests/util/meson.build
@@ -22,7 +22,7 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/util',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('dyn_libs')

--- a/lib/portage/tests/versions/meson.build
+++ b/lib/portage/tests/versions/meson.build
@@ -6,5 +6,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/versions',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/tests/xpak/meson.build
+++ b/lib/portage/tests/xpak/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__test__.py',
     ],
     subdir : 'portage/tests/xpak',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/_async/meson.build
+++ b/lib/portage/util/_async/meson.build
@@ -16,5 +16,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/_async',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/_dyn_libs/meson.build
+++ b/lib/portage/util/_dyn_libs/meson.build
@@ -10,5 +10,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/_dyn_libs',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/_eventloop/meson.build
+++ b/lib/portage/util/_eventloop/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/_eventloop',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/elf/meson.build
+++ b/lib/portage/util/elf/meson.build
@@ -5,5 +5,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/elf',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/endian/meson.build
+++ b/lib/portage/util/endian/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/endian',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/file_copy/meson.build
+++ b/lib/portage/util/file_copy/meson.build
@@ -3,5 +3,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/file_copy',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/futures/_asyncio/meson.build
+++ b/lib/portage/util/futures/_asyncio/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/futures/_asyncio',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/futures/executor/meson.build
+++ b/lib/portage/util/futures/executor/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/futures/executor',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/futures/meson.build
+++ b/lib/portage/util/futures/meson.build
@@ -10,7 +10,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/futures',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('executor')

--- a/lib/portage/util/iterators/meson.build
+++ b/lib/portage/util/iterators/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util/iterators',
-    pure : false
+    pure : not native_extensions
 )

--- a/lib/portage/util/meson.build
+++ b/lib/portage/util/meson.build
@@ -36,7 +36,7 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/util',
-    pure : false
+    pure : not native_extensions
 )
 
 subdir('elf')

--- a/lib/portage/xml/meson.build
+++ b/lib/portage/xml/meson.build
@@ -4,5 +4,5 @@ py.install_sources(
         '__init__.py',
     ],
     subdir : 'portage/xml',
-    pure : false
+    pure : not native_extensions
 )

--- a/meson.build
+++ b/meson.build
@@ -7,12 +7,15 @@ project(
 )
 
 py_mod = import('python')
-# TODO: Add "pure : false" here instead of py.install_sources() when requiring Meson >=0.64.0.
+# TODO: Add "pure : not native_extensions" here instead of py.install_sources()
+# when requiring Meson >=0.64.0.
 py = py_mod.find_installation()
 
 sed = find_program('sed', required : true)
 
 system_wide = get_option('system-wide')
+native_extensions = get_option('native-extensions')
+
 eprefix = get_option('eprefix')
 prefixdir = get_option('prefix')
 datadir = get_option('datadir')
@@ -90,7 +93,7 @@ endif
 subdir('bin')
 subdir('lib')
 
-if get_option('native-extensions')
+if native_extensions
     subdir('src')
 endif
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ build-backend = 'mesonpy'
 requires = ['meson-python']
 
 [tool.meson-python.args]
+# To get a pure wheel:
+# python -m build --wheel -Csetup-args="-Dnative-extensions=false"
 setup = ['-Dsystem-wide=false']
 
 [project.scripts]


### PR DESCRIPTION
It will only build a pure wheel when pure is true in all cases.

To get a pure wheel, run:
```
python -m build --wheel -Csetup-args="-Dnative-extensions=false"
```