### PR TITLE
Remove obsolete _eintr_func_wrapper

### DIFF
--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -345,29 +345,6 @@ class _unicode_module_wrapper:
         return result
 
 
-class _eintr_func_wrapper:
-    """
-    Wraps a function and handles EINTR by calling the function as
-    many times as necessary (until it returns without raising EINTR).
-    """
-
-    __slots__ = ("_func",)
-
-    def __init__(self, func):
-        self._func = func
-
-    def __call__(self, *args, **kwargs):
-        while True:
-            try:
-                rval = self._func(*args, **kwargs)
-                break
-            except OSError as e:
-                if e.errno != errno.EINTR:
-                    raise
-
-        return rval
-
-
 import os as _os
 
 _os_overrides = {
@@ -375,7 +352,7 @@ _os_overrides = {
     id(_os.popen): _os.popen,
     id(_os.read): _os.read,
     id(_os.system): _os.system,
-    id(_os.waitpid): _eintr_func_wrapper(_os.waitpid),
+    id(_os.waitpid): _os.waitpid,
 }
 
 

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -297,7 +297,7 @@ def _lockfile_iteration(
 
     # try for a non-blocking lock, if it's held, throw a message
     # we're waiting on lockfile and use a blocking attempt.
-    locking_method = portage._eintr_func_wrapper(_get_lock_fn())
+    locking_method = _get_lock_fn()
     try:
         if "__PORTAGE_TEST_HARDLINK_LOCKS" in os.environ:
             raise OSError(errno.ENOSYS, "Function not implemented")


### PR DESCRIPTION
This wrapper is obsolete since python 3.5 implemented EINTR retry in the standard library.

Bug: https://bugs.gentoo.org/525552