### PR TITLE
FileCopier: multiprocessing spawn compat

### DIFF
--- a/lib/portage/util/_async/FileCopier.py
+++ b/lib/portage/util/_async/FileCopier.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 Gentoo Authors
+# Copyright 2013-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import os as _os
@@ -20,16 +20,20 @@ class FileCopier(AsyncTaskFuture):
 
     def _start(self):
         self.future = asyncio.ensure_future(
-            self.scheduler.run_in_executor(ForkExecutor(loop=self.scheduler), self._run)
+            self.scheduler.run_in_executor(
+                ForkExecutor(loop=self.scheduler),
+                self._target,
+                self.src_path,
+                self.dest_path,
+            )
         )
         super()._start()
 
-    def _run(self):
-        src_path = _unicode_encode(
-            self.src_path, encoding=_encodings["fs"], errors="strict"
-        )
+    @staticmethod
+    def _target(src_path, dest_path):
+        src_path = _unicode_encode(src_path, encoding=_encodings["fs"], errors="strict")
         dest_path = _unicode_encode(
-            self.dest_path, encoding=_encodings["fs"], errors="strict"
+            dest_path, encoding=_encodings["fs"], errors="strict"
         )
         copyfile(src_path, dest_path)
         apply_stat_permissions(dest_path, _os.stat(src_path))


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/915099