### PR TITLE
process.spawn: add abstraction layer for os.fork()

### DIFF
--- a/lib/portage/tests/locks/test_lock_nonblock.py
+++ b/lib/portage/tests/locks/test_lock_nonblock.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2020 Gentoo Authors
+# Copyright 2011-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import tempfile
@@ -19,7 +19,6 @@ class LockNonblockTestCase(TestCase):
             lock1 = portage.locks.lockfile(path)
             pid = os.fork()
             if pid == 0:
-                portage._ForkWatcher.hook(portage._ForkWatcher)
                 portage.locks._close_fds()
                 # Disable close_fds since we don't exec
                 # (see _setup_pipes docstring).

--- a/lib/portage/util/locale.py
+++ b/lib/portage/util/locale.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 Gentoo Authors
+# Copyright 2015-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """
@@ -118,7 +118,6 @@ def check_locale(silent=False, env=None):
 
     pid = os.fork()
     if pid == 0:
-        portage._ForkWatcher.hook(portage._ForkWatcher)
         try:
             if env is not None:
                 try:


### PR DESCRIPTION
Since os.fork() is unsafe in threaded processes, add a basic
abstraction layer that will ultimately allow support of other process
cloning implementations.

Usage of os.fork() is now wrapped in a _start_fork function which can
easily be replaced with an alternative implementation.  This function
takes target, args, and kwargs arguments which are equivalent to
the corresponding multiprocessing.Process parameters. It also has
fd_pipes and close_fds parameters, since implementation of these is
dependent on the process cloning implementation.

The process cloning implementation does not need to be bothered with
the details of the _exec function, since spawn uses an _exec_wrapper
function as a target function which calls _exec and handles any
exceptions appropriately (special exception handling is required for
success of test_spawnE2big related to bug 830187).

Bug: https://bugs.gentoo.org/916566