### PR TITLE
unpack: Limit memory usage when decompressing xz

### DIFF
--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -544,7 +544,7 @@ unpack() {
 						"with EAPI '${EAPI}'. Instead use 'xz'."
 				fi
 				if ___eapi_unpack_supports_xz; then
-					__unpack_tar "xz -T$(___makeopts_jobs) -d"
+					__unpack_tar "xz -T$(___makeopts_jobs) --memlimit-mt-decompress=50% -d"
 				else
 					__vecho "unpack ${x}: file format not recognized. Ignoring."
 				fi
@@ -557,7 +557,7 @@ unpack() {
 						"with EAPI '${EAPI}'. Instead use 'txz'."
 				fi
 				if ___eapi_unpack_supports_txz; then
-					XZ_OPT="-T$(___makeopts_jobs)" tar xof "${srcdir}${x}" || die "${myfail}"
+					XZ_OPT="-T$(___makeopts_jobs) --memlimit-mt-decompress=50%" tar xof "${srcdir}${x}" || die "${myfail}"
 				else
 					__vecho "unpack ${x}: file format not recognized. Ignoring."
 				fi

--- a/lib/portage/util/compression_probe.py
+++ b/lib/portage/util/compression_probe.py
@@ -38,7 +38,7 @@ _compressors = {
     },
     "xz": {
         "compress": "xz -T{JOBS} --memlimit-compress=50% -q ${BINPKG_COMPRESS_FLAGS}",
-        "decompress": "xz -T{JOBS} -d",
+        "decompress": "xz -T{JOBS} --memlimit-mt-decompress=50% -d",
         "package": "app-arch/xz-utils",
     },
     "zstd": {


### PR DESCRIPTION
Each thread requires memory and it's quite easy to use too much memory. We already use --memlimit-compress=50% to restrict the memory usage when compressing, let's to the same for decompressing.