### PR TITLE
_emerge: use binpkg coloring for pkg_pretend

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -865,12 +865,13 @@ class Scheduler(PollScheduler):
             if self._terminated_tasks:
                 raise asyncio.CancelledError
 
-            out_str = "Running pre-merge checks for " + colorize("INFORM", x.cpv)
-            self._status_msg(out_str)
-
             root_config = x.root_config
             settings = self._allocate_config(root_config.root)
             settings.setcpv(x)
+
+            color = "PKG_BINARY_MERGE" if x.built else "INFORM"
+            self._status_msg(f"Running pre-merge checks for {colorize(color, x.cpv)}")
+
             if not x.built:
                 # Get required SRC_URI metadata (it's not cached in x.metadata
                 # because some packages have an extremely large SRC_URI value).

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -1260,12 +1260,14 @@ class Scheduler(PollScheduler):
             and not mod_echo_output
         ):
             for mysettings, key, logentries in self._failed_pkgs_die_msgs:
+                color = "PKG_BINARY_MERGE" if pkg.built else "INFORM"
+
                 root_msg = ""
                 if mysettings["ROOT"] != "/":
                     root_msg = f" merged to {mysettings['ROOT']}"
                 print()
                 printer.einfo(
-                    f"Error messages for package {colorize('INFORM', key)}{root_msg}:"
+                    f"Error messages for package {colorize(color, key)}{root_msg}:"
                 )
                 print()
                 for phase in portage.const.EBUILD_PHASES:
@@ -2001,7 +2003,10 @@ class Scheduler(PollScheduler):
 
     def _failed_pkg_msg(self, failed_pkg, action, preposition):
         pkg = failed_pkg.pkg
-        msg = f"{bad('Failed')} to {action} {colorize('INFORM', pkg.cpv)}"
+
+        color = "PKG_BINARY_MERGE" if failed_pkg.pkg.built else "INFORM"
+
+        msg = f"{bad('Failed')} to {action} {colorize(color, pkg.cpv)}"
         if pkg.root_config.settings["ROOT"] != "/":
             msg += f" {preposition} {pkg.root}"
 

--- a/lib/portage/elog/mod_echo.py
+++ b/lib/portage/elog/mod_echo.py
@@ -22,7 +22,9 @@ def process(mysettings, key, logentries, fulltext):
         and "PORTAGE_LOG_FILE" in mysettings
     ):
         logfile = mysettings["PORTAGE_LOG_FILE"]
-    _items.append((mysettings["ROOT"], key, logentries, logfile))
+
+    binary = mysettings.configdict["pkg"]["MERGE_TYPE"] == "binary"
+    _items.append((mysettings["ROOT"], key, logentries, logfile, binary))
 
 
 def finalize():
@@ -42,14 +44,17 @@ def finalize():
 def _finalize():
     global _items
     printer = EOutput()
-    for root, key, logentries, logfile in _items:
+    for root, key, logentries, logfile, binary in _items:
+        color = "PKG_BINARY_MERGE" if binary else "INFORM"
+
         print()
+
         if root == "/":
-            printer.einfo(_("Messages for package %s:") % colorize("INFORM", key))
+            printer.einfo(_("Messages for package %s:") % colorize(color, key))
         else:
             printer.einfo(
                 _("Messages for package %(pkg)s merged to %(root)s:")
-                % {"pkg": colorize("INFORM", key), "root": root}
+                % {"pkg": colorize(color, key), "root": root}
             )
         if logfile is not None:
             printer.einfo(_("Log file: %s") % colorize("INFORM", logfile))


### PR DESCRIPTION
For the 'Running pre-merge checks' message, we write:
```
>>> Running pre-merge checks for X
```

X is currently always in green, while the emerge list above might have the atom X listed in purple if it's a binpkg.

Change X to be colored based on if it's a binpkg or not.

Bug: https://bugs.gentoo.org/914159