### PR TITLE
actions: Use psf/black@23.12.1 and sync pre-commit version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
           echo "::set-output name=missed::$(
           find bin -type f -not -name '*.py' -not -name '*.sh' | \
           xargs grep -l '#!/usr/bin/env python' | tr $'\n' ' ')"
-      - uses: psf/black@stable
+      - uses: psf/black@23.12.1
         with:
             src: . ${{ steps.stragglers.outputs.missed }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.12.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/pylint


### PR DESCRIPTION
The versions must be consistent, since psf/black@stable now refers to 24.1.1 which triggers some reformatting relative to black 23.x.

The consistency should correct lint failures like this:

https://github.com/gentoo/portage/actions/runs/7667403073/job/20950314014?pr=1239

https://github.com/gentoo/portage/pull/1240 will migrate to black 24.1.x.