### PR TITLE
emerge: ensure paths are UTF-8 encoded in _needs_move()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ Features:
 Bug fixes:
 * Prevent gpg from removing /dev/null when unlocking signing key (bug #912808).
 
+* emerge: ensure paths are UTF-8 encoded in _needs_move() (bug #913103).
+
 portage-3.0.51 (2023-08-20)
 --------------
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -6273,12 +6273,15 @@ class dblink:
         if mydmode is None or not stat.S_ISREG(mydmode) or mymode != mydmode:
             return True
 
+        src_bytes = _unicode_encode(mysrc, encoding=_encodings["fs"], errors="strict")
+        dest_bytes = _unicode_encode(mydest, encoding=_encodings["fs"], errors="strict")
+
         if "xattr" in self.settings.features:
             excluded_xattrs = self.settings.get("PORTAGE_XATTR_EXCLUDE", "")
-            if not _cmpxattr(mysrc, mydest, exclude=excluded_xattrs):
+            if not _cmpxattr(src_bytes, dest_bytes, exclude=excluded_xattrs):
                 return True
 
-        return not filecmp.cmp(mysrc, mydest, shallow=False)
+        return not filecmp.cmp(src_bytes, dest_bytes, shallow=False)
 
 
 def merge(

--- a/lib/portage/util/movefile.py
+++ b/lib/portage/util/movefile.py
@@ -105,10 +105,11 @@ def _copyxattr(src, dest, exclude=None):
             )
 
 
-def _cmpxattr(src, dest, exclude=None):
+def _cmpxattr(src: bytes, dest: bytes, exclude=None) -> bool:
     """
     Compares extended attributes between |src| and |dest| and returns True
-    if they are equal or xattrs are not supported, False otherwise
+    if they are equal or xattrs are not supported, False otherwise.
+    Assumes all given paths are UTF-8 encoded.
     """
     try:
         src_attrs = xattr.list(src)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/913103