### PR TITLE
bindbapi: Fix pickling for MergeProcess

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -139,14 +139,19 @@ class bindbapi(fakedbapi):
         return self._aux_cache_slot_dict_cache
 
     def __getstate__(self):
-        # This attribute is not picklable, but it automatically
-        # regenerates after unpickling when set to None.
-        _aux_cache_slot_dict = self._aux_cache_slot_dict_cache
-        self._aux_cache_slot_dict_cache = None
-        try:
-            return super().__getstate__()
-        finally:
-            self._aux_cache_slot_dict_cache = _aux_cache_slot_dict
+        state = self.__dict__.copy()
+        # These attributes are not picklable, so they are automatically
+        # regenerated after unpickling.
+        state["_aux_cache_slot_dict_cache"] = None
+        state["_instance_key"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if self._multi_instance:
+            self._instance_key = self._instance_key_multi_instance
+        else:
+            self._instance_key = self._instance_key_cpv
 
     @property
     def writable(self):


### PR DESCRIPTION
Both the `_aux_cache_slot_dict_cache` and `_instance_key` attributes are
unpicklable, so fix `__getstate__` to exclude them both from the state.
Override `__setstate__` to initialize _instance_key appropriately.
These changes prevent the following error:
```
AttributeError: Can't pickle local object 'slot_dict_class.<locals>.LocalSlotDict'
```
Fixes: b9a85ff987ea ("MergeProcess: Support QueryCommand with spawn start method")
Bug: https://bugs.gentoo.org/916106