### PR TITLE
emerge-delta-webrsync: cd to TMPDIR before rsync

### DIFF
--- a/misc/emerge-delta-webrsync
+++ b/misc/emerge-delta-webrsync
@@ -553,6 +553,7 @@ sync_local() {
 			chown -R ${ownership} "${TMPDIR}"
 			rsync_opts+=" --owner --group"
 		fi
+		cd "${TMPDIR}" || die "failed to change directory to TMPDIR"
 		chmod 755 .
 		rsync ${rsync_opts} . "${repo_location%%/}"
 		cd "${DISTDIR}"


### PR DESCRIPTION
The cd to TMPDIR before rsync was erroneously removed in commit fa0f8720e168c95bcd6a8bd57d5abf09c488fd32. Apparently this problem was not reported earlier because this code path only executes when tarsync is not installed, and the emerge-delta-webrsync postinstall suggests to install tarsync since version 3.7.3 released near the end of 2015.

Bug: https://bugs.gentoo.org/922923
Fixes: fa0f8720e168 ("emerge-delta-webrsync: handle gentoo-YYYYMMDD directory name")