### PR TITLE
sync: don't use ipv6 for rsync when it's disabled

### DIFF
--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -631,8 +631,8 @@ def spawn(
         fd_pipes[1] = pw
         fd_pipes[2] = pw
 
-    # Cache _has_ipv6() result for use in child processes.
-    _has_ipv6()
+    # Cache has_ipv6() result for use in child processes.
+    has_ipv6()
 
     # This caches the libc library lookup and _unshare_validator results
     # in the current process, so that results are cached for use in
@@ -751,7 +751,7 @@ def spawn(
 __has_ipv6 = None
 
 
-def _has_ipv6():
+def has_ipv6():
     """
     Test that both userland and kernel support IPv6, by attempting
     to create a socket and listen on any unused port of the IPv6
@@ -812,7 +812,7 @@ def _configure_loopback_interface():
             ifindex = rtnl.get_link_ifindex(b"lo")
             rtnl.set_link_up(ifindex)
             rtnl.add_address(ifindex, socket.AF_INET, "10.0.0.1", 8)
-            if _has_ipv6():
+            if has_ipv6():
                 rtnl.add_address(ifindex, socket.AF_INET6, "fd::1", 8)
     except OSError as e:
         writemsg(

--- a/lib/portage/sync/modules/rsync/rsync.py
+++ b/lib/portage/sync/modules/rsync/rsync.py
@@ -18,6 +18,7 @@ from portage import _unicode_decode
 from portage import os
 from portage.const import VCS_DIRS, TIMESTAMP_FORMAT, RSYNC_PACKAGE_ATOM
 from portage.output import create_color_func, yellow, blue, bold
+from portage.process import has_ipv6
 from portage.sync.getaddrinfo_validate import getaddrinfo_validate
 from portage.sync.syncbase import NewBase
 from portage.util import writemsg, writemsg_level, writemsg_stdout
@@ -253,9 +254,7 @@ class RsyncSync(NewBase):
             family = socket.AF_UNSPEC
             if "-4" in all_rsync_opts or "--ipv4" in all_rsync_opts:
                 family = socket.AF_INET
-            elif socket.has_ipv6 and (
-                "-6" in all_rsync_opts or "--ipv6" in all_rsync_opts
-            ):
+            elif has_ipv6() and ("-6" in all_rsync_opts or "--ipv6" in all_rsync_opts):
                 family = socket.AF_INET6
 
             addrinfos = None
@@ -279,7 +278,7 @@ class RsyncSync(NewBase):
             if addrinfos:
                 AF_INET = socket.AF_INET
                 AF_INET6 = None
-                if socket.has_ipv6:
+                if has_ipv6():
                     AF_INET6 = socket.AF_INET6
 
                 ips_v4 = []

--- a/lib/portage/tests/process/test_unshare_net.py
+++ b/lib/portage/tests/process/test_unshare_net.py
@@ -42,7 +42,7 @@ class UnshareNetTestCase(TestCase):
                 f"Unable to unshare: {errno.errorcode.get(self.ABILITY_TO_UNSHARE, '?')}"
             )
         env = os.environ.copy()
-        env["IPV6"] = "1" if portage.process._has_ipv6() else ""
+        env["IPV6"] = "1" if portage.process.has_ipv6() else ""
         self.assertEqual(
             portage.process.spawn(
                 [BASH_BINARY, "-c", UNSHARE_NET_TEST_SCRIPT], unshare_net=True, env=env


### PR DESCRIPTION
socket.has_ipv6 gives a false result:

```sh
$ sysctl net.ipv6.conf.all.disable_ipv6=1
net.ipv6.conf.all.disable_ipv6 = 1
$ python
Python 3.11.8 (main, Feb 24 2024, 17:10:38) [GCC 13.2.1 20240210] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.has_ipv6
True
```

This patch uses the built-in _has_ipv6() function, which returns the correct result.

Bug: https://bugs.gentoo.org/927241