### PR TITLE
gpkg: do not consider symlinks targets for size estimation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ Bug fixes:
 * binarytree: Fix _inject_repo_revisions to ignore remote packages for which
   source repostories are missing, triggering KeyError (PR #1391).
 
+* gpkg: do not consider symlinks targets for size estimation (bug #942512).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -1960,14 +1960,10 @@ class gpkg:
 
                 image_max_link_length = max(image_max_link_length, path_link_length)
 
-                try:
-                    file_size = os.path.getsize(f)
-                except FileNotFoundError:
-                    # Ignore file not found if symlink to non-existing file
-                    if os.path.islink(f):
-                        continue
-                    else:
-                        raise
+                if stat.S_ISLNK(file_stat.st_mode):
+                    continue
+
+                file_size = os.path.getsize(f)
                 image_total_size += file_size
                 image_max_file_size = max(image_max_file_size, file_size)
 
@@ -2055,14 +2051,10 @@ class gpkg:
             image_max_link_length = max(image_max_link_length, path_link_length)
 
             if os.path.isfile(path):
-                try:
-                    file_size = os.path.getsize(path)
-                except FileNotFoundError:
-                    # Ignore file not found if symlink to non-existing file
-                    if os.path.islink(path):
-                        continue
-                    else:
-                        raise
+                if stat.S_ISLNK(file_stat.st_mode):
+                    continue
+
+                file_size = os.path.getsize(path)
                 image_total_size += file_size
                 if file_size > image_max_file_size:
                     image_max_file_size = file_size


### PR DESCRIPTION
Symlinks size is already accounted for, so there is no need to account for the pointed to file.
Moreover, previous code failed to handle permission error when using ROOT= and having absolute symlinks pointing to running root.

Bug: https://bugs.gentoo.org/942512