### PR TITLE
bintree: don't call trust helper unless bindb is writable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,8 @@ Release notes take the form of the following optional categories:
 portage-3.0.61 (UNRELEASED)
 --------------
 
-TODO
+Bug fixes:
+* bintree: Don't call trust helper unless bindb is writable (bug #915842, bug #920180).
 
 portage-3.0.60 (2024-01-02)
 --------------

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1334,7 +1334,7 @@ class binarytree:
             # when binpackages are involved, not only when we refuse unsigned
             # ones. (If the keys have expired we end up refusing signed but
             # technically invalid packages...)
-            if not pretend:
+            if not pretend and self.dbapi.writable:
                 self._run_trust_helper()
             gpkg_only = True
         else:


### PR DESCRIPTION
Followup to 6ae45739e208b7a9d59e0b6056be72a5791aae04. My qualm there wrt writable was whether or not doing something which mutated state (and therefore possibly the package list) would be confusing but that doesn't make much sense for a few reasons.

Anyway, change the test to be not just for no-pretend, but also whether the
bindb is writable too, as pretend is already a proxy for whether we may
not have privileges (I can imagine someone possibly having bindb privileges
but not /etc/portage/gnupg, so better to just head this off entirely).

Bug: https://bugs.gentoo.org/915842
Bug: https://bugs.gentoo.org/920180