### PR TITLE
bindbapi: Update state for package remove in aux_update

### DIFF
--- a/lib/portage/tests/update/test_move_slot_ent.py
+++ b/lib/portage/tests/update/test_move_slot_ent.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2019 Gentoo Authors
+# Copyright 2012-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -277,17 +277,24 @@ class MoveSlotEntTestCase(TestCase):
                     self.assertEqual(
                         "2/2.30", vardb.aux_get("dev-libs/A-1", ["SLOT"])[0]
                     )
-                    self.assertEqual(
-                        "0/2.30", bindb.aux_get("dev-libs/A-1", ["SLOT"])[0]
-                    )
+
+                    # Stale signed packages removed since a7bbb4fc4d38.
+                    self.assertRaises(KeyError, bindb.aux_get, "dev-libs/A-1", ["SLOT"])
+                    # self.assertEqual(
+                    #    "0/2.30", bindb.aux_get("dev-libs/A-1", ["SLOT"])[0]
+                    # )
 
                     # 0 -> 1
                     self.assertEqual("1", vardb.aux_get("dev-libs/B-1", ["SLOT"])[0])
-                    self.assertEqual("0", bindb.aux_get("dev-libs/B-1", ["SLOT"])[0])
+                    # Stale signed packages removed since a7bbb4fc4d38.
+                    self.assertRaises(KeyError, bindb.aux_get, "dev-libs/B-1", ["SLOT"])
+                    # self.assertEqual("0", bindb.aux_get("dev-libs/B-1", ["SLOT"])[0])
 
                     # 0/1 -> 1 (equivalent to 1/1)
                     self.assertEqual("1", vardb.aux_get("dev-libs/C-1", ["SLOT"])[0])
-                    self.assertEqual("0/1", bindb.aux_get("dev-libs/C-1", ["SLOT"])[0])
+                    # Stale signed packages removed since a7bbb4fc4d38.
+                    self.assertRaises(KeyError, bindb.aux_get, "dev-libs/C-1", ["SLOT"])
+                    # self.assertEqual("0/1", bindb.aux_get("dev-libs/C-1", ["SLOT"])[0])
 
                     # dont_apply_updates
                     self.assertEqual(

--- a/lib/portage/tests/update/test_update_dbentry.py
+++ b/lib/portage/tests/update/test_update_dbentry.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2013 Gentoo Foundation
+# Copyright 2012-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import sys
@@ -432,10 +432,13 @@ class UpdateDbentryTestCase(TestCase):
                     rdepend = vardb.aux_get("dev-libs/A-1", ["RDEPEND"])[0]
                     self.assertTrue(old_pattern.search(rdepend) is None)
                     self.assertTrue("dev-libs/M-moved" in rdepend)
-                    rdepend = bindb.aux_get("dev-libs/A-1", ["RDEPEND"])[0]
-                    print(old_pattern.search(rdepend) is None)
-                    self.assertFalse(old_pattern.search(rdepend) is None)
-                    self.assertFalse("dev-libs/M-moved" in rdepend)
+                    # Stale signed packages removed since a7bbb4fc4d38.
+                    self.assertRaises(
+                        KeyError, bindb.aux_get, "dev-libs/A-1", ["RDEPEND"]
+                    )
+                    # rdepend = bindb.aux_get("dev-libs/A-1", ["RDEPEND"])[0]
+                    # self.assertFalse(old_pattern.search(rdepend) is None)
+                    # self.assertFalse("dev-libs/M-moved" in rdepend)
                     rdepend = vardb.aux_get("dev-libs/B-1", ["RDEPEND"])[0]
                     self.assertTrue(old_pattern.search(rdepend) is None)
                     self.assertTrue("dev-libs/M-moved" in rdepend)


### PR DESCRIPTION
When removing a signed gpkg in aux_update, update internal state including $PKGDIR/Packages (important especially for FEATURES=pkgdir-index-trusted).

Bug: https://bugs.gentoo.org/920095
Fixes: a7bbb4fc4d38 ("Fix move_ent with signed binpkg")