### PR TITLE
Cancel prefetchers that have not started yet

### DIFF
--- a/lib/_emerge/Binpkg.py
+++ b/lib/_emerge/Binpkg.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -110,6 +110,10 @@ class Binpkg(CompositeTask):
         # use the scheduler and fetcher methods to
         # synchronize with the fetcher.
         prefetcher = self.prefetcher
+        if prefetcher is not None and not prefetcher.isAlive():
+            # Cancel it because it hasn't started yet.
+            prefetcher.cancel()
+            self.prefetcher = prefetcher = None
         if prefetcher is None:
             pass
         elif prefetcher.isAlive() and prefetcher.poll() is None:

--- a/lib/_emerge/CompositeTask.py
+++ b/lib/_emerge/CompositeTask.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.AsynchronousTask import AsynchronousTask
@@ -9,6 +9,12 @@ class CompositeTask(AsynchronousTask):
     __slots__ = ("_current_task",)
 
     _TASK_QUEUED = -1
+
+    def isAlive(self):
+        """
+        Returns True if started and returncode has not been set.
+        """
+        return self.returncode is None and self._current_task is not None
 
     def _cancel(self):
         if self._current_task is not None:

--- a/lib/_emerge/EbuildBuild.py
+++ b/lib/_emerge/EbuildBuild.py
@@ -96,6 +96,10 @@ class EbuildBuild(CompositeTask):
             return
 
         prefetcher = self.prefetcher
+        if prefetcher is not None and not prefetcher.isAlive():
+            # Cancel it because it hasn't started yet.
+            prefetcher.cancel()
+            self.prefetcher = prefetcher = None
         if prefetcher is None:
             pass
         elif prefetcher.isAlive() and prefetcher.poll() is None:


### PR DESCRIPTION
Cancel prefetchers that	have not started yet. This will cause the parallel-fetch SequentialTaskQueue to simply discard them, and a regular fetcher will be instantiated immediately. This prevents errors when accessing the pkg_path attribute of BinpkgPrefetcher instances that have not started yet.

Bug: https://bugs.gentoo.org/918636