### PR TITLE
Add more general BSD-friendly changes

### DIFF
--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -155,11 +155,25 @@ class dispatch:
             if not os.path.isdir(os.path.dirname(path)):
                 continue
 
+			# check whether find command is the GNU version
+			# if not, use BSD-style find arguments
+			s = subprocess.run(["find", "--version"], capture_output=True)
+			if s.returncode == 1:
+				gnu_find = False
+			else:
+				gnu_find = True
+
             basename = "*"
-            find_opts = ["-name", ".*", "-type", "d", "-prune", "-o"]
+			if gnu_find == True:
+            	find_opts = ["-name", ".*", "-type", "d", "-prune", "-o"]
+			else:
+				find_opts = ["--", "-name", ".*", "-type", "d", "-prune", "-o"]
             if not os.path.isdir(path):
                 path, basename = os.path.split(path)
+			if gnu_find == True:
                 find_opts = ["-maxdepth", "1"]
+			else:
+				find_opts = ["--", "-maxdepth", "1"]
             if "case-insensitive-fs" in portage.settings.features:
                 find_opts += ["-iname"]
             else:

--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -155,25 +155,12 @@ class dispatch:
             if not os.path.isdir(os.path.dirname(path)):
                 continue
 
-			# check whether find command is the GNU version
-			# if not, use BSD-style find arguments
-            s = subprocess.run(["find", "--version"], capture_output=True)
-            if s.returncode == 1:
-                gnu_find = False
-            else:
-                gnu_find = True
 
             basename = "*"
-            if gnu_find == True:
-                find_opts = ["-name", ".*", "-type", "d", "-prune", "-o"]
-            else:
-                find_opts = ["--", "-name", ".*", "-type", "d", "-prune", "-o"]
+            find_opts = ["-name", ".*", "-type", "d", "-prune", "-o"]
             if not os.path.isdir(path):
                 path, basename = os.path.split(path)
-                if gnu_find == True:
-                    find_opts = ["-maxdepth", "1"]
-                else:
-                    find_opts = ["--", "-maxdepth", "1"]
+            	find_opts = ["-maxdepth", "1"]
             if "case-insensitive-fs" in portage.settings.features:
                 find_opts += ["-iname"]
             else:

--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -157,23 +157,23 @@ class dispatch:
 
 			# check whether find command is the GNU version
 			# if not, use BSD-style find arguments
-			s = subprocess.run(["find", "--version"], capture_output=True)
-			if s.returncode == 1:
-				gnu_find = False
-			else:
-				gnu_find = True
+            s = subprocess.run(["find", "--version"], capture_output=True)
+            if s.returncode == 1:
+                gnu_find = False
+            else:
+                gnu_find = True
 
             basename = "*"
-			if gnu_find == True:
-            	find_opts = ["-name", ".*", "-type", "d", "-prune", "-o"]
-			else:
-				find_opts = ["--", "-name", ".*", "-type", "d", "-prune", "-o"]
+            if gnu_find == True:
+                find_opts = ["-name", ".*", "-type", "d", "-prune", "-o"]
+            else:
+                find_opts = ["--", "-name", ".*", "-type", "d", "-prune", "-o"]
             if not os.path.isdir(path):
                 path, basename = os.path.split(path)
-			if gnu_find == True:
-                find_opts = ["-maxdepth", "1"]
-			else:
-				find_opts = ["--", "-maxdepth", "1"]
+                if gnu_find == True:
+                    find_opts = ["-maxdepth", "1"]
+                else:
+                    find_opts = ["--", "-maxdepth", "1"]
             if "case-insensitive-fs" in portage.settings.features:
                 find_opts += ["-iname"]
             else:

--- a/bin/etc-update
+++ b/bin/etc-update
@@ -130,6 +130,13 @@ scan() {
 	for path in ${SCAN_PATHS} ; do
 		path="${EROOT%/}${path}"
 
+		# test for BSD find
+		find --version 2>&1 | grep "invalid" >/dev/null
+		if [[ $? = 0 ]] ; then
+			find_opts=( -- )
+		else
+			find_opts=()
+		fi
 		if [[ ! -d ${path} ]] ; then
 			# Protect files that don't exist (bug #523684). If the
 			# parent directory doesn't exist, we can safely skip it.

--- a/bin/etc-update
+++ b/bin/etc-update
@@ -130,13 +130,6 @@ scan() {
 	for path in ${SCAN_PATHS} ; do
 		path="${EROOT%/}${path}"
 
-		# test for BSD find
-		find --version 2>&1 | grep "invalid" >/dev/null
-		if [[ $? = 0 ]] ; then
-			find_opts=( -- )
-		else
-			find_opts=()
-		fi
 		if [[ ! -d ${path} ]] ; then
 			# Protect files that don't exist (bug #523684). If the
 			# parent directory doesn't exist, we can safely skip it.


### PR DESCRIPTION
Portage is a package manager that allows the user the most choice on how to customize their system. Some users may want to use Portage in an environment where the GNU coreutils are not fully present or are not present at all. This patch allows for support for the linux version of the BSD find(1) and the BSD-native command to be used with etc-update and dispatch-conf. 