### PR TITLE
Do not use shlex.split for CONFIG_PROTECT

### DIFF
--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -202,7 +202,7 @@ class dispatch:
         protect_obj = portage.util.ConfigProtect(
             config_root,
             config_paths,
-            portage.util.shlex_split(portage.settings.get("CONFIG_PROTECT_MASK", "")),
+            portage.settings.get("CONFIG_PROTECT_MASK", "").split(),
             case_insensitive=("case-insensitive-fs" in portage.settings.features),
         )
 
@@ -616,4 +616,4 @@ if len(sys.argv) > 1:
     # for testing
     d.grind(sys.argv[1:])
 else:
-    d.grind(portage.util.shlex_split(portage.settings.get("CONFIG_PROTECT", "")))
+    d.grind(portage.settings.get("CONFIG_PROTECT", "").split())

--- a/bin/portageq
+++ b/bin/portageq
@@ -410,8 +410,8 @@ try:
         from portage.util import ConfigProtect
 
         settings = portage.settings
-        protect = portage.util.shlex_split(settings.get("CONFIG_PROTECT", ""))
-        protect_mask = portage.util.shlex_split(settings.get("CONFIG_PROTECT_MASK", ""))
+        protect = settings.get("CONFIG_PROTECT", "").split()
+        protect_mask = settings.get("CONFIG_PROTECT_MASK", "").split()
         protect_obj = ConfigProtect(
             root,
             protect,
@@ -449,8 +449,8 @@ try:
         from portage.util import ConfigProtect
 
         settings = portage.settings
-        protect = portage.util.shlex_split(settings.get("CONFIG_PROTECT", ""))
-        protect_mask = portage.util.shlex_split(settings.get("CONFIG_PROTECT_MASK", ""))
+        protect = settings.get("CONFIG_PROTECT", "").split()
+        protect_mask = settings.get("CONFIG_PROTECT_MASK", "").split()
         protect_obj = ConfigProtect(
             root,
             protect,

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -55,7 +55,7 @@ from portage.package.ebuild.getmaskingstatus import _getmaskingstatus, _MaskReas
 from portage._sets import SETPREFIX
 from portage._sets.base import InternalPackageSet
 from portage.dep._slot_operator import evaluate_slot_operator_equal_deps
-from portage.util import ConfigProtect, shlex_split, new_protect_filename
+from portage.util import ConfigProtect, new_protect_filename
 from portage.util import cmp_sort_key, writemsg, writemsg_stdout
 from portage.util import ensure_dirs, normalize_path
 from portage.util import writemsg_level, write_atomic
@@ -10650,8 +10650,8 @@ class depgraph:
                 settings = self._frozen_config.roots[root].settings
                 protect_obj[root] = ConfigProtect(
                     settings["PORTAGE_CONFIGROOT"],
-                    shlex_split(settings.get("CONFIG_PROTECT", "")),
-                    shlex_split(settings.get("CONFIG_PROTECT_MASK", "")),
+                    settings.get("CONFIG_PROTECT", "").split(),
+                    settings.get("CONFIG_PROTECT_MASK", "").split(),
                     case_insensitive=("case-insensitive-fs" in settings.features),
                 )
 

--- a/lib/_emerge/post_emerge.py
+++ b/lib/_emerge/post_emerge.py
@@ -93,7 +93,7 @@ def post_emerge(myaction, myopts, myfiles, target_root, trees, mtimedb, retval):
     settings.regenerate()
     settings.lock()
 
-    config_protect = portage.util.shlex_split(settings.get("CONFIG_PROTECT", ""))
+    config_protect = settings.get("CONFIG_PROTECT", "").split()
     infodirs = settings.get("INFOPATH", "").split(":") + settings.get(
         "INFODIR", ""
     ).split(":")

--- a/lib/portage/_global_updates.py
+++ b/lib/portage/_global_updates.py
@@ -15,7 +15,7 @@ from portage.update import (
     update_config_files,
     update_dbentry,
 )
-from portage.util import grabfile, shlex_split, writemsg, writemsg_stdout, write_atomic
+from portage.util import grabfile, writemsg, writemsg_stdout, write_atomic
 
 
 def _global_updates(trees, prev_mtimes, quiet=False, if_mtime_changed=True):
@@ -227,8 +227,8 @@ def _do_global_updates(trees, prev_mtimes, quiet=False, if_mtime_changed=True):
 
         update_config_files(
             root,
-            shlex_split(mysettings.get("CONFIG_PROTECT", "")),
-            shlex_split(mysettings.get("CONFIG_PROTECT_MASK", "")),
+            mysettings.get("CONFIG_PROTECT", "").split(),
+            mysettings.get("CONFIG_PROTECT_MASK", "").split(),
             repo_map,
             match_callback=_config_repo_match,
             case_insensitive="case-insensitive-fs" in mysettings.features,

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -1863,8 +1863,8 @@ class dblink:
         if self._protect_obj is None:
             self._protect_obj = ConfigProtect(
                 self._eroot,
-                portage.util.shlex_split(self.settings.get("CONFIG_PROTECT", "")),
-                portage.util.shlex_split(self.settings.get("CONFIG_PROTECT_MASK", "")),
+                self.settings.get("CONFIG_PROTECT", "").split(),
+                self.settings.get("CONFIG_PROTECT_MASK", "").split(),
                 case_insensitive=("case-insensitive-fs" in self.settings.features),
             )
 
@@ -2142,8 +2142,8 @@ class dblink:
         if not include_config:
             confprot = ConfigProtect(
                 settings["EROOT"],
-                portage.util.shlex_split(settings.get("CONFIG_PROTECT", "")),
-                portage.util.shlex_split(settings.get("CONFIG_PROTECT_MASK", "")),
+                settings.get("CONFIG_PROTECT", "").split(),
+                settings.get("CONFIG_PROTECT_MASK", "").split(),
                 case_insensitive=("case-insensitive-fs" in settings.features),
             )
 

--- a/lib/portage/emaint/modules/sync/sync.py
+++ b/lib/portage/emaint/modules/sync/sync.py
@@ -298,9 +298,7 @@ class SyncRepos:
 
         chk_updated_cfg_files(
             self.emerge_config.target_config.root,
-            portage.util.shlex_split(
-                self.emerge_config.target_config.settings.get("CONFIG_PROTECT", "")
-            ),
+            self.emerge_config.target_config.settings.get("CONFIG_PROTECT", "").split(),
         )
 
         msgs = []


### PR DESCRIPTION
PMS says this is a whitespace-separated list, so we should not treat it as a shell expression.