### PR TITLE
bin/ebuild.sh: disable globskipdots in Bash 5.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,12 @@ Features:
   as well as / for all EAPIs rather than instead of / for EAPI 6 and below
   (bug #435066).
 
+Bug fixes:
+* ebuild: Handle Bash 5.2's change in behavior which enables the shopt
+  'globskipdots' by default. This is needed to avoid breaking existing
+  working ebuilds. Future EAPIs will need to adjust the logic
+  added by this change. See bug #907061.
+
 portage-3.0.65 (2024-06-04)
 --------------
 

--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -18,7 +18,7 @@ source "${PORTAGE_BIN_PATH}/isolated-functions.sh" || exit 1
 # used instead.
 __check_bash_version() {
 	# Figure out which min version of bash we require.
-	# Adjust patsub_replacement logic below on new EAPI!
+	# Adjust patsub_replacement/globskipdots logic below on new EAPI!
 	local maj min
 	if ___eapi_bash_3_2 ; then
 		maj=3 min=2
@@ -52,16 +52,16 @@ __check_bash_version() {
 		shopt -s compat32
 	fi
 
-	# patsub_replacement is a new option in bash-5.2 that is also default-on
+	# patsub_replacement and globskipdots are new options in bash-5.2 that are also default-on
 	# in that release. The default value is not gated by BASH_COMPAT (see bug #881383),
 	# hence we need to disable it for older Bashes to avoid behaviour changes in ebuilds
 	# and eclasses.
 	#
 	# New EAPI note: a newer EAPI (after 8) may well adopt Bash 5.2 as its minimum version.
 	# If it does, this logic will need to be adjusted to only disable patsub_replacement
-	# for < ${new_api}!
+	# and globskipdots for < ${new_api}!
 	if (( BASH_VERSINFO[0] >= 6 || ( BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 2 ) )) ; then
-		shopt -u patsub_replacement
+		shopt -u patsub_replacement globskipdots
 	fi
 
 }


### PR DESCRIPTION
See 69cac73ba0a7bcf2e2cff88c60d389895a550623.

globskipdots is a new option in bash-5.2 that is also default-on in that release. The default value is not gated by BASH_COMPAT (see bug #907061), hence we need to disable it for older Bashes to avoid behaviour changes in ebuilds and eclasses.

Bug: https://bugs.gentoo.org/907061