### PR TITLE
selinux: fully disable selinux-awareness for FEATURES="-selinux"

### DIFF
--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -3446,7 +3446,7 @@ class config:
     def selinux_enabled(self):
         if getattr(self, "_selinux_enabled", None) is None:
             self._selinux_enabled = 0
-            if "selinux" in self["USE"].split():
+            if "selinux" in self.features:
                 if selinux:
                     if selinux.is_selinux_enabled() == 1:
                         self._selinux_enabled = 1

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -736,6 +736,11 @@ dependencies.
 .B sandbox
 Enable sandbox\-ing when running \fBemerge\fR(1) and \fBebuild\fR(1).
 .TP
+.B selinux
+Enable SELinux awareness.  Portage will install objects to the filesystem with
+a SELinux context calculated from the current loaded policy.
+Do not toggle this \fBFEATURE\fR yourself.
+.TP
 .B sesandbox
 Enable SELinux sandbox\-ing.  Do not toggle this \fBFEATURE\fR yourself.
 .TP


### PR DESCRIPTION
It should be expected that FEATURES="-selinux" will completely disable selinux awareness; the system administrator should be able to recover from a situation where labeling is invalid using portage without having to fully disabling SELinux from being loaded by the kernel.