### PR TITLE
sync/git: invoke add_safe_directory() earlier when updating a repo

### DIFF
--- a/lib/portage/sync/modules/git/git.py
+++ b/lib/portage/sync/modules/git/git.py
@@ -152,6 +152,8 @@ class GitSync(NewBase):
             {"GIT_CEILING_DIRECTORIES": self._gen_ceiling_string(self.repo.location)}
         )
 
+        self.add_safe_directory()
+
         if self.repo.module_specific_options.get("sync-git-env"):
             shlexed_env = shlex_split(self.repo.module_specific_options["sync-git-env"])
             env = {
@@ -260,8 +262,6 @@ class GitSync(NewBase):
             git_cmd_opts += (
                 f" {self.repo.module_specific_options['sync-git-pull-extra-opts']}"
             )
-
-        self.add_safe_directory()
 
         try:
             remote_branch = portage._unicode_decode(


### PR DESCRIPTION
Otherwise "git rev-parse --is-shallow-repository" may fail

```
fatal: detected dubious ownership in repository at '/home/flo/repos/gentoo/tex-overlay' To add an exception for this directory, call:
        git config --global --add safe.directory /home/flo/data/repos/gentoo/tex-overlay
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/portage/util/_async/AsyncFunction.py", line 41, in _target_wrapper
    result = target(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/portage/sync/controller.py", line 172, in sync
    taskmaster.run_tasks(tasks, func, status, options=task_opts)
  File "/usr/lib/python3.12/site-packages/portage/sync/controller.py", line 65, in run_tasks
    result = getattr(inst, func)(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/portage/sync/syncbase.py", line 370, in sync
    return self.update()
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/portage/sync/modules/git/git.py", line 242, in update
    subprocess.check_output(
  File "/usr/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', '--is-shallow-repository']' returned non-zero exit status 128.
```