### PR TITLE
Inroducing Invalid_errors

### DIFF
--- a/lib/portage/emaint/main.py
+++ b/lib/portage/emaint/main.py
@@ -136,7 +136,7 @@ class TaskHandler:
                 "module_output": self.module_output,
                 # pass in a copy of the options so a module can not pollute or change
                 # them for other tasks if there is more to do.
-                "options": options.copy(),
+                "options": options.copy() if options else None,
             }
             returncode, msgs = getattr(inst, func)(**kwargs)
             returncodes.append(returncode)

--- a/lib/portage/tests/dbapi/test_bintree.py
+++ b/lib/portage/tests/dbapi/test_bintree.py
@@ -87,7 +87,7 @@ class BinarytreeTestCase(TestCase):
         bt = binarytree(pkgdir=os.getenv("TMPDIR", "/tmp"), settings=MagicMock())
         ppopulate_local.return_value = {}
         bt.populate()
-        ppopulate_local.assert_called_once_with(reindex=True)
+        ppopulate_local.assert_called_once_with(reindex=True, invalid_errors=True)
         self.assertFalse(bt._populating)
         self.assertTrue(bt.populated)
 
@@ -95,7 +95,9 @@ class BinarytreeTestCase(TestCase):
     def test_populate_calls_twice_populate_local_if_updates(self, ppopulate_local):
         bt = binarytree(pkgdir=os.getenv("TMPDIR", "/tmp"), settings=MagicMock())
         bt.populate()
-        self.assertIn(call(reindex=True), ppopulate_local.mock_calls)
+        self.assertIn(
+            call(reindex=True, invalid_errors=True), ppopulate_local.mock_calls
+        )
         self.assertIn(call(), ppopulate_local.mock_calls)
         self.assertEqual(ppopulate_local.call_count, 2)
 


### PR DESCRIPTION
Introducing Invalid_errors var to enable suppression
of invalid binary error
see also: https://github.com/gentoo/gentoolkit/pull/35