### PR TITLE
Fix python 3.9 CI jobs since 92ff02b9189f

### DIFF
--- a/lib/portage/tests/emerge/conftest.py
+++ b/lib/portage/tests/emerge/conftest.py
@@ -805,7 +805,7 @@ def _generate_all_baseline_commands(playground, binhost):
         test_commands["binhost emerge"] = Noop()
     else:
         # The next emerge has been added to split this test from the rest:
-        make_package = Emerge("--buildpkg", "dev-libs/A")
+        make_package = Emerge("-e", "--buildpkg", "dev-libs/A")
         getbinpkgonly = Emerge(
             "-e",
             "--getbinpkgonly",


### PR DESCRIPTION
Use emerge -e to fix this error we've seen since
https://github.com/gentoo/portage/pull/1272 92ff02b9189f for python 3.9 CI jobs:

https://github.com/gentoo/portage/actions/runs/8014796128/job/21893963019
```
test_portage_baseline[binhost emerge-gpkg] - AssertionError: 'emerge' failed with args '('-e', '--getbinpkgonly', 'dev-libs/A')'
```
```
emerge: there are no binary packages to satisfy "dev-libs/B[flag]". (dependency required by "dev-libs/A-1::test_repo" [binary]) (dependency required by "dev-libs/A" [argument])
```
Fixes: 92ff02b9189f ("emerge: Skip installed packages with emptytree in depgraph selection")
Bug: https://bugs.gentoo.org/651018

Also see https://github.com/gentoo/portage/pull/1277.