### PR TITLE
Fix a depgraph crash with useoldpkg and subslot bumps

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -8177,6 +8177,7 @@ class depgraph:
                     ):
                         return pkg, existing_node
 
+            matched_oldpkg = [x for x in matched_oldpkg if x in matched_packages]
             visible_matches = []
             if matched_oldpkg:
                 visible_matches = [


### PR DESCRIPTION
This resolves a "list index out of range" error that could happen with when a package's subslot is bumped and --useoldpkg is used. (We countered this in a ChromeOS uprev.)

Due to the subslot bump, the code will filter matched_packages to only contain the latest version. However, this didn't update matched_oldpkg, which would now contain stale packages and cause logic errors.

Fix this by filtering matched_oldpkg again before its use.