### PR TITLE
quickpkg: enable include-unmodified-config by default

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -420,9 +420,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--include-unmodified-config",
         choices=["y", "n"],
-        default="n",
+        default="y",
         metavar="<y|n>",
-        help="include files protected by CONFIG_PROTECT that have not been modified since installation (as a security precaution, default is 'n')",
+        help="include files protected by CONFIG_PROTECT that have not been modified since installation",
     )
     options, args = parser.parse_known_args(sys.argv[1:])
     if not options.ignore_default_opts:

--- a/man/quickpkg.1
+++ b/man/quickpkg.1
@@ -38,7 +38,7 @@ default is 'n').
 .TP
 .BR "\-\-include\-unmodified\-config < y | n >"
 Include files protected by CONFIG_PROTECT that have not been modified
-since installation (as a security precaution, default is 'n').
+since installation.
 .TP
 .BR \-\-umask=UMASK
 The umask used during package creation (default is 0077).


### PR DESCRIPTION
If the user has not modified an installed config file, there should be no risk of exposing secret information by including the file.

This makes quickpkg behave more reasonably with
FEATURES="config-protect-if-modified", which has been enabled by default since 304dfb0fb09b799eec526d0703c44fc6a92ef13d.

Bug: https://bugs.gentoo.org/939896