### PR TITLE
Do not link NO_COLOR to isatty or TERM

### DIFF
--- a/bin/ebuild
+++ b/bin/ebuild
@@ -126,10 +126,7 @@ def main():
         portage.debug.set_trace(True)
 
     if not opts.color == "y" and (
-        opts.color == "n"
-        or portage.util.no_color(portage.settings)
-        or portage.settings.get("TERM") == "dumb"
-        or not sys.stdout.isatty()
+        opts.color == "n" or portage.util.no_color(portage.settings)
     ):
         portage.output.nocolor()
         portage.settings.unlock()

--- a/bin/egencache
+++ b/bin/egencache
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2009-2022 Gentoo Authors
+# Copyright 2009-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import os
@@ -1096,7 +1096,7 @@ try:
         if "PATH" in os.environ:
             env["PATH"] = os.environ["PATH"]
 
-        if not sys.stdout.isatty() or no_color(os.environ):
+        if no_color(os.environ):
             portage.output.nocolor()
             env["NO_COLOR"] = "true"
 

--- a/lib/_emerge/AbstractEbuildProcess.py
+++ b/lib/_emerge/AbstractEbuildProcess.py
@@ -80,12 +80,6 @@ class AbstractEbuildProcess(SpawnProcess):
             self._async_wait()
             return
 
-        if self.background:
-            # Automatically prevent color codes from showing up in logs,
-            # since we're not displaying to a terminal anyway.
-            self.settings["NOCOLOR"] = "true"
-            self.settings["NO_COLOR"] = "true"
-
         start_ipc_daemon = False
         if self._enable_ipc_daemon:
             self.settings.pop("PORTAGE_EBUILD_EXIT_FILE", None)

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
@@ -2753,10 +2753,6 @@ def adjust_config(myopts, settings):
         else:
             portage.output.havecolor = 0
             settings["NO_COLOR"] = "true"
-        settings.backup_changes("NO_COLOR")
-    elif settings.get("TERM") == "dumb" or not sys.stdout.isatty():
-        portage.output.havecolor = 0
-        settings["NO_COLOR"] = "true"
         settings.backup_changes("NO_COLOR")
 
     if "--pkg-format" in myopts:

--- a/lib/portage/_emirrordist/main.py
+++ b/lib/portage/_emirrordist/main.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Gentoo Authors
+# Copyright 2013-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
@@ -236,7 +236,7 @@ def emirrordist_main(args):
     # completely controlled by commandline arguments.
     env = {}
 
-    if not sys.stdout.isatty():
+    if portage.util.no_color(os.environ):
         portage.output.nocolor()
         env["NO_COLOR"] = "true"
 

--- a/man/ebuild.1
+++ b/man/ebuild.1
@@ -1,4 +1,4 @@
-.TH "EBUILD" "1" "Mar 2023" "Portage @VERSION@" "Portage"
+.TH "EBUILD" "1" "Nov 2023" "Portage @VERSION@" "Portage"
 .SH "NAME"
 ebuild \- a low level interface to the Portage system
 .SH "SYNOPSIS"
@@ -203,9 +203,7 @@ information to stdout.
 .TP
 .BR "\-\-color < y | n >"
 Enable or disable color output.  This option will override \fINO_COLOR\fR
-and \fINOCOLOR\fR (see \fBmake.conf\fR(5)) and may also be used to force
-color output when stdout is not a tty (by default, color is disabled
-unless stdout is a tty).
+and \fINOCOLOR\fR (see \fBmake.conf\fR(5)).
 .TP
 .BR "\-\-force"
 When used together with the digest or manifest command,

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1,4 +1,4 @@
-.TH "EMERGE" "1" "Mar 2023" "Portage @VERSION@" "Portage"
+.TH "EMERGE" "1" "Nov 2023" "Portage @VERSION@" "Portage"
 .SH "NAME"
 emerge \- Command\-line interface to the Portage system
 .SH "SYNOPSIS"
@@ -514,9 +514,7 @@ information about \fBFEATURES\fR settings).
 .TP
 .BR "\-\-color < y | n >"
 Enable or disable color output.  This option will override \fINO_COLOR\fR
-and \fINOCOLOR\fR (see \fBmake.conf\fR(5)) and may also be used to force
-color output when stdout is not a tty (by default, color is disabled
-unless stdout is a tty).
+and \fINOCOLOR\fR (see \fBmake.conf\fR(5)).
 .TP
 .BR \-\-columns
 Used alongside \fB\-\-pretend\fR to cause the package name, new version,


### PR DESCRIPTION
Do not link NO_COLOR to isatty or TERM, in order to allow more explicit control. Also do not foce NO_COLOR for background jobs in AbstractEbuildProcess.

The link between NO_COLOR and the --color option is currently preserved, though it could be useful to decouple them, since the user may want to set NO_COLOR just for ebuild processes while keeping color enabled in the portage UI. However, this would drastically change the result of having NO_COLOR set to true in make.conf, so they remain coupled for now.

Bug: https://bugs.gentoo.org/918515