### PR TITLE
fetch: ignore force-mirror feature when try_mirrors is false

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Bug fixes:
 
 * vartree: keep build dir if postinst fails (bug #704866).
 
+* fetch: fix fetching of layout.conf when FEATURES=force-mirror (bug #877793).
+
 portage-3.0.51 (2023-08-20)
 --------------
 

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -980,7 +980,7 @@ def fetch(
     ]
 
     restrict_fetch = "fetch" in restrict
-    force_mirror = "force-mirror" in features and not restrict_mirror
+    force_mirror = "force-mirror" in features and not restrict_mirror and try_mirrors
 
     file_uri_tuples = []
     # Check for 'items' attribute since OrderedDict is not a dict.


### PR DESCRIPTION
When fetching layout.conf, we call fetch(try_mirrors=False) to force direct use of the primary URI being passed and ignore mirrors.

The force-mirror feature causes fetch to ignore the primary URI.

Ignoring both the primary URI and mirrors leads to an unfetchable file. Give precedence to the try_mirrors parameter since we really only set it to False when fetching layout.conf from a mirror.

Bug: https://bugs.gentoo.org/877793