### PR TITLE
phase-functions: prematurely delete WORKDIR if FEATURES=merge-wait

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -723,6 +723,13 @@ __dyn_install() {
 		>> DEBUGBUILD
 	fi
 	trap - SIGINT SIGQUIT
+
+	# Prematurely delete WORKDIR in case merge-wait is enabled to
+	# decrease the space used by portage build directories until the
+	# packages are merged and cleaned.
+	if has merge-wait ${FEATURES} && ! has keepwork ${FEATURES}; then
+		rm -rf "${WORKDIR}"
+	fi
 }
 
 __dyn_help() {


### PR DESCRIPTION
Using the merge-wait feature together with many parallel emerge jobs potentially leads to a high disk space usage due to the created portage build directories waiting for their packages to be merged into the live filesystem prior portage will clean them. This can easily lead to out-of-space errors.

Prematurely deleting WORKDIR at the end of src_install() helps reducing the temporarily used disk space. All that portage need to merge a package into the live filesystem are the files in the image/ directory (D). (At least in theory)

