### PR TITLE
Fix deprecated datetime.datetime.utcnow() usage

### DIFF
--- a/lib/portage/repository/storage/hardlink_rcu.py
+++ b/lib/portage/repository/storage/hardlink_rcu.py
@@ -266,7 +266,11 @@ class HardlinkRcuRepoStorage(RepoStorageInterface):
                 st = os.stat(snap_path)
             except OSError:
                 continue
-            snap_timestamp = datetime.datetime.utcfromtimestamp(st.st_mtime)
-            if (datetime.datetime.utcnow() - snap_timestamp) < snap_ttl:
+            snap_timestamp = datetime.datetime.fromtimestamp(
+                st.st_mtime, tz=datetime.timezone.utc
+            )
+            if (
+                datetime.datetime.now(datetime.timezone.utc) - snap_timestamp
+            ) < snap_ttl:
                 continue
             await self._check_call(["rm", "-rf", snap_path])

--- a/lib/portage/sync/modules/rsync/rsync.py
+++ b/lib/portage/sync/modules/rsync/rsync.py
@@ -437,7 +437,11 @@ class RsyncSync(NewBase):
                             raise RuntimeError("Timestamp not found in Manifest")
                         if (
                             self.max_age != 0
-                            and (datetime.datetime.utcnow() - ts.ts).days > self.max_age
+                            and (
+                                datetime.datetime.now(datetime.timezone.utc)
+                                - ts.ts.replace(tzinfo=datetime.timezone.utc)
+                            ).days
+                            > self.max_age
                         ):
                             out.quiet = False
                             out.ewarn(

--- a/lib/portage/tests/sync/test_sync_local.py
+++ b/lib/portage/tests/sync/test_sync_local.py
@@ -141,7 +141,7 @@ class SyncLocalTestCase(TestCase):
                     )
                 )
 
-        bump_timestamp.timestamp = datetime.datetime.utcnow()
+        bump_timestamp.timestamp = datetime.datetime.now(datetime.timezone.utc)
 
         bump_timestamp_cmds = ((homedir, bump_timestamp),)
 


### PR DESCRIPTION
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

Beware that this may break interaction with gemato timestamps if they are not UTC aware:
```python
>>> datetime.datetime.now(datetime.UTC) - datetime.datetime.utcnow()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can't subtract offset-naive and offset-aware datetimes
```

Also at least python3.11 is required for the datetime.UTC alias for datetime.timezone.utc.