### PR TITLE
JobStatusDisplay: show length of merge-wait queue

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Features:
 * emerge: Make bare --root-deps option install build-time dependencies to ROOT
   as well as / for all EAPIs rather than instead of / for EAPI 6 and below
   (bug #435066).
+* Show length of merge-wait queue as part of the status display
 
 Bug fixes:
 * ebuild: Handle Bash 5.2's change in behavior which enables the shopt

--- a/lib/_emerge/JobStatusDisplay.py
+++ b/lib/_emerge/JobStatusDisplay.py
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import io
@@ -38,6 +38,7 @@ class JobStatusDisplay:
         object.__setattr__(self, "quiet", quiet)
         object.__setattr__(self, "xterm_titles", xterm_titles)
         object.__setattr__(self, "maxval", 0)
+        object.__setattr__(self, "merge_wait", 0)
         object.__setattr__(self, "merges", 0)
         object.__setattr__(self, "_changed", False)
         object.__setattr__(self, "_displayed", False)
@@ -261,6 +262,13 @@ class JobStatusDisplay:
             f.add_literal_data(failed_str)
             f.pop_style()
             f.add_literal_data(" failed")
+
+        if self.merge_wait:
+            f.add_literal_data(", ")
+            f.push_style(number_style)
+            f.add_literal_data(f"{self.merge_wait}")
+            f.pop_style()
+            f.add_literal_data(" merge wait")
 
         padding = self._jobs_column_width - len(plain_output.getvalue())
         if padding > 0:

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -1557,6 +1557,7 @@ class Scheduler(PollScheduler):
             self._deallocate_config(build.settings)
         self._jobs -= 1
         self._status_display.running = self._jobs
+        self._status_display.merge_wait = len(self._merge_wait_queue)
         self._schedule()
 
     def _extract_exit(self, build):
@@ -1833,6 +1834,8 @@ class Scheduler(PollScheduler):
                     # serialize install unless parallel-install is enabled.
                     if task.is_system_pkg:
                         break
+
+                self._status_display.merge_wait = len(self._merge_wait_queue)
 
             if self._schedule_tasks_imp():
                 state_change += 1


### PR DESCRIPTION
Since FEATURES=merge-wait is now the default, the length of the merge-wait queue becomes more relevant. Hence show it as part of portage's job status display.