### PR TITLE
install-qa-check.d: try to detect gcc warnings past color

### DIFF
--- a/bin/install-qa-check.d/90gcc-warnings
+++ b/bin/install-qa-check.d/90gcc-warnings
@@ -162,7 +162,7 @@ gcc_warn_check() {
 		# Force C locale to work around slow multibyte locales, bug #160234
 		# Force text mode as newer grep will treat non-ASCII (e.g. UTF-8) as
 		# binary when we run in the C locale.
-		f=$(LC_CTYPE=C LC_COLLATE=C "${grep_cmd}" -E -a "${joined_msgs}" "${PORTAGE_LOG_FILE}" | uniq)
+		f=$(LC_ALL='C' sed -E -e $'s/\033\[[0-9;]*[A-Za-z]//g' < "${PORTAGE_LOG_FILE}" | LC_CTYPE=C LC_COLLATE=C "${grep_cmd}" -E -a "${joined_msgs}" | uniq)
 		if [[ -n ${f} ]] ; then
 			abort="yes"
 


### PR DESCRIPTION
We have some code we use for config-impl-decl which can strip color codes out via sed. This is always necessary for config.log because if color exists it will still be there.

The assumption was, likely, that build.log as managed by portage will also be ansifilter'd by portage, and therefore stripping color is unnecessary. But in fact, some people do like color and intentionally avoid stripping it. This rendered the QA check effectively broken. Instead we should make no assumptions, and explicitly strip this too.