### PR TITLE
depclean: return failure when no packages are selected for depclean

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,12 @@ Release notes take the form of the following optional categories:
 * Bug fixes
 * Cleanups
 
+portage-3.0.59 (UNRELEASED)
+
+Features:
+* emerge: depclean now returns with failure if no packages are matched
+  (bug #917120)
+
 portage-3.0.58 (2023-12-14)
 --------------
 

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -843,7 +843,7 @@ def action_depclean(
                 )
         if not matched_packages:
             writemsg_level(f">>> No packages selected for removal by {action}\n")
-            return 0
+            return 1
 
     # The calculation is done in a separate function so that depgraph
     # references go out of scope and the corresponding memory


### PR DESCRIPTION
Based on the preceding writemsg, one might think that this function could be used for more than depcleans, but there's no other reference to it in the codebase.

With this patch:
```
$ sudo ./bin/emerge --debug --verbose --depclean foo; echo $? myaction depclean
myopts {'--debug': True, '--binpkg-respect-use': 'y', '--quiet-build': 'y', '--regex-search-auto': 'y', '--verbose': True} [DEBUG] Using selector: EpollSelector
--- Couldn't find 'foo' to depclean.
>>> No packages selected for removal by depclean
1
```
Without:
```
$ sudo ./bin/emerge --debug --verbose --depclean foo; echo $? myaction depclean
myopts {'--debug': True, '--binpkg-respect-use': 'y', '--quiet-build': 'y', '--regex-search-auto': 'y', '--verbose': True} [DEBUG] Using selector: EpollSelector
--- Couldn't find 'foo' to depclean.
>>> No packages selected for removal by depclean
0
```
Bug: https://bugs.gentoo.org/917120