### PR TITLE
Stop implicitly manipulating `NO_COLOR`/`NOCOLOR`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,11 @@ Release notes take the form of the following optional categories:
 portage-3.0.56 (UNRELEASED)
 --------------
 
+Breaking changes:
+* ebuild: no longer implicitly set NOCOLOR and NO_COLOR when color output
+  is disabled for emerge itself.  In order to obtain color-free logs, please
+  either explicitly set NO_COLOR environment variable or use e.g. ansifilter.
+
 Features:
 * sync: git: Add sync-git-verify-max-age-days option.
 

--- a/bin/ebuild
+++ b/bin/ebuild
@@ -132,10 +132,6 @@ def main():
         or not sys.stdout.isatty()
     ):
         portage.output.nocolor()
-        portage.settings.unlock()
-        portage.settings["NO_COLOR"] = "true"
-        portage.settings.backup_changes("NO_COLOR")
-        portage.settings.lock()
 
     apply_priorities(portage.settings)
 

--- a/lib/_emerge/AbstractEbuildProcess.py
+++ b/lib/_emerge/AbstractEbuildProcess.py
@@ -80,12 +80,6 @@ class AbstractEbuildProcess(SpawnProcess):
             self._async_wait()
             return
 
-        if self.background:
-            # Automatically prevent color codes from showing up in logs,
-            # since we're not displaying to a terminal anyway.
-            self.settings["NOCOLOR"] = "true"
-            self.settings["NO_COLOR"] = "true"
-
         start_ipc_daemon = False
         if self._enable_ipc_daemon:
             self.settings.pop("PORTAGE_EBUILD_EXIT_FILE", None)

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2749,15 +2749,10 @@ def adjust_config(myopts, settings):
     if "--color" in myopts:
         if "y" == myopts["--color"]:
             portage.output.havecolor = 1
-            settings["NO_COLOR"] = ""
         else:
             portage.output.havecolor = 0
-            settings["NO_COLOR"] = "true"
-        settings.backup_changes("NO_COLOR")
     elif settings.get("TERM") == "dumb" or not sys.stdout.isatty():
         portage.output.havecolor = 0
-        settings["NO_COLOR"] = "true"
-        settings.backup_changes("NO_COLOR")
 
     if "--pkg-format" in myopts:
         settings["PORTAGE_BINPKG_FORMAT"] = myopts["--pkg-format"]

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -591,9 +591,6 @@ class ResolverPlayground:
             "PORTAGE_TMPDIR": os.path.join(self.eroot, "var/tmp"),
         }
 
-        if portage.util.no_color(os.environ):
-            make_conf["NO_COLOR"] = os.environ["NO_COLOR"]
-
         # Pass along PORTAGE_USERNAME and PORTAGE_GRPNAME since they
         # need to be inherited by ebuild subprocesses.
         if "PORTAGE_USERNAME" in os.environ:


### PR DESCRIPTION
Stop implicitly forcing `NO_COLOR` and `NOCOLOR` in ebuild environment. This is undesired for several reasons:

1. It makes it impossible to control color for emerge output independently of command output, e.g. when one goes to a pty while the other goes to logs.

2. It makes it impossible to get color output in logs when running `emerge --jobs ...`.

3. Forcing `NO_COLOR=1` turns out to cause random test failures, and while fixing them is commendable, it is a pain for arch testing and it is currently blocking stabilization requests.

With the new approach, the color output in programs is consistent between using ``--jobs`` or ``--quiet-build``, and not.  Therefore, both cases generate uniform logs.  In order to obtain logs free of color codes, one can either filter them via `ansifilter(1)` (as the manpages already recommend) or explicitly set `NO_COLOR`.

Furthermore, one can combine color-free build output (for clean logs) with colorful emerge output by using:

    NO_COLOR=true emerge --color y ...

Bug: https://bugs.gentoo.org/918515