### PR TITLE
estrip: update for modern elfutils by passing -R

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,10 @@ Features:
 * bintree: Add new API member (invalid_paths) to allow gentoolkit to later
   clean up invalid binpkgs (bug #900224).
 
-* Run PORTAGE_TRUST_HELPER before remote binary package operations.
+* gpkg: Run PORTAGE_TRUST_HELPER before remote binary package operations (bug #913070).
+
+* emerge: Use appropriate colors if binpkgs are used in e.g. pkg_pretend
+  messages as well as elog's mod_echo module (bug #914159).
 
 Bug fixes:
 * Prevent gpg from removing /dev/null when unlocking signing key (bug #912808).

--- a/bin/estrip
+++ b/bin/estrip
@@ -172,7 +172,7 @@ case $(${STRIP} --version 2>/dev/null) in
 	# elfutils default behavior is always safe, so don't need to specify
 	# any flags at all
 	SAFE_STRIP_FLAGS=""
-	DEF_STRIP_FLAGS="--remove-comment"
+	DEF_STRIP_FLAGS="-R .comment -R .GCC.command.line -R .note.gnu.gold-version"
 	SPLIT_STRIP_FLAGS="-f"
 	;;
 *GNU*) # sys-devel/binutils


### PR DESCRIPTION
Since elfutils 0.170, eu-strip supports -R / --remove-section option [0] """
strip: Add -R, --remove-section=SECTION and --keep-section=SECTION. """

"--remove-comment" is the same as "-R .comment". (eu-strip still does not support -N / --strip-symbol option, which would be good to use when it is implemented (Bug #686282).)

<elfutils-0.170 was deleted almost 2 years ago:
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=7a0474559d4361a75a90aadc2b0f5ec46d85f359

Call eu-strip with the same -R options as for GNU strip / llvm-strip:
  -R .comment -R .GCC.command.line -R .note.gnu.gold-version

[0] https://sourceware.org/git/?p=elfutils.git;a=blob;f=NEWS;h=3d097c68438489b028e2eb6931f8287fd9a46652;hb=HEAD#l197

Bug: https://bugs.gentoo.org/728100