### PR TITLE
socks5: Use run_coroutine_exitfuncs()

### DIFF
--- a/lib/portage/tests/util/test_socks5.py
+++ b/lib/portage/tests/util/test_socks5.py
@@ -216,10 +216,9 @@ class Socks5ServerTestCase(TestCase):
                 self.assertEqual(result, content)
         finally:
             try:
-                # Also run_exitfuncs to test atexit hook cleanup.
-                await socks5.proxy.stop()
+                # Also run_coroutine_exitfuncs to test atexit hook cleanup.
                 self.assertNotEqual(portage.process._exithandlers, [])
-                portage.process.run_exitfuncs()
+                await portage.process.run_coroutine_exitfuncs()
                 self.assertEqual(portage.process._exithandlers, [])
             finally:
                 portage.process._exithandlers = previous_exithandlers

--- a/lib/portage/util/_eventloop/asyncio_event_loop.py
+++ b/lib/portage/util/_eventloop/asyncio_event_loop.py
@@ -15,7 +15,6 @@ except ImportError:
     PidfdChildWatcher = None
 
 import portage
-from portage.util import socks5
 
 
 class AsyncioEventLoop(_AbstractEventLoop):
@@ -75,17 +74,6 @@ class AsyncioEventLoop(_AbstractEventLoop):
             self._closing = False
 
     async def _close_main(self):
-        # Even though this has an exit hook, invoke it here so that
-        # we can properly wait for it and avoid messages like this:
-        # [ERROR] Task was destroyed but it is pending!
-        if socks5.proxy.is_running():
-            # TODO: Convert socks5.proxy.stop() to a regular coroutine
-            # function so that it doesn't need to be wrapped like this.
-            async def stop_socks5_proxy():
-                await socks5.proxy.stop()
-
-            portage.process.atexit_register(stop_socks5_proxy)
-
         await portage.process.run_coroutine_exitfuncs()
         portage.process.run_exitfuncs()
 


### PR DESCRIPTION
Since commit c3ebdbb42e72 from https://github.com/gentoo/portage/pull/1295 the atexit_register(proxy.stop) call in the get_socks5_proxy function can accept a coroutine function to execute in run_coroutine_exitfuncs(), so convert the ProxyManager stop method to a coroutine and use run_coroutine_exitfuncs().

Bug: https://bugs.gentoo.org/925240