### PR TITLE
Cast _download_suffix to str before concatenation

### DIFF
--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -1009,7 +1009,7 @@ class portdbapi(dbapi):
 
             if mystat is None:
                 try:
-                    mystat = os.stat(file_path + _download_suffix)
+                    mystat = os.stat(file_path + str(_download_suffix))
                 except OSError:
                     pass
 


### PR DESCRIPTION
If the `_download_suffix` was not loaded before, the concatenate operation will fail with `TypError` exception:

```
Traceback (most recent call last):
  File "/tmp/main.py", line 90, in <module>
    depgraph.display_problems()
  File "/home/arkq/.local/lib/python3.10/site-packages/_emerge/depgraph.py", line 10756, in display_problems
    self._show_circular_deps(self._dynamic_config._circular_deps_for_display)
  File "/home/arkq/.local/lib/python3.10/site-packages/_emerge/depgraph.py", line 10075, in _show_circular_deps
    self.display(handler.merge_list)
  File "/home/arkq/.local/lib/python3.10/site-packages/_emerge/depgraph.py", line 10263, in display
    return display(self, mylist, favorites, verbosity)
  File "/home/arkq/.local/lib/python3.10/site-packages/_emerge/resolver/output.py", line 863, in __call__
    self.verbose_size(pkg, None, pkg_info)
  File "/home/arkq/.local/lib/python3.10/site-packages/_emerge/resolver/output.py", line 318, in verbose_size
    myfilesdict = db.getfetchsizes(pkg.cpv, **kwargs)
  File "/home/arkq/.local/lib/python3.10/site-packages/portage/dbapi/porttree.py", line 1012, in getfetchsizes
    mystat = os.stat(file_path + _download_suffix)
TypeError: can only concatenate str (not "_LazyImportFrom") to str
```