### PR TITLE
_validate_deps: Discard configdict["pkg"]["USE"]

### DIFF
--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -54,6 +54,7 @@ class ResolverPlayground:
             "make.conf",
             "modules",
             "package.accept_keywords",
+            "package.env",
             "package.keywords",
             "package.license",
             "package.mask",


### PR DESCRIPTION
Since configdict["pkg"]["USE"] may contain package.use settings from config.setcpv, it is inappropriate to use here (bug 675748), so discard it. This is only an issue because configdict["pkg"] is a sub-optimal place to extract metadata from. This issue does not necessarily indicate a flaw in the Package constructor, since passing in precalculated USE can be valid for things like autounmask USE changes.

Bug: https://bugs.gentoo.org/675748