### PR TITLE
Reapply "config: Don't directly modify FEATURES"

### DIFF
--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -2206,7 +2206,9 @@ class config:
                 # "test" is in IUSE and USE=test is masked, so execution
                 # of src_test() probably is not reliable. Therefore,
                 # temporarily disable FEATURES=test just for this package.
-                self["FEATURES"] = " ".join(x for x in self.features if x != "test")
+                self["FEATURES"] = " ".join(
+                    x for x in sorted(self.features) if x != "test"
+                )
 
         # Allow _* flags from USE_EXPAND wildcards to pass through here.
         use.difference_update(


### PR DESCRIPTION
This change addresses the feedback from https://github.com/gentoo/portage/pull/1098#issuecomment-1761638611

As pointed out by @zmedico, It turns out we need to keep the open coded filter because otherwise we create a persistent copy.