### PR TITLE
_calc_depclean: add dep_check action

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -11723,6 +11723,7 @@ def backtrack_depgraph(
     myaction: Optional[str],
     myfiles: list[str],
     spinner: "_emerge.stdout_spinner.stdout_spinner",
+    frozen_config: Optional[_frozen_depgraph_config] = None,
 ) -> tuple[Any, depgraph, list[str]]:
     """
 
@@ -11747,6 +11748,7 @@ def _backtrack_depgraph(
     myaction: Optional[str],
     myfiles: list[str],
     spinner: "_emerge.stdout_spinner.stdout_spinner",
+    frozen_config: Optional[_frozen_depgraph_config] = None,
 ) -> tuple[Any, depgraph, list[str], int, int]:
     debug = "--debug" in myopts
     mydepgraph = None
@@ -11756,7 +11758,10 @@ def _backtrack_depgraph(
     backtracker = Backtracker(max_depth)
     backtracked = 0
 
-    frozen_config = _frozen_depgraph_config(settings, trees, myopts, myparams, spinner)
+    if frozen_config is None:
+        frozen_config = _frozen_depgraph_config(
+            settings, trees, myopts, myparams, spinner
+        )
 
     while backtracker:
         if debug and mydepgraph is not None:

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -15,6 +15,7 @@ py.install_sources(
         'test_bdeps.py',
         'test_binary_pkg_ebuild_visibility.py',
         'test_blocker.py',
+        'test_broken_deps.py',
         'test_changed_deps.py',
         'test_circular_choices.py',
         'test_circular_choices_rust.py',

--- a/lib/portage/tests/resolver/test_broken_deps.py
+++ b/lib/portage/tests/resolver/test_broken_deps.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class BrokenDepsTestCase(TestCase):
+    def testBrokenDeps(self):
+        """
+        Test the _calc_depclean "dep_check" action which will eventually
+        be used to check for unsatisfied deps of installed packages
+        for bug 921333.
+        """
+        ebuilds = {
+            "dev-qt/qtcore-5.15.12": {
+                "EAPI": "8",
+            },
+            "dev-qt/qtcore-5.15.11-r1": {
+                "EAPI": "8",
+            },
+            "dev-qt/qtxmlpatterns-5.15.12": {
+                "EAPI": "8",
+                "DEPEND": "=dev-qt/qtcore-5.15.12*",
+                "RDEPEND": "=dev-qt/qtcore-5.15.12*",
+            },
+            "dev-qt/qtxmlpatterns-5.15.11": {
+                "EAPI": "8",
+                "DEPEND": "=dev-qt/qtcore-5.15.11*",
+                "RDEPEND": "=dev-qt/qtcore-5.15.11*",
+            },
+            "kde-frameworks/syntax-highlighting-5.113.0": {
+                "EAPI": "8",
+                "DEPEND": ">=dev-qt/qtxmlpatterns-5.15.9:5",
+            },
+        }
+        installed = {
+            "dev-qt/qtcore-5.15.12": {
+                "EAPI": "8",
+            },
+            "dev-qt/qtxmlpatterns-5.15.11": {
+                "EAPI": "8",
+                "DEPEND": "=dev-qt/qtcore-5.15.11*",
+                "RDEPEND": "=dev-qt/qtcore-5.15.11*",
+            },
+            "kde-frameworks/syntax-highlighting-5.113.0": {
+                "EAPI": "8",
+                "DEPEND": ">=dev-qt/qtxmlpatterns-5.15.9:5",
+            },
+        }
+
+        world = ("kde-frameworks/syntax-highlighting",)
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                [],
+                action="dep_check",
+                success=True,
+                unsatisfied_deps={
+                    "dev-qt/qtxmlpatterns-5.15.11": {"=dev-qt/qtcore-5.15.11*"}
+                },
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, world=world
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
Add a dep_check action which can be used to check the
dependencies of all installed packages. The plan is for depgraph
to use this action to check for broken dependencies prior to the
merge order calculation. The new frozen_config parameter will
allow depgraph to pass a shared frozen config to _calc_depclean.

The result of the dep_check action becomes stale as soon as there
is any change to the installed packages. So, in order to account
for dependencies that may become broken or satisfied during the
process of updating installed packages, the merge order
calculation will need to refresh the dep_check calculation for
every merge order choice that it makes. This refresh will need
to be optimized to identify the portion of the graph that would
become stale due to a given change, so that it can avoid
unnecessary repetition of work.

Bug: https://bugs.gentoo.org/921333