### PR TITLE
man: use groff escape sequence for tilde characters

### DIFF
--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -62,20 +62,20 @@ operators:
 	\fI<\fRmedia\-libs/libgd\-1.6
 .fi
 .TP
-.B Extended Atom Prefixes [!~] and Postfixes [*]
+.B Extended Atom Prefixes [!\(ti] and Postfixes [*]
 Now to get even fancier, we provide the ability to define blocking packages and
 version range matching.  Also note that these extended prefixes/postfixes may
 be combined in any way with the atom classes defined above.
 .RS
 .TP
-.I ~
+.I \(ti
 means match any revision of the base version specified.  So in the
 example below, we would match versions '1.0.2a', '1.0.2a\-r1', '1.0.2a\-r2',
 etc...
 
 \fBExample\fR:
 .nf
-	\fI~\fRnet\-libs/libnet\-1.0.2a
+	\fI\(ti\fRnet\-libs/libnet\-1.0.2a
 .fi
 .TP
 .I !
@@ -120,7 +120,7 @@ Beginning with \fBEAPI 1\fR, any atom can be constrained to match a specific
 \fBExamples\fR:
 .nf
 	x11\-libs/qt:3
-	\fI~\fRx11\-libs/qt-3.3.8:3
+	\fI\(ti\fRx11\-libs/qt-3.3.8:3
 	\fI>=\fRx11\-libs/qt-3.3.8:3
 	\fI=\fRx11\-libs/qt-3.3*:3
 .fi
@@ -572,7 +572,7 @@ file name, should be separated by whitespace.
 Should contain a list of URIs for the sources main sites and other further
 package dependent information.
 .TP
-.B KEYWORDS\fR = \fI[\-~][x86,ppc,sparc,mips,alpha,arm,hppa,...]
+.B KEYWORDS\fR = \fI[\-\(ti][x86,ppc,sparc,mips,alpha,arm,hppa,...]
 .P
 
 KEYWORDS works in conjunction with ACCEPT_KEYWORDS (see \fBmake.conf\fR(5))
@@ -590,9 +590,9 @@ Any ebuild that then has
 "amd64" in KEYWORDS will be unmasked by default.
 
 On an "unstable"
-amd64 system, ACCEPT_KEYWORDS will be set to "amd64 ~amd64", with the
+amd64 system, ACCEPT_KEYWORDS will be set to "amd64 \(tiamd64", with the
 tilde denoting "unstable." Then, if an ebuild has \fIeither\fR
-"amd64" or "~amd64" in KEYWORDS, it will be keyword unmasked by default on
+"amd64" or "\(tiamd64" in KEYWORDS, it will be keyword unmasked by default on
 that system. Similarly, if an ebuild is known to not be compatible
 with a particular architecture, the "\-" prefix ( i.e. "\-amd64") setting
 can be specified to mask it only on that arch.
@@ -612,7 +612,7 @@ This would be done by specifying "\-ppc", for example. This will ensure that
 it is explicitly keyword\-masked for that architecture.
 .IP \(bu
 When submitting an ebuild to Gentoo Linux, it is the project policy to only
-have "~arch" set in KEYWORDS
+have "\(tiarch" set in KEYWORDS
 for the architecture for which it has been successfully tested, and no more.
 As the ebuild receives more testing, Gentoo arch teams will gradually expand
 the KEYWORDS settings to "bump" the package to unstable, and possibly stable.
@@ -1605,7 +1605,7 @@ SRC_URI="ftp://alpha.gnu.org/pub/gnu/${PN}/${P}.tar.gz"
 
 LICENSE="GPL\-2"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="\(tiamd64"
 
 BDEPEND="nls? ( sys-devel/gettext )"
 

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1290,10 +1290,10 @@ Symbol	Mask Type
 
 #	package.mask
 *	missing keyword
-~	unstable keyword
+\(ti	unstable keyword
 .TE
 
-\fBNOTE:\fR The unstable keyword symbol (~) will not be shown in cases
+\fBNOTE:\fR The unstable keyword symbol (\(ti) will not be shown in cases
 in which the corresponding unstable keywords have been accepted
 globally via \fBACCEPT_KEYWORDS\fR.
 .TP
@@ -1370,7 +1370,7 @@ The \fBKEYWORDS\fR variable in an \fBebuild\fR file is also used for masking
 a package still in testing.  There are architecture\-specific keywords for
 each package that let \fBportage\fR know which systems are compatible with
 the package.  Packages which compile on an architecture, but have not been
-proven to be "stable", are masked with a tilde (\fB~\fR) in front of the
+proven to be "stable", are masked with a tilde (\fB\(ti\fR) in front of the
 architecture name.  \fBemerge\fR examines the \fBACCEPT_KEYWORDS\fR environment
 variable to allow or disallow the emerging of a package masked by
 \fBKEYWORDS\fR.  To inform \fBemerge\fR that it should build these 'testing'

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -51,9 +51,9 @@ Defaults to the value of $CHOST.
 .TP
 \fBACCEPT_KEYWORDS\fR = \fI[space delimited list of KEYWORDS]\fR
 Enable testing of ebuilds that have not yet been deemed 'stable'.  Users
-of the 'x86' architecture would set this to '~x86' while ppc users would
-set this to '~ppc'.  This is an incremental variable.  Only define a
-~arch.
+of the 'x86' architecture would set this to '\(tix86' while ppc users would
+set this to '\(tippc'.  This is an incremental variable.  Only define a
+\(tiarch.
 .br
 Defaults to the value of $ARCH.
 .TP

--- a/man/portage.5
+++ b/man/portage.5
@@ -607,7 +607,7 @@ Files in this directory, including make.conf, repos.conf, sets.conf,
 and any file with a name that begins with "package." can also be directories.
 
 If it is a directory, then all the files in that directory, excluding files
-that begin with '.' or end with '~', will be sorted in lexical order by file
+that begin with '.' or end with '\(ti', will be sorted in lexical order by file
 name and summed together as if they were a single file.
 
 .I Example:
@@ -761,9 +761,9 @@ modifies effective KEYWORDS (rather than ACCEPT_KEYWORDS).
 
 .I Example:
 # always use unstable libgd
-media\-libs/libgd ~x86
+media\-libs/libgd \(tix86
 # only use stable mplayer
-media\-video/mplayer \-~x86
+media\-video/mplayer \-\(tix86
 # always use unstable netcat
 net-analyzer/netcat
 .fi
@@ -775,7 +775,7 @@ three special tokens:
 
 .nf
 \fB*\fR  package is visible if it is stable on any architecture
-\fB~*\fR package is visible if it is in testing on any architecture
+\fB\(ti*\fR package is visible if it is in testing on any architecture
 \fB**\fR package is always visible (KEYWORDS are ignored completely)
 .fi
 
@@ -1683,7 +1683,7 @@ given package should vary depending on which profile the user has selected.
 # add stable keyword to libgd
 media\-libs/libgd x86
 # remove stable keyword from mplayer and add unstable keyword
-media\-video/mplayer \-x86 ~x86
+media\-video/mplayer \-x86 \(tix86
 # remove all keywords from netcat
 net-analyzer/netcat -*
 .fi


### PR DESCRIPTION
groff replaces normal tilde (~) with a weird "modifier" on output. Use the escape sequence from groff_char(7) to avoid this.