### PR TITLE
Detect and handle unnecessary package reinstall (bug 915494)

### DIFF
--- a/lib/portage/dep/_slot_operator.py
+++ b/lib/portage/dep/_slot_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 Gentoo Foundation
+# Copyright 2012-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.dep import Atom, paren_enclose, use_reduce
@@ -101,7 +101,11 @@ def _eval_deps(dep_struct, vardbs):
                 if best_version:
                     best_version = best_version[-1]
                     try:
-                        best_version = vardb._pkg_str(best_version, None)
+                        best_version = (
+                            best_version
+                            if hasattr(best_version, "slot")
+                            else vardb._pkg_str(best_version, None)
+                        )
                     except (KeyError, InvalidData):
                         pass
                     else:


### PR DESCRIPTION
Compare package rebuilds/reinstalls to installed packages of the same
exact version, and eliminate unecessary rebuilds/reinstalls triggered
solely by the `@__auto_slot_operator_replace_installed__` set. This is
careful to obey the user's wishes if they have explicitly requested
for a package to be rebuilt or reinstalled for some reason.

The SonameSkipUpdateTestCase::testSonameSkipUpdateNoPruneRebuilds
test case shows that the new depgraph._eliminate_rebuilds method
eliminates a backtracking run that is needed for the
testSonameSkipUpdate test case to succeed via prune_rebuilds
backtracking which was added for bug 439688.

Bug: https://bugs.gentoo.org/915494