### PR TITLE
bin/ebuild: Discard merge-wait from FEATURES

### DIFF
--- a/bin/ebuild
+++ b/bin/ebuild
@@ -304,6 +304,10 @@ def main():
 
     tmpsettings.features.discard("fail-clean")
 
+    # We don't implement merge-wait for the ebuild command, so discard
+    # it from FEATURES. This prevents premature WORKDIR removal.
+    tmpsettings.features.discard("merge-wait")
+
     if "merge" in pargs and "noauto" in tmpsettings.features:
         print("Disabling noauto in features... merge disables it. (qmerge doesn't)")
         tmpsettings.features.discard("noauto")


### PR DESCRIPTION
We don't implement merge-wait for the ebuild command, so discard it from FEATURES. This prevents premature WORKDIR removal (see https://github.com/gentoo/portage/pull/1302#issuecomment-1989714617).

Fixes: 8eb2502bf264 from https://github.com/gentoo/portage/pull/1302 ("phase-functions: prematurely delete WORKDIR if FEATURES=merge-wait")