### PR TITLE
install-qa-checks.d: suppress some gnulib implicit configure declarations

### DIFF
--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -49,6 +49,15 @@ add_default_skips() {
 		res_ndestroy
 		statacl
 	)
+
+	QA_CONFIG_IMPL_DECL_SKIP+=(
+		# Available in c23, these gnulib checks are expected to fail
+		alignof
+		static_assert
+		unreachable
+		# also gnulib, but checks both linux/non-linux headers
+		MIN
+	)
 }
 
 find_log_targets() {


### PR DESCRIPTION
These happen in tons of GNU packages because of using gnulib, which pulls in macros that check for some functionality and spit out an implicit function declaration error if they aren't supported, which is *expected*.