### PR TITLE
_EbuildFetcherProcess: Suppress CancelledError

### DIFF
--- a/lib/_emerge/EbuildFetcher.py
+++ b/lib/_emerge/EbuildFetcher.py
@@ -373,7 +373,7 @@ class _EbuildFetcherProcess(ForkProcess):
         def cache_result(result):
             try:
                 self._uri_map = result.result()
-            except Exception:
+            except (CancelledError, Exception):
                 # The caller handles this when it retrieves the result.
                 pass
 


### PR DESCRIPTION
Suppress CancelledError when attempting to cache the result in the _async_uri_map method. The cancelled result is returned for the caller to handle.

Bug: https://bugs.gentoo.org/937888