### PR TITLE
Rely on os.register_at_fork for _ForkWatcher hook invocation

### DIFF
--- a/lib/portage/tests/locks/test_lock_nonblock.py
+++ b/lib/portage/tests/locks/test_lock_nonblock.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2020 Gentoo Authors
+# Copyright 2011-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import tempfile
@@ -19,7 +19,6 @@ class LockNonblockTestCase(TestCase):
             lock1 = portage.locks.lockfile(path)
             pid = os.fork()
             if pid == 0:
-                portage._ForkWatcher.hook(portage._ForkWatcher)
                 portage.locks._close_fds()
                 # Disable close_fds since we don't exec
                 # (see _setup_pipes docstring).

--- a/lib/portage/util/locale.py
+++ b/lib/portage/util/locale.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 Gentoo Authors
+# Copyright 2015-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """
@@ -118,7 +118,6 @@ def check_locale(silent=False, env=None):
 
     pid = os.fork()
     if pid == 0:
-        portage._ForkWatcher.hook(portage._ForkWatcher)
         try:
             if env is not None:
                 try:


### PR DESCRIPTION
Because os.register_at_fork is used instead of multiprocessing.util.register_after_fork since commit cc7c40199850acb3d36f0a6452987231d592c360, we can rely on the _ForkWatcher hook being automatically invoked after os.fork().

Fixes: https://github.com/gentoo/portage/pull/1173