### PR TITLE
DepPrioritySatisfiedRange: strengthen _ignore_runtime for runtime slot dep operators

### DIFF
--- a/lib/_emerge/DepPriorityNormalRange.py
+++ b/lib/_emerge/DepPriorityNormalRange.py
@@ -37,7 +37,13 @@ class DepPriorityNormalRange:
     def _ignore_runtime(cls, priority):
         if priority.__class__ is not DepPriority:
             return False
-        return bool(priority.optional or not priority.buildtime)
+        # If we ever allow "optional" runtime_slot_op, we'll need
+        # to adjust this appropriately. But only build time dependencies
+        # are optional right now, so it's not an issue as-is.
+        return bool(
+            not priority.runtime_slot_op
+            and (priority.optional or not priority.buildtime)
+        )
 
     ignore_medium = _ignore_runtime
     ignore_medium_soft = _ignore_runtime_post

--- a/lib/_emerge/DepPrioritySatisfiedRange.py
+++ b/lib/_emerge/DepPrioritySatisfiedRange.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.DepPriority import DepPriority
@@ -89,7 +89,16 @@ class DepPrioritySatisfiedRange:
     def _ignore_runtime(cls, priority):
         if priority.__class__ is not DepPriority:
             return False
-        return bool(priority.satisfied or priority.optional or not priority.buildtime)
+        # We could split this up into 2 variants (ignoring satisfied
+        # runtime_slot_op, and not) if we need more granularity for ignore_priority
+        # in future.
+        return bool(
+            (
+                (not priority.runtime_slot_op)
+                or (priority.satisfied and priority.runtime_slot_op)
+            )
+            and (priority.satisfied or priority.optional or not priority.buildtime)
+        )
 
     ignore_medium = _ignore_runtime
     ignore_medium_soft = _ignore_satisfied_buildtime_slot_op

--- a/lib/portage/tests/resolver/test_runtime_cycle_merge_order.py
+++ b/lib/portage/tests/resolver/test_runtime_cycle_merge_order.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Gentoo Foundation
+# Copyright 2016-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -6,8 +6,6 @@ from portage.tests.resolver.ResolverPlayground import (
     ResolverPlayground,
     ResolverPlaygroundTestCase,
 )
-
-import pytest
 
 
 class RuntimeCycleMergeOrderTestCase(TestCase):
@@ -77,7 +75,6 @@ class RuntimeCycleMergeOrderTestCase(TestCase):
         finally:
             playground.cleanup()
 
-    @pytest.mark.xfail()
     def testBuildtimeRuntimeCycleMergeOrder(self):
         installed = {
             "dev-util/cmake-3.26.5-r2": {
@@ -192,10 +189,12 @@ class RuntimeCycleMergeOrderTestCase(TestCase):
                     "--usepkg": True,
                 },
                 success=True,
+                # It would also work to punt the dev-util/cmake upgrade
+                # until the end, given it's already installed.
                 mergelist=[
+                    "dev-util/cmake-3.27.8",
                     "net-libs/nghttp2-1.57.0",
                     "[binary]net-misc/curl-8.4.0",
-                    "dev-util/cmake-3.27.8",
                 ],
             ),
         )


### PR DESCRIPTION
In the reported bug, net-misc/curl gets merged (binary), then dev-util/cmake gets
bulit (from source) which fails because one of the built curl's dependencies
(net-libs/nghttp2) is missing:
```
[binary   R    ] net-misc/curl-8.4.0::test_repo  USE="http2%*" 0 KiB
[ebuild     U  ] dev-util/cmake-3.27.8::test_repo [3.26.5-r2::test_repo] 0 KiB
[ebuild  N     ] net-libs/nghttp2-1.57.0::test_repo  0 KiB
```

We should consider the existing dev-util/cmake as sufficient for nghttp2 and instead do:
1. net-libs/nghttp2-1.57.0
2. net-misc/curl-8.4.0 (binary)
3. dev-util/cmake-3.27.8 (upgrade, we didn't need to do this first as we already had a CMake installed)

Bug: https://bugs.gentoo.org/918683
Signed-off-by: Sam James <sam@gentoo.org>