### PR TITLE
BinpkgPrefetcher: Emit eerror message for binarytree inject failure

### DIFF
--- a/lib/_emerge/BinpkgPrefetcher.py
+++ b/lib/_emerge/BinpkgPrefetcher.py
@@ -7,7 +7,10 @@ import sys
 from _emerge.BinpkgFetcher import BinpkgFetcher
 from _emerge.CompositeTask import CompositeTask
 from _emerge.BinpkgVerifier import BinpkgVerifier
+import portage
 from portage import os
+from portage.elog import messages as elog_messages
+from portage.util import no_color
 
 
 class BinpkgPrefetcher(CompositeTask):
@@ -48,6 +51,7 @@ class BinpkgPrefetcher(CompositeTask):
             self.wait()
             return
 
+        injected_pkg = None
         stdout_orig = sys.stdout
         stderr_orig = sys.stderr
         out = io.StringIO()
@@ -67,12 +71,33 @@ class BinpkgPrefetcher(CompositeTask):
 
             output_value = out.getvalue()
             if output_value:
-                self.scheduler.output(
-                    output_value,
-                    log_path=self.scheduler.fetch.log_file,
-                    background=self.background,
-                )
+                if injected_pkg is None:
+                    msg = ["Binary package is not usable:"]
+                    msg.extend("\t" + line for line in output_value.splitlines())
+                    self._elog("eerror", msg)
+                else:
+                    self.scheduler.output(
+                        output_value,
+                        log_path=self.scheduler.fetch.log_file,
+                        background=self.background,
+                    )
 
         self._current_task = None
         self.returncode = 1 if injected_pkg is None else os.EX_OK
         self.wait()
+
+    def _elog(self, elog_funcname, lines, phase="other"):
+        out = io.StringIO()
+        elog_func = getattr(elog_messages, elog_funcname)
+        global_havecolor = portage.output.havecolor
+        try:
+            portage.output.havecolor = not no_color(self._bintree.settings)
+            for line in lines:
+                elog_func(line, phase=phase, key=self.pkg.cpv, out=out)
+        finally:
+            portage.output.havecolor = global_havecolor
+        msg = out.getvalue()
+        if msg:
+            self.scheduler.output(
+                msg, background=self.background, log_path=self.scheduler.fetch.log_file
+            )


### PR DESCRIPTION
Since it is confusing when emerge exits due to an error that only shows in the fetch log, emit an eerror message when binarytree inject fails:
```
>>> Running pre-merge checks for sys-libs/glibc-2.38-r10
 * Fetching in the background:
 * /var/cache/binpkgs/sys-libs/glibc/glibc-2.38-r10-5.gpkg.tar.partial
 * To view fetch progress, run in another terminal:
 * tail -f /var/log/emerge-fetch.log
>>> Failed to emerge sys-libs/glibc-2.38-r10

 * Messages for package sys-libs/glibc-2.38-r10:

 * Binary package is not usable:
 *      !!!
 *      gpg: keyblock resource '/etc/portage/gnupg/pubring.kbx': No such file or directory
 *     	[GNUPG:] ERROR add_keyblock_resource 33587281
 *     	[GNUPG:] PLAINTEXT 74 0
 *     	[GNUPG:] NEWSIG
 *     	gpg: Signature made Wed 20 Mar 2024 10:34:45 PM CET
 *     	gpg:                using RSA key 534E4209AB49EEE1C19D96162C44695DB9F6043D
 *     	[GNUPG:] ERROR keydb_search 33554445
 *     	[GNUPG:] ERROR keydb_search 33554445
 *     	[GNUPG:] ERRSIG 2C44695DB9F6043D 1 10 01 1710970485 9 534E4209AB49EEE1C19D96162C44695DB9F6043D
 *     	[GNUPG:] NO_PUBKEY 2C44695DB9F6043D
 *      !!! Invalid binary package: '/var/cache/binpkgs/sys-devel/binutils/binutils-2.41-r5-4.gpkg.tar.partial', GPG verify failed
```
Fixes: 0ff49114cec7 ("binarytree: Handle inject failures")
Bug: https://bugs.gentoo.org/927632