### PR TITLE
Run PORTAGE_TRUST_HELPER before remote binary package operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           python -m pip install --upgrade pip
           # setuptools needed for 3.12+ because of https://github.com/mesonbuild/meson/issues/7702.
           python -m pip install pytest setuptools
+
+          # symlink /bin/true to /usr/bin/getuto (or do we want to grab the script from github?)
+          sudo ln -s /bin/true /usr/bin/getuto
       - name: Test meson install --destdir /tmp/install-root
         run: |
           echo -e "[binaries]\npython = '$(command -v python)'" > /tmp/native.ini

--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -150,8 +150,8 @@ PORTAGE_ELOG_MAILFROM="portage@localhost"
 # Signing command used by egencache
 PORTAGE_GPG_SIGNING_COMMAND="gpg --sign --digest-algo SHA256 --clearsign --yes --default-key \"\${PORTAGE_GPG_KEY}\" --homedir \"\${PORTAGE_GPG_DIR}\" \"\${FILE}\""
 
-# Trust helper for updating package signing keys
-PORTAGE_TRUST_HELPER="/usr/bin/getuto -q"
+# Trust helper executable for installing and updating package verification keys
+PORTAGE_TRUST_HELPER="/usr/bin/getuto"
 
 # btrfs.* attributes are irrelevant, see bug #527636.
 # security.* attributes may be special (see bug 461868), but

--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -150,6 +150,9 @@ PORTAGE_ELOG_MAILFROM="portage@localhost"
 # Signing command used by egencache
 PORTAGE_GPG_SIGNING_COMMAND="gpg --sign --digest-algo SHA256 --clearsign --yes --default-key \"\${PORTAGE_GPG_KEY}\" --homedir \"\${PORTAGE_GPG_DIR}\" \"\${FILE}\""
 
+# Trust helper for updating package signing keys
+PORTAGE_TRUST_HELPER="/usr/bin/getuto -q"
+
 # btrfs.* attributes are irrelevant, see bug #527636.
 # security.* attributes may be special (see bug 461868), but
 # security.capability is specifically not excluded (bug 548516).

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1236,6 +1236,9 @@ class binarytree:
 
     def _run_trust_helper(self):
         portage_trust_helper = self.settings.get("PORTAGE_TRUST_HELPER", "true")
+        if portage_trust_helper == "true":
+            return 0
+
         # getuto is a shell script...
         ret = os.waitstatus_to_exitcode(os.system(portage_trust_helper))
         if ret == 127:

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1243,12 +1243,14 @@ class binarytree:
         if ret.returncode == 127:
             raise OSError(
                 _(
-                    "Did not find trust helper. Install app-portage/getuto or set PORTAGE_TRUST_HELPER=\"\""
+                    'Did not find trust helper. Install app-portage/getuto or set PORTAGE_TRUST_HELPER=""'
                 )
             )
         elif ret.returncode != 0:
             raise OSError(
-                _("Failed to run trust helper executable for binary package verification: Error ")
+                _(
+                    "Failed to run trust helper executable for binary package verification: Error "
+                )
                 + str(ret.returncode)
             )
 

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1239,8 +1239,7 @@ class binarytree:
         if portage_trust_helper == "true":
             return 0
 
-        # getuto is a shell script...
-        ret = subprocess.run(portage_trust_helper, shell=True)
+        ret = subprocess.run(portage_trust_helper)
         if ret.returncode == 127:
             raise OSError(
                 _(
@@ -1249,7 +1248,7 @@ class binarytree:
             )
         elif ret.returncode != 0:
             raise OSError(
-                _("Failed to run trust helper for binary package verification: Error ")
+                _("Failed to run trust helper executable for binary package verification: Error ")
                 + str(ret.returncode)
             )
 

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1235,15 +1235,15 @@ class binarytree:
         return pkgindex if update_pkgindex else None
 
     def _run_trust_helper(self):
-        portage_trust_helper = self.settings.get("PORTAGE_TRUST_HELPER", "true")
-        if portage_trust_helper == "true":
-            return 0
+        portage_trust_helper = self.settings.get("PORTAGE_TRUST_HELPER", "")
+        if portage_trust_helper == "":
+            return
 
         ret = subprocess.run(portage_trust_helper)
         if ret.returncode == 127:
             raise OSError(
                 _(
-                    "Did not find trust helper. Install app-portage/getuto or set PORTAGE_TRUST_HELPER=true"
+                    "Did not find trust helper. Install app-portage/getuto or set PORTAGE_TRUST_HELPER=\"\""
                 )
             )
         elif ret.returncode != 0:

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1240,17 +1240,17 @@ class binarytree:
             return 0
 
         # getuto is a shell script...
-        ret = os.waitstatus_to_exitcode(os.system(portage_trust_helper))
-        if ret == 127:
+        ret = subprocess.run(portage_trust_helper, shell=True)
+        if ret.returncode == 127:
             raise OSError(
                 _(
                     "Did not find trust helper. Install app-portage/getuto or set PORTAGE_TRUST_HELPER=true"
                 )
             )
-        elif ret != 0:
+        elif ret.returncode != 0:
             raise OSError(
                 _("Failed to run trust helper for binary package verification: Error ")
-                + str(ret)
+                + str(ret.returncode)
             )
 
     def _populate_remote(self, getbinpkg_refresh=True):

--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -315,6 +315,7 @@ environ_filter = frozenset(
         "PORTAGE_RSYNC_RETRIES",
         "PORTAGE_SSH_OPTS",
         "PORTAGE_SYNC_STALE",
+        "PORTAGE_TRUST_HELPER",
         "PORTAGE_USE",
         "PORTAGE_LOG_FILTER_FILE_CMD",
         "PORTAGE_LOGDIR",

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1209,13 +1209,13 @@ Defaults to /var/tmp.
 This should not be set to point anywhere under location of any repository.
 .TP
 \fBPORTAGE_TRUST_HELPER\fR = \fI[path]\fR
-Defines a shell command line which initializes and maintains
+Defines an executable file which initializes and maintains
 /etc/portage/gnupg, installing keys that are trusted for binary package
 signing, and refreshing these keys from a key server. This helper is called
 before all operations involving remote binary packages if and only if
 binpkg-request-signature is in \fBFEATURES\fR.
 .br
-Defaults to "/usr/bin/getuto -q" (provided by app-portage/getuto).
+Defaults to "/usr/bin/getuto" (provided by app-portage/getuto).
 .TP
 \fBPORTAGE_USERNAME\fR = \fI[user]\fR
 Defines the username to use when executing in userpriv/etc... modes (i.e.

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1209,9 +1209,9 @@ Defaults to /var/tmp.
 This should not be set to point anywhere under location of any repository.
 .TP
 \fBPORTAGE_TRUST_HELPER\fR = \fI[path]\fR
-Defines an executable file which initializes and maintains
+Defines a shell command line which initializes and maintains
 /etc/portage/gnupg, installing keys that are trusted for binary package
-signing, and refreshing these keys from a key server. The helper is called
+signing, and refreshing these keys from a key server. This helper is called
 before all operations involving remote binary packages if and only if
 binpkg-request-signature is in \fBFEATURES\fR.
 .br

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1208,6 +1208,15 @@ Defaults to /var/tmp.
 
 This should not be set to point anywhere under location of any repository.
 .TP
+\fBPORTAGE_TRUST_HELPER\fR = \fI[path]\fR
+Defines an executable file which initializes and maintains
+/etc/portage/gnupg, installing keys that are trusted for binary package
+signing, and refreshing these keys from a key server. The helper is called
+before all operations involving remote binary packages if and only if
+binpkg-request-signature is in \fBFEATURES\fR.
+.br
+Defaults to "/usr/bin/getuto -q" (provided by app-portage/getuto).
+.TP
 \fBPORTAGE_USERNAME\fR = \fI[user]\fR
 Defines the username to use when executing in userpriv/etc... modes (i.e.
 non-root).


### PR DESCRIPTION
Tested to do what it's supposed to do... 