### PR TITLE
Fix error with repositories with git config "log.showSignature" enabled

### DIFF
--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -447,7 +447,15 @@ class GitSync(NewBase):
                 env = os.environ.copy()
                 env["GNUPGHOME"] = openpgp_env.home
 
-            rev_cmd = [self.bin_command, "log", "-n1", "--pretty=format:%G?", revision]
+            rev_cmd = [
+                self.bin_command,
+                "-c",
+                "log.showsignature=0",
+                "log",
+                "-n1",
+                "--pretty=format:%G?",
+                revision,
+            ]
             try:
                 status = portage._unicode_decode(
                     subprocess.check_output(


### PR DESCRIPTION
For example, emaint sync will show "No valid signature found: unknown issue". This can be because the user has set "log.showSignature" in their git config, which produces output that portage doesn't expect. To prevent this, explicitly disable "log.showSignature" when calling git.