### PR TITLE
Add workaround for loading libc on musl

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,8 +6,15 @@ Release notes take the form of the following optional categories:
 * Bug fixes
 * Cleanups
 
+portage-3.0.64 (UNRELEASED)
+--------------
+
+Bug fixes:
+
+
 portage-3.0.63 (2024-02-25)
 --------------
+* ctypes: Add workaround for loading libc on musl
 
 Bug fixes:
 * emerge: Skip installed packages with emptytree in depgraph selection (bug #651018).

--- a/lib/portage/dbapi/_MergeProcess.py
+++ b/lib/portage/dbapi/_MergeProcess.py
@@ -10,7 +10,7 @@ import fcntl
 import portage
 from portage import os, _unicode_decode
 from portage.package.ebuild._ipc.QueryCommand import QueryCommand
-from portage.util._ctypes import find_library
+from portage.util._ctypes import load_libc
 import portage.elog.messages
 from portage.util._async.ForkProcess import ForkProcess
 from portage.util import no_color
@@ -64,7 +64,7 @@ class MergeProcess(ForkProcess):
         # process, so that it's only done once rather than
         # for each child process.
         if platform.system() == "Linux" and "merge-sync" in settings.features:
-            find_library("c")
+            load_libc()
 
         # Inherit stdin by default, so that the pdb SIGUSR1
         # handler is usable for the subprocess.

--- a/lib/portage/dbapi/_SyncfsProcess.py
+++ b/lib/portage/dbapi/_SyncfsProcess.py
@@ -4,7 +4,7 @@
 import functools
 
 from portage import os
-from portage.util._ctypes import find_library, LoadLibrary
+from portage.util._ctypes import load_libc
 from portage.util._async.ForkProcess import ForkProcess
 
 
@@ -24,15 +24,9 @@ class SyncfsProcess(ForkProcess):
 
     @staticmethod
     def _get_syncfs():
-        filename = find_library("c")
-        if filename is not None:
-            library = LoadLibrary(filename)
-            if library is not None:
-                try:
-                    return library.syncfs
-                except AttributeError:
-                    pass
-
+        (libc, _) = load_libc()
+        if libc is not None:
+            return getattr(libc, "syncfs", None)
         return None
 
     @staticmethod

--- a/lib/portage/util/_ctypes.py
+++ b/lib/portage/util/_ctypes.py
@@ -48,3 +48,18 @@ def LoadLibrary(name):
         _library_handles[name] = handle
 
     return handle
+
+
+def load_libc():
+    """
+    Loads the C standard library, returns a tuple with the CDLL handle and
+    the filename. Returns (None, None) if unavailable.
+    """
+    filename = find_library("c")
+    if filename is None:
+        # find_library fails for musl where there is no soname
+        filename = "libc.so"
+    try:
+        return (LoadLibrary(filename), filename)
+    except OSError:
+        return (None, None)

--- a/lib/portage/util/locale.py
+++ b/lib/portage/util/locale.py
@@ -16,7 +16,7 @@ import traceback
 
 import portage
 from portage.util import _unicode_decode, writemsg_level
-from portage.util._ctypes import find_library, LoadLibrary
+from portage.util._ctypes import load_libc
 from portage.util.futures import asyncio
 
 
@@ -46,10 +46,7 @@ def _check_locale(silent):
     try:
         from portage.util import libc
     except ImportError:
-        libc_fn = find_library("c")
-        if libc_fn is None:
-            return None
-        libc = LoadLibrary(libc_fn)
+        (libc, _) = load_libc()
         if libc is None:
             return None
 


### PR DESCRIPTION
musl libc has no soname, which causes ctypes.util.find_library to fail. As a fallback, try to load "libc.so".