### PR TITLE
SpawnProcess: Optimize away null input for create_pipe=False

### DIFF
--- a/lib/portage/util/_async/ForkProcess.py
+++ b/lib/portage/util/_async/ForkProcess.py
@@ -91,11 +91,8 @@ class ForkProcess(SpawnProcess):
                     # When called via process.spawn, SpawnProcess
                     # will have created a pipe earlier, so it would be
                     # redundant to do it here (it could also trigger spawn
-                    # recursion via set_term_size as in bug 923750). Use
-                    # /dev/null for master_fd, triggering early return
-                    # of _main, followed by _async_waitpid.
-                    # TODO: Optimize away the need for master_fd here.
-                    master_fd = os.open(os.devnull, os.O_RDONLY)
+                    # recursion via set_term_size as in bug 923750).
+                    master_fd = None
                     slave_fd = None
 
                 self._files = self._files_dict(connection=connection, slave_fd=slave_fd)


### PR DESCRIPTION
When create_pipe=False support was added in commit e8b31c86eaed from https://github.com/gentoo/portage/pull/1253, a null input file descriptor was used for PipeLogger and BuildLogger instances. Optimize this away, eliminating the unnecessary loggers.

Fixes: e8b31c86eaed ("ForkProcess: Prevent redundant pipe and set_term_size recursion")
Bug: https://bugs.gentoo.org/916566