### PR TITLE
pyproject.toml, NEWS: declare pytest markers.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@ Bug fixes:
 * Convert portageq helper to a function to avoid breaking external callers
   (bug #916287, bug #916296).
 
+Cleanups:
+* Add pytest markers: ft, unit and stress.
+
 portage-3.0.54 (2023-10-25)
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,10 @@ gpkg-sign = 'portage.util.bin_entry_point:bin_entry_point'
 portageq = 'portage.util.bin_entry_point:bin_entry_point'
 quickpkg = 'portage.util.bin_entry_point:bin_entry_point'
 regenworld = 'portage.util.bin_entry_point:bin_entry_point'
+
+[tool.pytest.ini_options]
+markers = [
+    "ft: functional tests (select: '-m ft'; deselect with '-m \"not ft\"')",
+    "stress: stress tests (select: '-m stress'; deselect with '-m \"not stress\"')",
+    "unit: unit tests (select: '-m unit'; deselect with '-m \"not unit\"')",
+]


### PR DESCRIPTION
Declare pytest markers. They can be used to select what tests (not) to run, e.g.:

  pytest -m ft  # to select tests marked with"ft"
  pytest -m "not ft"  # to skip tests marked with "ft"

to list the markers:

  pytest --markers