### PR TITLE
ResolverPlayground: Create $EPREFIX/usr/bin/python symlink

### DIFF
--- a/lib/portage/tests/dbapi/test_portdb_cache.py
+++ b/lib/portage/tests/dbapi/test_portdb_cache.py
@@ -223,7 +223,7 @@ class PortdbCacheTestCase(TestCase):
             pythonpath = PORTAGE_PYM_PATH + pythonpath
 
         env = {
-            "PATH": os.environ.get("PATH", ""),
+            "PATH": settings["PATH"],
             "PORTAGE_OVERRIDE_EPREFIX": eprefix,
             "PORTAGE_PYTHON": portage_python,
             "PORTAGE_REPOSITORIES": settings.repositories.config_string(),

--- a/lib/portage/tests/emerge/test_baseline.py
+++ b/lib/portage/tests/emerge/test_baseline.py
@@ -97,7 +97,7 @@ async def _async_test_baseline(playground, binhost, commands):
     profile_path = settings.profile_path
     user_config_dir = os.path.join(os.sep, eprefix, USER_CONFIG_PATH)
 
-    path = os.environ.get("PATH")
+    path = settings.get("PATH")
     if path is not None and not path.strip():
         path = None
     if path is None:

--- a/lib/portage/tests/emerge/test_config_protect.py
+++ b/lib/portage/tests/emerge/test_config_protect.py
@@ -191,7 +191,7 @@ src_install() {
         fake_bin = os.path.join(eprefix, "bin")
         portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
 
-        path = os.environ.get("PATH")
+        path = settings.get("PATH")
         if path is not None and not path.strip():
             path = None
         if path is None:

--- a/lib/portage/tests/emerge/test_emerge_blocker_file_collision.py
+++ b/lib/portage/tests/emerge/test_emerge_blocker_file_collision.py
@@ -98,7 +98,7 @@ src_install() {
         portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
         profile_path = settings.profile_path
 
-        path = os.environ.get("PATH")
+        path = settings.get("PATH")
         if path is not None and not path.strip():
             path = None
         if path is None:

--- a/lib/portage/tests/emerge/test_emerge_slot_abi.py
+++ b/lib/portage/tests/emerge/test_emerge_slot_abi.py
@@ -111,7 +111,7 @@ class SlotAbiEmergeTestCase(TestCase):
         portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
         profile_path = settings.profile_path
 
-        path = os.environ.get("PATH")
+        path = settings.get("PATH")
         if path is not None and not path.strip():
             path = None
         if path is None:

--- a/lib/portage/tests/emerge/test_libc_dep_inject.py
+++ b/lib/portage/tests/emerge/test_libc_dep_inject.py
@@ -186,7 +186,7 @@ class LibcDepInjectEmergeTestCase(TestCase):
         portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
         profile_path = settings.profile_path
 
-        path = os.environ.get("PATH")
+        path = settings.get("PATH")
         if path is not None and not path.strip():
             path = None
         if path is None:
@@ -420,7 +420,7 @@ class LibcDepInjectEmergeTestCase(TestCase):
         portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
         profile_path = settings.profile_path
 
-        path = os.environ.get("PATH")
+        path = settings.get("PATH")
         if path is not None and not path.strip():
             path = None
         if path is None:

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2021 Gentoo Authors
+# Copyright 2010-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import bz2
@@ -139,6 +139,7 @@ class ResolverPlayground:
             # EPREFIX/bin is used by fake true_binaries. Real binaries goes into EPREFIX/usr/bin
             eubin = os.path.join(self.eprefix, "usr", "bin")
             ensure_dirs(eubin)
+            os.symlink(portage._python_interpreter, os.path.join(eubin, "python"))
             for x in self.portage_bin:
                 os.symlink(os.path.join(PORTAGE_BIN_PATH, x), os.path.join(eubin, x))
 
@@ -683,7 +684,7 @@ class ResolverPlayground:
             create_trees_kwargs["target_root"] = self.target_root
 
         env = {
-            "PATH": os.environ["PATH"],
+            "PATH": f"{self.eprefix}/usr/sbin:{self.eprefix}/usr/bin:{os.environ['PATH']}",
             "PORTAGE_REPOSITORIES": "\n".join(
                 "[%s]\n%s"
                 % (

--- a/lib/portage/tests/sync/test_sync_local.py
+++ b/lib/portage/tests/sync/test_sync_local.py
@@ -387,7 +387,7 @@ class SyncLocalTestCase(TestCase):
             "GENTOO_COMMITTER_NAME": committer_name,
             "GENTOO_COMMITTER_EMAIL": committer_email,
             "HOME": homedir,
-            "PATH": os.environ["PATH"],
+            "PATH": settings["PATH"],
             "PORTAGE_GRPNAME": os.environ["PORTAGE_GRPNAME"],
             "PORTAGE_USERNAME": os.environ["PORTAGE_USERNAME"],
             "PYTHONDONTWRITEBYTECODE": os.environ.get("PYTHONDONTWRITEBYTECODE", ""),


### PR DESCRIPTION
This ensures that CrossDepPriorityTestCase uses the correct python implementation when it calls emerge, by overriding behavior of `#!/usr/bin/env python` shebangs.

Fixes: 1d856747ada4 ("DepPriority{Normal,Satisfied}Range: weaken _ignore_runtime for cross root")