### PR TITLE
sync: add a 5 second timeout to gemato's openpgp refresh

### DIFF
--- a/lib/portage/sync/syncbase.py
+++ b/lib/portage/sync/syncbase.py
@@ -330,6 +330,7 @@ class SyncBase:
 
     def _get_openpgp_env(self, openpgp_key_path=None, debug=False):
         if gemato is not None:
+            timeout = 15
             # Override global proxy setting with one provided in emerge configuration
             if "http_proxy" in self.spawn_kwargs["env"]:
                 proxy = self.spawn_kwargs["env"]["http_proxy"]
@@ -337,14 +338,15 @@ class SyncBase:
                 proxy = self.spawn_kwargs["env"]["https_proxy"]
             else:
                 proxy = None
+                timeout = 5
 
             if openpgp_key_path:
                 openpgp_env = gemato.openpgp.OpenPGPEnvironment(
-                    proxy=proxy, debug=debug
+                    proxy=proxy, debug=debug, timeout=timeout
                 )
             else:
                 openpgp_env = gemato.openpgp.OpenPGPSystemEnvironment(
-                    proxy=proxy, debug=debug
+                    proxy=proxy, debug=debug, timeout=timeout
                 )
 
             return openpgp_env


### PR DESCRIPTION
If it takes more than 5 seconds to download a miniscule file from https://gentoo.org/.well-known/openpgpkey/ then something has gone dreadfully wrong. Most commonly, what went wrong is that the user has broken ipv6 connectivity and requests simply hangs forever (no joke -- it doesn't implement Happy Eyeballs and closed the multiple bug reports as "please use stackoverflow to ask questions about how to use requests, we are not a support forum").

Pass a timeout so that we eventually give up and try ipv4 instead. This is a crude hack and the proper solution is to make gemato handle this better, but until gemato is fixed to use a better download library we do the best we can.

Bug: https://github.com/psf/requests/issues/6788
Bug: https://github.com/projg2/gemato/issues/35
Bug: https://bugs.gentoo.org/779766