### PR TITLE
sync/git: fetch/clone with --verbose if not quiet

### DIFF
--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -139,8 +139,12 @@ class GitSync(NewBase):
         """
         if not self.has_bin:
             return (1, False)
+
+        opts = self.options.get("emerge_config").opts
+
         git_cmd_opts = ""
         quiet = self.settings.get("PORTAGE_QUIET") == "1"
+        verbose = "--verbose" in opts
 
         # We don't want to operate with a .git outside of the given
         # repo in any circumstances.
@@ -170,6 +174,8 @@ class GitSync(NewBase):
 
         if quiet:
             git_cmd_opts += " --quiet"
+        elif verbose:
+            git_cmd_opts += " --verbose"
 
         # The logic here is a bit delicate. We need to balance two things:
         # 1. Having a robust sync mechanism which works unattended.


### PR DESCRIPTION
Invoking git fetch/clone with --verbose shows the URL of the remote, which is viable information. Otherwise the user may believe that they are using a different remote then they are actually using.