### PR TITLE
JobStatusDisplay: increase the default width to 100

### DIFF
--- a/lib/_emerge/JobStatusDisplay.py
+++ b/lib/_emerge/JobStatusDisplay.py
@@ -64,7 +64,7 @@ class JobStatusDisplay:
         if self._isatty:
             width = portage.output.get_term_size()[1]
         else:
-            width = 80
+            width = 100
         self._set_width(width)
 
     def _set_width(self, width):


### PR DESCRIPTION
Conservatively modernize the default width value from 80 to
100. Usually, I do not care much about the width, but the job status display holds more information these days, compared to the times where this value was set.

Plus, self._isatty has the tendency to return false, even though portage is actually run within a tty. The prime examples causing this are systemd-run (and run0). Therefore, a conservatively increasing the value is sensible.