### PR TITLE
tar_safe_extract: Use tarfile.fully_trusted_filter

### DIFF
--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -628,6 +628,15 @@ class tar_safe_extract:
         if self.closed:
             raise OSError("Tar file is closed.")
         temp_dir = tempfile.TemporaryDirectory(dir=dest_dir)
+        # The below tar member security checks can be refactored as a filter function
+        # that raises an exception. Use tarfile.fully_trusted_filter for now, which
+        # is simply an identity function:
+        # def fully_trusted_filter(member, dest_path):
+        #     return member
+        try:
+            self.tar.extraction_filter = tarfile.fully_trusted_filter
+        except AttributeError:
+            pass
         try:
             while True:
                 member = self.tar.next()


### PR DESCRIPTION
This suppresses a DeprecationWarning triggered because the tarfile.data_filter will become the new default in python3.14. The fully_trusted filter should be suitable here because tar_safe_extract already performs security validation on tar members prior to extraction.

Bug: https://bugs.gentoo.org/933433

@syu-nya 