### PR TITLE
BuildLogger: Fix portage.locks._open_fds memory leak

### DIFF
--- a/lib/portage/util/_async/BuildLogger.py
+++ b/lib/portage/util/_async/BuildLogger.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
@@ -30,6 +30,11 @@ class _file_close_wrapper(ObjectProxy):
 
     def _get_target(self):
         return object.__getattribute__(self, "_file")
+
+    def __getattribute__(self, attr):
+        if attr == "close":
+            return object.__getattribute__(self, attr)
+        return getattr(object.__getattribute__(self, "_file"), attr)
 
     def close(self):
         file = object.__getattribute__(self, "_file")


### PR DESCRIPTION
The _file_close_wrapper __getattribute__ method needs to be overridden to expose its close method, otherwise the underlying file's close method is called and the closed file object remains as a memory leak in the global portage.locks._open_fds dict. For reference, see similar classes like portage.util.atomic_ofstream which overrides methods in the same way.

Bug: https://bugs.gentoo.org/919072
Fixes:  https://github.com/gentoo/portage/pull/1199  df212738bbb2 ("BuildLogger: Close self._stdin after fork")

NOTE: This leak seems to be not much of a leak because the file descriptor numbers tend to recycle and kick the previous instances out of _open_fds.