### PR TITLE
_safe_loop: Discard wrapped asyncio.run loop that was closed

### DIFF
--- a/lib/portage/util/futures/_asyncio/__init__.py
+++ b/lib/portage/util/futures/_asyncio/__init__.py
@@ -311,6 +311,13 @@ def _safe_loop(create: Optional[bool] = True) -> Optional[_AsyncioEventLoop]:
             _thread_weakrefs.loops = weakref.WeakValueDictionary()
         try:
             loop = _thread_weakrefs.loops[thread_key]
+            if loop.is_closed():
+                # Discard wrapped asyncio.run loop that was closed.
+                del _thread_weakrefs.loops[thread_key]
+                if loop is _thread_weakrefs.mainloop:
+                    _thread_weakrefs.mainloop = None
+                loop = None
+                raise KeyError(thread_key)
         except KeyError:
             if not create:
                 return None


### PR DESCRIPTION
Since commit cb0c09d8cecb, _get_running_loop can wrap loops from asyncio.run, so these loops need to be discarded if they've been closed.

Fixes: cb0c09d8cecb ("Support coroutine exitfuncs for non-main loops")
Bug: https://bugs.gentoo.org/938761
Bug: https://bugs.gentoo.org/761538