### PR TITLE
set_term_size: Wait asynchronously if event loop is running

### DIFF
--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -527,6 +527,9 @@ def spawn(
         mycommand = mycommand.split()
 
     env = os.environ if env is None else env
+    # Sometimes os.environ can fail to pickle as shown in bug 923750
+    # comment 4, so copy it to a dict.
+    env = env if isinstance(env, dict) else dict(env)
 
     env_stats = None
     if warn_on_large_env:


### PR DESCRIPTION
When set_term_size is called from an asynchronous context, we
can wait for the process to exit asynchronously. This will
prevent a "RuntimeError: This event loop is already running"
error in the future when synchronous spawn calls will need
to run the event loop in order to wait for the spawned
process(es).

Bug: https://bugs.gentoo.org/923750
Signed-off-by: Zac Medico <zmedico@gentoo.org>
