### PR TITLE
SpawnProcess/ForkProcess: pass stdin via fd_pipes if not background

### DIFF
--- a/lib/_emerge/SpawnProcess.py
+++ b/lib/_emerge/SpawnProcess.py
@@ -62,7 +62,7 @@ class SpawnProcess(SubProcess):
             self.fd_pipes = self.fd_pipes.copy()
         fd_pipes = self.fd_pipes
 
-        if fd_pipes or self.logfile:
+        if fd_pipes or self.logfile or not self.background:
             master_fd, slave_fd = self._pipe(fd_pipes)
 
             can_log = self._can_log(slave_fd)

--- a/lib/portage/util/_async/ForkProcess.py
+++ b/lib/portage/util/_async/ForkProcess.py
@@ -52,7 +52,7 @@ class ForkProcess(SpawnProcess):
                 'fd_pipes only supported with HAVE_SEND_HANDLE or multiprocessing start method "fork"'
             )
 
-        if self.fd_pipes or self.logfile:
+        if self.fd_pipes or self.logfile or not self.background:
             # Log via multiprocessing.Pipe if necessary.
             connection, self._child_connection = multiprocessing.Pipe(
                 duplex=self._HAVE_SEND_HANDLE


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/916116