### PR TITLE
sync: Add method to download zip archives

### DIFF
--- a/lib/portage/sync/modules/zipfile/__init__.py
+++ b/lib/portage/sync/modules/zipfile/__init__.py
@@ -21,10 +21,11 @@ module_spec = {
             "sourcefile": "zipfile",
             "class": "ZipFile",
             "description": doc,
-            "functions": ["sync"],
+            "functions": ["sync", "retrieve_head"],
             "func_desc": {
                 "sync": "Performs an archived http download of the "
                 + "repository, then unpacks it.",
+                "retrieve_head": "Returns the checksum of the unpacked archive.",
             },
             "validate_config": CheckSyncConfig,
             "module_specific_options": (),

--- a/lib/portage/sync/modules/zipfile/__init__.py
+++ b/lib/portage/sync/modules/zipfile/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024  Alexey Gladkov <gladkov.alexey@gmail.com>
+
+doc = """Zipfile plug-in module for portage.
+Performs a http download of a portage snapshot and unpacks it to the repo
+location."""
+__doc__ = doc[:]
+
+
+import os
+
+from portage.sync.config_checks import CheckSyncConfig
+
+
+module_spec = {
+    "name": "zipfile",
+    "description": doc,
+    "provides": {
+        "zipfile-module": {
+            "name": "zipfile",
+            "sourcefile": "zipfile",
+            "class": "ZipFile",
+            "description": doc,
+            "functions": ["sync"],
+            "func_desc": {
+                "sync": "Performs an archived http download of the "
+                + "repository, then unpacks it.",
+            },
+            "validate_config": CheckSyncConfig,
+            "module_specific_options": (),
+        },
+    },
+}

--- a/lib/portage/sync/modules/zipfile/zipfile.py
+++ b/lib/portage/sync/modules/zipfile/zipfile.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024  Alexey Gladkov <gladkov.alexey@gmail.com>
+
+import os
+import os.path
+import logging
+import zipfile
+import shutil
+import tempfile
+import urllib.request
+
+import portage
+from portage.util import writemsg_level
+from portage.sync.syncbase import SyncBase
+
+
+class ZipFile(SyncBase):
+    """ZipFile sync module"""
+
+    short_desc = "Perform sync operations on GitHub repositories"
+
+    @staticmethod
+    def name():
+        return "ZipFile"
+
+    def __init__(self):
+        SyncBase.__init__(self, "emerge", ">=sys-apps/portage-2.3")
+
+    def sync(self, **kwargs):
+        """Sync the repository"""
+        if kwargs:
+            self._kwargs(kwargs)
+
+        # initial checkout
+        zip_uri = self.repo.sync_uri
+
+        with urllib.request.urlopen(zip_uri) as response:
+            with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+                shutil.copyfileobj(response, tmp_file)
+            zip_file = tmp_file.name
+
+        if not zipfile.is_zipfile(zip_file):
+            msg = "!!! file is not a zip archive."
+            self.logger(self.xterm_titles, msg)
+            writemsg_level(msg + "\n", noiselevel=-1, level=logging.ERROR)
+
+            os.unlink(zip_file)
+
+            return (1, False)
+
+        # Drop previous tree
+        shutil.rmtree(self.repo.location)
+
+        with zipfile.ZipFile(zip_file) as archive:
+            strip_comp = 0
+
+            for f in archive.namelist():
+                f = os.path.normpath(f)
+                if os.path.basename(f) == "profiles":
+                    strip_comp = f.count("/")
+                    break
+
+            for n in archive.infolist():
+                p = os.path.normpath(n.filename)
+
+                if os.path.isabs(p):
+                    continue
+
+                parts = p.split("/")
+                dstpath = os.path.join(self.repo.location, *parts[strip_comp:])
+
+                if n.is_dir():
+                    os.makedirs(dstpath, mode=0o755, exist_ok=True)
+                    continue
+
+                with archive.open(n) as srcfile:
+                    with open(dstpath, "wb") as dstfile:
+                        shutil.copyfileobj(srcfile, dstfile)
+
+        os.unlink(zip_file)
+
+        return (os.EX_OK, True)

--- a/lib/portage/sync/modules/zipfile/zipfile.py
+++ b/lib/portage/sync/modules/zipfile/zipfile.py
@@ -26,6 +26,15 @@ class ZipFile(SyncBase):
     def __init__(self):
         SyncBase.__init__(self, "emerge", ">=sys-apps/portage-2.3")
 
+    def retrieve_head(self, **kwargs):
+        """Get information about the checksum of the unpacked archive"""
+        if kwargs:
+            self._kwargs(kwargs)
+        info = portage.grabdict(os.path.join(self.repo.location, ".info"))
+        if "etag" in info:
+            return (os.EX_OK, info["etag"][0])
+        return (1, False)
+
     def sync(self, **kwargs):
         """Sync the repository"""
         if kwargs:

--- a/lib/portage/tests/sync/meson.build
+++ b/lib/portage/tests/sync/meson.build
@@ -1,6 +1,7 @@
 py.install_sources(
     [
         'test_sync_local.py',
+        'test_sync_zipfile.py',
         '__init__.py',
         '__test__.py',
     ],

--- a/lib/portage/tests/sync/test_sync_zipfile.py
+++ b/lib/portage/tests/sync/test_sync_zipfile.py
@@ -1,0 +1,99 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import http.server
+import os
+import shutil
+import socketserver
+import subprocess
+import tempfile
+import textwrap
+import threading
+from functools import partial
+
+import portage
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+
+
+class test_sync_zipfile_case(TestCase):
+    def test_sync_zipfile(self):
+        cpv = "dev-libs/A-0"
+        ebuilds = {
+            cpv: {"EAPI": "8"},
+        }
+        etag = "foo"
+
+        server = None
+        playground = None
+        tmpdir = tempfile.mkdtemp()
+        try:
+
+            class Handler(http.server.SimpleHTTPRequestHandler):
+                def end_headers(self):
+                    self.send_header("etag", etag)
+                    super().end_headers()
+
+            server = socketserver.TCPServer(
+                ("127.0.0.1", 0),
+                partial(Handler, directory=tmpdir),
+            )
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+
+            playground = ResolverPlayground(
+                ebuilds=ebuilds,
+            )
+            settings = playground.settings
+
+            env = settings.environ()
+
+            repos_conf = textwrap.dedent(
+                """
+                [test_repo]
+                location = %(location)s
+                sync-type = zipfile
+                sync-uri = %(sync-uri)s
+                auto-sync = true
+            """
+            )
+
+            repo_location = f"{playground.eprefix}/var/repositories/test_repo"
+
+            env["PORTAGE_REPOSITORIES"] = repos_conf % {
+                "location": repo_location,
+                "sync-uri": "http://{}:{}/test_repo.zip".format(*server.server_address),
+            }
+
+            shutil.make_archive(os.path.join(tmpdir, "test_repo"), "zip", repo_location)
+
+            ebuild = playground.trees[playground.eroot]["porttree"].dbapi.findname(cpv)
+            self.assertTrue(os.path.exists(ebuild))
+            shutil.rmtree(repo_location)
+            self.assertFalse(os.path.exists(ebuild))
+
+            result = subprocess.run(
+                [
+                    "emerge",
+                    "--sync",
+                ],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            output = result.stdout.decode(errors="replace")
+            try:
+                self.assertEqual(result.returncode, os.EX_OK)
+            except Exception:
+                print(output)
+                raise
+
+            repo = settings.repositories["test_repo"]
+            sync_mod = portage.sync.module_controller.get_class("zipfile")
+            status, repo_revision = sync_mod().retrieve_head(options={"repo": repo})
+            self.assertEqual(status, os.EX_OK)
+            self.assertEqual(repo_revision, etag)
+        finally:
+            if server is not None:
+                server.shutdown()
+            shutil.rmtree(tmpdir)
+            playground.cleanup()

--- a/man/portage.5
+++ b/man/portage.5
@@ -1140,7 +1140,7 @@ expire while it is in use by a running process.
 .B sync\-type
 Specifies type of synchronization performed by `emerge \-\-sync`.
 .br
-Valid non\-empty values: cvs, git, mercurial, rsync, svn, webrsync
+Valid non\-empty values: cvs, git, mercurial, rsync, zipfile, svn, webrsync
 (emerge\-webrsync)
 .br
 This attribute can be set to empty value to disable synchronization of given
@@ -1165,6 +1165,8 @@ cvs: [cvs://]:access_method:[username@]hostname[:port]:/path
 git: (git|git+ssh|http|https)://[username@]hostname[:port]/path
 .br
 rsync: (rsync|ssh)://[username@]hostname[:port]/(module|path)
+.br
+zipfile: (http|https)://hostname[:port]/path/to/zipfile.zip
 .TP
 Examples:
 .RS
@@ -1326,6 +1328,13 @@ auto\-sync = yes
 location = /var/lib/layman/voip
 sync\-type = laymanator
 sync\-uri = git://anongit.gentoo.org/proj/voip.git
+auto\-sync = yes
+
+# Overlay with latest ebuild repository snapshot.
+[snapshot]
+location = /var/db/repos/snapshot
+sync\-type = zipfile
+sync\-uri = https://github.com/gentoo/gentoo/archive/refs/heads/master.zip
 auto\-sync = yes
 .fi
 .RE


### PR DESCRIPTION
Add a simple method for synchronizing repository as a snapshot in a zip archive. The implementation does not require external utilities to download and unpack archive. This makes the method very cheap.

The main usecase being considered is obtaining snapshots of github repositories, but many other web interfaces for git also support receiving snapshots in zip format.

For example, to get a snapshot of the master branch:

  https://github.com/gentoo/portage/archive/refs/heads/master.zip
  https://gitweb.gentoo.org/proj/portage.git/snapshot/portage-master.zip

or a link to a snapshot of the tag:

  https://github.com/gentoo/portage/archive/refs/tags/portage-3.0.61.zip