### PR TITLE
Add PORTAGE_LOG_FILE_SEP option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ portage-3.0.68 (UNRELEASED)
 Features:
 * Allow "portageq envvar" to treat a trailing * as a wildcard, matching multiple
   variables. Useful for multilib.
+* Introduce PORTAGE_LOG_FILE_SEP, allowing to configure the separator between
+  the components of the log files produced by portage.
 
 portage-3.0.67 (2025-01-22)
 --------------

--- a/cnf/make.conf.example
+++ b/cnf/make.conf.example
@@ -125,11 +125,16 @@
 #
 # PORTAGE_LOGDIR is the location where portage will store all the logs it
 #     creates from each individual merge. They are stored as
-#     ${CATEGORY}:${PF}:YYYYMMDD-HHMMSS.log in the directory specified.
+#     ${CATEGORY}<sep>${PF}<sep>YYYYMMDD-HHMMSS.log in the directory specified,
+#     where <sep> is specified via PORTAGE_LOG_FILE_SEP, which defaults to ':'.
 #     If the directory does not exist, it will be created automatically and
 #     group permissions will be applied to it.  If the directory already
 #     exists, portage will not modify its permissions.
 #PORTAGE_LOGDIR=""
+#
+# PORTAGE_LOG_FILE_SEP specifies the separator between the components of the
+# log files in PORTAGE_LOGDIR.
+#PORTAGE_LOG_FILE_SEP=":"
 #
 # PORTDIR_OVERLAY is a directory where local ebuilds may be stored without
 #     concern that they will be deleted by rsync updates. Default is not

--- a/lib/portage/package/ebuild/prepare_build_dirs.py
+++ b/lib/portage/package/ebuild/prepare_build_dirs.py
@@ -411,23 +411,20 @@ def _prepare_workdir(mysettings):
             errors="replace",
         )
 
+        # The separator used between the individual name components of the log file.
+        sep = mysettings.get("PORTAGE_LOG_FILE_SEP", ":")
+
         if "split-log" in mysettings.features:
             log_subdir = os.path.join(logdir, "build", mysettings["CATEGORY"])
             mysettings["PORTAGE_LOG_FILE"] = os.path.join(
                 log_subdir,
-                f"{mysettings['PF']}:{logid_time}.log{compress_log_ext}",
+                f"{mysettings['PF']}{sep}{logid_time}.log{compress_log_ext}",
             )
         else:
             log_subdir = logdir
             mysettings["PORTAGE_LOG_FILE"] = os.path.join(
                 logdir,
-                "%s:%s:%s.log%s"
-                % (
-                    mysettings["CATEGORY"],
-                    mysettings["PF"],
-                    logid_time,
-                    compress_log_ext,
-                ),
+                f"{mysettings['CATEGORY']}{sep}{mysettings['PF']}{sep}{logid_time}.log{compress_log_ext}",
             )
 
         if log_subdir is logdir:

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1187,10 +1187,15 @@ PORTAGE_LOG_FILTER_FILE_CMD="bash -c \\"ansifilter; exec cat\\""
 .B PORTAGE_LOGDIR
 This variable defines the directory in which per\-ebuild logs are kept.
 Logs are created only when this is set. They are stored as
-${CATEGORY}:${PF}:YYYYMMDD\-HHMMSS.log in the directory specified. If the
-directory does not exist, it will be created automatically and group
+${CATEGORY}<sep>${PF}<sep>YYYYMMDD\-HHMMSS.log in the directory specified,
+where <sep> is specified via PORTAGE_LOG_FILE_SEP, which defaults to ':'.
+If the directory does not exist, it will be created automatically and group
 permissions will be applied to it.  If the directory already exists, portage
 will not modify its permissions.
+.TP
+.B PORTAGE_LOG_FILE_SEP
+This variable defines the separator used between the components of the log
+files in PORTAGE_LOGDIR. Defaults to ':'.
 .TP
 .B PORTAGE_LOGDIR_CLEAN
 This variable should contain a command for portage to call in order


### PR DESCRIPTION
Portage uses the colon (:) as a separator between the components of a log file under PORTAGE_LOGDIR. However, the colon is often used as a "word" separator by shells and consoles, which makes it not user-friendly to select the full path of the log file. For example, double-clicking on a portage log file path in Kitty will not select the complete path, only the substring of the path up to the nearest colon.

Therefore, this introduces PORTAGE_LOG_FILE_SEP, which allows the user to choose the separator used for log files. To keep the existing behavior, PORTAGE_LOG_FILE_SEP defaults to ':'.