### PR TITLE
MergeProcess: Use multiprocessing.Pipe to decouple fd_pipes

### DIFF
--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -4198,7 +4198,7 @@ class dblink:
             if str_buffer:
                 str_buffer = _unicode_encode("".join(str_buffer))
                 while str_buffer:
-                    str_buffer = str_buffer[os.write(self._pipe, str_buffer) :]
+                    str_buffer = str_buffer[os.write(self._pipe.fileno(), str_buffer) :]
 
     def _emerge_log(self, msg):
         emergelog(False, msg)


### PR DESCRIPTION
Use multiprocessing.Pipe to decouple from the fd_pipes implementation since that currently only works for the multiprocessing "fork" start method.

Bug: https://bugs.gentoo.org/915903