### PR TITLE
circular_dependency: Handle SonameAtom

### DIFF
--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2020 Gentoo Authors
+# Copyright 2010-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import logging
@@ -132,8 +132,19 @@ class circular_dependency_handler:
             for ppkg, atom in parent_atoms:
                 if ppkg == parent:
                     changed_parent = ppkg
-                    parent_atom = atom.unevaluated_atom
+                    parent_atom = atom
                     break
+
+            if parent_atom.package:
+                parent_atom = parent_atom.unevaluated_atom
+            else:
+                # Treat soname deps as unconditional for now. In some
+                # cases they can be avoided by a rebuild with changed
+                # USE, but ebuilds sometimes do not specify the
+                # corresponding conditional dependency (especially for
+                # system packages like gcc which provides libstdc++.so.6
+                # and libgcc_s.so.1).
+                continue
 
             try:
                 affecting_use = extract_affecting_use(


### PR DESCRIPTION
Treat soname deps as unconditional for now. In some
cases they can be avoided by a rebuild with changed
USE, but ebuilds sometimes do not specify the
corresponding conditional dependency (especially for
system packages like gcc which provides libstdc++.so.6
and libgcc_s.so.1).

Bug: https://bugs.gentoo.org/919311