### PR TITLE
make.globals: add bcachefs_effective.* and bcachefs.* to PORTAGE_XATTR_EXCLUDE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ Bug fixes:
   working ebuilds. Future EAPIs will need to adjust the logic
   added by this change. See bug #907061.
 
+* make.globals: add bcachefs_effective.* and bcachefs.* to PORTAGE_XATTR_EXCLUDE
+
 * vartree, movefile: Warn when rewriting a symlink (bug #934514).
 
 * repository: config: Allow a repository to be configured using one of its

--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -159,7 +159,8 @@ PORTAGE_TRUST_HELPER="/usr/bin/getuto"
 # system.nfs4_acl attributes are irrelevant, see bug #475496.
 # user.* attributes are not supported on tmpfs (bug 640290), but
 # user.pax.* is supported with the patch from bug 470644.
-PORTAGE_XATTR_EXCLUDE="btrfs.* security.evm security.ima
+PORTAGE_XATTR_EXCLUDE="bcachefs.* bcachefs_effective.*
+	btrfs.* security.evm security.ima
 	security.selinux system.nfs4_acl user.apache_handler
 	user.Beagle.* user.dublincore.* user.mime_encoding user.xdg.*"
 


### PR DESCRIPTION
Just like btrfs the bcachefs filesystem makes heaviy use of xattrs.

In my case

emerge --config gentoo-kernel failed with

install-xattr: setxattr() failed: Operation not supported

a strace revealed

setxattr("/boot/efi/8410476acd4b1e12c678fc815c18f551/6.9.5-gentoo-dist/linux", "bcachefs_effective.background_co"..., "zstd", 4, 0) = -1 EOPNOTSUPP (Operation not supported)

and indeed, the source file to the install operation was under /usr/src which had background compression enabled. As a result, install-xattr tried to copy the attribute over to the destination file and failed.