### PR TITLE
sets: VariableSet: honour 'excludes'

### DIFF
--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -114,4 +114,5 @@ class = portage.sets.dbapi.ChangedDepsSet
 [rust-rebuild]
 class = portage.sets.dbapi.VariableSet
 variable = BDEPEND
-includes = dev-lang/rust dev-lang/rust-bin virtual/rust
+includes = dev-lang/rust dev-lang/rust-bin
+excludes_output = dev-lang/rust dev-lang/rust-bin

--- a/lib/portage/tests/sets/base/test_variable_set.py
+++ b/lib/portage/tests/sets/base/test_variable_set.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
@@ -13,11 +13,17 @@ class VariableSetTestCase(TestCase):
 
         # Using local set definition because @golang-rebuild migrated to dev-lang/go since bug 919751.
         golang_rebuild = "{class=portage.sets.dbapi.VariableSet,variable=BDEPEND,includes=dev-lang/go}"
+        #
+        rust_with_rustc_rebuild = "{class=portage.sets.dbapi.VariableSet,variable=BDEPEND,includes=dev-lang/rust dev-lang/rust-bin}"
 
         ebuilds = {
             "dev-go/go-pkg-1": {"BDEPEND": "dev-lang/go"},
             "www-client/firefox-1": {
-                "BDEPEND": "|| ( virtual/rust:0/a virtual/rust:0/b )"
+                "BDEPEND": "|| ( dev-lang/rust dev-lang/rust-bin )"
+            },
+            "dev-lang/rust-1": {"BDEPEND": "|| ( dev-lang/rust dev-lang/rust-bin )"},
+            "dev-lang/rust-bin-1": {
+                "BDEPEND": "|| ( dev-lang/rust-bin dev-lang/rust )"
             },
         }
         installed = ebuilds
@@ -32,6 +38,16 @@ class VariableSetTestCase(TestCase):
             ResolverPlaygroundTestCase(
                 ["@rust-rebuild"],
                 mergelist=["www-client/firefox-1"],
+                success=True,
+            ),
+            ResolverPlaygroundTestCase(
+                [f"@rust-with-rustc-rebuild{rust_with_rustc_rebuild}"],
+                mergelist=[
+                    "www-client/firefox-1",
+                    "dev-lang/rust-1",
+                    "dev-lang/rust-bin-1",
+                ],
+                ignore_mergelist_order=True,
                 success=True,
             ),
         )


### PR DESCRIPTION
    sets: VariableSet: honour 'excludes'

    This allows defining @golang-rebuild and @rust-rebuild in such a way that
    dev-lang/go and dev-lang/rust (and -bin) are excluded, as users don't
    usually want to rebuild the toolchain there, just packages affected
    by static linking and such.

    For VariableSet:
    * Make 'excludes' do something for VariableSet where variable is *DEPEND:
      operate on the actual *DEPEND match, not the package in question though.

      I'm not convinced this is super-useful as it is, but I wanted to try
      preserve 'excludes' semantics as it is for other variables than *DEPEND.

    * Add 'excludes_output' which drops matches on the original package being
      tested/filtered.

      e.g.
       variable = BDEPEND
       includes = dev-lang/rust
       excludes_output = dev-lang/rust
      will include any package with dev-lang/rust in BDEPEND, unless that
      package is itself dev-lang/rust.

    For sets/portage.conf:
    * Make '@rust-rebuild' include packages with BDEPEND on dev-lang/rust
      or dev-lang/rust-bin, but exclude dev-lang/rust or dev-lang/rust-bin
      themselves from being included in the set.

    * Drop obsolete virtual/rust from '@rust-rebuild'.

    Bug: https://bugs.gentoo.org/906044
    Bug: https://bugs.gentoo.org/919751
    Bug: https://bugs.gentoo.org/953884
    Signed-off-by: Sam James <sam@gentoo.org>