### PR TITLE
asyncio: Use default sleep / ensure_future implementations when possible

### DIFF
--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -186,6 +186,9 @@ def ensure_future(coro_or_future, loop=None):
     @rtype: asyncio.Future (or compatible)
     @return: an instance of Future
     """
+    if loop is None:
+        return _real_asyncio.ensure_future(coro_or_future)
+
     loop = _wrap_loop(loop)
     if isinstance(loop._asyncio_wrapper, _AsyncioEventLoop):
         # Use the real asyncio loop and ensure_future.

--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -210,9 +210,12 @@ def sleep(delay, result=None, loop=None):
     @param result: result of the future
     @type loop: asyncio.AbstractEventLoop (or compatible)
     @param loop: event loop
-    @rtype: asyncio.Future (or compatible)
-    @return: an instance of Future
+    @rtype: collections.abc.Coroutine or asyncio.Future
+    @return: an instance of Coroutine or Future
     """
+    if loop is None:
+        return _real_asyncio.sleep(delay, result=result)
+
     loop = _wrap_loop(loop)
     future = loop.create_future()
     handle = loop.call_later(delay, future.set_result, result)

--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -119,7 +119,7 @@ def run(coro):
 run.__doc__ = _real_asyncio.run.__doc__
 
 
-def create_subprocess_exec(*args, **kwargs):
+def create_subprocess_exec(*args, loop=None, **kwargs):
     """
     Create a subprocess.
 
@@ -140,7 +140,6 @@ def create_subprocess_exec(*args, **kwargs):
     @rtype: asyncio.subprocess.Process (or compatible)
     @return: asyncio.subprocess.Process interface
     """
-    loop = _wrap_loop(kwargs.pop("loop", None))
     # Python 3.4 and later implement PEP 446, which makes newly
     # created file descriptors non-inheritable by default.
     kwargs.setdefault("close_fds", False)


### PR DESCRIPTION
When a loop argument is not given, use the default asyncio sleep / ensure_future implementations and avoid unnecessary _wrap_loop usage.

Bug: https://bugs.gentoo.org/761538