### PR TITLE
binrepos.conf: Support "frozen" attribute

### DIFF
--- a/lib/portage/binrepo/config.py
+++ b/lib/portage/binrepo/config.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from collections import OrderedDict
@@ -12,6 +12,7 @@ from portage.util.configparser import SafeConfigParser, ConfigParserError, read_
 
 class BinRepoConfig:
     __slots__ = (
+        "frozen",
         "name",
         "name_fallback",
         "fetchcommand",
@@ -19,6 +20,7 @@ class BinRepoConfig:
         "resumecommand",
         "sync_uri",
     )
+    _bool_opts = ("frozen",)
 
     def __init__(self, opts):
         """
@@ -26,6 +28,9 @@ class BinRepoConfig:
         """
         for k in self.__slots__:
             setattr(self, k, opts.get(k.replace("_", "-")))
+        for k in self._bool_opts:
+            if isinstance(getattr(self, k, None), str):
+                setattr(self, k, getattr(self, k).lower() in ("true", "yes"))
 
     def info_string(self):
         """
@@ -38,6 +43,8 @@ class BinRepoConfig:
         if self.priority is not None:
             repo_msg.append(indent + "priority: " + str(self.priority))
         repo_msg.append(indent + "sync-uri: " + self.sync_uri)
+        if self.frozen:
+            repo_msg.append(f"{indent}frozen: {str(self.frozen).lower()}")
         repo_msg.append("")
         return "\n".join(repo_msg)
 
@@ -48,6 +55,7 @@ class BinRepoConfigLoader(Mapping):
 
         # Defaults for value interpolation.
         parser_defaults = {
+            "frozen": "false",
             "EPREFIX": settings["EPREFIX"],
             "EROOT": settings["EROOT"],
             "PORTAGE_CONFIGROOT": settings["PORTAGE_CONFIGROOT"],

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1408,7 +1408,7 @@ class binarytree:
                 url = base_url.rstrip("/") + "/Packages"
                 f = None
 
-                if not getbinpkg_refresh and local_timestamp:
+                if local_timestamp and (repo.frozen or not getbinpkg_refresh):
                     raise UseCachedCopyOfRemoteIndex()
 
                 try:
@@ -1566,11 +1566,12 @@ class binarytree:
                             noiselevel=-1,
                         )
             except UseCachedCopyOfRemoteIndex:
+                desc = "frozen" if repo.frozen else "up-to-date"
                 writemsg_stdout("\n")
                 writemsg_stdout(
                     colorize(
                         "GOOD",
-                        _("Local copy of remote index is up-to-date and will be used."),
+                        _("Local copy of remote index is %s and will be used.") % desc,
                     )
                     + "\n"
                 )

--- a/man/portage.5
+++ b/man/portage.5
@@ -1,4 +1,4 @@
-.TH "PORTAGE" "5" "Apr 2023" "Portage @VERSION@" "Portage"
+.TH "PORTAGE" "5" "May 2024" "Portage @VERSION@" "Portage"
 .SH NAME
 portage \- the heart of Gentoo
 .SH "DESCRIPTION"
@@ -641,6 +641,12 @@ is intended to be used as a replacement for the \fBmake.conf\fR(5)
 .RS
 .I Attributes supported in DEFAULT section:
 .RS
+.TP
+.B frozen = yes|no|true|false
+Use the most recently cached copy of the remote index, and do not
+attempt to refresh it. This should only be set temporarily in order to
+guarantee consistent and reproducible dependency calculations (for
+mixed binary and source updates).
 .TP
 .B fetchcommand
 Specifies a \fBFETCHCOMMAND\fR used to fetch files from a repository,


### PR DESCRIPTION
In order to allow consistent and reproducible dependency calculations during mixed source and binary updates, add a "frozen" binrepos.conf attribute which will freeze binrepo index updates and cause messsages to indicate that the repo is frozen rather than up-to-date:

    Local copy of remote index is frozen and will be used.

This should only be set temporarily in order to guarantee consistent and reproducible dependency calculations for mixed binary and source updates.

Bug: https://bugs.gentoo.org/932739