### PR TITLE
Optimize runtime cycle ignore_priority leaf selection loop for topological sort

### DIFF
--- a/lib/portage/tests/resolver/test_merge_order.py
+++ b/lib/portage/tests/resolver/test_merge_order.py
@@ -385,9 +385,9 @@ class MergeOrderTestCase(TestCase):
                 # RDEPEND in the other. However, it is not respected because
                 # it would result in a temporarily broken RDEPEND, so we instead
                 # rely on satisfied installed build-time dependencies.
-                # merge_order_assertions=(
-                #    ("app-misc/circ-buildtime-a-1", "app-misc/circ-buildtime-c-1"),
-                # ),
+                merge_order_assertions=(
+                    ("app-misc/circ-buildtime-a-1", "app-misc/circ-buildtime-c-1"),
+                ),
                 mergelist=[
                     (
                         "app-misc/circ-buildtime-b-1",
@@ -703,9 +703,9 @@ class MergeOrderTestCase(TestCase):
                     "app-misc/circ-direct-b-1",
                     "x11-base/xorg-server-1.14.1",
                     "media-libs/mesa-9.1.3",
+                    "app-misc/circ-buildtime-a-1",
                     "app-misc/circ-buildtime-c-1",
                     "app-misc/circ-buildtime-b-1",
-                    "app-misc/circ-buildtime-a-1",
                     "app-misc/some-app-c-1",
                     "app-misc/circ-satisfied-a-1",
                     "app-misc/circ-satisfied-c-1",


### PR DESCRIPTION
Since increasing ignore_priority can only lead to a larger selection of leaf nodes, there is no need to increase ignore_priority to search for smaller groups of leaf nodes.

It was the "only harvest one node at a time" part of commit 3487594cd8f4 that caused the test case to succeed.

Fixes: 3487594cd8f4 ("Increase ignore_priority during topological sort for runtime cycle")
Bug: https://bugs.gentoo.org/917259