### PR TITLE
ebuild.sh: Warn about colon-separated argument in sandbox functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ Features:
 * emerge: depclean now returns with failure if no packages are matched
   (bug #917120)
 
+Bug fixes:
+* addread, addwrite, adddeny, addpredict: Warn about passing a colon-separated
+  list of paths as argument (bug #920654).
+
 portage-3.0.58 (2023-12-14)
 --------------
 

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -162,7 +162,10 @@ fi
 __sb_append_var() {
 	local _v=$1 ; shift
 	local var="SANDBOX_${_v}"
-	[[ -z $1 || -n $2 ]] && die "Usage: add$(LC_ALL=C tr "[:upper:]" "[:lower:]" <<< "${_v}") <colon-delimited list of paths>"
+	[[ $# -eq 1 ]] || die "Usage: add${_v,,} <path>"
+	# Make this fatal after 2024-12-31
+	[[ ${1} == *:* ]] \
+		&& eqawarn "QA Notice: add${_v,,} called with colon-separated argument"
 	export ${var}="${!var:+${!var}:}$1"
 }
 # bash-4 version:
@@ -173,8 +176,9 @@ addwrite()   { __sb_append_var WRITE   "$@" ; }
 adddeny()    { __sb_append_var DENY    "$@" ; }
 addpredict() { __sb_append_var PREDICT "$@" ; }
 
+addread /
+addread "${PORTAGE_TMPDIR}/portage"
 addwrite "${PORTAGE_TMPDIR}/portage"
-addread "/:${PORTAGE_TMPDIR}/portage"
 [[ -n ${PORTAGE_GPG_DIR} ]] && addpredict "${PORTAGE_GPG_DIR}"
 
 # Avoid sandbox violations in temporary directories.


### PR DESCRIPTION
According to PMS and the Devmanual, only a single item is allowed as argument for addread, addwrite, adddeny and addpredict:
https://projects.gentoo.org/pms/8/pms.html#x1-12300012.3.3
https://devmanual.gentoo.org/function-reference/sandbox-functions/

Bug: https://bugs.gentoo.org/920654