### PR TITLE
phase-functions: Do not explicitly export S and D

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -596,10 +596,6 @@ __dyn_install() {
 	__vecho
 	__vecho ">>> Install ${CATEGORY}/${PF} into ${D}"
 
-	# Our custom version of libtool uses ${S} and ${D} to fix
-	# invalid paths in .la files
-	export S D
-
 	# Reset exeinto(), docinto(), insinto(), and into() state variables
 	# in case the user is running the install phase multiple times
 	# consecutively via the ebuild command.


### PR DESCRIPTION
This was added in 2002 with 6a6ec1eea155c (portage-cvs.git) and is currently a no-op, since in all currently used EAPIs portage does export S and D.

Exporting S and D is also diametral to the current push to no longer export PMS variables (bug #721088).