### PR TITLE
doebuild: Call _setup_locale

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -43,6 +43,7 @@ portage.proxy.lazyimport.lazyimport(
     "portage.util._async.SchedulerInterface:SchedulerInterface",
     "portage.util._eventloop.global_event_loop:global_event_loop",
     "portage.util.ExtractKernelVersion:ExtractKernelVersion",
+    "_emerge.EbuildPhase:_setup_locale",
 )
 
 from portage import (
@@ -1033,6 +1034,13 @@ def doebuild(
         doebuild_environment(
             myebuild, mydo, myroot, mysettings, debug, use_cache, mydbapi
         )
+
+        # For returnproc or returnpid assume that the event loop is running
+        # so we can't run the event loop to call _setup_locale in this case
+        # and we have to assume the caller took care of it (otherwise
+        # config.environ() will raise AssertionError).
+        if not (returnproc or returnpid):
+            asyncio.run(_setup_locale(mysettings))
 
         if mydo in clean_phases:
             builddir_lock = None


### PR DESCRIPTION
Call _setup_locale in order to prevent an AssertionError from config.environ() for the config phase (or any other phase for that matter).

For returnproc or returnpid assume that the event loop is running so we can't run the event loop to call _setup_locale in this case and we have to assume the caller took care of it (otherwise config.environ() will raise AssertionError).

Update DoebuildFdPipesTestCase to use EAPI 8 and test the pkg_config function with an ebuild located in /var/db/pkg just like emerge --config does. Set LC_ALL=C just before doebuild calls in order to try and trigger the config.environ() split_LC_ALL assertion.

Bug: https://bugs.gentoo.org/925863