### PR TITLE
etc-update: set SELinux security labels on merged files

### DIFF
--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -12,6 +12,7 @@
 #
 
 import atexit
+import errno
 import re
 import subprocess
 import sys
@@ -398,6 +399,8 @@ class dispatch:
                     mystat = os.lstat(conf["new"])
                     os.chmod(mrgconf, mystat[ST_MODE])
                     os.chown(mrgconf, mystat[ST_UID], mystat[ST_GID])
+                    if "selinux" in portage.settings.features:
+                        self.copy_selinux_label(conf["current"], mrgconf)
                     newconf = mrgconf
                     continue
                 elif c == "l":
@@ -433,6 +436,30 @@ class dispatch:
             print()
 
         perform_conf_update_session_hooks("post-session")
+
+    def copy_selinux_label(self, curconf, newconf):
+        """Copy the SELinux security label from the current config file to
+        the new/merged config file."""
+        try:
+            label = os.getxattr(curconf, "security.selinux")
+        except OSError as e:
+            if e.errno == errno.ENOTSUP:
+                # Filesystem does not support xattrs
+                return
+            writemsg(
+                f"dispatch-conf: Failed getting SELinux label on {curconf}; ignoring...\n",
+                noiselevel=-1,
+            )
+            return
+
+        if label:
+            try:
+                os.setxattr(newconf, "security.selinux", label)
+            except OSError:
+                writemsg(
+                    f"dispatch-conf: Failed setting SELinux label on {newconf}; ignoring...\n",
+                    noiselevel=-1,
+                )
 
     def replace(self, newconf, curconf):
         """Replace current config with the new/merged version.  Also logs

--- a/bin/etc-update
+++ b/bin/etc-update
@@ -631,6 +631,7 @@ do_merge() {
 					else
 						chown --reference="${ofile}" "${mfile}"
 						chmod --reference="${ofile}" "${mfile}"
+						${selinux} && chcon --reference="${ofile}" "${mfile}"
 					fi
 					do_mv_ln ${mv_opts} "${mfile}" "${ofile}"
 					rm ${rm_opts} "${file}"
@@ -815,6 +816,8 @@ export PORTAGE_TMPDIR
 SCAN_PATHS=${*:-${CONFIG_PROTECT}}
 [[ " ${FEATURES} " == *" case-insensitive-fs "* ]] && \
 	case_insensitive=true || case_insensitive=false
+[[ " ${FEATURES} " == *" selinux "* ]] && \
+	selinux=true || selinux=false
 
 TMP="${PORTAGE_TMPDIR}/etc-update-$$"
 trap "die terminated" SIGTERM


### PR DESCRIPTION
For files merged with etc-update, also set their SELinux security labels. Without this, merged files will have the type user_tmp_t and cause issues on enforcing SELinux systems.