### PR TITLE
binarytree.move_ent: Allocate path with binpkg_format

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,8 @@ Bug fixes:
 
 * Pass through MAKEFLAGS and exclude from environment.bz2 (bug #692576).
 
+* binarytree.move_ent: Allocate path with binpkg_format (bug #923530).
+
 portage-3.0.66.1 (2024-09-18)
 --------------
 

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -796,7 +796,9 @@ class binarytree:
             # assuming that it will be deleted by eclean-pkg when its
             # time comes.
             mynewcpv = _pkg_str(mynewcpv, metadata=metadata, db=self.dbapi)
-            allocated_pkg_path = self.getname(mynewcpv, allocate_new=True)
+            allocated_pkg_path = self.getname(
+                mynewcpv, allocate_new=True, remote_binpkg_format=binpkg_format
+            )
             update_path = allocated_pkg_path + ".partial"
             self._ensure_dir(os.path.dirname(update_path))
             update_path_lock = None


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/923530