### PR TITLE
ebuild: do not drop FEATURES=test when USE=-test

### DIFF
--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -2205,20 +2205,6 @@ class config:
                 "BASH_FUNC____in_portage_iuse%%"
             ] = "() { [[ $1 =~ ${PORTAGE_IUSE} ]]; }"
 
-        ebuild_force_test = not restrict_test and self.get("EBUILD_FORCE_TEST") == "1"
-
-        if "test" in explicit_iuse or iuse_implicit_match("test"):
-            if "test" in self.features:
-                if ebuild_force_test and "test" in self.usemask:
-                    self.usemask = frozenset(x for x in self.usemask if x != "test")
-            if restrict_test or ("test" in self.usemask and not ebuild_force_test):
-                # "test" is in IUSE and USE=test is masked, so execution
-                # of src_test() probably is not reliable. Therefore,
-                # temporarily disable FEATURES=test just for this package.
-                self["FEATURES"] = " ".join(
-                    x for x in sorted(self.features) if x != "test"
-                )
-
         # Allow _* flags from USE_EXPAND wildcards to pass through here.
         use.difference_update(
             [


### PR DESCRIPTION
By convention the "test" USE flag is used to control dependencies required for execution of the src_test function.

The "test" USE flag has no special meaning in PMS.

The Gentoo Policy Guide [1] advises that ebuilds must make use of RESTRICT to disable tests based on USE flags.

Current versions of Portage will not run tests when RESTRICT=test is set, regardless of the FEATURES setting.

This code in Portage predates the Gentoo policy. It is unneeded since the policy was created and ebuilds have been updated with the necessary RESTRICT values.

[1] https://projects.gentoo.org/qa/policy-guide/other-metadata.html#pg0703