### PR TITLE
run_exitfuncs: Support loop close via hook

### DIFF
--- a/lib/portage/tests/__init__.py
+++ b/lib/portage/tests/__init__.py
@@ -16,6 +16,7 @@ from portage import os
 from portage.util import no_color
 from portage import _encodings
 from portage import _unicode_decode
+from portage.const import PORTAGE_PYM_PATH
 from portage.output import colorize
 from portage.proxy.objectproxy import ObjectProxy
 
@@ -63,6 +64,24 @@ def cnf_sbindir():
     if portage._not_installed:
         return str(cnf_bindir)
     return os.path.join(portage.const.EPREFIX or "/", "usr", "sbin")
+
+
+def get_pythonpath():
+    """
+    Prefix current PYTHONPATH with PORTAGE_PYM_PATH, and normalize.
+    """
+    pythonpath = os.environ.get("PYTHONPATH")
+    if pythonpath is not None and not pythonpath.strip():
+        pythonpath = None
+    if pythonpath is not None and pythonpath.split(":")[0] == PORTAGE_PYM_PATH:
+        pass
+    else:
+        if pythonpath is None:
+            pythonpath = ""
+        else:
+            pythonpath = ":" + pythonpath
+        pythonpath = PORTAGE_PYM_PATH + pythonpath
+    return pythonpath
 
 
 class TestCase(unittest.TestCase):

--- a/lib/portage/tests/util/test_socks5.py
+++ b/lib/portage/tests/util/test_socks5.py
@@ -3,14 +3,16 @@
 
 import asyncio
 import functools
+import os
 import shutil
 import socket
 import struct
+import subprocess
 import tempfile
 import time
 
 import portage
-from portage.tests import TestCase
+from portage.tests import TestCase, get_pythonpath
 from portage.util import socks5
 from portage.util.futures.executor.fork import ForkExecutor
 from portage.util._eventloop.global_event_loop import global_event_loop
@@ -199,10 +201,10 @@ class Socks5ServerTestCase(TestCase):
         path = "/index.html"
         proxy = None
         tempdir = tempfile.mkdtemp()
-        previous_exithandlers = portage.process._exithandlers
+        previous_exithandlers = portage.process._coroutine_exithandlers
 
         try:
-            portage.process._exithandlers = []
+            portage.process._coroutine_exithandlers = []
             with AsyncHTTPServer(host, {path: content}, loop) as server:
                 settings = {
                     "PORTAGE_TMPDIR": tempdir,
@@ -225,11 +227,11 @@ class Socks5ServerTestCase(TestCase):
         finally:
             try:
                 # Also run_coroutine_exitfuncs to test atexit hook cleanup.
-                self.assertNotEqual(portage.process._exithandlers, [])
+                self.assertNotEqual(portage.process._coroutine_exithandlers, [])
                 await portage.process.run_coroutine_exitfuncs()
-                self.assertEqual(portage.process._exithandlers, [])
+                self.assertEqual(portage.process._coroutine_exithandlers, [])
             finally:
-                portage.process._exithandlers = previous_exithandlers
+                portage.process._coroutine_exithandlers = previous_exithandlers
                 shutil.rmtree(tempdir)
 
 
@@ -269,3 +271,55 @@ class Socks5ServerLoopCloseTestCase(TestCase):
             shutil.rmtree(tempdir)
 
         return not socks5.proxy.is_running()
+
+
+class Socks5ServerAtExitTestCase(TestCase):
+    """
+    For bug 937384, test that the socks5 proxy is automatically
+    terminated by portage.process.run_exitfuncs(), using a subprocess
+    for isolation.
+
+    Note that if the subprocess is created via fork then it will be
+    vulnerable to python issue 83856 which is only fixed in python3.13,
+    so this test uses python -c to ensure that atexit hooks will work.
+    """
+
+    def testSocks5ServerAtExit(self):
+        tempdir = tempfile.mkdtemp()
+        try:
+            env = os.environ.copy()
+            env["PYTHONPATH"] = get_pythonpath()
+            output = subprocess.check_output(
+                [
+                    portage._python_interpreter,
+                    "-c",
+                    """
+import sys
+
+from portage.const import PORTAGE_BIN_PATH
+from portage.util import socks5
+from portage.util._eventloop.global_event_loop import global_event_loop
+
+tempdir = sys.argv[0]
+loop = global_event_loop()
+
+settings = {
+    "PORTAGE_TMPDIR": tempdir,
+    "PORTAGE_BIN_PATH": PORTAGE_BIN_PATH,
+}
+
+socks5.get_socks5_proxy(settings)
+loop.run_until_complete(socks5.proxy.ready())
+print(socks5.proxy._proc.pid, flush=True)
+""",
+                    tempdir,
+                ],
+                env=env,
+            )
+
+            pid = int(output.strip())
+
+            with self.assertRaises(ProcessLookupError):
+                os.kill(pid, 0)
+        finally:
+            shutil.rmtree(tempdir)


### PR DESCRIPTION
Handle the case where the loop has not been explicitly closed before exit. In this case, run_exitfuncs previously tried to call coroutine functions as though they were normal functions, which obvously would not behave correctly.

Solve this problem by storing the coroutine functions in a separate _coroutine_exithandlers list that belongs exclusively to the run_coroutine_exitfuncs function, so that it is safe to close the loop and call run_coroutine_exitfuncs from inside a run_exitfuncs hook. A _thread_weakrefs_atexit hook already exists that will close weakly referenced loops. The _thread_weakrefs_atexit hook is now fixed to release its lock when it closes a loop, since the same lock may need to be re-acquired when run_coroutine_exitfuncs runs.

The included test case demonstrates that run_exitfuncs will run via an atexit hook and correctly terminate the socks5 proxy in a standalone program using the portage API (like eclean).

Due to a deadlock that will occur if an _exit_function atexit hook from the multiprocessing module executes before run_exitfuncs, a portage.process._atexit_register_run_exitfuncs() function needs to be called in order to re-order the hooks after the first process has been started via the multiprocessing module. The natural place to call this is in the ForkProcess class, using a global variable to trigger the call just once.

Fixes: https://github.com/gentoo/portage/pull/1295 c3ebdbb42e72 ("elog/mod_custom: Spawn processes in background")
Bug: https://bugs.gentoo.org/937384