### PR TITLE
Pass through MAKEFLAGS and exclude from environment.bz2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,8 @@ Bug fixes:
 
 * Scheduler: Handle SIGWINCH for JobStatusDisplay (bug #945382).
 
+* Pass through MAKEFLAGS and exclude from environment.bz2 (bug #692576).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/bin/save-ebuild-env.sh
+++ b/bin/save-ebuild-env.sh
@@ -24,6 +24,9 @@ __save_ebuild_env() {
 				unset PYTHONPATH
 			fi
 		fi
+
+		# Discard stale GNU Make POSIX Jobserver flags.
+		unset MAKEFLAGS
 	fi
 
 	# misc variables inherited from the calling environment

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2023 Gentoo Authors
+# Copyright 1998-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # pylint: disable=ungrouped-imports
 
@@ -657,6 +657,7 @@ def create_trees(
         # environment to apply to the config that's associated
         # with ROOT != "/", so pass a nearly empty dict for the env parameter.
         env_sequence = (
+            "MAKEFLAGS",
             "PATH",
             "PORTAGE_GRPNAME",
             "PORTAGE_REPOSITORIES",

--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2021 Gentoo Authors
+# Copyright 2010-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = (
@@ -112,6 +112,7 @@ environ_whitelist = frozenset(
         "FEATURES",
         "FILESDIR",
         "HOME",
+        "MAKEFLAGS",
         "MERGE_TYPE",
         "NOCOLOR",
         "NO_COLOR",

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -599,11 +599,12 @@ def doebuild_environment(
                     )
                     mysettings.features.remove(feature)
 
-        if "MAKEOPTS" not in mysettings:
+        # MAKEOPTS conflicts with MAKEFLAGS, so skip this if MAKEFLAGS exists.
+        if "MAKEOPTS" not in mysettings and "MAKEFLAGS" not in mysettings:
             nproc = get_cpu_count()
             if nproc:
                 mysettings["MAKEOPTS"] = "-j%d" % (nproc)
-            if "GNUMAKEFLAGS" not in mysettings and "MAKEFLAGS" not in mysettings:
+            if "GNUMAKEFLAGS" not in mysettings:
                 mysettings["GNUMAKEFLAGS"] = (
                     f"--load-average {nproc} --output-sync=line"
                 )

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1,4 +1,4 @@
-.TH "MAKE.CONF" "5" "Jan 2024" "Portage @VERSION@" "Portage"
+.TH "MAKE.CONF" "5" "Aug 2024" "Portage @VERSION@" "Portage"
 .SH "NAME"
 make.conf \- custom settings for Portage
 .SH "SYNOPSIS"
@@ -947,6 +947,14 @@ which only the linker understands (see \fBgcc\fR(1)).
 Setting this and other *FLAGS variables arbitrarily may cause compile or
 runtime failures. Bug reports submitted when nonstandard values are
 enabled for these flags may be closed as INVALID.
+.TP
+.B MAKEFLAGS
+Use this variable instead of \fBMAKEOPTS\fR if you want to inject a
+centralized job server for make. In this case \fBMAKEOPTS\fR should be
+unset or else it can cause the make jobserver mode to reset. Include
+a \fB--jobserver-auth=fifo:PATH\fR flag to specify the path of the
+centralized jobserver fifo, which needs to be readable and writable by
+the portage group when userpriv is enabled.
 .TP
 .B MAKEOPTS
 Use this variable if you want to use parallel make.  For example, if you


### PR DESCRIPTION
Allow the MAKEFLAGS environment variable to pass through, in case a centralized GNU Make POSIX Jobserver is available. In order to prevent persistence of this variable in environment.bz2, exclude it when the __save_ebuild_env --exclude-init-phases argument is given.

Ultimately we may want to add support for portage to parse MAKEFLAGS and use it to allocate job tokens in various circumstances. For example, emerge could allocate a job token for each job started for emerge --jobs. This would remove a job token from the pool that is available to nested make calls, but is reasonable because nested make calls will execute jobs serially when no jobserver tokens remain.

Bug: https://bugs.gentoo.org/692576