### PR TITLE
install_qa_check: Fix noclean interaction with merge-wait

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Bug fixes:
 
 * gpkg: do not consider symlinks targets for size estimation (bug #942512).
 
+* install_qa_check: Fix noclean interaction with merge-wait (bug #942760).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -259,7 +259,9 @@ install_qa_check() {
 	# Prematurely delete WORKDIR in case merge-wait is enabled to
 	# decrease the space used by portage build directories until the
 	# packages are merged and cleaned.
-	if has merge-wait ${FEATURES} && ! has keepwork ${FEATURES}; then
+	if has merge-wait ${FEATURES} &&
+		! has keepwork ${FEATURES} &&
+		! has noclean ${FEATURES} ; then
 		rm -rf "${WORKDIR}"
 	fi
 }


### PR DESCRIPTION
Fixes: 8ac72ee300c1 ("install_qa_check: prematurely delete WORKDIR if FEATURES=merge-wait")
Bug: https://bugs.gentoo.org/942760