### PR TITLE
bindbapi: add SIZE to _pkg_str_aux_keys

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -84,9 +84,12 @@ class bindbapi(fakedbapi):
     _known_keys = frozenset(
         list(fakedbapi._known_keys) + ["CHOST", "repository", "USE"]
     )
+    # Must include keys used to create _pkg_str attributes used in
+    # the fakedbapi _instance_key_multi_instance method.
     _pkg_str_aux_keys = fakedbapi._pkg_str_aux_keys + (
         "BUILD_ID",
         "BUILD_TIME",
+        "SIZE",
         "_mtime_",
     )
 


### PR DESCRIPTION
The _pkg_str_aux_keys are used inside dbapi.update_ents,
and need to contain SIZE in order for the fakedbapi
_instance_key_multi_instance method to operate correctly.

Incorrect operation of _instance_key_multi_instance could
prevent binarytree.inject from removing an old instance
from its internal state. It could also trigger a KeyError
in bindbapi.aux_update as in bug 918597, since it could
cause binarytree.getname to return a non-existent path.
It could also cause binarytree.getname to return an
existing but incorrect path, which might trigger an
InvalidBinaryPackageFormat exception as in bug 906675.

Bug: https://bugs.gentoo.org/906675
Bug: https://bugs.gentoo.org/918597
Bug: https://bugs.gentoo.org/919668