### PR TITLE
Remove LD_PRELOAD environment variable mask

### DIFF
--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -112,6 +112,7 @@ environ_whitelist = frozenset(
         "FEATURES",
         "FILESDIR",
         "HOME",
+        "LD_PRELOAD",
         "MAKEFLAGS",
         "MERGE_TYPE",
         "NOCOLOR",


### PR DESCRIPTION
This pull request removes LD_PRELOAD from the environment variables masked by Portage.

* Portage's sandbox appears to support prepending to an existing LD_PRELOAD: https://github.com/gentoo/sandbox/blob/7240cc9fb7cd6a9bc83b9ade5a385633f42e58d1/data/sandbox.bashrc#L4-L8
* When the sandbox is disabled, LD_PRELOAD doesn't appear to be used at all by Portage.

However, Portage currently masks LD_PRELOAD, nullifying this functionality. Having LD_PRELOAD as a Portage variable can be useful for various reasons, in my specific case using a custom allocator when supported by the build process.

I have tested this myself and it appears to work properly for the above use case, with and without the sandbox enabled (although the sandbox has its own custom allocator).