### PR TITLE
emerge: enable "avoid spamming too much info about unused binpkgs" again

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -1256,9 +1256,10 @@ class depgraph:
 
             # We don't want to list the same USE flags for multiple build IDs
             seen.setdefault(pkg.root, dict())
-            if (pkg.root, pkg.cpv) not in seen or flag_display not in seen[pkg.root][
-                pkg.cpv
-            ]:
+            if (
+                pkg.cpv not in seen[pkg.root]
+                or flag_display not in seen[pkg.root][pkg.cpv]
+            ):
                 seen[pkg.root].setdefault(pkg.cpv, set()).add(flag_display)
                 # The user can paste this line into package.use
                 messages.append(f"    ={pkg.cpv} {flag_display}")


### PR DESCRIPTION
In commit a6853d5493b7bed37e60c2e3b7536b209500ba3f this code in _show_ignored_binaries_respect_use was refactored to handle pkg.root. But it was refactored incorrectly -- the storage/lookup key started off as:

```
seen[pkg.cpv]
```

and was refactored so the storage key was:
```
seen[pkg.root][pkg.cpv]
```

and the lookup key was
```
seen[(pkg.root, pkg.cpv)]
```

As a result, we never detected a previously seen USE flags combo, and the logic to avoid spamming too much info was a no-op; the info was spammed, instead.

Note that even though we have more code than before this patch, we actually have less code. The black code formatter decided that since the line length was decreased, this entire code block should be reformatted, murdering the diff view and dividing less code across *more* lines. This is not my fault and I refuse to be held accountable for it -- if you git blame this and do not know what happened, understand that it happens despite my objections.