### PR TITLE
misc-functions.sh: Sort NEEDED and NEEDED.ELF.2

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -223,6 +223,12 @@ install_qa_check() {
 				echo "${obj} ${needed}"	>> "${PORTAGE_BUILDDIR}"/build-info/NEEDED
 				echo "${arch#EM_};${obj};${soname};${rpath};${needed}" >> "${PORTAGE_BUILDDIR}"/build-info/NEEDED.ELF.2
 			done <<< ${scanelf_output}
+
+			# scanelf's output ordering is non-deterministic.
+			local needed
+			for needed in "${PORTAGE_BUILDDIR}"/build-info/NEEDED{,.ELF.2}; do
+				LC_ALL=C sort -o "${needed}" "${needed}"
+			done
 		fi
 
 		[[ -n "${QA_SONAME_NO_SYMLINK}" ]] && \


### PR DESCRIPTION
I've noticed that scalelf doesn't produce deterministic output. This change adds a sort to the NEEDED and NEEDED.ELF.2 files to remove a source of non-determinism when building binpkgs.

This change was cherry picked from:
https://chromium-review.googlesource.com/c/chromiumos/third_party/portage_tool/+/4018820/2/bin/misc-functions.sh

Bug: https://bugs.gentoo.org/914441