### PR TITLE
eapi.sh: Drop ___eapi_has_dohtml_deprecated()

### DIFF
--- a/bin/eapi.sh
+++ b/bin/eapi.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2012-2023 Gentoo Authors
+# Copyright 2012-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # PHASES
@@ -78,10 +78,6 @@ ___eapi_has_einstall() {
 
 ___eapi_has_dohtml() {
 	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-slot-abi|5|6)$ ]]
-}
-
-___eapi_has_dohtml_deprecated() {
-	[[ ${1-${EAPI-0}} == 6 ]]
 }
 
 ___eapi_has_dolib_libopts() {

--- a/bin/ebuild-helpers/dohtml
+++ b/bin/ebuild-helpers/dohtml
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2009-2018 Gentoo Foundation
+# Copyright 2009-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
@@ -7,10 +7,6 @@ source "${PORTAGE_BIN_PATH}"/isolated-functions.sh || exit 1
 if ! ___eapi_has_dohtml; then
 	die "'${0##*/}' has been banned for EAPI '${EAPI}'"
 	exit 1
-fi
-
-if ___eapi_has_dohtml_deprecated; then
-	eqawarn "QA Notice: '${0##*/}' is deprecated in EAPI '${EAPI}'"
 fi
 
 # Use safe cwd, avoiding unsafe import for bug #469338.


### PR DESCRIPTION
This was added because of a council decision 10 years ago: https://projects.gentoo.org/council/meeting-logs/20140909-summary.txt

It has outlived its usefulness since dohtml is banned in EAPI 7 and later.