### PR TITLE
ForkProcess: Implement fd_pipes via send_handle

### DIFF
--- a/lib/portage/tests/process/test_ForkProcess.py
+++ b/lib/portage/tests/process/test_ForkProcess.py
@@ -4,6 +4,7 @@
 import functools
 import multiprocessing
 import tempfile
+from unittest.mock import patch
 
 from portage import os
 from portage.tests import TestCase
@@ -37,3 +38,9 @@ class ForkProcessTestCase(TestCase):
 
             with open(logfile.name, "rb") as output:
                 self.assertEqual(output.read(), test_string.encode("utf-8"))
+
+    def test_spawn_logfile_no_send_handle(self):
+        with patch(
+            "portage.util._async.ForkProcess.ForkProcess._HAVE_SEND_HANDLE", new=False
+        ):
+            self.test_spawn_logfile()


### PR DESCRIPTION
This new fd_pipes implementation is only enabled
when the multiprocessing start method is not fork,
ensuring backward compatibility with existing
ForkProcess callers that rely on the fork start
method.

Note that the new fd_pipes implementation uses a
thread via run_in_executor, and threads are not
recommended for mixing with the fork start method
due to cpython issue 84559.

Bug: https://bugs.gentoo.org/915896