### PR TITLE
doebuild: Add returnproc parameter and deprecate returnpid

### DIFF
--- a/lib/_emerge/EbuildMetadataPhase.py
+++ b/lib/_emerge/EbuildMetadataPhase.py
@@ -108,6 +108,7 @@ class EbuildMetadataPhase(SubProcess):
             fcntl.fcntl(master_fd, fcntl.F_GETFL) | os.O_NONBLOCK,
         )
 
+        os.set_inheritable(slave_fd, True)
         fd_pipes[slave_fd] = slave_fd
         settings["PORTAGE_PIPE_FD"] = str(slave_fd)
 
@@ -124,7 +125,7 @@ class EbuildMetadataPhase(SubProcess):
             mydbapi=self.portdb,
             tree="porttree",
             fd_pipes=fd_pipes,
-            returnpid=True,
+            returnproc=True,
         )
         settings.pop("PORTAGE_PIPE_FD", None)
 
@@ -137,7 +138,7 @@ class EbuildMetadataPhase(SubProcess):
             self._async_wait()
             return
 
-        self._proc = portage.process.Process(retval[0])
+        self._proc = retval
 
     def _output_handler(self):
         while True:


### PR DESCRIPTION
Raise NotImplementedError if returnproc is enabled for anything other than the "depend" phase, since corresponding returnpid support has long been deprecated.

Bug: https://bugs.gentoo.org/916566