### PR TITLE
find_smallest_cycle: Increase ignore_priority to find smaller cycles

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -9345,9 +9345,10 @@ class depgraph:
                                     smallest_cycle = selected_nodes
                                     ignore_priority = priority
 
-                        # Exit this loop with the lowest possible priority, which
-                        # minimizes the use of installed packages to break cycles.
-                        if smallest_cycle is not None:
+                        if smallest_cycle is not None and len(smallest_cycle) == 1:
+                            # The cycle can't get any smaller than this,
+                            # so there is no need to search further since
+                            # we try to minimize ignore_priority.
                             break
 
                     return smallest_cycle, ignore_priority

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -49,6 +49,7 @@ py.install_sources(
         'test_profile_default_eapi.py',
         'test_profile_package_set.py',
         'test_rebuild.py',
+        'test_rebuild_ghostscript.py',
         'test_regular_slot_change_without_revbump.py',
         'test_required_use.py',
         'test_runtime_cycle_merge_order.py',

--- a/lib/portage/tests/resolver/test_alternatives_gzip.py
+++ b/lib/portage/tests/resolver/test_alternatives_gzip.py
@@ -1,8 +1,6 @@
 # Copyright 2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import pytest
-
 from portage.tests import TestCase
 from portage.tests.resolver.ResolverPlayground import (
     ResolverPlayground,
@@ -10,7 +8,6 @@ from portage.tests.resolver.ResolverPlayground import (
 )
 
 
-@pytest.mark.xfail()
 class AlternativesGzipTestCase(TestCase):
     def testAlternativesGzip(self):
         """
@@ -19,8 +16,8 @@ class AlternativesGzipTestCase(TestCase):
         find_smallest_cycle selects a large cycle and the topological
         sort produces poor results when leaf_nodes returns
         app-alternatives/gzip as part of a large group of nodes.
-        This problem might be solved by implementing a finer-grained
-        ignore_priority for leaf_nodes calls.
+        This problem was solved by increasing ignore_priority in order
+        to find a smaller cycle.
         """
         ebuilds = {
             "app-alternatives/gzip-1": {

--- a/lib/portage/tests/resolver/test_merge_order.py
+++ b/lib/portage/tests/resolver/test_merge_order.py
@@ -382,10 +382,12 @@ class MergeOrderTestCase(TestCase):
                 ambiguous_merge_order=True,
                 # The following merge order assertion reflects optimal order for
                 # a circular relationship which is DEPEND in one direction and
-                # RDEPEND in the other.
-                merge_order_assertions=(
-                    ("app-misc/circ-buildtime-a-1", "app-misc/circ-buildtime-c-1"),
-                ),
+                # RDEPEND in the other. However, it is not respected because
+                # it would result in a temporarily broken RDEPEND, so we instead
+                # rely on satisfied installed build-time dependencies.
+                # merge_order_assertions=(
+                #    ("app-misc/circ-buildtime-a-1", "app-misc/circ-buildtime-c-1"),
+                # ),
                 mergelist=[
                     (
                         "app-misc/circ-buildtime-b-1",
@@ -699,15 +701,15 @@ class MergeOrderTestCase(TestCase):
                     "!app-misc/installed-blocker-a",
                     "app-misc/circ-direct-a-1",
                     "app-misc/circ-direct-b-1",
+                    "app-misc/circ-satisfied-a-1",
+                    "app-misc/circ-satisfied-c-1",
+                    "app-misc/circ-satisfied-b-1",
+                    "app-misc/circ-buildtime-c-1",
+                    "app-misc/circ-buildtime-b-1",
+                    "app-misc/circ-buildtime-a-1",
+                    "app-misc/some-app-c-1",
                     "x11-base/xorg-server-1.14.1",
                     "media-libs/mesa-9.1.3",
-                    "app-misc/circ-buildtime-a-1",
-                    "app-misc/circ-buildtime-b-1",
-                    "app-misc/circ-buildtime-c-1",
-                    "app-misc/some-app-c-1",
-                    "app-misc/circ-satisfied-a-1",
-                    "app-misc/circ-satisfied-b-1",
-                    "app-misc/circ-satisfied-c-1",
                 ],
             ),
         )

--- a/lib/portage/tests/resolver/test_rebuild_ghostscript.py
+++ b/lib/portage/tests/resolver/test_rebuild_ghostscript.py
@@ -1,0 +1,160 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class RebuildGhostscriptTestCase(TestCase):
+    def testRebuildGhostscript(self):
+        """
+        Test bug 703676, where app-text/libspectre was rebuilt before
+        its app-text/ghostscript-gpl DEPEND.
+        """
+        ebuilds = {
+            "app-text/ghostscript-gpl-10.01.1": {
+                "EAPI": "8",
+                "DEPEND": "gtk? ( x11-libs/gtk+:3 )",
+                "RDEPEND": "gtk? ( x11-libs/gtk+:3 )",
+                "IUSE": "gtk",
+            },
+            "app-text/ghostscript-gpl-10.01.2": {
+                "EAPI": "8",
+                "SLOT": "0/10.01",
+                "DEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "RDEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "IUSE": "dbus gtk",
+            },
+            "app-text/libspectre-0.2.11": {
+                "EAPI": "8",
+                "DEPEND": ">=app-text/ghostscript-gpl-9.53.0:=",
+                "RDEPEND": ">=app-text/ghostscript-gpl-9.53.0:=",
+            },
+            "app-text/libspectre-0.2.12": {
+                "EAPI": "8",
+                "DEPEND": ">=app-text/ghostscript-gpl-9.53.0:=",
+                "RDEPEND": ">=app-text/ghostscript-gpl-9.53.0:=",
+            },
+            "net-dns/avahi-0.8-r7": {
+                "EAPI": "8",
+                "DEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "RDEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "IUSE": "dbus gtk",
+            },
+            "net-print/cups-2.4.6": {
+                "EAPI": "8",
+                "DEPEND": "zeroconf? ( >=net-dns/avahi-0.6.31-r2[dbus] )",
+                "RDEPEND": "zeroconf? ( >=net-dns/avahi-0.6.31-r2[dbus] )",
+                "IUSE": "zeroconf",
+            },
+            "sys-apps/dbus-1.15.6": {
+                "EAPI": "8",
+            },
+            "x11-libs/gtk+-3.24.38": {
+                "EAPI": "8",
+                "SLOT": "3",
+                "DEPEND": "cups? ( >=net-print/cups-2.0 )",
+                "RDEPEND": "cups? ( >=net-print/cups-2.0 )",
+                "IUSE": "cups",
+            },
+            "x11-libs/goffice-0.10.55": {
+                "EAPI": "8",
+                "DEPEND": ">=app-text/libspectre-0.2.6:=",
+                "RDEPEND": ">=app-text/libspectre-0.2.6:=",
+            },
+        }
+
+        installed = {
+            "app-text/ghostscript-gpl-10.01.1": {
+                "EAPI": "8",
+                "DEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "RDEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "IUSE": "dbus gtk",
+                "USE": "dbus gtk",
+            },
+            "app-text/libspectre-0.2.11": {
+                "EAPI": "8",
+                "DEPEND": ">=app-text/ghostscript-gpl-9.53.0:0/10.01=",
+                "RDEPEND": ">=app-text/ghostscript-gpl-9.53.0:0/10.01=",
+            },
+            "net-dns/avahi-0.8-r7": {
+                "EAPI": "8",
+                "DEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "RDEPEND": "dbus? ( sys-apps/dbus ) gtk? ( x11-libs/gtk+:3 )",
+                "IUSE": "dbus gtk",
+                "USE": "dbus gtk",
+            },
+            "net-print/cups-2.4.6": {
+                "EAPI": "8",
+                "DEPEND": "zeroconf? ( >=net-dns/avahi-0.6.31-r2[dbus] )",
+                "RDEPEND": "zeroconf? ( >=net-dns/avahi-0.6.31-r2[dbus] )",
+                "IUSE": "zeroconf",
+                "USE": "zeroconf",
+            },
+            "sys-apps/dbus-1.15.6": {
+                "EAPI": "8",
+            },
+            "x11-libs/gtk+-3.24.38": {
+                "EAPI": "8",
+                "SLOT": "3",
+                "DEPEND": "cups? ( >=net-print/cups-2.0 )",
+                "RDEPEND": "cups? ( >=net-print/cups-2.0 )",
+                "IUSE": "cups",
+                "USE": "cups",
+            },
+            "x11-libs/goffice-0.10.55": {
+                "EAPI": "8",
+                "DEPEND": ">=app-text/libspectre-0.2.6:0=",
+                "RDEPEND": ">=app-text/libspectre-0.2.6:0=",
+            },
+        }
+
+        world = [
+            "x11-libs/goffice",
+        ]
+
+        user_config = {
+            "make.conf": ('USE="cups dbus gtk zeroconf"',),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["@world"],
+                options={"--deep": True, "--update": True},
+                success=True,
+                mergelist=[
+                    "app-text/ghostscript-gpl-10.01.2",
+                    "app-text/libspectre-0.2.12",
+                ],
+            ),
+            ResolverPlaygroundTestCase(
+                ["@world"],
+                options={"--emptytree": True},
+                success=True,
+                mergelist=[
+                    "sys-apps/dbus-1.15.6",
+                    "app-text/ghostscript-gpl-10.01.2",
+                    "app-text/libspectre-0.2.12",
+                    "x11-libs/goffice-0.10.55",
+                    "net-dns/avahi-0.8-r7",
+                    "net-print/cups-2.4.6",
+                    "x11-libs/gtk+-3.24.38",
+                ],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=installed,
+            world=world,
+            user_config=user_config,
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
Fix AlternativesGzipTestCase by increasing ignore_priority in
order to find smaller cycles. This causes some changes in merge
order for MergeOrderTestCase, but they appear to be acceptable
since they prevent temporarily unsatisfied RDEPEND by relying
on satisfied installed build-time dependencies.

Add a test case for [bug 690436](https://bugs.gentoo.org/690436), since the change to merge order
in MergeOrderTestCase is related (see commit 680276cc4d4f).

Bug: https://bugs.gentoo.org/690436
Bug: https://bugs.gentoo.org/917259