### PR TITLE
vartree, movefile: Warn when rewriting a symlink

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ Bug fixes:
   working ebuilds. Future EAPIs will need to adjust the logic
   added by this change. See bug #907061.
 
+* vartree, movefile: Warn when rewriting a symlink (bug #934514).
+
 portage-3.0.65 (2024-06-04)
 --------------
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -5563,6 +5563,16 @@ class dblink:
                 myabsto = myabsto.lstrip(sep)
                 if self.settings and self.settings["D"]:
                     if myto.startswith(self.settings["D"]):
+                        self._eqawarn(
+                            "preinst",
+                            [
+                                _(
+                                    "QA Notice: Absolute symlink %s points to %s inside the image directory.\n"
+                                    "Removing the leading %s from its path."
+                                )
+                                % (mydest, myto, self.settings["D"])
+                            ],
+                        )
                         myto = myto[len(self.settings["D"]) - 1 :]
                 # myrealto contains the path of the real file to which this symlink points.
                 # we can simply test for existence of this file to see if the target has been merged yet

--- a/lib/portage/util/movefile.py
+++ b/lib/portage/util/movefile.py
@@ -210,6 +210,11 @@ def movefile(
         try:
             target = os.readlink(src)
             if mysettings and "D" in mysettings and target.startswith(mysettings["D"]):
+                writemsg(
+                    f"!!! {_('Absolute symlink points to image directory.')}\n",
+                    noiselevel=-1,
+                )
+                writemsg(f"!!! {dest} -> {target}\n", noiselevel=-1)
                 target = target[len(mysettings["D"]) - 1 :]
             # Atomically update the path if it exists.
             try:


### PR DESCRIPTION
See PMS section 13.4.1 (Rewriting):
Any absolute symlink whose link starts with D must be rewritten with the leading D removed. The package manager should issue a notice when doing this.

Bug: https://bugs.gentoo.org/934514