### PR TITLE
_run_pkg_pretend: Refer to emerge-fetch.log for binpkg parallel-fetch

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -948,6 +948,16 @@ class Scheduler(PollScheduler):
                             # handles fetch, verification, and the
                             # bintree.inject call which moves the file.
                             fetched = fetcher.pkg_path
+                        else:
+                            msg = (
+                                "Fetching in the background:",
+                                fetcher.pkg_path,
+                                "To view fetch progress, run in another terminal:",
+                                f"tail -f {self._fetch_log}",
+                            )
+                            out = portage.output.EOutput()
+                            for l in msg:
+                                out.einfo(l)
                         if await fetcher.async_wait() != os.EX_OK:
                             failures += 1
                             self._record_pkg_failure(x, settings, fetcher.returncode)


### PR DESCRIPTION
If there is a parallel-fetch task fetching a binpkg in the background, refer to emerge-fetch.log for status updates, just like the Binpkg class does prior to pkg_setup.

Bug: https://bugs.gentoo.org/760893