### PR TITLE
github: test python3.14 with default forkserver start method overridden to spawn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,7 @@ jobs:
           export PYTEST_ADDOPTS="-vv -ra -l -o console_output_style=count -n $(nproc) --dist=worksteal"
           # Use pytest-rerunfailures to workaround pytest-xdist worker crashes with spawn start-method (bug 924416).
           [[ "${{ matrix.start-method }}" == "spawn" ]] && PYTEST_ADDOPTS+=" --reruns 5 --only-rerun 'worker .* crashed while running'"
+          [[ "${{ matrix.start-method }}" == "fork" ]] &&
+              [[ "${{ matrix.python-version }}" == "3.14-dev" ]] &&
+              PYTEST_ADDOPTS+=" --reruns 5 --only-rerun 'node down: Not properly terminated'"
           meson test -C /tmp/build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
             start-method: 'spawn'
           - python-version: '3.13-dev'
             start-method: 'spawn'
-          - python-version: '3.14-dev'
-            start-method: 'fork'
           - python-version: 'pypy-3.10'
             start-method: 'spawn'
       fail-fast: false

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -19,6 +19,9 @@ import traceback
 import os as _os
 import warnings
 
+if multiprocessing.get_start_method() == "forkserver":
+    multiprocessing.set_start_method("spawn", force=True)
+
 from dataclasses import dataclass
 from functools import lru_cache, partial
 from typing import Any, Optional, Callable, Union


### PR DESCRIPTION
Maybe the forkserver method will work better in a future release, but for v3.14.0a2 it is not usable due to this error:
```OSError: AF_UNIX path too long```

Bug: https://bugs.gentoo.org/941956