### PR TITLE
meson.build: Install dist-info METADATA

### DIFF
--- a/cnf/METADATA
+++ b/cnf/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: portage
+Version: @VERSION@

--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,20 @@ if native_extensions
     subdir('src')
 endif
 
+if system_wide
+	METADATA = configure_file(
+		input : 'cnf/METADATA',
+		output : 'METADATA',
+		configuration : conf_data
+	)
+	install_data(
+		[
+			METADATA
+		],
+		install_dir : py.get_install_dir() / 'portage-@0@.dist-info'.format(conf_data.get('VERSION'))
+	)
+endif
+
 test(
     'pytest',
     py,


### PR DESCRIPTION
Install dist-info METADATA for pip to resolve dependencies:
```console
# pip freeze | grep portage
portage==3.0.63
```
Suggested-by: Eli Schwartz <eschwartz93@gmail.com>
Bug: https://bugs.gentoo.org/920330