### PR TITLE
tests: resolver: Add xfail test for ada/D bootstrap chain (bug #951296)

### DIFF
--- a/lib/portage/tests/resolver/test_bootstrap_deps.py
+++ b/lib/portage/tests/resolver/test_bootstrap_deps.py
@@ -132,3 +132,130 @@ class BootstrapChainTestCase(TestCase):
                 self.assertEqual(test_case.test_success, True, test_case.fail_msg)
         finally:
             playground.cleanup()
+
+    def testBootstrapChainDisruptedShortcutWithShortcutFirst(self):
+        ebuilds = {
+            "dev-libs/A-1": {
+                "EAPI": "8",
+                "SLOT": "1",
+                "IUSE": "B",
+                "BDEPEND": "B? ( || ( <dev-libs/B-2 dev-libs/A:1[B] ) )",
+            },
+            "dev-libs/A-2": {
+                "EAPI": "8",
+                "SLOT": "2",
+                "IUSE": "B C ",
+                "BDEPEND": "B? ( || ( <dev-libs/B-3 dev-libs/A:2[B] <dev-libs/A-2[B] ) ) C? ( || ( dev-libs/A:2[C(+)] <dev-libs/A-2[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+            "dev-libs/A-3": {
+                "EAPI": "8",
+                "SLOT": "3",
+                "IUSE": "B C",
+                "BDEPEND": "B? ( || ( <dev-libs/B-4 dev-libs/A:3[B] <dev-libs/A-3[B] ) ) C? ( || ( dev-libs/A:3[C(+)] <dev-libs/A-3[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+            "dev-libs/A-4": {
+                "EAPI": "8",
+                "SLOT": "4",
+                "IUSE": "B C",
+                "BDEPEND": "B? ( || ( <dev-libs/B-5 dev-libs/A:4[B] <dev-libs/A-4[B] ) ) C? ( || ( dev-libs/A:4[C(+)] <dev-libs/A-4[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+            "dev-libs/B-1": {},
+            "dev-libs/B-2": {},
+            "dev-libs/B-3": {},
+            "dev-libs/B-4": {},
+        }
+
+        installed = {
+            "dev-libs/A-4": {
+                "SLOT": "4",
+                "IUSE": "B C",
+                "USE": "C",
+                "BDEPEND": "B? ( || ( <dev-libs/B-5 dev-libs/A:4[B] <dev-libs/A-4[B] ) ) C? ( || ( dev-libs/A:4[C(+)] <dev-libs/A-4[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+        }
+
+        user_config = {
+            "package.use": ("dev-libs/A B C",),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A:4", "=dev-libs/B-4"],
+                success=True,
+                mergelist=["dev-libs/B-4", "dev-libs/A-4"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, user_config=user_config, debug=True
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    @pytest.mark.xfail(reason="bug #951296")
+    def testBootstrapChainDisruptedShortcutWithShortcutLast(self):
+        ebuilds = {
+            "dev-libs/A-1": {
+                "EAPI": "8",
+                "SLOT": "1",
+                "IUSE": "B",
+                "BDEPEND": "B? ( || ( dev-libs/A:1[B] <dev-libs/B-2 ) )",
+            },
+            "dev-libs/A-2": {
+                "EAPI": "8",
+                "SLOT": "2",
+                "IUSE": "B C ",
+                "BDEPEND": "B? ( || ( dev-libs/A:2[B] <dev-libs/A-2[B] <dev-libs/B-3 ) ) C? ( || ( dev-libs/A:2[C(+)] <dev-libs/A-2[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+            "dev-libs/A-3": {
+                "EAPI": "8",
+                "SLOT": "3",
+                "IUSE": "B C",
+                "BDEPEND": "B? ( || ( dev-libs/A:3[B] <dev-libs/A-3[B] <dev-libs/B-4 ) ) C? ( || ( dev-libs/A:3[C(+)] <dev-libs/A-3[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+            "dev-libs/A-4": {
+                "EAPI": "8",
+                "SLOT": "4",
+                "IUSE": "B C",
+                "BDEPEND": "B? ( || ( dev-libs/A:4[B] <dev-libs/A-4[B] <dev-libs/B-5 ) ) C? ( || ( dev-libs/A:4[C(+)] <dev-libs/A-4[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+            "dev-libs/B-1": {},
+            "dev-libs/B-2": {},
+            "dev-libs/B-3": {},
+            "dev-libs/B-4": {},
+        }
+
+        installed = {
+            "dev-libs/A-4": {
+                "SLOT": "4",
+                "IUSE": "B C",
+                "USE": "C",
+                "BDEPEND": "B? ( || ( dev-libs/A:4[B] <dev-libs/A-4[B] <dev-libs/B-5 ) ) C? ( || ( dev-libs/A:4[C(+)] <dev-libs/A-4[C(+)] <dev-libs/A-2[C(+)] ) )",
+            },
+        }
+
+        user_config = {
+            "package.use": ("dev-libs/A B C",),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A:4", "=dev-libs/B-4"],
+                success=True,
+                mergelist=["dev-libs/B-4", "dev-libs/A-4"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, user_config=user_config, debug=True
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
Two tests for cases where the shortcut is first and last in the any-of-many dependency respectively.

With current behavior portage can correctly handle it if its first but not if its last.

Bug: https://bugs.gentoo.org/951296