### PR TITLE
dbapi: KeyError tolerance during package moves

### DIFF
--- a/lib/portage/exception.py
+++ b/lib/portage/exception.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2020 Gentoo Authors
+# Copyright 1998-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import signal
@@ -28,6 +28,10 @@ class PortageKeyError(KeyError, PortageException):
 
 class CorruptionError(PortageException):
     """Corruption indication"""
+
+
+class CorruptionKeyError(CorruptionError, PortageKeyError):
+    """KeyError raised when corruption is detected (cause should be accesssible as __cause__)"""
 
 
 class InvalidDependString(PortageException):


### PR DESCRIPTION
Raise a new CorruptionKeyError exception type instead of a plain KeyError when os.stat fails. Treat this type of exception as a warning during package moves.

Also fix this error that the test case triggered in the binarytree.remove method:
```
  NameError: name 'binpkg_path' is not defined
```
Bug: https://bugs.gentoo.org/920828