### PR TITLE
doc: Drop remaining package_ebuild_eapi_4_slot_abi

### DIFF
--- a/doc/package/ebuild.docbook
+++ b/doc/package/ebuild.docbook
@@ -9,7 +9,6 @@
 &package_ebuild_eapi_2;
 &package_ebuild_eapi_3;
 &package_ebuild_eapi_4;
-&package_ebuild_eapi_4_slot_abi;
 &package_ebuild_eapi_5;
 </section>
 </chapter>


### PR DESCRIPTION
Those where dropped in d34f2dcec57e ("Remove support for 4-slot-abi EAPI"), but this one wasn't removed causing doc build failures:

 * python3_12: running meson_src_compile ninja -v -j11 -l12
[1/7] /usr/bin/ln -srnf ../portage-9999/doc/api/conf.py ../portage-9999/doc/api/index.rst doc/api/ [2/7] /usr/bin/xmlto -o doc --searchpath doc/fragment -m ../portage-9999/doc/custom.xsl xhtml-nochunks ../portage-9999/doc/portage.docbook FAILED: doc/portage.html
/usr/bin/xmlto -o doc --searchpath doc/fragment -m ../portage-9999/doc/custom.xsl xhtml-nochunks ../portage-9999/doc/portage.docbook xmlto: /data-scratch/var-tmp/portage/sys-apps/portage-9999/work/portage-9999-python3_12/../portage-9999/doc/portage.docbook does not validate (status 1) xmlto: Fix document syntax or use --skip-validation option /data-scratch/var-tmp/portage/sys-apps/portage-9999/work/portage-9999/doc/package/ebuild.docbook:12: parser error : Entity 'package_ebuild_eapi_4_slot_abi' not defined &package_ebuild_eapi_4_slot_abi;
                                ^
/data-scratch/var-tmp/portage/sys-apps/portage-9999/work/portage-9999/doc/package/ebuild.docbook:15: parser error : chunk is not well balanced

^
/data-scratch/var-tmp/portage/sys-apps/portage-9999/work/portage-9999/doc/package.docbook:3: parser error : Entity 'package_ebuild' failed to parse &package_ebuild;
                ^
/data-scratch/var-tmp/portage/sys-apps/portage-9999/work/portage-9999/doc/package.docbook:4: parser error : chunk is not well balanced

^
/data-scratch/var-tmp/portage/sys-apps/portage-9999/work/portage-9999-python3_12/../portage-9999/doc/portage.docbook:57: parser error : Entity 'package' failed to parse &package;
         ^

Fixes: d34f2dcec57e2bd5c52baff7eccdd2e70b0b6684