### PR TITLE
Set SYSROOT for has/best_version so that they work when IPC is disabled

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,13 @@ Release notes take the form of the following optional categories:
 * Bug fixes
 * Cleanups
 
+portage-3.0.57 (UNRELEASED)
+--------------
+
+Bug fixes:
+* Set SYSROOT appropriately for best_version and has_version so that they work
+  when cross-compiling and IPC is disabled.
+
 portage-3.0.56 (2023-12-01)
 --------------
 

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -907,7 +907,11 @@ __eapi8_src_prepare() {
 
 ___best_version_and_has_version_common() {
 	local atom root root_arg
-	local -a cmd=()
+
+	# If ROOT is set to / below then SYSROOT cannot point elsewhere. Even if
+	# ROOT is untouched, setting SYSROOT=/ for this command will always work.
+	local -a cmd=(env SYSROOT=/)
+
 	case $1 in
 		--host-root|-r|-d|-b)
 			root_arg=$1
@@ -932,7 +936,7 @@ ___best_version_and_has_version_common() {
 				# Since portageq requires the root argument be consistent
 				# with EPREFIX, ensure consistency here (bug #655414).
 				root=/${PORTAGE_OVERRIDE_EPREFIX#/}
-				cmd+=(env EPREFIX="${PORTAGE_OVERRIDE_EPREFIX}")
+				cmd+=(EPREFIX="${PORTAGE_OVERRIDE_EPREFIX}")
 			else
 				root=/
 			fi ;;
@@ -948,7 +952,7 @@ ___best_version_and_has_version_common() {
 						# Use /${PORTAGE_OVERRIDE_EPREFIX#/} to support older
 						# EAPIs, as it is equivalent to BROOT.
 						root=/${PORTAGE_OVERRIDE_EPREFIX#/}
-						cmd+=(env EPREFIX="${PORTAGE_OVERRIDE_EPREFIX}")
+						cmd+=(EPREFIX="${PORTAGE_OVERRIDE_EPREFIX}")
 						;;
 				esac
 			else


### PR DESCRIPTION
This issue broke cross-compiling.