### PR TITLE
bintree: use urllib provided attributes for hostname, user and password

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1344,23 +1344,13 @@ class binarytree:
         for repo in reversed(list(self._binrepos_conf.values())):
             base_url = repo.sync_uri
             parsed_url = urlparse(base_url)
-            host = parsed_url.netloc
+            host = parsed_url.hostname or ""
             port = parsed_url.port
-            user = None
-            passwd = None
-            user_passwd = ""
+            user = parsed_url.username
+            passwd = parsed_url.password
+            user_passwd = user + "@" if user else ""
             gpkg_only_warned = False
 
-            if "@" in host:
-                user, host = host.split("@", 1)
-                user_passwd = user + "@"
-                if ":" in user:
-                    user, passwd = user.split(":", 1)
-
-            if port is not None:
-                port_str = f":{port}"
-                if host.endswith(port_str):
-                    host = host[: -len(port_str)]
             pkgindex_file = os.path.join(
                 self.settings["EROOT"],
                 CACHE_PATH,


### PR DESCRIPTION
In addition to simplifying it also solves an issue with parsing raw ipv6 addresses.

Bug: https://bugs.gentoo.org/921400

```
>>> test = urlparse("ssh://[::1]/var/cache/binpkgs")
>>> test.netloc
'[::1]'
>>> test.hostname
'::1'
>>> test = urlparse("ssh://[::1]:23/var/cache/binpkgs")
>>> test.netloc
'[::1]:23'
>>> test.hostname
'::1'
>>> test = urlparse("ssh://test@[fe80::1ff:fe23:4567:890a]:23/var/cache/binpkgs")
>>> test.netloc
'test@[fe80::1ff:fe23:4567:890a]:23'
>>> test.hostname
'fe80::1ff:fe23:4567:890a'
>>> test.port
23
>>> test = urlparse("ssh://test:password@[fe80::1ff:fe23:4567:890a]:23/var/cache/binpkgs")
>>> test.netloc
'test:password@[fe80::1ff:fe23:4567:890a]:23'
>>> test.hostname
'fe80::1ff:fe23:4567:890a'
>>> test.port
23
>>> test.username
'test'
>>> test.password
'password'
```