### PR TITLE
Support PROPERTIES=test_userpriv not to drop perms for tests

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -503,7 +503,8 @@ __dyn_test() {
 	fi
 
 	if has test ${PORTAGE_RESTRICT} && ! has all ${ALLOW_TEST} &&
-			! { has test_network ${PORTAGE_PROPERTIES} && has network ${ALLOW_TEST}; }
+			! { has test_network ${PORTAGE_PROPERTIES} && has network ${ALLOW_TEST}; } &&
+			! { has test_privileged ${PORTAGE_PROPERTIES} && has privileged ${ALLOW_TEST}; }
 	then
 		einfo "Skipping make test/check due to ebuild restriction."
 		__vecho ">>> Test phase [disabled because of RESTRICT=test]: ${CATEGORY}/${PF}"

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -2114,6 +2114,9 @@ class config:
                     "test" in restrict
                     and not "all" in allow_test
                     and not ("test_network" in properties and "network" in allow_test)
+                    and not (
+                        "test_privileged" in properties and "privileged" in allow_test
+                    )
                 )
 
         if restrict_test and "test" in self.features:

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -239,6 +239,9 @@ def _doebuild_spawn(phase, settings, actionmap=None, **kwargs):
             ebuild_sh_arg,
         )
 
+    if phase == "test" and "test_privileged" in settings["PORTAGE_PROPERTIES"].split():
+        kwargs["droppriv"] = False
+
     settings["EBUILD_PHASE"] = phase
     try:
         return spawn(cmd, settings, **kwargs)

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -808,6 +808,11 @@ is installed.
 The package manager may run tests that require an internet connection, even if
 the ebuild has
 .IR RESTRICT=test .
+.TP
+.I test_privileged
+The package manager may run tests that require superuser permissions, even if
+the ebuild has
+.IR RESTRICT=test .
 .RE
 .PD 1
 .TP

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1317,6 +1317,10 @@ Run tests in packages specifying \fBPROPERTIES\fR="\fBtest_network\fR".  Note
 that this will most likely cause Internet access during the test suite which
 could cause additional costs, privacy concerns and intermittent test failures.
 .TP
+.B privileged
+Run tests in packages specifying \fBPROPERTIES\fR="\fBtest_privileged\fR".  Note
+that this will cause the test suite to be run with superuser permissions.
+.TP
 .RE
 .TP
 .B RESUMECOMMAND


### PR DESCRIPTION
Support PROPERTIES=test_userpriv and a corresponding ALLOW_TEST=userpriv to disable FEATURES=userpriv when running the test phase.  This can be used e.g. in dev-python/reflink that needs to be able to mount filesystem on a loopback device for testing.

Bug: https://bugs.gentoo.org/924585