### PR TITLE
estrip: Support debug info deduplication with sys-devel/dwz

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -15,8 +15,8 @@ exp_tf() {
 		eval ${var}_${flag}=$(tf has ${flag} ${!var})
 	done
 }
-exp_tf FEATURES compressdebug installsources nostrip splitdebug xattr
-exp_tf PORTAGE_RESTRICT binchecks installsources splitdebug strip
+exp_tf FEATURES compressdebug dedupdebug installsources nostrip splitdebug xattr
+exp_tf PORTAGE_RESTRICT binchecks dedupdebug installsources splitdebug strip
 
 if ! ___eapi_has_prefix_variables; then
 	EPREFIX= ED=${D}
@@ -201,6 +201,10 @@ fi
 [[ ${debugedit} ]] && debugedit_found=true || debugedit_found=false
 debugedit_warned=false
 
+dwz=$(type -P dwz)
+[[ ${dwz} ]] && dwz_found=true || dwz_found=false
+dwz_warned=false
+
 __multijob_init
 
 # Setup ${T} filesystem layout that we care about.
@@ -246,6 +250,32 @@ __try_symlink() {
 		ln -s "${target}" "${name}" ||
 		[[ -L ${name} ]] ||
 		die "failed to create symlink '${name}'"
+}
+
+# Usage: dedup_elf_debug <src> <inode_dedupdebug>
+dedup_elf_debug() {
+	${FEATURES_dedupdebug} || return 0
+	${PORTAGE_RESTRICT_dedupdebug} && return 0
+
+	debug-print-function "${FUNCNAME}" "$@"
+
+	if ! ${dwz_found} ; then
+		if ! ${dwz_warned} ; then
+			dwz_warned=true
+			ewarn "FEATURES=dedupdebug is enabled but the dwz binary could not be"
+			ewarn "found. This feature will not work unless dwz is installed!"
+		fi
+		return 0
+	fi
+
+	local src=$1              # File to dedup debug symbols
+	local inode_dedupdebug=$2 # Temp path for hard link tracking
+
+	# We already dedupdebug-ed this inode.
+	[[ -L ${inode_dedupdebug} ]] && return 0
+
+	"${dwz}" -- "${src}"
+	touch "${inode_dedupdebug}"
 }
 
 # Usage: save_elf_debug <src> <inode_debug> [splitdebug]
@@ -355,6 +385,7 @@ process_elf() {
 			xt_data=$(dump_xattrs "${x}")
 		fi
 		save_elf_sources "${x}"
+		dedup_elf_debug "${x}" "${inode_link}_dedupdebug"
 	fi
 
 	if ${strip_this} ; then

--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -67,6 +67,7 @@ class EbuildPhase(CompositeTask):
     _features_display = (
         "ccache",
         "compressdebug",
+        "dedupdebug",
         "distcc",
         "fakeroot",
         "installsources",

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -176,6 +176,7 @@ SUPPORTED_FEATURES = frozenset(
         "compressdebug",
         "compress-index",
         "config-protect-if-modified",
+        "dedupdebug",
         "digest",
         "distcc",
         "distlocks",

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -754,6 +754,9 @@ see the \fBQA CONTROL VARIABLES\fR section for more specific exemptions.
 .I bindist
 Distribution of built packages is restricted.
 .TP
+.I dedupdebug
+Disables dedupdebug for specific packages.
+.TP
 .I fetch
 like \fImirror\fR but the files will not be fetched via \fBSRC_URI\fR either.
 .TP

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -465,12 +465,18 @@ redundant on\-the\-fly compression.  The resulting file will be called
 .B compressdebug
 Compress the debug sections in the split debug files with zlib to save
 space.  See \fBsplitdebug\fR for general split debug
-information (upon which this feature depends).
+information (upon which this feature depends).  See also \fBdedupdebug\fR
+for further debug info size reduction.
 .TP
 .B config\-protect\-if\-modified
 This causes the \fBCONFIG_PROTECT\fR behavior to be skipped for files
 that have not been modified since they were installed. This feature is
 enabled by default.
+.TP
+.B dedupdebug
+Prior to the debugging info being split and compressed, they are
+deduplicated.  This feature works only if dwz is installed, and is also
+disabled by \fBnostrip\fR.
 .TP
 .B digest
 Autogenerate digests for packages when running the


### PR DESCRIPTION
This this gates behind FEATURES=dedupdebug, and packages can opt-out with RESTRICT=dedupdebug, though I'm not sure why a package would need to opt this out, unless dwz could break something I'm not aware of...

Bug: https://bugs.gentoo.org/906368