### PR TITLE
Revert "EbuildPhase: async_check_locale"

### DIFF
--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -24,7 +24,6 @@ from portage.package.ebuild.prepare_build_dirs import (
     _prepare_fake_distdir,
     _prepare_fake_filesdir,
 )
-from portage.eapi import _get_eapi_attrs
 from portage.util import writemsg, ensure_dirs
 from portage.util._async.AsyncTaskFuture import AsyncTaskFuture
 from portage.util._async.BuildLogger import BuildLogger
@@ -55,32 +54,10 @@ portage.proxy.lazyimport.lazyimport(
     + "_post_src_install_write_metadata,"
     + "_preinst_bsdflags",
     "portage.util.futures.unix_events:_set_nonblocking",
-    "portage.util.locale:async_check_locale,split_LC_ALL",
 )
 from portage import os
 from portage import _encodings
 from portage import _unicode_encode
-
-
-async def _setup_locale(settings):
-    eapi_attrs = _get_eapi_attrs(settings["EAPI"])
-    if eapi_attrs.posixish_locale:
-        split_LC_ALL(settings)
-        settings["LC_COLLATE"] = "C"
-        # check_locale() returns None when check can not be executed.
-        if await async_check_locale(silent=True, env=settings.environ()) is False:
-            # try another locale
-            for l in ("C.UTF-8", "en_US.UTF-8", "en_GB.UTF-8", "C"):
-                settings["LC_CTYPE"] = l
-                if await async_check_locale(silent=True, env=settings.environ()):
-                    # TODO: output the following only once
-                    # writemsg(
-                    #     _("!!! LC_CTYPE unsupported, using %s instead\n")
-                    #     % self.settings["LC_CTYPE"]
-                    # )
-                    break
-            else:
-                raise AssertionError("C locale did not pass the test!")
 
 
 class EbuildPhase(CompositeTask):
@@ -117,9 +94,6 @@ class EbuildPhase(CompositeTask):
         self._start_task(AsyncTaskFuture(future=future), self._async_start_exit)
 
     async def _async_start(self):
-
-        await _setup_locale(self.settings)
-
         need_builddir = self.phase not in EbuildProcess._phases_without_builddir
 
         if need_builddir:

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -29,6 +29,7 @@ portage.proxy.lazyimport.lazyimport(
     "portage.dbapi.vartree:vartree",
     "portage.package.ebuild.doebuild:_phase_func_map",
     "portage.util.compression_probe:_compressors",
+    "portage.util.locale:check_locale,split_LC_ALL",
 )
 from portage import bsd_chflags, load_mod, os, selinux, _unicode_decode
 from portage.const import (
@@ -3367,17 +3368,20 @@ class config:
                 mydict["EBUILD_PHASE_FUNC"] = phase_func
 
         if eapi_attrs.posixish_locale:
-            if mydict.get("LC_ALL"):
-                # Sometimes this method is called for processes
-                # that are not ebuild phases, so only raise
-                # AssertionError for actual ebuild phases.
-                if phase and phase not in ("clean", "cleanrm", "fetch"):
-                    raise AssertionError(
-                        f"LC_ALL={mydict['LC_ALL']} for posixish locale. It seems that split_LC_ALL was not called for phase {phase}?"
-                    )
-            elif "LC_ALL" in mydict:
-                # Delete placeholder from split_LC_ALL.
-                del mydict["LC_ALL"]
+            split_LC_ALL(mydict)
+            mydict["LC_COLLATE"] = "C"
+            # check_locale() returns None when check can not be executed.
+            if check_locale(silent=True, env=mydict) is False:
+                # try another locale
+                for l in ("C.UTF-8", "en_US.UTF-8", "en_GB.UTF-8", "C"):
+                    mydict["LC_CTYPE"] = l
+                    if check_locale(silent=True, env=mydict):
+                        # TODO: output the following only once
+                        # 						writemsg(_("!!! LC_CTYPE unsupported, using %s instead\n")
+                        # 								% mydict["LC_CTYPE"])
+                        break
+                else:
+                    raise AssertionError("C locale did not pass the test!")
 
         if not eapi_attrs.exports_PORTDIR:
             mydict.pop("PORTDIR", None)

--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -15,7 +15,6 @@ __all__ = (
     "set_child_watcher",
     "get_event_loop_policy",
     "set_event_loop_policy",
-    "run",
     "shield",
     "sleep",
     "Task",
@@ -105,14 +104,6 @@ def set_child_watcher(watcher):
     """Equivalent to calling
     get_event_loop_policy().set_child_watcher(watcher)."""
     return get_event_loop_policy().set_child_watcher(watcher)
-
-
-# Emulate run since it's the preferred python API.
-def run(coro):
-    return _safe_loop().run_until_complete(coro)
-
-
-run.__doc__ = _real_asyncio.run.__doc__
 
 
 def create_subprocess_exec(*args, **kwargs):


### PR DESCRIPTION
This reverts commit c95fc64abf9698263090b3ffd4a056e989dd2be1 since we had assumed EbuildMetadataPhase._start would serialize access to the portdbapi doebuild_settings attribute, and that assumption broke when _async_start was introduced in order to call async_check_locale.

Bug: https://bugs.gentoo.org/923841
Bug: https://bugs.gentoo.org/924319