### PR TITLE
depclean: drop direct circular deps in merge order calculation

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
@@ -1642,7 +1642,11 @@ def _calc_depclean(settings, trees, ldpath_mtimes, myopts, action, args_set, spi
                                 if mypriority.runtime:
                                     mypriority.runtime_slot_op = True
 
-                            graph.add(child_node, node, priority=mypriority)
+                            # Drop direct circular deps because the unmerge order
+                            # calculation does not handle them well as demonstrated
+                            # by the test case for bug 916135.
+                            if child_node is not node:
+                                graph.add(child_node, node, priority=mypriority)
 
         if debug:
             writemsg_level("\nunmerge digraph:\n\n", noiselevel=-1, level=logging.DEBUG)

--- a/lib/portage/tests/resolver/test_depclean_order.py
+++ b/lib/portage/tests/resolver/test_depclean_order.py
@@ -1,7 +1,5 @@
-# Copyright 2013 Gentoo Foundation
+# Copyright 2013-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-
-import pytest
 
 from portage.tests import TestCase
 from portage.tests.resolver.ResolverPlayground import (
@@ -60,8 +58,12 @@ class SimpleDepcleanTestCase(TestCase):
         finally:
             playground.cleanup()
 
-    @pytest.mark.xfail()
     def testIDEPENDDepclean(self):
+        """
+        Test for bug 916135, where a direct circular dependency caused
+        the unmerge order to fail to account for IDEPEND.
+        """
+
         ebuilds = {
             "dev-util/A-1": {},
             "dev-libs/B-1": {


### PR DESCRIPTION
Drop direct circular deps in the depclean merge order calculation, since it does not handle them well as shown by the test case for bug 916135 (https://github.com/gentoo/portage/pull/1147).

Bug: https://bugs.gentoo.org/916135