### PR TITLE
pylintrc: give fully qualified name to overgeneral-exceptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.0.0a7
+    rev: v3.1.0
     hooks:
       - id: pylint
         additional_dependencies:

--- a/pylintrc
+++ b/pylintrc
@@ -482,4 +482,4 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException
+overgeneral-exceptions=builtins.BaseException


### PR DESCRIPTION
* Ability to give unqualified names will be removed in pylint-3.1.0.

https://pylint.pycqa.org/en/latest/whatsnew/3/3.0/index.html#changes-requiring-user-actions
