### PR TITLE
make.globals: Set PORTAGE_USERNAME and PORTAGE_GRPNAME variables

### DIFF
--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -55,6 +55,10 @@ BINPKG_GPG_VERIFY_BASE_COMMAND="/usr/bin/gpg --verify --batch --no-tty --no-auto
 # The binary package default GPG home directory for verify
 BINPKG_GPG_VERIFY_GPG_HOME="/etc/portage/gnupg"
 
+# The user and group will be used when drop root privileges
+PORTAGE_USERNAME="portage"
+PORTAGE_GRPNAME="portage"
+
 # The user and group will be used when drop root privileges during GPG verify
 GPG_VERIFY_USER_DROP="nobody"
 GPG_VERIFY_GROUP_DROP="nogroup"


### PR DESCRIPTION
"man 5 make.conf" states that "PORTAGE_USERNAME" and "PORTAGE_GRPNAME" default to "portage":
- https://github.com/gentoo/portage/blob/597229aff02810764223a4cdd1e8056142d70ed0/man/make.conf.5#L1257-L1261
- https://github.com/gentoo/portage/blob/597229aff02810764223a4cdd1e8056142d70ed0/man/make.conf.5#L1109-L1113

But, the two variables are not set in the files pointed out by "man 5 make.conf":
https://github.com/gentoo/portage/blob/597229aff02810764223a4cdd1e8056142d70ed0/man/make.conf.5#L21-L31

This commits solves the discrepancy.

Bug: https://bugs.gentoo.org/941977