### PR TITLE
Skip self update logic when installation.TYPE != SYSTEM

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -17,6 +17,7 @@ import portage
 from portage import os
 from portage import _encodings
 from portage import _unicode_encode
+from portage import installation
 from portage.cache.mappings import slot_dict_class
 from portage.elog.messages import eerror
 from portage.output import colorize, create_color_func, red
@@ -339,6 +340,9 @@ class Scheduler(PollScheduler):
             )
 
     def _handle_self_update(self):
+        if installation.TYPE != installation.TYPES.SYSTEM:
+            return os.EX_OK
+
         if self._opts_no_self_update.intersection(self.myopts):
             return os.EX_OK
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -50,6 +50,7 @@ portage.proxy.lazyimport.lazyimport(
 from portage import (
     bsd_chflags,
     eapi_is_supported,
+    installation,
     merge,
     os,
     selinux,
@@ -3280,10 +3281,13 @@ def _prepare_self_update(settings):
 
 
 def _handle_self_update(settings, vardb):
-    cpv = settings.mycpv
-    if settings["ROOT"] == "/" and portage.dep.match_from_list(
-        portage.const.PORTAGE_PACKAGE_ATOM, [cpv]
+    if installation.TYPE != installation.TYPES.SYSTEM:
+        return False
+    if settings["ROOT"] != "/":
+        return False
+    if not portage.dep.match_from_list(
+        portage.const.PORTAGE_PACKAGE_ATOM, [settings.mycpv]
     ):
-        _prepare_self_update(settings)
-        return True
-    return False
+        return False
+    _prepare_self_update(settings)
+    return True


### PR DESCRIPTION
If we are running from source (git) or as a module installed via pip, we don't need to worry about overwriting the existing system install via an ebuild installation.