### PR TITLE
SchedulerInterface/PollScheduler: Add _loop property

### DIFF
--- a/lib/_emerge/PollScheduler.py
+++ b/lib/_emerge/PollScheduler.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import threading
@@ -38,6 +38,13 @@ class PollScheduler:
         self._sched_iface = SchedulerInterface(
             self._event_loop, is_background=self._is_background
         )
+
+    @property
+    def _loop(self):
+        """
+        Returns the real underlying asyncio loop.
+        """
+        return self._event_loop._loop
 
     def _is_background(self):
         return self._background

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -783,7 +783,7 @@ class depgraph:
                     ebuild_hash=ebuild_hash,
                     portdb=portdb,
                     repo_path=repo_path,
-                    settings=portdb.doebuild_settings,
+                    settings=settings,
                     deallocate_config=deallocate_config,
                 )
                 proc.addExitListener(self._dynamic_deps_proc_exit(pkg, fake_vartree))

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -775,7 +775,7 @@ class portdbapi(dbapi):
             try:
                 if (
                     threading.current_thread() is threading.main_thread()
-                    and loop is asyncio._safe_loop()
+                    and loop._loop is asyncio._safe_loop()._loop
                 ):
                     # In this case use self._doebuild_settings_lock to manage concurrency.
                     deallocate_config = loop.create_future()

--- a/lib/portage/tests/ebuild/test_doebuild_spawn.py
+++ b/lib/portage/tests/ebuild/test_doebuild_spawn.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2015 Gentoo Foundation
+# Copyright 2010-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import textwrap
@@ -86,6 +86,7 @@ class DoebuildSpawnTestCase(TestCase):
             open(os.path.join(settings["T"], "environment"), "wb").close()
 
             scheduler = SchedulerInterface(global_event_loop())
+            self.assertTrue(scheduler._loop is global_event_loop()._loop)
             for phase in ("_internal_test",):
                 # Test EbuildSpawnProcess by calling doebuild.spawn() with
                 # returnpid=False. This case is no longer used by portage

--- a/lib/portage/tests/ebuild/test_ipc_daemon.py
+++ b/lib/portage/tests/ebuild/test_ipc_daemon.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Gentoo Authors
+# Copyright 2010-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import tempfile
@@ -77,6 +77,7 @@ class IpcDaemonTestCase(TestCase):
                 task_scheduler = TaskScheduler(
                     iter([daemon, proc]), max_jobs=2, event_loop=event_loop
                 )
+                self.assertTrue(task_scheduler._loop is event_loop._loop)
 
                 self.received_command = False
 

--- a/lib/portage/util/_async/SchedulerInterface.py
+++ b/lib/portage/util/_async/SchedulerInterface.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2021 Gentoo Authors
+# Copyright 2012-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import gzip
@@ -48,6 +48,13 @@ class SchedulerInterface(SlotObject):
         self._is_background = is_background
         for k in self._event_loop_attrs:
             setattr(self, k, getattr(event_loop, k))
+
+    @property
+    def _loop(self):
+        """
+        Returns the real underlying asyncio loop.
+        """
+        return self._event_loop._loop
 
     @staticmethod
     def _return_false():


### PR DESCRIPTION
This allows async_aux_get to easily verify the identity of the underlying loop so that this assertion will not fail:
```
_start_with_metadata
	(settings.configdict["pkg"]["SRC_URI"],) = aux_get_task.future.result()
											   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/portage/dbapi/porttree.py", line 786, in async_aux_get
	raise AssertionError(
AssertionError: async_aux_get called from thread <_MainThread(MainThread, started 281473559502880)> with loop <_emerge.Scheduler.Scheduler._iface_class object at 0xffff8e3a8840>
Terminated
```
Fixes: 389bb304abf5 ("async_aux_get: Use EbuildMetadataPhase deallocate_config future")
Bug: https://bugs.gentoo.org/925333