### PR TITLE
GPG: Proactively stop to avoid "GPG keepalive failed" error in pypy ci jobs

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
@@ -341,10 +341,6 @@ def quickpkg_main(options, args, eout):
         portage.settings.features.remove("xattr")
         portage.settings.lock()
 
-    if portage.settings.get("BINPKG_GPG_SIGNING_KEY", None):
-        gpg = GPG(portage.settings)
-        gpg.unlock()
-
     infos = {}
     infos["successes"] = []
     infos["missing"] = []
@@ -444,11 +440,18 @@ if __name__ == "__main__":
     def sigwinch_handler(signum, frame):
         lines, eout.term_columns = portage.output.get_term_size()
 
+    gpg = None
+    if portage.settings.get("BINPKG_GPG_SIGNING_KEY", None):
+        gpg = GPG(portage.settings)
+        gpg.unlock()
+
     signal.signal(signal.SIGWINCH, sigwinch_handler)
     try:
         retval = quickpkg_main(options, args, eout)
     finally:
         os.umask(old_umask)
         signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+        if gpg is not None:
+            gpg.stop()
         global_event_loop().close()
     sys.exit(retval)

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import collections
@@ -548,8 +548,10 @@ def action_build(
             mergelist_shown = True
             if retval != os.EX_OK:
                 return retval
+        return os.EX_OK
 
-    else:
+    gpg = None
+    try:
         if not mergelist_shown:
             # If we haven't already shown the merge list above, at
             # least show warnings about missed updates and such.
@@ -688,8 +690,10 @@ def action_build(
                         ldpath_mtimes,
                         autoclean=1,
                     )
-
         return retval
+    finally:
+        if gpg is not None:
+            gpg.stop()
 
 
 def action_config(settings, trees, myopts, myfiles):

--- a/lib/portage/tests/gpkg/test_gpkg_gpg.py
+++ b/lib/portage/tests/gpkg/test_gpkg_gpg.py
@@ -1,4 +1,4 @@
-# Copyright Gentoo Foundation 2006-2020
+# Copyright 2022-2024 Gentoo Authors
 # Portage Unit Testing Functionality
 
 import io
@@ -26,6 +26,7 @@ class test_gpkg_gpg_case(TestCase):
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -68,6 +69,8 @@ class test_gpkg_gpg_case(TestCase):
                 InvalidSignature, binpkg_2.decompress, os.path.join(tmpdir, "test")
             )
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()
 
@@ -81,6 +84,7 @@ class test_gpkg_gpg_case(TestCase):
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -112,6 +116,8 @@ class test_gpkg_gpg_case(TestCase):
             )
 
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()
 
@@ -133,6 +139,7 @@ class test_gpkg_gpg_case(TestCase):
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -151,6 +158,8 @@ class test_gpkg_gpg_case(TestCase):
             binpkg_2 = gpkg(settings, "test", os.path.join(tmpdir, "test-1.gpkg.tar"))
             binpkg_2.decompress(os.path.join(tmpdir, "test"))
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()
 
@@ -165,6 +174,7 @@ class test_gpkg_gpg_case(TestCase):
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -195,6 +205,8 @@ class test_gpkg_gpg_case(TestCase):
                 MissingSignature, binpkg_2.decompress, os.path.join(tmpdir, "test")
             )
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()
 
@@ -208,6 +220,7 @@ class test_gpkg_gpg_case(TestCase):
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -264,6 +277,8 @@ qGAN3VUF+8EsdcsV781H0F86PANhyBgEYTGDrnItTGe3/vAPjCo=
                 InvalidSignature, binpkg_2.decompress, os.path.join(tmpdir, "test")
             )
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()
 
@@ -285,6 +300,7 @@ qGAN3VUF+8EsdcsV781H0F86PANhyBgEYTGDrnItTGe3/vAPjCo=
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -306,6 +322,8 @@ qGAN3VUF+8EsdcsV781H0F86PANhyBgEYTGDrnItTGe3/vAPjCo=
             )
 
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()
 
@@ -319,6 +337,7 @@ qGAN3VUF+8EsdcsV781H0F86PANhyBgEYTGDrnItTGe3/vAPjCo=
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
 
         try:
             settings = playground.settings
@@ -370,5 +389,7 @@ EP1pgSXXGtlUnv6akg/wueFJKEr9KQs=
             )
 
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()

--- a/lib/portage/tests/gpkg/test_gpkg_metadata_url.py
+++ b/lib/portage/tests/gpkg/test_gpkg_metadata_url.py
@@ -1,4 +1,4 @@
-# Copyright Gentoo Foundation 2006-2020
+# Copyright 2022-2024 Gentoo Authors
 # Portage Unit Testing Functionality
 
 import io
@@ -98,6 +98,7 @@ class test_gpkg_metadata_url_case(TestCase):
             }
         )
         tmpdir = tempfile.mkdtemp()
+        gpg = None
         try:
             settings = playground.settings
             gpg = GPG(settings)
@@ -156,5 +157,7 @@ IkCfAP49AOYjzuQPP0n5P0SGCINnAVEXN7QLQ4PurY/lt7cT2gEAq01stXjFhrz5
                 "http://127.0.0.1:" + str(port) + "/test-2.gpkg.tar",
             )
         finally:
+            if gpg is not None:
+                gpg.stop()
             shutil.rmtree(tmpdir)
             playground.cleanup()


### PR DESCRIPTION
GPG: Proactively stop to avoid "GPG keepalive failed" error in pypy ci jobs

This seems to help mitigate pypy ci job hangs like those fba76a545f2 triggered.

Use threading.Event for thread safety during GPG stop, and use the wait method to improve responsiveness for stop requests.

Bug: https://bugs.gentoo.org/924192