### PR TITLE
Extend QA_PREBUILT handling to QA_SONAME_NO_SYMLINK

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -555,7 +555,8 @@ __dyn_install() {
 
 		# These ones support regular expressions, so translate
 		# fnmatch patterns to regular expressions
-		for x in QA_DT_NEEDED QA_FLAGS_IGNORED QA_PRESTRIPPED QA_SONAME ; do
+		for x in QA_DT_NEEDED QA_FLAGS_IGNORED QA_PRESTRIPPED \
+			QA_SONAME QA_SONAME_NO_SYMLINK; do
 			if [[ $(declare -p ${x} 2>/dev/null) = declare\ -a* ]] ; then
 				eval "${x}=(\"\${${x}[@]}\" ${QA_PREBUILT//\*/.*})"
 			else

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -862,28 +862,6 @@ This should contain a list of file paths, relative to the image directory, of
 desktop files which should not be validated. The paths may contain regular
 expressions with escape\-quoted special characters.
 .TP
-.B QA_DT_NEEDED
-This should contain a list of file paths, relative to the image directory, of
-shared libraries that lack NEEDED entries. The paths may contain regular
-expressions with escape\-quoted special characters.
-.TP
-.B QA_EXECSTACK
-This should contain a list of file paths, relative to the image directory, of
-objects that require executable stack in order to run.
-The paths may contain fnmatch patterns.
-
-This variable is intended to be used on objects that truly need executable
-stack (i.e. not those marked to need it which in fact do not).
-.TP
-.B QA_FLAGS_IGNORED
-This should contain a list of file paths, relative to the image directory, of
-files that do not contain .GCC.command.line sections or contain .hash sections.
-The paths may contain regular expressions with escape\-quoted special
-characters.
-
-This variable is intended to be used on files of binary packages which ignore
-CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, and LDFLAGS variables.
-.TP
 .B QA_MULTILIB_PATHS
 This should contain a list of file paths, relative to the image directory, of
 files that should be ignored for the multilib\-strict checks.
@@ -905,6 +883,28 @@ which will be internally translated to regular expressions for
 the QA_* variables that support regular expressions instead
 of fnmatch patterns. The translation mechanism simply replaces
 "*" with ".*".
+.TP
+.B QA_DT_NEEDED
+This should contain a list of file paths, relative to the image directory, of
+shared libraries that lack NEEDED entries. The paths may contain regular
+expressions with escape\-quoted special characters.
+.TP
+.B QA_EXECSTACK
+This should contain a list of file paths, relative to the image directory, of
+objects that require executable stack in order to run.
+The paths may contain fnmatch patterns.
+
+This variable is intended to be used on objects that truly need executable
+stack (i.e. not those marked to need it which in fact do not).
+.TP
+.B QA_FLAGS_IGNORED
+This should contain a list of file paths, relative to the image directory, of
+files that do not contain .GCC.command.line sections or contain .hash sections.
+The paths may contain regular expressions with escape\-quoted special
+characters.
+
+This variable is intended to be used on files of binary packages which ignore
+CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, and LDFLAGS variables.
 .TP
 .B QA_PRESTRIPPED
 This should contain a list of file paths, relative to the image directory, of


### PR DESCRIPTION
https://bugs.gentoo.org/924953 was caused by `QA_SONAME_NO_SYMLINK` not inheriting the regex-transformed paths from `QA_PREBUILT` despite the ebuild.5 manpage implying this behavior based on the ordering of the QA variables.

The [tested ebuild](https://gitweb.gentoo.org/repo/proj/guru.git/commit/?id=0643c00df81ff8a08cff0d2f7e929ae341404212) contains:
```sh
QA_PREBUILT="
	usr/lib/*
	usr/lib64/*
"
```
which according to the `man 5 ebuild` should be enough to silence the following warning.
```
 * QA Notice: Missing soname symlink(s):
 * 
 * 	usr/lib64/amdvlk64.so.1 -> amdvlk64.so
 *
```

These commits make `QA_SONAME_NO_SYMLINK` inherit regex-transformed paths from `QA_PREBUILT` and update the QA variables, which are affected by `QA_PREBUILT`, in the ebuild.5 manpage.