### PR TITLE
find_smallest_cycle: Do not return single node for asap mode

### DIFF
--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -1,6 +1,7 @@
 py.install_sources(
     [
         'ResolverPlayground.py',
+        'test_alternatives_gzip.py',
         'test_aggressive_backtrack_downgrade.py',
         'test_autounmask.py',
         'test_autounmask_binpkg_use.py',

--- a/lib/portage/tests/resolver/test_alternatives_gzip.py
+++ b/lib/portage/tests/resolver/test_alternatives_gzip.py
@@ -1,0 +1,82 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class AlternativesGzipTestCase(TestCase):
+    def testAlternativesGzip(self):
+        """
+        Test bug 917259, where app-alternatives/gzip was upgraded before
+        its pigz RDEPEND was installed.
+        """
+        ebuilds = {
+            "app-alternatives/gzip-1": {
+                "EAPI": "8",
+                "RDEPEND": "reference? ( >=app-arch/gzip-1.12-r3 ) pigz? ( >=app-arch/pigz-2.8[-symlink(-)] )",
+                "IUSE": "reference pigz",
+                "REQUIRED_USE": "^^ ( reference pigz )",
+            },
+            "app-alternatives/gzip-0": {
+                "EAPI": "8",
+                "RDEPEND": "reference? ( >=app-arch/gzip-1.12-r3 ) pigz? ( app-arch/pigz[-symlink(-)] )",
+                "IUSE": "reference pigz",
+                "REQUIRED_USE": "^^ ( reference pigz )",
+            },
+            "app-arch/gzip-1.13": {
+                "EAPI": "8",
+                "PDEPEND": "app-alternatives/gzip",
+            },
+            "app-arch/pigz-2.8": {
+                "EAPI": "8",
+                "PDEPEND": "app-alternatives/gzip",
+            },
+        }
+
+        installed = {
+            "app-alternatives/gzip-0": {
+                "EAPI": "8",
+                "RDEPEND": "reference? ( >=app-arch/gzip-1.12-r3 ) pigz? ( app-arch/pigz[-symlink(-)] )",
+                "IUSE": "reference pigz",
+                "USE": "reference",
+            },
+            "app-arch/gzip-1.13": {
+                "EAPI": "8",
+                "PDEPEND": "app-alternatives/gzip",
+            },
+        }
+
+        world = ["app-alternatives/gzip", "app-arch/gzip"]
+
+        user_config = {
+            "package.use": ("app-alternatives/gzip -reference pigz",),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["@world"],
+                options={"--deep": True, "--update": True, "--verbose": True},
+                success=True,
+                mergelist=[
+                    "app-arch/pigz-2.8",
+                    "app-alternatives/gzip-1",
+                ],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=installed,
+            world=world,
+            user_config=user_config,
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
For asap mode, it is possible for gather_deps to prematurely select a single node instead of a cycle, as observed in bug
917259. Continue search for a true cycle in this case.

When not in asap mode, we sometimes need to select a single node here, as demonstrated by PerlRebuildBugTestCase which selects automake this way.

The included AlternativesGzipTestCase demonstrates correct behavior, though it fails to reproduce bug 917259. Even though this patch has not yet been proven to fix bug 917259, it is still useful because it limits the ability of find_smallest_cycle to misbehave.

Bug: https://bugs.gentoo.org/917259