### PR TITLE
emaint: Print 'usage: ' only once in help message

### DIFF
--- a/lib/portage/emaint/main.py
+++ b/lib/portage/emaint/main.py
@@ -62,7 +62,7 @@ class OptionItem:
 
 
 def usage(module_controller):
-    _usage = "usage: emaint [options] COMMAND"
+    _usage = "emaint [options] COMMAND"
 
     desc = (
         "The emaint program provides an interface to system health "


### PR DESCRIPTION
`ArgumentParser` prepends 'usage: ' to the usage message already.