### PR TITLE
emerge.1: Fix /var/log/emerge.log description

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1520,8 +1520,8 @@ Contains the default variables for the build process.  \fBDo not edit
 this file\fR.
 .TP
 .B /var/log/emerge.log
-Contains a log of all emerge output. This file is always appended to, so if you
-want to clean it, you need to do so manually.
+Contains a log of merged packages and invocations of \fBemerge\fR.  This file
+is always appended to, so if you want to clean it, you need to do so manually.
 .TP
 .B /var/log/emerge-fetch.log
 Contains a log of all the fetches in the previous emerge invocation.


### PR DESCRIPTION
/var/log/emerge.log doesn't "[contain] a log of all emerge output". This commit changes this description to better reflect what emerge.log contains:

- Packages that were built
- emerge's invocation (i.e. its command-line arguments)

I tried to keep it brief in honor of the other files' explanations.

For your reference, here's a snippet of my emerge.log:

```
1716721961: Started emerge on: May 26, 2024 13:12:40
1716721961:  *** emerge --oneshot --regex-search-auto=y hashcat
1716721964:  >>> emerge (1 of 1) app-crypt/hashcat-6.2.6-r1 to /
1716721964:  === (1 of 1) Cleaning (app-crypt/hashcat-6.2.6-r1::/var/db/repos/gentoo/app-crypt/hashcat/hashcat-6.2.6-r1.ebuild)
1716721964:  === (1 of 1) Compiling/Merging (app-crypt/hashcat-6.2.6-r1::/var/db/repos/gentoo/app-crypt/hashcat/hashcat-6.2.6-r1.ebuild)
1716722262:  === (1 of 1) Merging (app-crypt/hashcat-6.2.6-r1::/var/db/repos/gentoo/app-crypt/hashcat/hashcat-6.2.6-r1.ebuild)
1716722266:  >>> AUTOCLEAN: app-crypt/hashcat:0
1716722266:  === Unmerging... (app-crypt/hashcat-6.2.6-r1)
1716722268:  >>> unmerge success: app-crypt/hashcat-6.2.6-r1
1716722270:  === (1 of 1) Post-Build Cleaning (app-crypt/hashcat-6.2.6-r1::/var/db/repos/gentoo/app-crypt/hashcat/hashcat-6.2.6-r1.ebuild)
1716722270:  ::: completed emerge (1 of 1) app-crypt/hashcat-6.2.6-r1 to /
1716722270:  *** Finished. Cleaning up...
1716722270:  *** exiting successfully.
1716722270:  *** terminating.
```