### PR TITLE
depgraph: Ignore blockers when computing virtual deps visibility

### DIFF
--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -6022,6 +6022,8 @@ class depgraph:
 
         for atoms in rdepend.values():
             for atom in atoms:
+                if atom.blocker:
+                    continue
                 if ignore_use:
                     atom = atom.without_use
                 pkg, existing = self._select_package(pkg.root, atom)

--- a/lib/portage/tests/resolver/test_virtual_slot.py
+++ b/lib/portage/tests/resolver/test_virtual_slot.py
@@ -71,7 +71,13 @@ class VirtualSlotResolverTestCase(TestCase):
             },
             "virtual/jdk-1.7.0": {
                 "SLOT": "1.7",
-                "RDEPEND": "|| ( =dev-java/icedtea-7* =dev-java/oracle-jdk-bin-1.7.0* )",
+                "RDEPEND": """
+                    || (
+                        =dev-java/icedtea-7*
+                        =dev-java/oracle-jdk-bin-1.7.0*
+                    )
+                    !virtual/jdk-does-not-exist
+                """,
             },
         }
 


### PR DESCRIPTION
If a `virtual/` package declares a blocker to a package that doesn't
exist, then `_virt_deps_visible` incorrectly marks the virtual as
"not visible". Blockers should be ignored when performing the deps
visibility test since blockers are handled later in the pipeline.
