### PR TITLE
ForkProcess: Add target constructor parameter

### DIFF
--- a/lib/portage/util/_async/AsyncFunction.py
+++ b/lib/portage/util/_async/AsyncFunction.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 Gentoo Authors
+# Copyright 2015-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import pickle
@@ -16,13 +16,8 @@ class AsyncFunction(ForkProcess):
     "result" attribute after the forked process has exited.
     """
 
-    # NOTE: This class overrides the meaning of the SpawnProcess 'args'
-    # attribute, and uses it to hold the positional arguments for the
-    # 'target' function.
     __slots__ = (
-        "kwargs",
         "result",
-        "target",
         "_async_func_reader",
         "_async_func_reader_pw",
     )


### PR DESCRIPTION
If the _run method is not implemented, then use a new
"target" constructor parameter like multiprocessing.Process.
Support "args" and "kwargs" constructor parameters as well.

If the _run method is implemented, then behave in a backward
compatible manner, and ignore the "args" and "kwargs" constructor
parameters which are used by the AsyncFunction subclass.

Migrate AsyncFunction to ForkProcess target parameter.

Bug: https://bugs.gentoo.org/915099
Signed-off-by: Zac Medico <zmedico@gentoo.org>

