### PR TITLE
config: Allow a repository to be configured using one of its aliases

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,9 @@ Bug fixes:
 
 * vartree, movefile: Warn when rewriting a symlink (bug #934514).
 
+* repository: config: Allow a repository to be configured using one of its
+  aliases rather than its primary name.
+
 portage-3.0.65 (2024-06-04)
 --------------
 

--- a/lib/portage/repository/config.py
+++ b/lib/portage/repository/config.py
@@ -943,7 +943,9 @@ class RepoConfigLoader:
                         del prepos[repo_name]
                         continue
 
-                    if repo.name != repo_name:
+                    if repo.name != repo_name and (
+                        repo.aliases is None or repo_name not in repo.aliases
+                    ):
                         writemsg_level(
                             "!!! %s\n"
                             % _(
@@ -957,13 +959,13 @@ class RepoConfigLoader:
                         del prepos[repo_name]
                         continue
 
-                location_map[repo.location] = repo_name
-                treemap[repo_name] = repo.location
+                location_map[repo.location] = repo.name
+                treemap[repo.name] = repo.location
 
         # Add alias mappings, but never replace unaliased mappings.
         for repo_name, repo in list(prepos.items()):
             names = set()
-            names.add(repo_name)
+            names.add(repo.name)
             if repo.aliases:
                 aliases = stack_lists([repo.aliases], incremental=True)
                 names.update(aliases)


### PR DESCRIPTION
Currently, the `[name]` in repos.conf can only match the primary name. This is inconvenient if a repository wants to change its name without breaking existing configurations.

This raises the question of whether to then use the primary name or the alias in the UI and in the vardb. I went with the primary name because this is presumably the name that the repository actually wants you to use.

If the configured name matches neither the primary name nor an alias, then emaint sync will simply claim that it is not found, but that behaviour is unchanged from before.