### PR TITLE
SchedulerInterface/PollScheduler: _loadavg_latency's unit is seconds

### DIFF
--- a/lib/_emerge/PollScheduler.py
+++ b/lib/_emerge/PollScheduler.py
@@ -11,7 +11,7 @@ from _emerge.getloadavg import getloadavg
 
 
 class PollScheduler:
-    # max time between loadavg checks (milliseconds)
+    # max time between loadavg checks (seconds)
     _loadavg_latency = None
 
     def __init__(self, main=False, event_loop=None):


### PR DESCRIPTION
The unit of _loadavg_latency is seconds, not milliseconds, as it is used as first argument to an eventloop's call_later() function.