### PR TITLE
actions: Fix interaction between start-method and pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
               mv "${bin_file}"{.new,}
             fi
           done < <(find bin -maxdepth 1 -type f)
-          sed -i meson.build -e "s|'-m', 'pytest'|'-c', 'import multiprocessing, sys, pytest; multiprocessing.set_start_method(\"spawn\", force=True); sys.exit(pytest.console_main())'|"
       - name: Test meson install --destdir /tmp/install-root
         run: |
           echo -e "[binaries]\npython = '$(command -v python)'" > /tmp/native.ini
@@ -90,5 +89,6 @@ jobs:
           meson install -C /tmp/build --destdir /tmp/install-root
       - name: Run tests for ${{ matrix.python-version }}
         run: |
+          [[ "${{ matrix.start-method }}" == "spawn" ]] && export PORTAGE_MULTIPROCESSING_START_METHOD=spawn
           export PYTEST_ADDOPTS="-vv -ra -l -o console_output_style=count -n $(nproc) --dist=worksteal"
           meson test -C /tmp/build --verbose

--- a/lib/portage/tests/__init__.py
+++ b/lib/portage/tests/__init__.py
@@ -1,8 +1,9 @@
 # tests/__init__.py -- Portage Unit Test functionality
-# Copyright 2006-2023 Gentoo Authors
+# Copyright 2006-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import argparse
+import multiprocessing
 import sys
 import time
 import unittest
@@ -78,6 +79,15 @@ class TestCase(unittest.TestCase):
         self.cnf_etc_path = cnf_etc_path
         self.bindir = cnf_bindir
         self.sbindir = cnf_sbindir
+
+    def setUp(self):
+        """
+        Setup multiprocessing start method if needed. It needs to be
+        done relatively late in order to work with the pytest-xdist
+        plugin due to execnet usage.
+        """
+        if os.environ.get("PORTAGE_MULTIPROCESSING_START_METHOD") == "spawn":
+            multiprocessing.set_start_method("spawn", force=True)
 
     def assertRaisesMsg(self, msg, excClass, callableObj, *args, **kwargs):
         """Fail unless an exception of class excClass is thrown

--- a/lib/portage/tests/env/config/test_PortageModulesFile.py
+++ b/lib/portage/tests/env/config/test_PortageModulesFile.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2009 Gentoo Foundation
+# Copyright 2006-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage import os
@@ -13,6 +13,7 @@ class PortageModulesFileTestCase(TestCase):
     modules = ["spanky", "zmedico", "antarus", "ricer", "5", "6"]
 
     def setUp(self):
+        super().setUp()
         self.items = {}
         for k, v in zip(self.keys + self.invalid_keys, self.modules):
             self.items[k] = v

--- a/lib/portage/tests/news/test_NewsItem.py
+++ b/lib/portage/tests/news/test_NewsItem.py
@@ -1,5 +1,5 @@
 # test_NewsItem.py -- Portage Unit Testing Functionality
-# Copyright 2007-2023 Gentoo Authors
+# Copyright 2007-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -114,6 +114,7 @@ class NewsItemTestCase(TestCase):
     }
 
     def setUp(self) -> None:
+        super().setUp()
         self.profile_base = "/var/db/repos/gentoo/profiles/default-linux"
         self.profile = f"{self.profile_base}/x86/2007.0/"
         self.keywords = "x86"

--- a/lib/portage/tests/sets/files/test_config_file_set.py
+++ b/lib/portage/tests/sets/files/test_config_file_set.py
@@ -1,5 +1,5 @@
 # testConfigFileSet.py -- Portage Unit Testing Functionality
-# Copyright 2007 Gentoo Foundation
+# Copyright 2007-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import tempfile
@@ -13,6 +13,7 @@ class ConfigFileSetTestCase(TestCase):
     """Simple Test Case for ConfigFileSet"""
 
     def setUp(self):
+        super().setUp()
         fd, self.testfile = tempfile.mkstemp(
             suffix=".testdata", prefix=self.__class__.__name__, text=True
         )

--- a/lib/portage/tests/sets/files/test_static_file_set.py
+++ b/lib/portage/tests/sets/files/test_static_file_set.py
@@ -1,5 +1,5 @@
 # testStaticFileSet.py -- Portage Unit Testing Functionality
-# Copyright 2007 Gentoo Foundation
+# Copyright 2007-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import tempfile
@@ -13,6 +13,7 @@ class StaticFileSetTestCase(TestCase):
     """Simple Test Case for StaticFileSet"""
 
     def setUp(self):
+        super().setUp()
         fd, self.testfile = tempfile.mkstemp(
             suffix=".testdata", prefix=self.__class__.__name__, text=True
         )

--- a/lib/portage/tests/sets/shell/test_shell.py
+++ b/lib/portage/tests/sets/shell/test_shell.py
@@ -1,5 +1,5 @@
 # testCommandOututSet.py -- Portage Unit Testing Functionality
-# Copyright 2007-2020 Gentoo Authors
+# Copyright 2007-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.process import find_binary
@@ -11,7 +11,7 @@ class CommandOutputSetTestCase(TestCase):
     """Simple Test Case for CommandOutputSet"""
 
     def setUp(self):
-        pass
+        super().setUp()
 
     def tearDown(self):
         pass

--- a/lib/portage/tests/util/futures/test_retry.py
+++ b/lib/portage/tests/util/futures/test_retry.py
@@ -221,6 +221,7 @@ class RetryForkExecutorTestCase(RetryTestCase):
             self._executor = None
 
     def setUp(self):
+        super().setUp()
         self._setUpExecutor()
 
     def tearDown(self):


### PR DESCRIPTION
Use portage.test.TestCase setUp method to setup the multiprocessing start method if needed. It needs to be done relatively late in order to work with the pytest-xdist plugin due to execnet usage.

Bug: https://bugs.gentoo.org/914876