### PR TITLE
_needs_move() should replace file if filecmp fails for whatever reason

### DIFF
--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -6283,7 +6283,19 @@ class dblink:
             if not _cmpxattr(src_bytes, dest_bytes, exclude=excluded_xattrs):
                 return True
 
-        return not filecmp.cmp(src_bytes, dest_bytes, shallow=False)
+        try:
+            files_equal = filecmp.cmp(src_bytes, dest_bytes, shallow=False)
+        except Exception as e:
+            writemsg(
+                _(
+                    "Exception '%s' happened when comparing files %s and %s, will replace the latter\n"
+                )
+                % (e, mysrc, mydest),
+                noiselevel=-1,
+            )
+            return True
+
+        return not files_equal
 
 
 def merge(


### PR DESCRIPTION
When trying to update I've got "OSError: [Errno 5] Input/output error" exception traceback from portage originating from _needs_move(). It turned out that 3 files in my root filesystem were corrupted, which caused filecmp to fail. This patch makes portage replace original file in this case.