### PR TITLE
depclean: Strengthen IDEPEND in unmerge order

### DIFF
--- a/lib/_emerge/AbstractDepPriority.py
+++ b/lib/_emerge/AbstractDepPriority.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import copy
@@ -9,6 +9,7 @@ class AbstractDepPriority(SlotObject):
     __slots__ = (
         "buildtime",
         "buildtime_slot_op",
+        "installtime",
         "runtime",
         "runtime_post",
         "runtime_slot_op",

--- a/lib/_emerge/UnmergeDepPriority.py
+++ b/lib/_emerge/UnmergeDepPriority.py
@@ -12,18 +12,19 @@ class UnmergeDepPriority(AbstractDepPriority):
         "satisfied",
     )
     """
-	Combination of properties           Priority  Category
+    Combination of properties           Priority  Category
 
-	runtime_slot_op                        0       HARD
-	runtime                               -1       HARD
-	runtime_post                          -2       HARD
-	buildtime                             -3       SOFT
-	(none of the above)                   -3       SOFT
-	"""
+    installtime                            0       HARD
+    runtime_slot_op                       -1       HARD
+    runtime                               -2       HARD
+    runtime_post                          -3       HARD
+    buildtime                             -4       SOFT
+    (none of the above)                   -4       SOFT
+    """
 
     MAX = 0
-    SOFT = -3
-    MIN = -3
+    SOFT = -4
+    MIN = -4
 
     def __init__(self, **kwargs):
         AbstractDepPriority.__init__(self, **kwargs)
@@ -31,19 +32,23 @@ class UnmergeDepPriority(AbstractDepPriority):
             self.optional = True
 
     def __int__(self):
-        if self.runtime_slot_op:
+        if self.installtime:
             return 0
-        if self.runtime:
+        if self.runtime_slot_op:
             return -1
-        if self.runtime_post:
+        if self.runtime:
             return -2
-        if self.buildtime:
+        if self.runtime_post:
             return -3
-        return -3
+        if self.buildtime:
+            return -4
+        return -4
 
     def __str__(self):
         if self.ignored:
             return "ignored"
+        if self.installtime:
+            return "install time"
         if self.runtime_slot_op:
             return "hard slot op"
         myvalue = self.__int__()

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1568,11 +1568,12 @@ def _calc_depclean(settings, trees, ldpath_mtimes, myopts, action, args_set, spi
         graph = digraph()
         del cleanlist[:]
 
+        installtime = UnmergeDepPriority(installtime=True, runtime=True)
         runtime = UnmergeDepPriority(runtime=True)
         runtime_post = UnmergeDepPriority(runtime_post=True)
         buildtime = UnmergeDepPriority(buildtime=True)
         priority_map = {
-            "IDEPEND": runtime,
+            "IDEPEND": installtime,
             "RDEPEND": runtime,
             "PDEPEND": runtime_post,
             "BDEPEND": buildtime,
@@ -1683,6 +1684,8 @@ def _calc_depclean(settings, trees, ldpath_mtimes, myopts, action, args_set, spi
                         break
                 if not nodes:
                     raise AssertionError("no root nodes")
+                # Sort nodes for deterministic results.
+                nodes.sort(reverse=True)
                 if ignore_priority is not None:
                     # Some deps have been dropped due to circular dependencies,
                     # so only pop one node in order to minimize the number that

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -4007,7 +4007,9 @@ class depgraph:
             (
                 self._frozen_config._running_root.root,
                 edepend["IDEPEND"],
-                self._priority(cross=self._cross(pkg.root), runtime=True),
+                self._priority(
+                    cross=self._cross(pkg.root), installtime=True, runtime=True
+                ),
             ),
             (
                 myroot,


### PR DESCRIPTION
Increase priority of IDEPEND so that it is stronger than RDEPEND in unmerge order calculations. This causes IDEPEND to be unmerged afterwards when packages are involved in RDEPEND cycles.

Bug: https://bugs.gentoo.org/916135