### PR TITLE
actions: disable pytest-xdist for spawn start-method (workers crash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,8 @@ jobs:
       - name: Run tests for ${{ matrix.python-version }}
         run: |
           [[ "${{ matrix.start-method }}" == "spawn" ]] && export PORTAGE_MULTIPROCESSING_START_METHOD=spawn
-          export PYTEST_ADDOPTS="-vv -ra -l -o console_output_style=count -n $(nproc) --dist=worksteal"
+          # spawn start-method crashes pytest-xdist workers (bug 924416)
+          [[ "${{ matrix.start-method }}" == "spawn" ]] && \
+            export PYTEST_ADDOPTS="-vv -ra -l -o console_output_style=count" || \
+            export PYTEST_ADDOPTS="-vv -ra -l -o console_output_style=count -n $(nproc) --dist=worksteal"
           meson test -C /tmp/build --verbose


### PR DESCRIPTION
https://github.com/gentoo/portage/pull/1265 triggered intermittent pytest-xdist worker crashes.

Bug: https://bugs.gentoo.org/924416