### PR TITLE
Scheduler: Handle SIGWINCH for JobStatusDisplay

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@ Bug fixes:
 
 * Process elog messages for emerge --config (bug #904702).
 
+* Scheduler: Handle SIGWINCH for JobStatusDisplay (bug #945382).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/lib/_emerge/JobStatusDisplay.py
+++ b/lib/_emerge/JobStatusDisplay.py
@@ -65,11 +65,9 @@ class JobStatusDisplay:
             if not isinstance(v, str):
                 self._term_codes[k] = v.decode(encoding, "replace")
 
-        if self._isatty:
-            width = portage.output.get_term_size()[1]
-        else:
-            width = self.max_display_width
-        self._set_width(width)
+        if not self._isatty:
+            self._set_width(self.max_display_width)
+        self.sigwinch()
 
     def _set_width(self, width):
         if width == getattr(self, "width", None):
@@ -78,6 +76,12 @@ class JobStatusDisplay:
             width = self.max_display_width
         object.__setattr__(self, "width", width)
         object.__setattr__(self, "_jobs_column_width", width - 32)
+
+    def sigwinch(self):
+        if not self._isatty:
+            return
+        width = portage.output.get_term_size()[1]
+        self._set_width(width)
 
     @property
     def out(self):

--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -522,16 +522,11 @@ def get_term_size(fd=None):
         fd = sys.stdout
     if not hasattr(fd, "isatty") or not fd.isatty():
         return (0, 0)
-    try:
-        import curses
 
-        try:
-            curses.setupterm(term=os.environ.get("TERM", "unknown"), fd=fd.fileno())
-            return curses.tigetnum("lines"), curses.tigetnum("cols")
-        except curses.error:
-            pass
-    except ImportError:
-        pass
+    # Do not use curses.tigetnum("lines") or curses.tigetnum("cols") because it
+    # returns stale values after terminal resize. Do not use curses.initscr().getmaxyx()
+    # since that has unwanted side-effects, requiring a call to `stty sane` to restore a
+    # sane state.
 
     try:
         proc = subprocess.Popen(["stty", "size"], stdout=subprocess.PIPE, stderr=fd)


### PR DESCRIPTION
Do not use curses in the get_term_size function, since curses caches the terminal width and does not account for resize.

Bug: https://bugs.gentoo.org/945382