### PR TITLE
Scheduler: Support parallel-install with merge-wait

### DIFF
--- a/lib/_emerge/PackageMerge.py
+++ b/lib/_emerge/PackageMerge.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from _emerge.CompositeTask import CompositeTask
@@ -7,7 +7,7 @@ from portage.output import colorize
 
 
 class PackageMerge(CompositeTask):
-    __slots__ = ("merge", "postinst_failure")
+    __slots__ = ("is_system_pkg", "merge", "postinst_failure")
 
     def _should_show_status(self):
         return (

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -652,9 +652,12 @@ terminal to view parallel-fetch progress.
 .TP
 .B parallel\-install
 Use finer\-grained locks when installing packages, allowing for greater
-parallelism. Note that \fIparallel\-install\fR currently has no effect
-unless \fImerge\-wait\fR is disabled. For additional parallelism,
-disable \fIebuild\-locks\fR.
+parallelism. For additional parallelism disable \fIebuild\-locks\fR.
+Also disable \fImerge\-wait\fR for additional parallelism if desired,
+but that increases the possibility of random build failures. When
+\fIparallel\-install\fR is used together with \fImerge\-wait\fR,
+parallel installation occurs in batches when there are no builds
+running.
 .TP
 .B pid\-sandbox
 Isolate the process space for the ebuild processes. This makes it


### PR DESCRIPTION
For system packages, always serialize install regardless parallel-install, in order to mitigate failures triggered by fragile states as in bug 256616. For other packages, continue to populate self._task_queues.merge, which will serialize install unless parallel-install is enabled.

Fixes: 825db01b91a3 ("Add merge-wait FEATURES setting enabled by default")
Bug: https://bugs.gentoo.org/256616
Bug: https://bugs.gentoo.org/925213