### PR TITLE
binarytree: Fix _inject_repo_revisions to ignore remote packages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Release notes take the form of the following optional categories:
 Bug fixes:
 * depgraph: Ignore blockers when computing virtual deps visibility (PR #1387).
 
+* binarytree: Fix _inject_repo_revisions to ignore remote packages for which
+  source repostories are missing, triggering KeyError (PR #1391).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1948,9 +1948,16 @@ class binarytree:
         package was not built locally, and in this case its
         REPO_REVISIONS are not intended to be exposed.
         """
+        try:
+            repos = [
+                self.settings.repositories[repo_name] for repo_name in repo_revisions
+            ]
+        except KeyError:
+            # Missing repo implies package was not built locally from source.
+            return
         synced_repo_revisions = get_repo_revision_history(
             self.settings["EROOT"],
-            [self.settings.repositories[repo_name] for repo_name in repo_revisions],
+            repos,
         )
         header_repo_revisions = (
             json.loads(header["REPO_REVISIONS"]) if header.get("REPO_REVISIONS") else {}


### PR DESCRIPTION
For remote packages that reference source repos which do not exist locally, do not inject repo revisions.

Fixes: 5aed7289d516 ("bintree: Add REPO_REVISIONS to package index header")
Bug: https://bugs.gentoo.org/939299