### PR TITLE
Remove QA warning when no bash completions are found

### DIFF
--- a/bin/install-qa-check.d/60bash-completion
+++ b/bin/install-qa-check.d/60bash-completion
@@ -77,9 +77,6 @@ bashcomp_check() {
 			fi
 
 			if [[ -z ${completions[@]} ]]; then
-				qa_warnings+=(
-					"${f##*/}: does not define any completions (failed to source?)."
-				)
 				continue
 			fi
 


### PR DESCRIPTION
This triggers unwanted warnings in at least two known cases.

Bug: https://bugs.gentoo.org/928599
Bug: https://bugs.gentoo.org/928869