### PR TITLE
_EbuildFetcherProcess: Handle SIGTERM

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,9 @@ Bug fixes:
 * repository: config: Allow a repository to be configured using one of its
   aliases rather than its primary name (bug #935830).
 
+* emerge: Fix parallel-fetch to properly terminate FETCOMMAND processes when
+  needed, using a SIGTERM handler (bug #936273).
+
 portage-3.0.65 (2024-06-04)
 --------------
 

--- a/lib/_emerge/EbuildFetcher.py
+++ b/lib/_emerge/EbuildFetcher.py
@@ -4,6 +4,8 @@
 import copy
 import functools
 import io
+import multiprocessing
+import signal
 import sys
 
 import portage
@@ -17,11 +19,12 @@ from portage.package.ebuild.fetch import (
     _check_distfile,
     _drop_privs_userfetch,
     _want_userfetch,
-    fetch,
+    async_fetch,
 )
 from portage.util._async.AsyncTaskFuture import AsyncTaskFuture
 from portage.util._async.ForkProcess import ForkProcess
 from portage.util._pty import _create_pty_or_pipe
+from portage.util.futures import asyncio
 from _emerge.CompositeTask import CompositeTask
 
 
@@ -34,6 +37,7 @@ class EbuildFetcher(CompositeTask):
         "logfile",
         "pkg",
         "prefetch",
+        "pre_exec",
         "_fetcher_proc",
     )
 
@@ -253,6 +257,7 @@ class _EbuildFetcherProcess(ForkProcess):
             self._get_manifest(),
             self._uri_map,
             self.fetchonly,
+            self.pre_exec,
         )
         ForkProcess._start(self)
 
@@ -263,7 +268,10 @@ class _EbuildFetcherProcess(ForkProcess):
         self._settings = None
 
     @staticmethod
-    def _target(settings, manifest, uri_map, fetchonly):
+    def _target(settings, manifest, uri_map, fetchonly, pre_exec):
+        if pre_exec is not None:
+            pre_exec()
+
         # Force consistent color output, in case we are capturing fetch
         # output through a normal pipe due to unavailability of ptys.
         portage.output.havecolor = settings.get("NOCOLOR") not in ("yes", "true")
@@ -273,17 +281,53 @@ class _EbuildFetcherProcess(ForkProcess):
         if _want_userfetch(settings):
             _drop_privs_userfetch(settings)
 
-        rval = 1
         allow_missing = manifest.allow_missing or "digest" in settings.features
-        if fetch(
-            uri_map,
-            settings,
-            fetchonly=fetchonly,
-            digests=copy.deepcopy(manifest.getTypeDigests("DIST")),
-            allow_missing_digests=allow_missing,
-        ):
-            rval = os.EX_OK
-        return rval
+
+        async def main():
+            loop = asyncio.get_event_loop()
+            task = asyncio.ensure_future(
+                async_fetch(
+                    uri_map,
+                    settings,
+                    fetchonly=fetchonly,
+                    digests=copy.deepcopy(manifest.getTypeDigests("DIST")),
+                    allow_missing_digests=allow_missing,
+                )
+            )
+
+            def sigterm_handler(signum, _frame):
+                loop.call_soon_threadsafe(task.cancel)
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+            signal.signal(signal.SIGTERM, sigterm_handler)
+            try:
+                await task
+            except asyncio.CancelledError:
+                # If asyncio.CancelledError arrives too soon after fork/spawn
+                # then handers will not have an opportunity to terminate
+                # the corresponding process, so clean up after this race.
+                for proc in multiprocessing.active_children():
+                    proc.terminate()
+
+                # Use a non-zero timeout only for the first join because
+                # later joins are delayed by the first join.
+                timeout = 0.25
+                for proc in multiprocessing.active_children():
+                    proc.join(timeout)
+                    timeout = 0
+
+                for proc in multiprocessing.active_children():
+                    proc.kill()
+                    # Wait upon the process in order to ensure that its
+                    # pid will trigger ProcessLookupError for tests.
+                    proc.join()
+
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
+                os.kill(os.getpid(), signal.SIGTERM)
+
+            return os.EX_OK if task.result() else 1
+
+        return asyncio.run(main())
 
     def _get_ebuild_path(self):
         if self.ebuild_path is not None:

--- a/lib/portage/tests/ebuild/test_fetch.py
+++ b/lib/portage/tests/ebuild/test_fetch.py
@@ -1,9 +1,11 @@
-# Copyright 2019-2023 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import functools
 import io
+import multiprocessing
 import shlex
+import signal
 import tempfile
 import types
 
@@ -36,6 +38,85 @@ from _emerge.Package import Package
 
 
 class EbuildFetchTestCase(TestCase):
+
+    async def _test_interrupt(self, loop, server, async_fetch, pkg, ebuild_path):
+        """Test interrupt, with server responses temporarily paused."""
+        server.pause()
+        pr, pw = multiprocessing.Pipe(duplex=False)
+        timeout = loop.create_future()
+        loop.add_reader(pr.fileno(), lambda: timeout.done() or timeout.set_result(None))
+        self.assertEqual(
+            await async_fetch(
+                pkg,
+                ebuild_path,
+                timeout=timeout,
+                pre_exec=functools.partial(self._pre_exec_interrupt_patch, pw),
+            ),
+            -signal.SIGTERM,
+        )
+        loop.remove_reader(pr.fileno())
+        pw.close()
+
+        # Read pid written by _async_spawn_fetch_pre_wait hook (the
+        # corresponding write served to trigger the timeout above).
+        pid = pr.recv()
+
+        # Read pid written by _async_spawn_fetch_post_terminate hook,
+        # in order to know when the ProcessLookupError test should
+        # succeed.
+        pid = pr.recv()
+        pr.close()
+
+        # Poll the process table until the pid has disappeared,
+        # and fail if a short timeout expires.
+        tries = 10
+        while tries:
+            tries -= 1
+
+            msg = None
+            if tries <= 0:
+                try:
+                    with open(f"/proc/{pid}/status") as f:
+                        for line in f:
+                            if line.startswith("State:"):
+                                msg = line
+                                break
+                except OSError:
+                    pass
+
+            try:
+                with self.assertRaises(ProcessLookupError, msg=msg):
+                    os.kill(pid, 0)
+            except Exception:
+                if tries <= 0:
+                    raise
+                await asyncio.sleep(0.1)
+            else:
+                break
+
+        server.resume()
+
+    @staticmethod
+    def _pre_exec_interrupt_patch(pw):
+        portage.package.ebuild.fetch._async_spawn_fetch_pre_wait = functools.partial(
+            EbuildFetchTestCase._fetch_pre_wait,
+            pw,
+        )
+        portage.package.ebuild.fetch._async_spawn_fetch_post_terminate = (
+            functools.partial(
+                EbuildFetchTestCase._fetch_post_terminate,
+                pw,
+            )
+        )
+
+    @staticmethod
+    def _fetch_pre_wait(pw, proc):
+        pw.send(proc.pid)
+
+    @staticmethod
+    def _fetch_post_terminate(pw, proc):
+        pw.send(proc.pid)
+
     def testEbuildFetch(self):
         user_config = {
             "make.conf": ('GENTOO_MIRRORS="{scheme}://{host}:{port}"',),
@@ -338,7 +419,7 @@ class EbuildFetchTestCase(TestCase):
 
             config_pool = config_pool_cls(settings)
 
-            def async_fetch(pkg, ebuild_path):
+            def async_fetch(pkg, ebuild_path, pre_exec=None, timeout=None):
                 fetcher = EbuildFetcher(
                     config_pool=config_pool,
                     ebuild_path=ebuild_path,
@@ -346,9 +427,15 @@ class EbuildFetchTestCase(TestCase):
                     fetchall=True,
                     pkg=pkg,
                     scheduler=loop,
+                    pre_exec=pre_exec,
                 )
                 fetcher.start()
-                return fetcher.async_wait()
+                waiter = fetcher.async_wait()
+                if timeout is not None:
+                    timeout.add_done_callback(
+                        lambda timeout: waiter.done() or fetcher.cancel()
+                    )
+                return waiter
 
             for cpv in ebuilds:
                 metadata = dict(
@@ -413,6 +500,13 @@ class EbuildFetchTestCase(TestCase):
                 for k in settings["AA"].split():
                     with open(os.path.join(settings["DISTDIR"], k), "rb") as f:
                         self.assertEqual(f.read(), distfiles[k])
+
+                # Test interrupt, with server responses temporarily paused.
+                for k in settings["AA"].split():
+                    os.unlink(os.path.join(settings["DISTDIR"], k))
+                loop.run_until_complete(
+                    self._test_interrupt(loop, server, async_fetch, pkg, ebuild_path)
+                )
 
                 # Test empty files in DISTDIR
                 for k in settings["AA"].split():


### PR DESCRIPTION
Fix _EbuildFetcherProcess to handle SIGTERM, so that FETCHCOMMAND processes will not be left running in the background:

* Convert the fetch function to an async_fetch coroutine function so that it can use asyncio.CancelledError handlers to terminate running processes.

* Use multiprocessing.active_children() to detect and terminate any processes that asyncio.CancelledError handlers did not have an opportunity to terminate because the exception arrived too soon after fork/spawn.

* Add unit test to verify that a child process is correctly killed when EbuildFetcher is cancelled, with short timeout in case it takes some time for the process to disappear.

Bug: https://bugs.gentoo.org/936273