### PR TITLE
emerge-webrsync: Create repo location with $PORTAGE_USERNAME:$PORTAGE_GRPNAME ownership

### DIFF
--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -83,6 +83,7 @@ eval "$("${portageq}" envvar -v DISTDIR EPREFIX FEATURES \
 	PORTAGE_BIN_PATH PORTAGE_CONFIGROOT PORTAGE_GPG_DIR \
 	PORTAGE_NICENESS PORTAGE_REPOSITORIES PORTAGE_RSYNC_EXTRA_OPTS \
 	PORTAGE_RSYNC_OPTS PORTAGE_TEMP_GPG_DIR PORTAGE_TMPDIR \
+	PORTAGE_USERNAME PORTAGE_GRPNAME \
 	USERLAND http_proxy https_proxy ftp_proxy)"
 export http_proxy https_proxy ftp_proxy
 
@@ -410,7 +411,7 @@ sync_local() {
 
 	[[ ${PORTAGE_QUIET} -eq 1 ]] || einfo "Syncing local repository ..."
 
-	local ownership="portage:portage"
+	local ownership="${PORTAGE_USERNAME}:${PORTAGE_GRPNAME}"
 	if has usersync ${FEATURES} ; then
 		case "${USERLAND}" in
 			BSD)

--- a/bin/emerge-webrsync
+++ b/bin/emerge-webrsync
@@ -697,7 +697,14 @@ main() {
 
 	handle_pgp_setup
 
-	[[ -d ${repo_location} ]] || mkdir -p "${repo_location}"
+	if [[ ! -d ${repo_location} ]]; then
+		mkdir -p "${repo_location}" || die
+
+		if has usersync ${FEATURES} ; then
+			chown "${PORTAGE_USERNAME}":"${PORTAGE_GRPNAME}" "${repo_location}" || die
+		fi
+	fi
+
 	if [[ ! -w ${repo_location} ]] ; then
 		die "Repository '${repo_name}' is not writable: ${repo_location}"
 	fi


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/707980