### PR TITLE
Ban non-PMS helpers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ portage-3.0.54 (UNRELEASED)
 
 TODO
 
+Breaking changes:
+* Finally ban non-PMS helpers portageq, prepinfo, prepman, prepstrip and
+  prepallstrip (bug #899898, bug #906129, bug #906156).
+
 portage-3.0.53 (2023-10-20)
 --------------
 

--- a/bin/ebuild-helpers/portageq
+++ b/bin/ebuild-helpers/portageq
@@ -4,5 +4,5 @@
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
-eqawarn "QA Notice: '${0##*/}' is not allowed in ebuild scope"
-exec "${PORTAGE_BIN_PATH}"/portageq-wrapper "$@"
+die "'${0##*/}' is not allowed in ebuild scope"
+exit 1

--- a/bin/ebuild-helpers/prepallstrip
+++ b/bin/ebuild-helpers/prepallstrip
@@ -4,14 +4,5 @@
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
-if ___eapi_has_dostrip; then
-	die "${0##*/}: ${0##*/} has been banned for EAPI '${EAPI}'; use 'dostrip' instead"
-fi
-
-eqawarn "QA Notice: '${0##*/}' is not allowed in ebuild scope"
-
-if ! ___eapi_has_prefix_variables; then
-	ED=${D}
-fi
-
-exec prepstrip "${ED}"
+die "'${0##*/}' is not allowed in ebuild scope"
+exit 1

--- a/bin/ebuild-helpers/prepinfo
+++ b/bin/ebuild-helpers/prepinfo
@@ -4,37 +4,5 @@
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
-eqawarn "QA Notice: '${0##*/}' is not allowed in ebuild scope"
-
-if ! ___eapi_has_prefix_variables ; then
-	ED=${D}
-fi
-
-if [[ -z ${1} ]] ; then
-	infodir="/usr/share/info"
-else
-	if [[ -d ${ED%/}/${1#/}/share/info ]] ; then
-		infodir="${1#/}/share/info"
-	else
-		infodir="${1#/}/info"
-	fi
-fi
-
-if [[ ! -d ${ED%/}/${infodir#/} ]] ; then
-	if [[ -n $1 ]] ; then
-		__vecho "${0##*/}: '${infodir}' does not exist!"
-		exit 1
-	else
-		exit 0
-	fi
-fi
-
-find "${ED%/}/${infodir#/}" -type d -print0 | while read -r -d $'\0' x ; do
-	for f in "${x}"/.keepinfodir*; do
-		[[ -e ${f} ]] && continue 2
-	done
-
-	rm -f "${x}"/dir{,.info}{,.Z,.gz,.bz2,.lzma,.lz,.xz,.zst}
-done
-
-exit 0
+die "'${0##*/}' is not allowed in ebuild scope"
+exit 1

--- a/bin/ebuild-helpers/prepman
+++ b/bin/ebuild-helpers/prepman
@@ -2,11 +2,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Note: this really does nothing these days. It's going to be banned
-# when the last consumers are gone.
-
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
-eqawarn "QA Notice: '${0##*/}' is not allowed in ebuild scope"
-
-exit 0
+die "'${0##*/}' is not allowed in ebuild scope"
+exit 1

--- a/bin/ebuild-helpers/prepstrip
+++ b/bin/ebuild-helpers/prepstrip
@@ -4,10 +4,5 @@
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 
-if ___eapi_has_dostrip; then
-	die "${0##*/}: ${0##*/} has been banned for EAPI '${EAPI}'; use 'dostrip' instead"
-fi
-
-eqawarn "QA Notice: '${0##*/}' is not allowed in ebuild scope"
-
-__PORTAGE_HELPER=prepstrip exec "${PORTAGE_BIN_PATH}"/estrip "${@}"
+die "'${0##*/}' is not allowed in ebuild scope"
+exit 1

--- a/bin/estrip
+++ b/bin/estrip
@@ -30,9 +30,8 @@ if ${PORTAGE_RESTRICT_strip} || ${FEATURES_nostrip} ; then
 	${FEATURES_installsources} || exit 0
 fi
 
-[[ ${__PORTAGE_HELPER} == prepstrip ]] && prepstrip=true || prepstrip=false
+prepstrip=false
 
-if ! ${prepstrip}; then
 while [[ $# -gt 0 ]] ; do
 	case $1 in
 	--ignore)
@@ -130,7 +129,6 @@ while [[ $# -gt 0 ]] ; do
 	shift
 done
 set -- "${ED}"
-fi
 
 PRESERVE_XATTR=false
 if [[ ${KERNEL} == linux ]] && ${FEATURES_xattr} ; then

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -147,19 +147,6 @@ install_qa_check() {
 		# Portage regenerates this on the installed system.
 		rm -f "${ED%/}"/usr/share/info/dir{,.info}{,.Z,.gz,.bz2,.lzma,.lz,.xz,.zst} \
 			|| die "rm failed"
-		# Recurse into subdirs. Remove this code after 2023-12-31. #899898
-		while read -r -d '' x; do
-			( shopt -s failglob; : "${x}"/.keepinfodir* ) 2>/dev/null \
-				&& continue
-			for f in "${x}"/dir{,.info}{,.Z,.gz,.bz2,.lzma,.lz,.xz,.zst}; do
-				if [[ -e ${f} ]]; then
-					eqawarn "QA Notice: Removing Info directory file '${f}'."
-					eqawarn "Relying on this behavior is deprecated and may"
-					eqawarn "cause file collisions in future."
-					rm -f "${f}" || die "rm failed"
-				fi
-			done
-		done < <(find "${ED%/}"/usr/share/info -mindepth 1 -type d -print0)
 	fi
 
 	# If binpkg-docompress is enabled, apply compression before creating


### PR DESCRIPTION
Finally ban portageq, prepinfo, prepman, prepstrip and prepallstrip.

Closes: https://bugs.gentoo.org/899898
Closes: https://bugs.gentoo.org/906129
Closes: https://bugs.gentoo.org/906156
