### PR TITLE
unpack: Don't display "Unpacking ..." for skipped files, match file extensions case-sensitively

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,9 @@ Bug fixes:
 * emerge: Fix parallel-fetch to properly terminate FETCHCOMMAND processes when
   needed, using a SIGTERM handler (bug #936273).
 
+* unpack: Don't display "Unpacking ..." message for skipped files.
+  Match file extensions case-sensitively in old EAPIs, fixes PMS compliance.
+
 portage-3.0.65 (2024-06-04)
 --------------
 

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -334,7 +334,7 @@ unpack() {
 		y=${y##*.}
 		y_insensitive=$(LC_ALL=C tr "[:upper:]" "[:lower:]" <<< "${y}")
 
-		# wrt PMS 11.3.3.13 Misc Commands
+		# wrt PMS 12.3.15 Misc Commands
 		if [[ ${x} != */* ]]; then
 			# filename without path of any kind
 			srcdir=${DISTDIR}/


### PR DESCRIPTION
As discussed in `#gentoo-pms`.

PMS currently says that "Any unrecognised file format shall be skipped silently." This wording was added with the draft of what later became EAPI 4: https://gitweb.gentoo.org/proj/pms.git/commit/?id=634c32f231e1bc94d64588e2b2edf0ad1ca60f1f

The commit message doesn't give any rationale for "silently". It may well be that the wording is a remnant of the rejected `unpack --if-compressed` item. See the [discussion in the 2009-04-23 council meeting](https://projects.gentoo.org/council/meeting-logs/20090423.txt) (starting at 21:35).

Patch for PMS (presumably, replacing "silently" with "without raising an error") will follow.
