### PR TITLE
emerge: Use finally instead of atexit for xtermTitleReset

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -54,7 +54,6 @@ from portage.output import (
     darkgreen,
     red,
     xtermTitle,
-    xtermTitleReset,
 )
 
 good = create_color_func("GOOD")
@@ -3827,15 +3826,6 @@ def run_action(emerge_config):
         sys.exit(128 + signum)
 
     signal.signal(signal.SIGTERM, emergeexitsig)
-
-    def emergeexit():
-        """This gets out final log message in before we quit."""
-        if "--pretend" not in emerge_config.opts:
-            emergelog(xterm_titles, " *** terminating.")
-        if xterm_titles:
-            xtermTitleReset()
-
-    portage.atexit_register(emergeexit)
 
     if emerge_config.action in ("config", "metadata", "regen", "sync"):
         if "--pretend" in emerge_config.opts:

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -12,9 +12,11 @@ portage.proxy.lazyimport.lazyimport(
     globals(),
     "logging",
     "portage.dep:Atom",
+    "portage.output:xtermTitleReset",
     "portage.util:writemsg_level",
     "textwrap",
     "_emerge.actions:load_emerge_config,run_action," + "validate_ebuild_environment",
+    "_emerge.emergelog:emergelog",
     "_emerge.help:emerge_help",
     "_emerge.is_valid_package_atom:insert_category_into_atom",
 )
@@ -1310,3 +1312,11 @@ def emerge_main(args: Optional[list[str]] = None):
             if "porttree" in x.lazy_items:
                 continue
             x["porttree"].dbapi.close_caches()
+
+        # This gets out final log message in before we quit.
+        xterm_titles = "notitles" not in emerge_config.target_config.settings.features
+        if "--pretend" not in emerge_config.opts:
+            emergelog(xterm_titles, " *** terminating.")
+
+        if xterm_titles:
+            xtermTitleReset()


### PR DESCRIPTION
The xtermTitleReset function will trigger a RuntimeError when called via an atexit hook in python 3.12, since it forks to run PROMPT_COMMAND. Avoid this problem by calling it in a finally block instead of atexit.

Bug: https://bugs.gentoo.org/917033