### PR TITLE
tar_stream_writer: Add missing error attribute

### DIFF
--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -100,6 +100,7 @@ class tar_stream_writer:
         self.closed = False
         self.container = container
         self.killed = False
+        self.error = False
         self.tar_format = tar_format
         self.tarinfo = tarinfo
         self.uid = uid


### PR DESCRIPTION
This attribute was previously initialized only
in an exception handler.

Fixes: b8c3f38ec5ee ("Add more error handling for binpkgs")
Bug: https://bugs.gentoo.org/933385