### PR TITLE
Prefer installed leaves in runtime cycle topological sort

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -9498,6 +9498,12 @@ class depgraph:
                     if smallest_leaves is None:
                         smallest_leaves = [cycle_digraph.order[-1]]
 
+                    # Prefer installed leaves, in order to avoid
+                    # merging something too early.
+                    installed_leaves = [pkg for pkg in smallest_leaves if pkg.installed]
+                    if installed_leaves:
+                        smallest_leaves = installed_leaves
+
                     # Only harvest one node at a time, in order to
                     # minimize the number of ignored dependencies.
                     cycle_digraph.remove(smallest_leaves[0])


### PR DESCRIPTION
In order to avoid possibly merging a package too early, prefer installed leaves in runtime cycle topological sort. This fixes an AlternativesGzipTestCase failure that arose after 2e298ea7ba36 caused leaves to be selected in a slightly different order.

Bug: https://bugs.gentoo.org/917259