### PR TITLE
WIP Auto resolve cyclic USE conflicts by trying the first suggestion

### DIFF
--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -405,7 +405,7 @@ class Package(Task):
             except InvalidData as e:
                 self._invalid_metadata(k + ".syntax", f"{k}: {e}")
 
-    def copy(self):
+    def copy(self, operation=None):
         return Package(
             built=self.built,
             cpv=self.cpv,
@@ -413,7 +413,7 @@ class Package(Task):
             installed=self.installed,
             metadata=self._raw_metadata,
             onlydeps=self.onlydeps,
-            operation=self.operation,
+            operation=operation or self.operation,
             root_config=self.root_config,
             type_name=self.type_name,
         )

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -8936,15 +8936,7 @@ class depgraph:
 
                 if not unresolved_blocks and depends_on_order:
                     for inst_pkg, inst_task in depends_on_order:
-                        uninst_task = Package(
-                            built=inst_pkg.built,
-                            cpv=inst_pkg.cpv,
-                            installed=inst_pkg.installed,
-                            metadata=inst_pkg._metadata,
-                            operation="uninstall",
-                            root_config=inst_pkg.root_config,
-                            type_name=inst_pkg.type_name,
-                        )
+                        uninst_task = inst_pkg.copy(operation="uninstall")
                         # Enforce correct merge order with a hard dep.
                         self._dynamic_config.digraph.addnode(
                             uninst_task, inst_task, priority=BlockerDepPriority.instance
@@ -9965,20 +9957,8 @@ class depgraph:
                     if inst_pkg:
                         # The package will be replaced by this one, so remove
                         # the corresponding Uninstall task if necessary.
-                        inst_pkg = inst_pkg[0]
-                        uninst_task = Package(
-                            built=inst_pkg.built,
-                            cpv=inst_pkg.cpv,
-                            installed=inst_pkg.installed,
-                            metadata=inst_pkg._metadata,
-                            operation="uninstall",
-                            root_config=inst_pkg.root_config,
-                            type_name=inst_pkg.type_name,
-                        )
-                        try:
-                            mygraph.remove(uninst_task)
-                        except KeyError:
-                            pass
+                        uninst_task = inst_pkg[0].copy(operation="uninstall")
+                        mygraph.discard(uninst_task)
 
                 if (
                     uninst_task is not None

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -293,7 +293,7 @@ class circular_dependency_handler:
                         " (This change might require USE changes on parent packages.)"
                     )
                 suggestions.append(msg)
-                final_solutions.setdefault(pkg, set()).add(solution)
+                final_solutions.setdefault(pkg, set()).add((parent, solution))
 
         return final_solutions, suggestions
 


### PR DESCRIPTION
Hi Zac or anyone else who has a clue how the depgraph works. :grin: 

This is the result of several days of mostly staring and occasionally typing during our recent Hackathon at work. The idea is to automatically resolve cyclic USE conflicts like this or the infamous freetype vs harfbuzz one.

```
[nomerge       ] kde-plasma/plasma-meta-6.1.4-r1:6::gentoo  USE="bluetooth browser-integration crash-handler cups display-manager firewall kwallet networkmanager pulseaudio (qt5) sddm smart systemd wallpapers xwayland -accessibility -colord -crypt -discover (-elogind) -flatpak -grub -gtk -oxygen-theme -plymouth -rdp -sdk -thunderbolt -unsupported -wacom -webengine" 
[nomerge       ]  sys-fs/udisks-2.10.1-r1:2::gentoo  USE="acl daemon introspection systemd -debug (-elogind) -lvm -nls (-selinux)" 
[nomerge       ]   sys-auth/polkit-125::gentoo  USE="daemon duktape introspection kde pam systemd -examples -gtk (-selinux) -test" 
[ebuild     U  ]    dev-libs/gobject-introspection-1.80.1-r2::gentoo [1.78.1-r2::gentoo] USE="-doctool -gtk-doc -test" PYTHON_SINGLE_TARGET="python3_12 -python3_10 -python3_11 -python3_13" 1016 KiB
[ebuild     U  ]     dev-libs/glib-2.80.4:2::gentoo [2.78.6:2::gentoo] USE="dbus elf introspection%* (mime) static-libs xattr -debug -doc% (-selinux) -sysprof -systemtap -test -utils (-gtk-doc%)" ABI_X86="(64) -32 (-x32)" 5407 KiB

Total: 2 packages (2 upgrades), Size of downloads: 6422 KiB

 * Error: circular dependencies:

(dev-libs/gobject-introspection-1.80.1-r2:0/0::gentoo, ebuild scheduled for merge) depends on
 (dev-libs/glib-2.80.4:2/2::gentoo, ebuild scheduled for merge) (buildtime)
  (dev-libs/gobject-introspection-1.80.1-r2:0/0::gentoo, ebuild scheduled for merge) (buildtime)

It might be possible to break this cycle
by applying the following change:
- dev-libs/glib-2.80.4 (Change USE: -introspection)
```

Portage tells you what to do, so why doesn't it just do that for you? This would be a great help for Gentoo users, Gentoo developers who go out of their way to keep these situations away from users (there was a lot of excitement on IRC!), and also Flatcar Linux, which hits several conflicts at once when building its image.

The initial results after my first attempt looked very encouraging.

```
[ebuild     U  ] dev-libs/gobject-introspection-common-1.80.1::gentoo [1.78.1::gentoo] 1016 KiB
[ebuild     U  ] dev-util/gdbus-codegen-2.80.4::gentoo [2.78.6::gentoo] PYTHON_SINGLE_TARGET="python3_12 -python3_10 -python3_11 -python3_13%" 5407 KiB
[ebuild     U  ] dev-libs/glib-2.80.4:2::gentoo [2.78.6:2::gentoo] USE="dbus elf (mime) static-libs xattr -debug -doc% -introspection% (-selinux) -sysprof -systemtap -test -utils (-gtk-doc%)" ABI_X86="(64) -32 (-x32)" 0 KiB
[ebuild     U  ] dev-libs/gobject-introspection-1.80.1-r2::gentoo [1.78.1-r2::gentoo] USE="-doctool -gtk-doc -test" PYTHON_SINGLE_TARGET="python3_12 -python3_10 -python3_11 -python3_13" 0 KiB
[blocks b      ] <dev-libs/gobject-introspection-1.80.1 ("<dev-libs/gobject-introspection-1.80.1" is soft blocking dev-libs/glib-2.80.4, dev-libs/gobject-introspection-common-1.80.1)
[ebuild     U  ] dev-libs/glib-2.80.4:2::gentoo [2.78.6:2::gentoo] USE="dbus elf introspection%* (mime) static-libs xattr -debug -doc% (-selinux) -sysprof -systemtap -test -utils (-gtk-doc%)" ABI_X86="(64) -32 (-x32)" 0 KiB

Total: 5 packages (5 upgrades), Size of downloads: 6422 KiB
Conflict: 1 block (all satisfied)
```

I then found that it was only resolving the first conflict and ignoring the rest, with Flatcar's case resulting in an invalid list. A little more work got it resolving each conflict in turn, which made Flatcar's case look better, but then the ordering went a little wobbly.

Finally, I found that it wasn't adding any dependencies required by the temporary solution. While these could maybe be handled, there are unlikely to be any additional dependencies in practise as the solution is usually `USE=+build` or `USE=-some-feature`. I therefore kept it simple by only attempting automatic resolution when there are no additional dependencies.

I am aware that this is probably broken in other ways too. It's not taking account of wider blockers, although again, there probably aren't any in practise, and they are unlikely to be an issue for the short period while the conflict is resolved.

Perhaps this inspires you to come up with something solid? I and many others would be extremely grateful. Failing that, perhaps you can give me some pointers.