### PR TITLE
bintree: support file scheme for binhost src-uri

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1411,15 +1411,18 @@ class binarytree:
 
                 # Don't use urlopen for https, unless
                 # PEP 476 is supported (bug #469888).
-                if repo.fetchcommand is None and (
-                    parsed_url.scheme not in ("https",) or _have_pep_476()
-                ):
+                if (
+                    repo.fetchcommand is None or parsed_url.scheme in ("", "file")
+                ) and (parsed_url.scheme not in ("https",) or _have_pep_476()):
                     try:
-                        f = _urlopen(
-                            url, if_modified_since=local_timestamp, proxies=proxies
-                        )
-                        if hasattr(f, "headers") and f.headers.get("timestamp", ""):
-                            remote_timestamp = f.headers.get("timestamp")
+                        if parsed_url.scheme in ("", "file"):
+                            f = open(f"{parsed_url.path.rstrip('/')}/Packages", "rb")
+                        else:
+                            f = _urlopen(
+                                url, if_modified_since=local_timestamp, proxies=proxies
+                            )
+                            if hasattr(f, "headers") and f.headers.get("timestamp", ""):
+                                remote_timestamp = f.headers.get("timestamp")
                     except OSError as err:
                         if (
                             hasattr(err, "code") and err.code == 304

--- a/lib/portage/util/_async/AsyncTaskFuture.py
+++ b/lib/portage/util/_async/AsyncTaskFuture.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Gentoo Foundation
+# Copyright 2018-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import os
@@ -19,6 +19,12 @@ class AsyncTaskFuture(AsynchronousTask):
     def _start(self):
         self.future = asyncio.ensure_future(self.future, self.scheduler)
         self.future.add_done_callback(self._done_callback)
+
+    def isAlive(self):
+        """
+        Returns True if self.future is an asyncio.Future that is not done.
+        """
+        return isinstance(self.future, asyncio.Future) and not self.future.done()
 
     def _cancel(self):
         if not self.future.done():


### PR DESCRIPTION
Add local file scheme support for binhost src-uri in bintree and BinpkgFetcher. Make BinpkgFetcher use a coroutine to avoid using callbacks. Add AsyncTaskFuture isAlive method that BinpkgFetcher can use to check FileCopier state. Add test command to test emerge -f --getbinpkgonly with local file scheme in binrepos.conf.

Also, fix the getbinpkgonly_fetchonly test command so that it does not rename binhost_dir to pkgdir. It seems like it should not do this, and it caused the getbinpkgonly_file_uri command to fail.

Bug: https://bugs.gentoo.org/920537