### PR TITLE
bintree: don't call trust helper with --pretend

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,9 @@ Bug fixes:
 
 * Avoid crash with blockers in depgraph for binpkg-respect-use notice (bug #916336).
 
+* Don't call trust helper (e.g. getuto) with --getbinpkg --pretend as we may
+  lack privileges to do anything (bug #915842).
+
 portage-3.0.54 (2023-10-25)
 --------------
 

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -174,6 +174,7 @@ def action_build(
             kwargs["add_repos"] = (quickpkg_vardb,)
 
         try:
+            kwargs["pretend"] = "--pretend" in emerge_config.opts
             emerge_config.target_config.trees["bintree"].populate(
                 getbinpkgs="--getbinpkg" in emerge_config.opts, **kwargs
             )
@@ -3471,6 +3472,8 @@ def run_action(emerge_config):
                 kwargs["add_repos"] = (
                     emerge_config.running_config.trees["vartree"].dbapi,
                 )
+
+            kwargs["pretend"] = "--pretend" in emerge_config.opts
 
             try:
                 mytrees["bintree"].populate(

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -831,6 +831,7 @@ class binarytree:
         add_repos=(),
         force_reindex=False,
         invalid_errors=True,
+        pretend=False,
     ):
         """
         Populates the binarytree with package metadata.
@@ -844,6 +845,10 @@ class binarytree:
         @type add_repos: sequence
         """
 
+        # TODO: Should we return here if we're --pretend? On the one hand,
+        # people might not want --pretend to affect state. On the other hand,
+        # it makes --pretend pretty useless with --getbinpkg as your index will
+        # be stale.
         if self._populating:
             return
 
@@ -898,7 +903,9 @@ class binarytree:
                         noiselevel=-1,
                     )
                 else:
-                    self._populate_remote(getbinpkg_refresh=getbinpkg_refresh)
+                    self._populate_remote(
+                        getbinpkg_refresh=getbinpkg_refresh, pretend=pretend
+                    )
 
         finally:
             self._populating = False
@@ -1290,7 +1297,7 @@ class binarytree:
             return
         ret.check_returncode()
 
-    def _populate_remote(self, getbinpkg_refresh=True):
+    def _populate_remote(self, getbinpkg_refresh=True, pretend=False):
         self._remote_has_index = False
         self._remotepkgs = {}
 
@@ -1299,7 +1306,8 @@ class binarytree:
             # when binpackages are involved, not only when we refuse unsigned
             # ones. (If the keys have expired we end up refusing signed but
             # technically invalid packages...)
-            self._run_trust_helper()
+            if not pretend:
+                self._run_trust_helper()
             gpkg_only = True
         else:
             gpkg_only = False

--- a/lib/portage/tests/dbapi/test_bintree.py
+++ b/lib/portage/tests/dbapi/test_bintree.py
@@ -120,7 +120,9 @@ class BinarytreeTestCase(TestCase):
         settings.__getitem__.return_value = "/some/path"
         bt = binarytree(pkgdir=os.getenv("TMPDIR", "/tmp"), settings=settings)
         bt.populate(getbinpkgs=True, getbinpkg_refresh=refresh)
-        ppopulate_remote.assert_called_once_with(getbinpkg_refresh=refresh)
+        ppopulate_remote.assert_called_once_with(
+            getbinpkg_refresh=refresh, pretend=False
+        )
 
     @patch("portage.dbapi.bintree.writemsg")
     @patch("portage.dbapi.bintree.BinRepoConfigLoader")
@@ -161,4 +163,4 @@ class BinarytreeTestCase(TestCase):
         settings.__getitem__.return_value = "/some/path"
         bt = binarytree(pkgdir=os.getenv("TMPDIR", "/tmp"), settings=settings)
         bt.populate(getbinpkgs=True)
-        ppopulate_remote.assert_called_once_with(getbinpkg_refresh=False)
+        ppopulate_remote.assert_called_once_with(getbinpkg_refresh=False, pretend=False)

--- a/lib/portage/tests/emerge/test_actions.py
+++ b/lib/portage/tests/emerge/test_actions.py
@@ -42,4 +42,6 @@ class RunActionTestCase(TestCase):
 
         run_action(config)
 
-        bt.populate.assert_called_once_with(getbinpkgs=False, getbinpkg_refresh=True)
+        bt.populate.assert_called_once_with(
+            getbinpkgs=False, getbinpkg_refresh=True, pretend=False
+        )


### PR DESCRIPTION
Trust helpers are likely to need privileges and it's a bit too far for pretend there, I think. People can run it manually if they want it done for them anyway.

We could check writable instead but I'd like to get a fix in for the regression first.

Bug: https://bugs.gentoo.org/915842