### PR TITLE
EbuildFetcher: multiprocessing spawn compat

### DIFF
--- a/lib/portage/tests/ebuild/test_fetch.py
+++ b/lib/portage/tests/ebuild/test_fetch.py
@@ -335,16 +335,7 @@ class EbuildFetchTestCase(TestCase):
                     )
                 )
 
-            # Tests only work with one ebuild at a time, so the config
-            # pool only needs a single config instance.
-            class config_pool:
-                @staticmethod
-                def allocate():
-                    return settings
-
-                @staticmethod
-                def deallocate(settings):
-                    pass
+            config_pool = config_pool_cls(settings)
 
             def async_fetch(pkg, ebuild_path):
                 fetcher = EbuildFetcher(
@@ -880,3 +871,16 @@ class EbuildFetchTestCase(TestCase):
                         self.assertEqual(filename_result, str(filename))
             finally:
                 shutil.rmtree(distdir)
+
+
+# Tests only work with one ebuild at a time, so the config
+# pool only needs a single config instance.
+class config_pool_cls:
+    def __init__(self, settings):
+        self._settings = settings
+
+    def allocate(self):
+        return self._settings
+
+    def deallocate(self, settings):
+        pass


### PR DESCRIPTION
Tested with this script:
```python
import contextlib
import multiprocessing
import unittest

from portage.tests.conftest import prepare_environment
from portage.tests.ebuild.test_fetch import EbuildFetchTestCase

if __name__ == "__main__":
    multiprocessing.set_start_method("spawn", force=True)
    with contextlib.contextmanager(prepare_environment.__wrapped__)():
        unittest.main()
```
Bug: https://bugs.gentoo.org/914876