### PR TITLE
process.spawn: Add returnproc parameter

### DIFF
--- a/lib/portage/tests/process/meson.build
+++ b/lib/portage/tests/process/meson.build
@@ -8,6 +8,7 @@ py.install_sources(
         'test_pickle.py',
         'test_poll.py',
         'test_spawn_fail_e2big.py',
+        'test_spawn_returnproc.py',
         'test_spawn_warn_large_env.py',
         'test_unshare_net.py',
         '__init__.py',

--- a/lib/portage/tests/process/test_spawn_returnproc.py
+++ b/lib/portage/tests/process/test_spawn_returnproc.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import signal
+
+from portage.process import find_binary, spawn
+from portage.tests import TestCase
+from portage.util._eventloop.global_event_loop import global_event_loop
+
+
+class SpawnReturnProcTestCase(TestCase):
+    def testSpawnReturnProcWait(self):
+        true_binary = find_binary("true")
+        self.assertNotEqual(true_binary, None)
+
+        loop = global_event_loop()
+
+        async def watch_pid():
+            proc = spawn([true_binary], returnproc=True)
+            self.assertEqual(await proc.wait(), os.EX_OK)
+
+            # A second wait should also work.
+            self.assertEqual(await proc.wait(), os.EX_OK)
+
+        loop.run_until_complete(watch_pid())
+
+    def testSpawnReturnProcTerminate(self):
+        sleep_binary = find_binary("sleep")
+        self.assertNotEqual(sleep_binary, None)
+
+        loop = global_event_loop()
+
+        async def watch_pid():
+            proc = spawn([sleep_binary, 9999], returnproc=True)
+            proc.terminate()
+            self.assertEqual(await proc.wait(), -signal.SIGTERM)
+
+        loop.run_until_complete(watch_pid())


### PR DESCRIPTION
In order to migrate away from unsafe os.fork() usage in threaded processes (https://github.com/python/cpython/issues/84559), add a returnproc parameter that is similar to returnpid, which causes spawn to return a single Process object instead of a list of pids.  The Process API is a subset of asyncio.subprocess.Process. The returnproc parameter conflicts with the logfile parameter, since the caller is expected to use the fd_pipes parameter to implement logging (this was also true for the returnpid parameter).

In the future, spawn will return objects of a different type but with a compatible interface to Process, in order to encapsulate implementation-dependent objects like multiprocessing.Process which are designed to manage the process lifecycle and need to persist until it exits.

Trigger a UserWarning when the returnpid parameter is used, in order to encourage migration to returnproc (do not use DeprecationWarning since it is hidden by default). This warning will be temporarily suppressed for portage internals, until they finish migrating to returnproc. There are probably very few if any external consumers of spawn with the returnpid parameter, so it seems safe to move quickly with this deprecation.

Bug: https://bugs.gentoo.org/916566