### PR TITLE
sqlite: multiprocessing spawn compat

### DIFF
--- a/lib/portage/cache/sqlite.py
+++ b/lib/portage/cache/sqlite.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
@@ -52,6 +52,19 @@ class database(fs_template.FsBased):
         config.setdefault("timeout", 15)
         self._config = config
         self._db_connection_info = None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # These attributes are not picklable, so they are automatically
+        # regenerated after unpickling.
+        state["_db_module"] = None
+        state["_db_error"] = None
+        state["_db_connection_info"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._import_sqlite()
 
     def _import_sqlite(self):
         # sqlite3 is optional with >=python-2.5

--- a/lib/portage/tests/dbapi/test_auxdb.py
+++ b/lib/portage/tests/dbapi/test_auxdb.py
@@ -31,7 +31,7 @@ class AuxdbTestCase(TestCase):
             import sqlite3
         except ImportError:
             self.skipTest("sqlite3 import failed")
-        self._test_mod("portage.cache.sqlite.database", picklable=False)
+        self._test_mod("portage.cache.sqlite.database", picklable=True)
 
     def _test_mod(self, auxdbmodule, multiproc=True, picklable=True):
         ebuilds = {


### PR DESCRIPTION
Override `__getstate__` to omit unpicklable attributes, and regenerate the unpicklable attributes after unpickling. Related test_auxdb update was in https://github.com/gentoo/portage/pull/1163.

Bug: https://bugs.gentoo.org/914876