### PR TITLE
 lib/portage/gpg.py: send gpg output to stdout, then send stdout to /dev/null

### DIFF
--- a/lib/portage/gpg.py
+++ b/lib/portage/gpg.py
@@ -35,7 +35,7 @@ class GPG:
             f"--homedir {self.signing_gpg_home} "
             f"--digest-algo {self.digest_algo} "
             f"--local-user {self.signing_gpg_key} "
-            "--output /dev/null /dev/null",
+            "--output - /dev/null",
         )
 
         if "gpg-keepalive" in self.settings.features:
@@ -61,7 +61,7 @@ class GPG:
                 writemsg(f"{colorize('WARN', str(e))}\n")
 
             cmd = shlex_split(varexpand(self.GPG_unlock_command, mydict=self.settings))
-            return_code = subprocess.Popen(cmd).wait()
+            return_code = subprocess.Popen(cmd, stdout=subprocess.DEVNULL).wait()
 
             if return_code == os.EX_OK:
                 writemsg_stdout(f"{colorize('GOOD', 'unlocked')}\n")


### PR DESCRIPTION
GnuPG removes the --output file on failure. Removing /dev/null breaks all kinds of things. So lets use a temporary file for the output instead.

If the file already exists then we remove it to prevent GnuPG from complaining about the file already existing and asking us if we want to choose a different --output file.

Closes: https://bugs.gentoo.org/912808