### PR TITLE
portage.VERSION: prevent infinite recursion when lazy loading

### DIFF
--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -715,6 +715,7 @@ if installation.TYPE == installation.TYPES.SOURCE:
             global VERSION
             if VERSION is not self:
                 return VERSION
+            VERSION = "HEAD"
             if os.path.isdir(os.path.join(PORTAGE_BASE_PATH, ".git")):
                 encoding = _encodings["fs"]
                 cmd = [
@@ -734,8 +735,6 @@ if installation.TYPE == installation.TYPES.SOURCE:
                 status = proc.wait()
                 if os.WIFEXITED(status) and os.WEXITSTATUS(status) == os.EX_OK:
                     VERSION = output.lstrip("portage-").strip().replace("-g", "+g")
-            else:
-                VERSION = "HEAD"
             return VERSION
 
     VERSION = _LazyVersion()


### PR DESCRIPTION
If we are running Portage from a git checkout but the git command is unavailable or broken, we never set the VERSION variable.