### PR TITLE
sync/git: update git remote url with sync-uri when necessary

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,9 @@ Bug fixes:
 
 * Eliminate unnecessary package reinstalls (bug #915494).
 
+* Update the git remote URL of an overlay with its configured sync-uri
+  when necessary (bug #905869).
+
 portage-3.0.52 (2023-10-03)
 --------------
 

--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -325,11 +325,7 @@ class GitSync(NewBase):
                 elif not quiet:
                     writemsg_level(" ".join(git_set_remote_url_cmd) + "\n")
 
-        git_cmd = "{} fetch {}{}".format(
-            self.bin_command,
-            git_remote,
-            git_cmd_opts,
-        )
+        git_cmd = f"{self.bin_command} fetch {git_remote}{git_cmd_opts}"
 
         if not quiet:
             writemsg_level(git_cmd + "\n")


### PR DESCRIPTION
If the repo is not volatile, update the URL of the git remote if it is not equal to the configured sync-uri.

<strike>Closes: https://bugs.gentoo.org/915991</strike>
Closes: https://bugs.gentoo.org/905869