### PR TITLE
find_smallest_cycle: Prefer installed nodes

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -9445,8 +9445,16 @@ class depgraph:
                                 smallest_cycle=smallest_cycle,
                                 traversed_nodes=traversed_nodes,
                             ):
-                                if smallest_cycle is None or len(selected_nodes) < len(
-                                    smallest_cycle
+                                if (
+                                    smallest_cycle is None
+                                    or len(selected_nodes) < len(smallest_cycle)
+                                    or (
+                                        all(node.installed for node in selected_nodes)
+                                        and any(
+                                            not node.installed
+                                            for node in smallest_cycle
+                                        )
+                                    )
                                 ):
                                     smallest_cycle = selected_nodes
                                     ignore_priority = priority


### PR DESCRIPTION
Like 9823f70c6e4ef3cdd6abb4d9fc599ce02a138125, prefer installed nodes in order to try and avoid merging something too early.

Bug: https://bugs.gentoo.org/921333