### PR TITLE
SpawnProcess: Use spawn returnproc parameter

### DIFF
--- a/lib/_emerge/EbuildMetadataPhase.py
+++ b/lib/_emerge/EbuildMetadataPhase.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.SubProcess import SubProcess
@@ -137,7 +137,7 @@ class EbuildMetadataPhase(SubProcess):
             self._async_wait()
             return
 
-        self.pid = retval[0]
+        self._proc = portage.process.Process(retval[0])
 
     def _output_handler(self):
         while True:

--- a/lib/_emerge/SpawnProcess.py
+++ b/lib/_emerge/SpawnProcess.py
@@ -1,4 +1,4 @@
-# Copyright 2008-2023 Gentoo Authors
+# Copyright 2008-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -123,23 +123,15 @@ class SpawnProcess(SubProcess):
                 kwargs[k] = v
 
         kwargs["fd_pipes"] = fd_pipes
-        kwargs["returnpid"] = True
+        kwargs["returnproc"] = True
         kwargs.pop("logfile", None)
 
-        retval = self._spawn(self.args, **kwargs)
+        self._proc = self._spawn(self.args, **kwargs)
 
         if slave_fd is not None:
             os.close(slave_fd)
         if null_input is not None:
             os.close(null_input)
-
-        if isinstance(retval, int):
-            # spawn failed
-            self.returncode = retval
-            self._async_wait()
-            return
-
-        self.pid = retval[0]
 
         if not fd_pipes:
             self._registered = True
@@ -232,7 +224,7 @@ class SpawnProcess(SubProcess):
         got_pty, master_fd, slave_fd = _create_pty_or_pipe(copy_term_size=stdout_pipe)
         return (master_fd, slave_fd)
 
-    def _spawn(self, args, **kwargs):
+    def _spawn(self, args: list[str], **kwargs) -> portage.process.Process:
         spawn_func = portage.process.spawn
 
         if self._selinux_type is not None:

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Gentoo Authors
+# Copyright 2010-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ["doebuild", "doebuild_environment", "spawn", "spawnebuild"]
@@ -2094,7 +2094,7 @@ def spawn(
         mysettings.configdict["env"]["LOGNAME"] = logname
 
     try:
-        if keywords.get("returnpid"):
+        if keywords.get("returnpid") or keywords.get("returnproc"):
             return spawn_func(mystring, env=mysettings.environ(), **keywords)
 
         proc = EbuildSpawnProcess(

--- a/lib/portage/util/_async/PopenProcess.py
+++ b/lib/portage/util/_async/PopenProcess.py
@@ -1,6 +1,7 @@
-# Copyright 2012-2021 Gentoo Authors
+# Copyright 2012-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import portage
 from _emerge.SubProcess import SubProcess
 
 
@@ -11,7 +12,7 @@ class PopenProcess(SubProcess):
     )
 
     def _start(self):
-        self.pid = self.proc.pid
+        self._proc = portage.process.Process(self.proc.pid)
         self._registered = True
 
         if self.pipe_reader is None:


### PR DESCRIPTION
Migrate SpawnProcess to use the spawn returnproc parameter, and make adaptations to descendent classes as needed. Introduce a portage.process.MultiprocessingProcess class for ForkProcess to wrap multiprocessing.Process instances, needed because ForkProcess inherits from SpawnProcess. Use portage.process.Process to wrap the pid in EbuildMetadataPhase, so that returnproc support in the doebuild function can be reserved for a later commit.

Bug: https://bugs.gentoo.org/916566