### PR TITLE
Account for runtime_slot_op in DepPriority sort for digraph.debug_print()

### DIFF
--- a/lib/_emerge/DepPriority.py
+++ b/lib/_emerge/DepPriority.py
@@ -19,24 +19,27 @@ class DepPriority(AbstractDepPriority):
 
         buildtime_slot_op                       0
         buildtime                              -1
-        runtime                                -2
-        runtime_post                           -3
-        optional                               -4
-        (none of the above)                    -5
+        runtime_slot_op                        -2
+        runtime                                -3
+        runtime_post                           -4
+        optional                               -5
+        (none of the above)                    -6
 
         """
 
         if self.optional:
-            return -4
+            return -5
         if self.buildtime_slot_op:
             return 0
         if self.buildtime:
             return -1
-        if self.runtime:
+        if self.runtime_slot_op:
             return -2
-        if self.runtime_post:
+        if self.runtime:
             return -3
-        return -5
+        if self.runtime_post:
+            return -4
+        return -6
 
     def __str__(self):
         if self.ignored:


### PR DESCRIPTION
Since 2e298ea7ba36, the digraph.debug_print() output may not display runtime_slot_op when appropriate, since it relies on DepPriority sort order to determine which priority is most relevant to display. Adjust DepPriority sort order to account for this, which makes the debug output for AlternativesGzipTestCase display runtime_slot_op where appropriate:
```
runtime cycle digraph (9 nodes):

(app-alternatives/gzip-1:0/0::test_repo, ebuild scheduled for merge) depends on
  (app-arch/pigz-2.8:0/0::test_repo, ebuild scheduled for merge) (runtime)
(sys-libs/zlib-1.3-r1:0/1::test_repo, ebuild scheduled for merge) depends on
  (sys-devel/automake-1.16.5-r1:0/0::test_repo, installed) (buildtime)
(sys-devel/automake-1.16.5-r1:0/0::test_repo, installed) depends on
  (dev-lang/perl-5.36.1-r3:0/0::test_repo, installed) (runtime)
  (app-alternatives/gzip-1:0/0::test_repo, ebuild scheduled for merge) (optional)
(app-arch/pigz-2.8:0/0::test_repo, ebuild scheduled for merge) depends on
  (sys-libs/zlib-1.3-r1:0/1::test_repo, ebuild scheduled for merge) (buildtime)
  (app-alternatives/gzip-1:0/0::test_repo, ebuild scheduled for merge) (runtime_post)
(dev-lang/perl-5.36.1-r3:0/0::test_repo, installed) depends on
  (sys-libs/zlib-1.3-r1:0/1::test_repo, ebuild scheduled for merge) (runtime)
  (virtual/libcrypt-2-r1:0/2::test_repo, installed) (runtime_slot_op)
(sys-libs/glibc-2.37-r7:0/0::test_repo, installed) depends on
  (dev-lang/perl-5.36.1-r3:0/0::test_repo, installed) (runtime)
  (sys-apps/locale-gen-2.23-r1:0/0::test_repo, installed) (runtime)
(sys-apps/locale-gen-2.23-r1:0/0::test_repo, installed) depends on
  (app-alternatives/gzip-1:0/0::test_repo, ebuild scheduled for merge) (runtime)
(virtual/libcrypt-2-r1:0/2::test_repo, installed) depends on
  (sys-libs/libxcrypt-4.4.36:0/0::test_repo, installed) (runtime)
(sys-libs/libxcrypt-4.4.36:0/0::test_repo, installed) depends on
  (sys-libs/glibc-2.37-r7:0/0::test_repo, installed) (runtime)
```
Bug: https://bugs.gentoo.org/918683