### PR TITLE
eend: Make missing argument an error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ Bug fixes:
 
 * save-ebuild-env.sh: Add functions from newer EAPIs to filter list
 
+* eend: Missing argument is now an error (bug #703520).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 source "${PORTAGE_BIN_PATH}/eapi.sh" || exit 1
@@ -367,13 +367,13 @@ __eend() {
 }
 
 eend() {
-	[[ -n $1 ]] || eqawarn "QA Notice: eend called without first argument"
+	[[ -n ${1} ]] || die "${FUNCNAME}(): Missing argument"
+	local retval=${1}
+	shift
 	if (( --__EBEGIN_EEND_COUNT < 0 )); then
 		__EBEGIN_EEND_COUNT=0
 		eqawarn "QA Notice: eend called without preceding ebegin in ${FUNCNAME[1]}"
 	fi
-	local retval=${1:-0}
-	shift
 
 	__eend ${retval} eerror "$*"
 


### PR DESCRIPTION
PMS says about eend: "Takes one fixed argument, which is a numeric return code, and an optional message in all subsequent arguments."

A QA notice was in place since commit 95cd9583d415 in 2021.

Bug: https://bugs.gentoo.org/703520