### PR TITLE
test_baseline: Improve robustness with cleanup

### DIFF
--- a/lib/portage/tests/emerge/conftest.py
+++ b/lib/portage/tests/emerge/conftest.py
@@ -406,7 +406,7 @@ def async_loop():
     yield asyncio._wrap_loop()
 
 
-@pytest.fixture(params=SUPPORTED_GENTOO_BINPKG_FORMATS, scope="module")
+@pytest.fixture(params=SUPPORTED_GENTOO_BINPKG_FORMATS, scope="function")
 def playground(request, tmp_path_factory):
     """Fixture that provides instances of ``ResolverPlayground``
     each one with one supported value for ``BINPKG_FORMAT``."""


### PR DESCRIPTION
The baseline tests need to cleanup the ResolverPlayground after each testcase, with each different parametrization. This is ensured by making the scope of the playground fixture the function instead of the module. With module the cleanup only happens before/after the switch from/to xpak and gpkg.

Signed-off-by: Gábor Oszkár Dénes <gaboroszkar@protonmail.com>