### PR TITLE
_wrap_loop: Prevent redundant AsyncioEventLoop instances

### DIFF
--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -19,7 +19,6 @@ __all__ = (
     "run",
     "shield",
     "sleep",
-    "Task",
     "wait",
     "wait_for",
 )
@@ -172,16 +171,6 @@ class Lock(_Lock):
         elif "loop" not in kwargs:
             kwargs["loop"] = _safe_loop()._loop
         super().__init__(**kwargs)
-
-
-class Task(Future):
-    """
-    Schedule the execution of a coroutine: wrap it in a future. A task
-    is a subclass of Future.
-    """
-
-    def __init__(self, coro, loop=None):
-        raise NotImplementedError
 
 
 def ensure_future(coro_or_future, loop=None):


### PR DESCRIPTION
Ultimately the loop arguments that necessitate the _wrap_loop function can be removed, because our aim since [bug 761538](https://bugs.gentoo.org/761538) should be to eliminate them. Meanwhile, we don't want _wrap_loop to return redundant AsyncioEventLoop instances if we can easily prevent it.

Therefore, use `_safe_loop(create=False)` to look up the AsyncioEventLoop instance associated with the current thread, and avoid creating redundant instances. This serves to guard against garbage collection of AsyncioEventLoop instances which may have _coroutine_exithandlers added by the atexit_register function since commit cb0c09d8cecb from [bug 937740](https://bugs.gentoo.org/937740).

If `_safe_loop(create=False)` fails to associate a loop with the current thread, raise an AssertionError for portage internal API consumers.  It's not known whether external API consumers will trigger this case, so if it happens then emit a UserWarning and return a temporary AsyncioEventLoop instance.

Fixes: https://github.com/gentoo/portage/pull/1368 cb0c09d8cecb ("Support coroutine exitfuncs for non-main loops")
Bug: https://bugs.gentoo.org/938127
Bug: https://bugs.gentoo.org/937740
Bug: https://bugs.gentoo.org/761538