### PR TITLE
install-qa-checks.d: suppress some gnulib implicit decls on musl

### DIFF
--- a/bin/install-qa-check.d/90config-impl-decl
+++ b/bin/install-qa-check.d/90config-impl-decl
@@ -58,6 +58,18 @@ add_default_skips() {
 		# also gnulib, but checks both linux/non-linux headers
 		MIN
 	)
+	if [[ ${CHOST} = *musl* ]]; then
+		QA_CONFIG_IMPL_DECL_SKIP+=(
+			# gnulib checks for functions that aren't available on musl.
+
+			# regex.m4 always emits these warnings, but they are noisy to fix
+			# and the check will correctly fail due to missing macros anyway.
+			re_set_syntax
+			re_compile_pattern
+			re_search
+			re_match
+		)
+	fi
 }
 
 find_log_targets() {


### PR DESCRIPTION
These happen in tons of GNU packages because of using gnulib's regex.m4 specifically, which pulls in a macro that checks for some functionality and spit out many implicit function declaration errors if regex.h isn't GNU's specifically.

The compile tests do fail either way, it's just very dirty in the logs.

Bug: https://bugs.gentoo.org/906027

Followup to 8256473c6a9fa93e7cf81c46fa920cd522507c21 / https://github.com/gentoo/portage/pull/1323