### PR TITLE
estrip: salt build IDs with ${CATEGORY}/${PF}:${SLOT}

### DIFF
--- a/bin/estrip
+++ b/bin/estrip
@@ -338,9 +338,26 @@ save_elf_debug() {
 			# Symlink so we can read the name back.
 			__try_symlink "${dst}" "${inode_debug}"
 
-			# If we don't already have build-id from debugedit, look it up
+			# If we don't already have build-id from debugedit, look it up.
+			# This should only happen with FEATURES=-installsources, as
+			# it's done in save_elf_sources.
 			if [[ -z ${buildid} ]] ; then
-				# convert the readelf output to something useful
+				if [[ ${path_of[debugedit]} ]]; then
+					# Salt the build ID to avoid collisions on
+					# bundled libraries.
+					buildid=$("${path_of[debugedit]}" -i \
+						-s "${CATEGORY}/${PF}:${SLOT}" \
+						"${x}")
+				elif ! contains_word buildid "${warned_for[debugedit]}"; then
+					warned_for[debugedit]+=" buildid"
+					ewarn "FEATURES=splitdebug is enabled but the debugedit binary could not be found"
+					ewarn "This feature will not work correctly with build IDs unless debugedit is installed!"
+				fi
+			fi
+
+			# If we (still) don't already have build-id from debugedit, look it up.
+			if [[ -z ${buildid} ]] ; then
+				# Convert the readelf output to something useful
 				buildid=$("${path_of[readelf]}" -n "${src}" 2>/dev/null | awk '/Build ID:/{ print $NF; exit }')
 			fi
 

--- a/bin/estrip
+++ b/bin/estrip
@@ -231,6 +231,7 @@ save_elf_sources() {
 	# (the -i flag below).  save that output so we don't need to recompute
 	# it later on in the save_elf_debug step.
 	buildid=$("${path_of[debugedit]}" -i \
+		-s "${CATEGORY}/${PF}:${SLOT}" \
 		-b "${WORKDIR}" \
 		-d "${prepstrip_sources_dir}" \
 		-l "${tmpdir}/sources/${x##*/}.${BASHPID}" \


### PR DESCRIPTION
Use debugedit to salt build IDs with ${CATEGORY}/${PF}:${SLOT} to avoid file collisions (same build ID generated as another package) where a bundled library is installed.

Bug: https://bugs.gentoo.org/549672
Bug: https://bugs.gentoo.org/953869