### PR TITLE
vartree: keep build dir if postinst fails

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ Bug fixes:
 
 * emerge: ensure paths are UTF-8 encoded in _needs_move() (bug #913103).
 
+* vartree: keep build dir if postinst fails (bug #704866).
+
 portage-3.0.51 (2023-08-20)
 --------------
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -6070,8 +6070,11 @@ class dblink:
                 ebuild_phase.wait()
                 self._elog_process()
 
-                if "noclean" not in self.settings.features and (
-                    retval == os.EX_OK or "fail-clean" in self.settings.features
+                # Keep the build dir around if postinst fails (bug #704866)
+                if (
+                    not self._postinst_failure
+                    and "noclean" not in self.settings.features
+                    and (retval == os.EX_OK or "fail-clean" in self.settings.features)
                 ):
                     if myebuild is None:
                         myebuild = os.path.join(inforoot, self.pkg + ".ebuild")


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/704866