### PR TITLE
sets: VariableSet: flatten dependencies

### DIFF
--- a/lib/portage/_sets/dbapi.py
+++ b/lib/portage/_sets/dbapi.py
@@ -172,7 +172,7 @@ class VariableSet(EverythingSet):
             for include in self._includes:
                 include_atoms.append(Atom(include))
 
-            for x in use_reduce(values, token_class=Atom):
+            for x in use_reduce(values, token_class=Atom, flat=True):
                 if not isinstance(x, Atom):
                     continue
 

--- a/lib/portage/tests/sets/base/test_variable_set.py
+++ b/lib/portage/tests/sets/base/test_variable_set.py
@@ -12,6 +12,9 @@ class VariableSetTestCase(TestCase):
     def testVariableSetEmerge(self):
         ebuilds = {
             "dev-go/go-pkg-1": {"BDEPEND": "dev-lang/go"},
+            "www-client/firefox-1": {
+                "BDEPEND": "|| ( virtual/rust:0/a virtual/rust:0/b )"
+            },
         }
         installed = ebuilds
         playground = ResolverPlayground(ebuilds=ebuilds, installed=installed)
@@ -20,6 +23,11 @@ class VariableSetTestCase(TestCase):
             ResolverPlaygroundTestCase(
                 ["@golang-rebuild"],
                 mergelist=["dev-go/go-pkg-1"],
+                success=True,
+            ),
+            ResolverPlaygroundTestCase(
+                ["@rust-rebuild"],
+                mergelist=["www-client/firefox-1"],
                 success=True,
             ),
         )


### PR DESCRIPTION
This is needed to pick up www-client/firefox's BDEPEND of "|| ( virtual/rust:0/a virtual/rust:0/b ...)" for @rust-rebuild.