### PR TITLE
ebuild: try to make maintainer mode checks a bit less prone to FP

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -2383,7 +2383,7 @@ def _check_build_log(mysettings, out=None):
     # Configuration:
     #  Automake:                   ${SHELL} /var/tmp/portage/dev-libs/yaz-3.0.47/work/yaz-3.0.47/config/missing --run automake-1.10
     am_maintainer_mode_re = re.compile(
-        r"/missing( --run|'|) (automake|autoconf|autoheader|aclocal)"
+        r"\bcd\b.*&&.*/missing( --run|'|) (automake|autoconf|autoheader|aclocal)"
     )
     am_maintainer_mode_exclude_re = re.compile(r"^\s*Automake:\s")
 


### PR DESCRIPTION
We sometimes get weird results. For example, in binutils/gdb, we get:

```
 * QA Notice: Automake "maintainer mode" detected:
 *
 * 	checking for aclocal... ${SHELL} /var/tmp/portage/dev-debug/gdb-15.1/work/gdb-15.1/missing aclocal-1.15
 * 	checking for autoconf... ${SHELL} /var/tmp/portage/dev-debug/gdb-15.1/work/gdb-15.1/missing autoconf
 * 	checking for autoheader... ${SHELL} /var/tmp/portage/dev-debug/gdb-15.1/work/gdb-15.1/missing autoheader
 * 	checking for aclocal... ${SHELL} /var/tmp/portage/dev-debug/gdb-15.1/work/gdb-15.1/missing aclocal-1.15
 * 	checking for autoconf... ${SHELL} /var/tmp/portage/dev-debug/gdb-15.1/work/gdb-15.1/missing autoconf
 * 	checking for autoheader... ${SHELL} /var/tmp/portage/dev-debug/gdb-15.1/work/gdb-15.1/missing autoheader
 ```

The current pattern looks for the definition of the "missing" script followed by known autotools commands. With a bit more effort, we can hopefully match the actual `make` commands that get produced as maintainer targets. As far as I can tell, they always include an attempt to cd to the project root and then run the maintainer target.