### PR TITLE
find_smallest_cycle: Optimize to traverse fewer nodes

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -9151,7 +9151,14 @@ class depgraph:
 
                 asap_nodes.extend(libc_pkgs)
 
-        def gather_deps(ignore_priority, mergeable_nodes, selected_nodes, node):
+        def gather_deps(
+            ignore_priority,
+            mergeable_nodes,
+            selected_nodes,
+            node,
+            smallest_cycle=None,
+            traversed_nodes=None,
+        ):
             """
             Recursively gather a group of nodes that RDEPEND on
             eachother. This ensures that they are merged as a group
@@ -9171,10 +9178,24 @@ class depgraph:
                 # RDEPENDs installed first, but ignore uninstalls
                 # (these occur when new portage blocks an older package version).
                 return False
+            if traversed_nodes is not None:
+                if node in traversed_nodes:
+                    # Identical to a previously traversed cycle.
+                    return False
+                traversed_nodes.add(node)
             selected_nodes.add(node)
+            if smallest_cycle is not None and len(selected_nodes) >= len(
+                smallest_cycle
+            ):
+                return False
             for child in mygraph.child_nodes(node, ignore_priority=ignore_priority):
                 if not gather_deps(
-                    ignore_priority, mergeable_nodes, selected_nodes, child
+                    ignore_priority,
+                    mergeable_nodes,
+                    selected_nodes,
+                    child,
+                    smallest_cycle=smallest_cycle,
+                    traversed_nodes=traversed_nodes,
                 ):
                     return False
             return True
@@ -9332,12 +9353,21 @@ class depgraph:
                             local_priority_range.MEDIUM_SOFT + 1,
                         )
                     ):
+                        # Traversed nodes for current priority
+                        traversed_nodes = set()
                         for node in nodes:
                             if not mygraph.parent_nodes(node):
                                 continue
+                            if node in traversed_nodes:
+                                continue
                             selected_nodes = set()
                             if gather_deps(
-                                priority, mergeable_nodes, selected_nodes, node
+                                priority,
+                                mergeable_nodes,
+                                selected_nodes,
+                                node,
+                                smallest_cycle=smallest_cycle,
+                                traversed_nodes=traversed_nodes,
                             ):
                                 if smallest_cycle is None or len(selected_nodes) < len(
                                     smallest_cycle

--- a/lib/portage/tests/resolver/test_rebuild_ghostscript.py
+++ b/lib/portage/tests/resolver/test_rebuild_ghostscript.py
@@ -137,9 +137,9 @@ class RebuildGhostscriptTestCase(TestCase):
                 mergelist=[
                     "sys-apps/dbus-1.15.6",
                     "x11-libs/gtk+-3.24.38",
+                    "app-text/ghostscript-gpl-10.01.2",
                     "net-print/cups-2.4.6",
                     "net-dns/avahi-0.8-r7",
-                    "app-text/ghostscript-gpl-10.01.2",
                     "app-text/libspectre-0.2.12",
                     "x11-libs/goffice-0.10.55",
                 ],

--- a/lib/portage/tests/resolver/test_runtime_cycle_merge_order.py
+++ b/lib/portage/tests/resolver/test_runtime_cycle_merge_order.py
@@ -56,8 +56,11 @@ class RuntimeCycleMergeOrderTestCase(TestCase):
                     ("app-misc/leaf-b-1", "app-misc/leaf-d-1", "app-misc/leaf-e-1"),
                     ("app-misc/branch-d-1", "app-misc/branch-e-1"),
                     "app-misc/runtime-c-1",
-                    ("app-misc/runtime-cycle-c-1", "app-misc/branch-c-1"),
-                    "app-misc/branch-b-1",
+                    (
+                        "app-misc/branch-b-1",
+                        "app-misc/runtime-cycle-c-1",
+                        "app-misc/branch-c-1",
+                    ),
                     ("app-misc/runtime-cycle-b-1", "app-misc/plugin-b-1"),
                     "app-misc/plugins-consumer-1",
                 ],


### PR DESCRIPTION
If gather_deps is traversing a cycle that is greater than or equal to the size of the current smallest_cycle, then abort early. Also abort early if we traverse a node encountered in a previous cycle for the same ignore_priority, since that means the two cycles are identical.

On my laptop, this brings the `emerge -pe @world` time down to 3m28.884s, compared to 10m44.268s with portage-3.0.55.

Bug: https://bugs.gentoo.org/918682