### PR TITLE
Support for new home-dir-template-copy FEATURE

### DIFF
--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -189,6 +189,7 @@ SUPPORTED_FEATURES = frozenset(
         "force-mirror",
         "getbinpkg",
         "gpg-keepalive",
+        "home-dir-template-copy",
         "icecream",
         "installsources",
         "ipc-sandbox",

--- a/lib/portage/package/ebuild/prepare_build_dirs.py
+++ b/lib/portage/package/ebuild/prepare_build_dirs.py
@@ -135,7 +135,7 @@ def prepare_build_dirs(myroot=None, settings=None, cleanup=False):
         # a temporary PORTAGE_TMPDIR setting (for fetchonly).
         _prepare_features_dirs(mysettings)
         # Support for home-dir-template-copy FEATURE:
-        if not cleanup and "home-dir-template-copy" in settings.features:
+        if "home-dir-template-copy" in settings.features:
             portage_username = mysettings.get("PORTAGE_USERNAME", "portage")
             home_template_dir = pwd.getpwnam(portage_username).pw_dir
             build_env_home_dir = mysettings["HOME"]

--- a/lib/portage/package/ebuild/prepare_build_dirs.py
+++ b/lib/portage/package/ebuild/prepare_build_dirs.py
@@ -7,6 +7,7 @@ import errno
 import gzip
 import stat
 import time
+import pwd
 
 import portage
 from portage import os, shutil, _encodings, _unicode_encode, _unicode_decode
@@ -133,6 +134,19 @@ def prepare_build_dirs(myroot=None, settings=None, cleanup=False):
         # Avoid spurious permissions adjustments when fetching with
         # a temporary PORTAGE_TMPDIR setting (for fetchonly).
         _prepare_features_dirs(mysettings)
+        # Support for home-dir-template-copy FEATURE:
+        if not cleanup and "home-dir-template-copy" in settings.features:
+            portage_username = mysettings.get("PORTAGE_USERNAME", "portage")
+            home_template_dir = pwd.getpwnam(portage_username).pw_dir
+            build_env_home_dir = mysettings["HOME"]
+            # Sanity checks on above values.
+            if not os.path.exists(home_template_dir):
+                writemsg(f"FEATURES home-dir-template-copy enabled but specified Linux home directory {home_template_dir} does not exist.", noiselevel=-1)
+                return 1
+            if not os.path.exists(build_env_home_dir):
+                writemsg(f"FEATURES home-dir-template-copy enabled but build HOME directory {build_env_home_dir} does not exist.", noiselevel=-1)
+                return 1
+            shutil.copytree(home_template_dir, build_env_home_dir, symlinks=True, dirs_exist_ok=True)
 
 
 def _adjust_perms_msg(settings, msg):

--- a/lib/portage/package/ebuild/prepare_build_dirs.py
+++ b/lib/portage/package/ebuild/prepare_build_dirs.py
@@ -141,12 +141,20 @@ def prepare_build_dirs(myroot=None, settings=None, cleanup=False):
             build_env_home_dir = mysettings["HOME"]
             # Sanity checks on above values.
             if not os.path.exists(home_template_dir):
-                writemsg(f"FEATURES home-dir-template-copy enabled but specified Linux home directory {home_template_dir} does not exist.", noiselevel=-1)
+                writemsg(
+                    f"FEATURES home-dir-template-copy enabled but specified Linux home directory {home_template_dir} does not exist.",
+                    noiselevel=-1,
+                )
                 return 1
             if not os.path.exists(build_env_home_dir):
-                writemsg(f"FEATURES home-dir-template-copy enabled but build HOME directory {build_env_home_dir} does not exist.", noiselevel=-1)
+                writemsg(
+                    f"FEATURES home-dir-template-copy enabled but build HOME directory {build_env_home_dir} does not exist.",
+                    noiselevel=-1,
+                )
                 return 1
-            shutil.copytree(home_template_dir, build_env_home_dir, symlinks=True, dirs_exist_ok=True)
+            shutil.copytree(
+                home_template_dir, build_env_home_dir, symlinks=True, dirs_exist_ok=True
+            )
 
 
 def _adjust_perms_msg(settings, msg):

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -536,6 +536,23 @@ Force emerges to always try to fetch files from the \fIPORTAGE_BINHOST\fR.  See
 Run GPG unlock command every 5 mins to avoid the passphrase expired.
 If your GPG is auto unlocked on login, you do not need this.
 .TP
+.B home\-dir\-template\-copy
+As part of the ebuild environment setup, copy the PORTAGE_USERNAME (default
+"portage") home directory (currently /var/lib/portage/home) into the build environment
+HOME directory. By default, Portage uses an empty home directory for each new build. 
+
+This is useful, for example, if the git-r3 eclass is being used to access a repository
+via ssh where keys and known_hosts values need to be specified in the ~/.ssh
+directory.
+
+It's also useful for adressing git's "fatal: detected dubious ownership in
+repository at..." error, which can occur when the ebuild is fetching from a
+local filesystem-resident repo. Running git to create an "--add safe.directory"
+exception \fInarrowly\fR to apply only to the portage user can be done as follows:
+
+    sudo -u portage git config --global --add safe.directory ...
+
+.TP
 .B icecream
 Enable portage support for the icecream package.
 .TP


### PR DESCRIPTION
If enabled, as part of the ebuild environment setup, copies the PORTAGE_USERNAME home directory into the build environment HOME directory. Useful predominantly for ebuilds that use the git-r3 eclass, to give a place to put SSH keys and user- specific git configuration files used during the build.

See bug #947822 for rationale and additional details.