### PR TITLE
tests: process: calculate size of E2BIG environment variable dynamically

### DIFF
--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -149,9 +149,9 @@ class tar_stream_writer:
         kill external program if any error happened in python
         """
         if self.proc is not None:
-            self.killed = True
-            self.proc.kill()
             self.proc.stdin.close()
+            self.proc.kill()
+            self.killed = True
             self.close()
 
     def _cmd_read_thread(self):
@@ -347,9 +347,9 @@ class tar_stream_reader:
         kill external program if any error happened in python
         """
         if self.proc is not None:
-            self.killed = True
-            self.proc.kill()
             self.proc.stdin.close()
+            self.proc.kill()
+            self.killed = True
             self.close()
 
     def read(self, bufsize=-1):


### PR DESCRIPTION
The size of the command line required to trigger E2BIG response from the
kernel is defined as MAX_ARG_STRLEN, which is equal to 32 * PAGE_SIZE.
Therefore the minimum size required to trigger the expected error
response must be calculated dynamically based on PAGE_SIZE.

Bug: https://bugs.gentoo.org/923368