### PR TITLE
Convert portageq helper to a function

### DIFF
--- a/bin/ebuild-helpers/portageq
+++ b/bin/ebuild-helpers/portageq
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Copyright 2009-2023 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
-source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
-
-die "'${0##*/}' is not allowed in ebuild scope"
-exit 1

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -1006,6 +1006,10 @@ best_version() {
 	___best_version_and_has_version_common "$@"
 }
 
+portageq() {
+    die "portageq is not allowed in ebuild scope"
+}
+
 if ___eapi_has_get_libdir; then
 	get_libdir() {
 		local libdir_var="LIBDIR_${ABI}"

--- a/bin/portageq-wrapper
+++ b/bin/portageq-wrapper
@@ -9,7 +9,6 @@ IFS=":"
 set -f # in case ${PATH} contains any shell glob characters
 
 for path in "${PORTAGE_BIN_PATH}" ${PATH}; do
-	[[ ${path} == */portage/*/ebuild-helpers* ]] && continue
 	[[ -x ${path}/portageq ]] || continue
 	PYTHONPATH=${PORTAGE_PYTHONPATH:-${PORTAGE_PYM_PATH}} \
 		exec "${PORTAGE_PYTHON:-/usr/bin/python}" "${path}/portageq" "$@"


### PR DESCRIPTION
This keeps it out of PATH in ebuilds to avoid breaking external utilities that call portageq.

Bug: https://bugs.gentoo.org/906129
Bug: https://bugs.gentoo.org/916287
Bug: https://bugs.gentoo.org/916296