### PR TITLE
portage.porttree: pass basic mypy checks

### DIFF
--- a/lib/_emerge/MetadataRegen.py
+++ b/lib/_emerge/MetadataRegen.py
@@ -62,7 +62,7 @@ class MetadataRegen(AsyncScheduler):
                         break
                     valid_pkgs.add(cpv)
                     ebuild_path, repo_path = portdb.findname2(cpv, myrepo=repo.name)
-                    if ebuild_path is None:
+                    if not ebuild_path:
                         raise AssertionError(
                             f"ebuild not found for '{cpv}{_repo_separator}{repo.name}'"
                         )

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -760,7 +760,7 @@ class depgraph:
             self._dynamic_config._package_tracker.add_installed_pkg(pkg)
             self._add_installed_sonames(pkg)
             ebuild_path, repo_path = portdb.findname2(pkg.cpv, myrepo=pkg.repo)
-            if ebuild_path is None:
+            if not ebuild_path:
                 fake_vartree.dynamic_deps_preload(pkg, None)
                 continue
             metadata, ebuild_hash = portdb._pull_valid_cache(

--- a/lib/_emerge/resolver/output.py
+++ b/lib/_emerge/resolver/output.py
@@ -1,8 +1,7 @@
 # Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-"""Resolver output display operation.
-"""
+"""Resolver output display operation."""
 
 __all__ = (
     "Display",

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -771,3 +771,12 @@ def _disable_legacy_globals():
     for k in _legacy_global_var_names:
         globals().pop(k, None)
     portage.data._initialized_globals.clear()
+
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from portage.package.ebuild.config import config as config_type
+
+    config: type[config_type]
+    settings: config_type

--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -20,6 +20,7 @@ try:
     import re
     import types
     import platform
+    from typing import TYPE_CHECKING
 
     # Temporarily delete these imports, to ensure that only the
     # wrapped versions are imported by portage internals.
@@ -50,6 +51,12 @@ except ImportError as e:
     )
     sys.stderr.write(f"    {e}\n\n")
     raise
+
+if TYPE_CHECKING:
+    from portage.package.ebuild.config import config as config_type
+
+    config: type[config_type]
+    settings: config_type
 
 try:
     import portage.proxy.lazyimport
@@ -771,12 +778,3 @@ def _disable_legacy_globals():
     for k in _legacy_global_var_names:
         globals().pop(k, None)
     portage.data._initialized_globals.clear()
-
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from portage.package.ebuild.config import config as config_type
-
-    config: type[config_type]
-    settings: config_type

--- a/lib/portage/data.py
+++ b/lib/portage/data.py
@@ -6,6 +6,7 @@ import grp
 import os
 import platform
 import pwd
+from typing import TYPE_CHECKING
 
 import portage
 from portage.localization import _
@@ -351,3 +352,9 @@ def _init(settings):
             v = 1
         globals()["secpass"] = v
         _initialized_globals.add("secpass")
+
+
+if TYPE_CHECKING:
+    portage_gid: int
+    portage_uid: int
+    secpass: int

--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 1998-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+from __future__ import annotations
 
 __all__ = ["dbapi"]
 
@@ -7,7 +8,7 @@ import functools
 import logging
 import re
 import sys
-from typing import Any, Optional, Literal
+from typing import TYPE_CHECKING, Any, Optional, Literal
 from collections.abc import Sequence
 
 import portage
@@ -35,27 +36,28 @@ from portage.localization import _
 from _emerge.Package import Package
 
 
-_AuxKeys = Literal[
-    "DEFINED_PHASES",
-    "DEPEND",
-    "EAPI",
-    "HDEPEND",
-    "HOMEPAGE",
-    "INHERITED",
-    "IUSE",
-    "KEYWORDS",
-    "LICENSE",
-    "PDEPEND",
-    "PROPERTIES",
-    "PROVIDE",
-    "RDEPEND",
-    "REQUIRED_USE",
-    "repository",
-    "RESTRICT",
-    "SRC_URI",
-    "SLOT",
-    "repository",
-]
+if TYPE_CHECKING:
+    _AuxKeys = Literal[
+        "DEFINED_PHASES",
+        "DEPEND",
+        "EAPI",
+        "HDEPEND",
+        "HOMEPAGE",
+        "INHERITED",
+        "IUSE",
+        "KEYWORDS",
+        "LICENSE",
+        "PDEPEND",
+        "PROPERTIES",
+        "PROVIDE",
+        "RDEPEND",
+        "REQUIRED_USE",
+        "repository",
+        "RESTRICT",
+        "SRC_URI",
+        "SLOT",
+        "repository",
+    ]
 
 
 class dbapi:

--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
 
 class dbapi:
     _category_re = re.compile(r"^\w[-.+\w]*$", re.UNICODE)
-    _categories: Optional[tuple[str, ...]] = None
+    _categories: tuple[str, ...] | None = None
     _use_mutable = False
     _known_keys = frozenset(auxdbkeys)
     _pkg_str_aux_keys = ("EAPI", "KEYWORDS", "SLOT", "repository")
@@ -136,7 +136,7 @@ class dbapi:
         raise NotImplementedError
 
     def aux_get(
-        self, mycpv: str, mylist: Sequence[_AuxKeys], myrepo: Optional[str] = None
+        self, mycpv: str, mylist: Sequence[_AuxKeys], myrepo: str | None = None
     ) -> list[str]:
         """Return the metadata keys in mylist for mycpv
         Args:

--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -52,7 +52,6 @@ if TYPE_CHECKING:
         "PROVIDE",
         "RDEPEND",
         "REQUIRED_USE",
-        "repository",
         "RESTRICT",
         "SRC_URI",
         "SLOT",

--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -7,7 +7,7 @@ import functools
 import logging
 import re
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional, Literal
 from collections.abc import Sequence
 
 import portage
@@ -33,6 +33,29 @@ from portage.exception import (
 )
 from portage.localization import _
 from _emerge.Package import Package
+
+
+_AuxKeys = Literal[
+    "DEFINED_PHASES",
+    "DEPEND",
+    "EAPI",
+    "HDEPEND",
+    "HOMEPAGE",
+    "INHERITED",
+    "IUSE",
+    "KEYWORDS",
+    "LICENSE",
+    "PDEPEND",
+    "PROPERTIES",
+    "PROVIDE",
+    "RDEPEND",
+    "REQUIRED_USE",
+    "repository",
+    "RESTRICT",
+    "SRC_URI",
+    "SLOT",
+    "repository",
+]
 
 
 class dbapi:
@@ -111,7 +134,7 @@ class dbapi:
         raise NotImplementedError
 
     def aux_get(
-        self, mycpv: str, mylist: str, myrepo: Optional[str] = None
+        self, mycpv: str, mylist: Sequence[_AuxKeys], myrepo: Optional[str] = None
     ) -> list[str]:
         """Return the metadata keys in mylist for mycpv
         Args:

--- a/lib/portage/dbapi/__init__.py
+++ b/lib/portage/dbapi/__init__.py
@@ -96,7 +96,7 @@ class dbapi:
         return result
 
     @staticmethod
-    def _cpv_sort_ascending(cpv_list: Sequence[Any]) -> None:
+    def _cpv_sort_ascending(cpv_list: list[str]) -> None:
         """
         Use this to sort self.cp_list() results in ascending
         order. It sorts in place and returns None.

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -55,7 +55,7 @@ import shlex
 import collections
 from collections import OrderedDict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -217,7 +217,7 @@ class portdbapi(dbapi):
         return main_repo.eclass_db
 
     def __init__(
-        self, _unused_param=DeprecationWarning, mysettings: Optional[config_type] = None
+        self, _unused_param=DeprecationWarning, mysettings: config_type | None = None
     ):
         """
         @param _unused_param: deprecated, use mysettings['PORTDIR'] instead
@@ -463,7 +463,7 @@ class portdbapi(dbapi):
         return None
 
     def findname(
-        self, mycpv: str, mytree: Optional[str] = None, myrepo: Optional[str] = None
+        self, mycpv: str, mytree: str | None = None, myrepo: str | None = None
     ) -> str:
         return self.findname2(mycpv, mytree, myrepo)[0]
 
@@ -526,8 +526,8 @@ class portdbapi(dbapi):
     def findname2(
         self,
         mycpv: str | _pkg_str,
-        mytree: Optional[str] = None,
-        myrepo: Optional[str] = None,
+        mytree: str | None = None,
+        myrepo: str | None = None,
     ) -> tuple[str, str]:
         """
         Returns the location of the CPV, and what overlay it was in.
@@ -682,8 +682,8 @@ class portdbapi(dbapi):
         self,
         mycpv: str,
         mylist: Sequence[_AuxKeys],
-        mytree: Optional[str] = None,
-        myrepo: Optional[str] = None,
+        mytree: str | None = None,
+        myrepo: str | None = None,
     ) -> list[str]:
         "stub code for returning auxiliary db information, such as SLOT, DEPEND, etc."
         'input: "sys-apps/foo-1.0",["SLOT","DEPEND","HOMEPAGE"]'
@@ -891,8 +891,8 @@ class portdbapi(dbapi):
     def getFetchMap(
         self,
         mypkg: str,
-        useflags: Optional[Sequence[str]] = None,
-        mytree: Optional[str] = None,
+        useflags: Sequence[str] | None = None,
+        mytree: str | None = None,
     ) -> dict[str, tuple[str, ...]]:
         """
         Get the SRC_URI metadata as a dict which maps each file name to a
@@ -918,8 +918,8 @@ class portdbapi(dbapi):
     def async_fetch_map(
         self,
         mypkg: str,
-        useflags: Optional[Sequence[str]] = None,
-        mytree: Optional[str] = None,
+        useflags: Sequence[str] | None = None,
+        mytree: str | None = None,
         loop: Any = None,
     ) -> dict[str, tuple[str, ...]]:
         """
@@ -994,9 +994,9 @@ class portdbapi(dbapi):
     def getfetchsizes(
         self,
         mypkg: str,
-        useflags: Optional[Sequence[str]] = None,
+        useflags: Sequence[str] | None = None,
         debug: int = 0,
-        myrepo: Optional[str] = None,
+        myrepo: str | None = None,
     ):
         # returns a filename:size dictionary of remaining downloads
         myebuild, mytree = self.findname2(mypkg, myrepo=myrepo)  # type: ignore[assignment]
@@ -1073,7 +1073,7 @@ class portdbapi(dbapi):
     def fetch_check(
         self,
         mypkg: str,
-        useflags: Optional[Sequence[str]] = None,
+        useflags: Sequence[str] | None = None,
         mysettings=None,
         all=False,
         myrepo=None,
@@ -1123,7 +1123,7 @@ class portdbapi(dbapi):
             return False
         return True
 
-    def cpv_exists(self, mykey: str, myrepo: Optional[str] = None) -> Literal[0, 1]:
+    def cpv_exists(self, mykey: str, myrepo: str | None = None) -> Literal[0, 1]:
         "Tells us whether an actual ebuild exists on disk (no masking)"
         cps2 = mykey.split("/")
         cps = catpkgsplit(mykey, silent=0)
@@ -1137,7 +1137,7 @@ class portdbapi(dbapi):
 
     def cp_all(  # type: ignore[override]
         self,
-        categories: Optional[Iterable[str]] = None,
+        categories: Iterable[str] | None = None,
         trees=None,
         reverse: bool = False,
         sort: bool = True,
@@ -1306,7 +1306,7 @@ class portdbapi(dbapi):
         mydep: type[DeprecationWarning] = DeprecationWarning,
         mykey: type[DeprecationWarning] = DeprecationWarning,
         mylist: type[DeprecationWarning] = DeprecationWarning,
-    ) -> Union[Sequence[str], str]:
+    ) -> Sequence[str] | str:
         """
         Caching match function.
 
@@ -1482,7 +1482,7 @@ class portdbapi(dbapi):
 
         return myval
 
-    def match(self, mydep: str, use_cache: int = 1) -> Union[Sequence[str], str]:
+    def match(self, mydep: str, use_cache: int = 1) -> Sequence[str] | str:
         return self.xmatch("match-visible", mydep)
 
     def gvisible(self, mylist):

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -65,7 +65,6 @@ if TYPE_CHECKING:
     from portage.versions import _pkg_str
 
 
-
 def close_portdbapi_caches():
     # The python interpreter does _not_ guarantee that destructors are
     # called for objects that remain when the interpreter exits, so we

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -54,7 +54,7 @@ import shlex
 
 import collections
 from collections import OrderedDict
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from urllib.parse import urlparse
 
@@ -560,9 +560,9 @@ class portdbapi(dbapi):
         if psplit is None or len(mysplit) != 2:
             raise InvalidPackageName(mycpv)
 
-        try:
-            cp = mycpv.cp  # type: ignore[attr-defined]
-        except AttributeError:
+        if isinstance(mycpv, _pkg_str):
+            cp = mycpv.cp
+        else:
             cp = mysplit[0] + "/" + psplit[0]
 
         if self._better_cache is None:
@@ -685,7 +685,7 @@ class portdbapi(dbapi):
 
         return (metadata, ebuild_hash)
 
-    def aux_get(  # type: ignore[override]
+    def aux_get(
         self,
         mycpv: str,
         mylist: Sequence[_AuxKeys],

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -60,16 +60,10 @@ from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from portage.dbapi import _AuxKeys
-    from portage.dep import _match_slot, Atom, match_from_list, use_reduce
+    from portage.dep import Atom
     from portage.package.ebuild.config import config as config_type
-    from portage.package.ebuild.fetch import _download_suffix
-    from portage.util import ensure_dirs, writemsg
-    from portage.util.listdir import listdir
-    from portage.versions import _pkg_str, catpkgsplit, catsplit, pkgsplit, ver_regexp
-    import portage.data
+    from portage.versions import _pkg_str
 
-    portage_gid: int
-    secpass: int
 
 
 def close_portdbapi_caches():

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -464,7 +464,7 @@ class portdbapi(dbapi):
 
     def findname(
         self, mycpv: str, mytree: Optional[str] = None, myrepo: Optional[str] = None
-    ) -> Optional[str]:
+    ) -> str:
         return self.findname2(mycpv, mytree, myrepo)[0]
 
     def getRepositoryPath(self, repository_id):
@@ -528,7 +528,7 @@ class portdbapi(dbapi):
         mycpv: str | _pkg_str,
         mytree: Optional[str] = None,
         myrepo: Optional[str] = None,
-    ) -> Union[tuple[None, int], tuple[str, str], tuple[str, None]]:
+    ) -> tuple[str, str]:
         """
         Returns the location of the CPV, and what overlay it was in.
         Searches overlays first, then PORTDIR; this allows us to return the first
@@ -538,12 +538,12 @@ class portdbapi(dbapi):
         If myrepo is not None it will find packages from this repository(overlay)
         """
         if not mycpv:
-            return (None, 0)
+            return ("", "")
 
         if myrepo is not None:
             mytree = self.treemap.get(myrepo)
             if mytree is None:
-                return (None, 0)
+                return ("", "")
         elif mytree is not None:
             # myrepo enables cached results when available
             myrepo = self.repositories.location_map.get(mytree)
@@ -999,9 +999,8 @@ class portdbapi(dbapi):
         myrepo: Optional[str] = None,
     ):
         # returns a filename:size dictionary of remaining downloads
-        mytree: str
         myebuild, mytree = self.findname2(mypkg, myrepo=myrepo)  # type: ignore[assignment]
-        if myebuild is None:
+        if not myebuild:
             raise AssertionError(_("ebuild not found for '%s'") % mypkg)
         pkgdir = os.path.dirname(myebuild)
         mf = self.repositories.get_repo_for_location(

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -3,7 +3,7 @@
 
 __all__ = ["vardbapi", "vartree", "dblink"] + ["write_contents", "tar_contents"]
 
-from typing import Any
+from typing import Any, Never
 import portage
 
 portage.proxy.lazyimport.lazyimport(
@@ -1684,7 +1684,7 @@ class vartree:
     def inject(self, mycpv: str) -> None:
         return
 
-    def get_provide(self, mycpv: str) -> list[Any]:
+    def get_provide(self, mycpv: str) -> list[Never]:
         return []
 
     def get_all_provides(self) -> dict[str, list[str]]:

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -3,6 +3,7 @@
 
 __all__ = ["vardbapi", "vartree", "dblink"] + ["write_contents", "tar_contents"]
 
+from typing import Any
 import portage
 
 portage.proxy.lazyimport.lazyimport(
@@ -1677,16 +1678,16 @@ class vartree:
     def getpath(self, mykey, filename=None):
         return self.dbapi.getpath(mykey, filename=filename)
 
-    def zap(self, mycpv):
+    def zap(self, mycpv: str) -> None:
         return
 
-    def inject(self, mycpv):
+    def inject(self, mycpv: str) -> None:
         return
 
-    def get_provide(self, mycpv):
+    def get_provide(self, mycpv: str) -> list[Any]:
         return []
 
-    def get_all_provides(self):
+    def get_all_provides(self) -> dict[str, list[str]]:
         return {}
 
     def dep_bestmatch(self, mydep, use_cache=1):

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -3,7 +3,7 @@
 
 __all__ = ["vardbapi", "vartree", "dblink"] + ["write_contents", "tar_contents"]
 
-from typing import Any, Never
+from typing import Never
 import portage
 
 portage.proxy.lazyimport.lazyimport(

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -3,7 +3,6 @@
 
 __all__ = ["vardbapi", "vartree", "dblink"] + ["write_contents", "tar_contents"]
 
-from typing import Never
 import portage
 
 portage.proxy.lazyimport.lazyimport(
@@ -1684,7 +1683,7 @@ class vartree:
     def inject(self, mycpv: str) -> None:
         return
 
-    def get_provide(self, mycpv: str) -> list[Never]:
+    def get_provide(self, mycpv: str) -> list[object]:
         return []
 
     def get_all_provides(self) -> dict[str, list[str]]:

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -1451,6 +1451,8 @@ class Atom(str):
     # Distiguishes soname atoms from other atom types
     soname = False
 
+    cp: str
+
     class _blocker:
         __slots__ = ("overlap",)
 
@@ -1468,9 +1470,9 @@ class Atom(str):
 
     def __init__(
         self,
-        s,
+        s: str,
         unevaluated_atom=None,
-        allow_wildcard=False,
+        allow_wildcard: bool = False,
         allow_repo=None,
         _use=None,
         eapi=None,

--- a/lib/portage/emaint/__init__.py
+++ b/lib/portage/emaint/__init__.py
@@ -1,5 +1,4 @@
 # Copyright 2005-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-"""System health checks and maintenance utilities.
-"""
+"""System health checks and maintenance utilities."""

--- a/lib/portage/emaint/modules/__init__.py
+++ b/lib/portage/emaint/modules/__init__.py
@@ -1,5 +1,4 @@
 # Copyright 2005-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-"""Plug-in modules for system health checks and maintenance.
-"""
+"""Plug-in modules for system health checks and maintenance."""

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -103,7 +103,7 @@ def _get_lock_fn():
 
 
 def _test_lock_fn(
-    lock_fn: typing.Callable[[str, int, int], typing.Callable[[], None]]
+    lock_fn: typing.Callable[[str, int, int], typing.Callable[[], None]],
 ) -> bool:
     fd, lock_path = tempfile.mkstemp()
     unlock_fn = None

--- a/lib/portage/package/ebuild/_config/VirtualsManager.py
+++ b/lib/portage/package/ebuild/_config/VirtualsManager.py
@@ -1,9 +1,12 @@
 # Copyright 2010 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+from __future__ import annotations
 
 __all__ = ("VirtualsManager",)
 
 from copy import deepcopy
+from typing import TYPE_CHECKING
+
 
 from portage import os
 from portage.dep import Atom
@@ -11,6 +14,9 @@ from portage.exception import InvalidAtom
 from portage.localization import _
 from portage.util import grabdict, stack_dictlist, writemsg
 from portage.versions import cpv_getkey
+
+if TYPE_CHECKING:
+    from portage.dbapi.vartree import vartree
 
 
 class VirtualsManager:
@@ -164,7 +170,7 @@ class VirtualsManager:
 
         return self._virtuals
 
-    def _populate_treeVirtuals(self, vartree):
+    def _populate_treeVirtuals(self, vartree: vartree) -> None:
         """
         Initialize _treeVirtuals from the given vartree.
         It must not have been initialized already, otherwise

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -19,7 +19,8 @@ import re
 import shlex
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional
+from typing import TYPE_CHECKING, Any
+from collections.abc import Iterator, Mapping
 import warnings
 
 from _emerge.Package import Package
@@ -246,18 +247,18 @@ class config:
 
     def __init__(
         self,
-        clone: Optional[config] = None,
-        mycpv: Optional[str] = None,
-        config_profile_path: Optional[str] = None,
-        config_incrementals: Optional[Mapping[str, str]] = None,
-        config_root: Optional[str] = None,
-        target_root: Optional[str] = None,
-        sysroot: Optional[str] = None,
-        eprefix: Optional[str] = None,
+        clone: config | None = None,
+        mycpv: str | None = None,
+        config_profile_path: str | None = None,
+        config_incrementals: Mapping[str, str] | None = None,
+        config_root: str | None = None,
+        target_root: str | None = None,
+        sysroot: str | None = None,
+        eprefix: str | None = None,
         local_config: bool = True,
-        env: Optional[Mapping[str, str]] = None,
+        env: Mapping[str, str] | None = None,
         _unmatched_removal: bool = False,
-        repositories: Optional[RepoConfigLoader] = None,
+        repositories: RepoConfigLoader | None = None,
     ):
         """
         @param clone: If provided, init will use deepcopy to copy by value the instance.

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -3111,7 +3111,7 @@ class config:
         self.getvirtuals()
         return self._virtuals_manager.get_virts_p()
 
-    def getvirtuals(self) -> dict[str, Any]:
+    def getvirtuals(self) -> dict[str, list[Atom]]:
         if self._virtuals_manager._treeVirtuals is None:
             # Hack around the fact that VirtualsManager needs a vartree
             # and vartree needs a config instance.

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1,5 +1,6 @@
 # Copyright 2010-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+from __future__ import annotations
 
 __all__ = [
     "autouse",
@@ -18,6 +19,7 @@ import re
 import shlex
 import sys
 import traceback
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional
 import warnings
 
 from _emerge.Package import Package
@@ -67,6 +69,7 @@ from portage.localization import _
 from portage.output import colorize
 from portage.process import fakeroot_capable, sandbox_capable
 from portage.repository.config import (
+    RepoConfigLoader,
     allow_profile_repo_deps,
     load_repository_config,
 )
@@ -104,6 +107,9 @@ from portage.package.ebuild._config.helper import (
     ordered_by_atom_specificity,
     prune_incremental,
 )
+
+if TYPE_CHECKING:
+    from portage.dbapi.vartree import vartree
 
 
 _feature_flags_cache = {}
@@ -233,20 +239,25 @@ class config:
     _environ_whitelist_re = special_env_vars.environ_whitelist_re
     _global_only_vars = special_env_vars.global_only_vars
 
+    categories: list[str]
+    depcachedir: str
+    features: features_set
+    repositories: RepoConfigLoader
+
     def __init__(
         self,
-        clone=None,
-        mycpv=None,
-        config_profile_path=None,
-        config_incrementals=None,
-        config_root=None,
-        target_root=None,
-        sysroot=None,
-        eprefix=None,
-        local_config=True,
-        env=None,
-        _unmatched_removal=False,
-        repositories=None,
+        clone: Optional[config] = None,
+        mycpv: Optional[str] = None,
+        config_profile_path: Optional[str] = None,
+        config_incrementals: Optional[Mapping[str, str]] = None,
+        config_root: Optional[str] = None,
+        target_root: Optional[str] = None,
+        sysroot: Optional[str] = None,
+        eprefix: Optional[str] = None,
+        local_config: bool = True,
+        env: Optional[Mapping[str, str]] = None,
+        _unmatched_removal: bool = False,
+        repositories: Optional[RepoConfigLoader] = None,
     ):
         """
         @param clone: If provided, init will use deepcopy to copy by value the instance.
@@ -959,7 +970,7 @@ class config:
 
                 # package.bashrc
                 for profile in profiles_complex:
-                    if not "profile-bashrcs" in profile.profile_formats:
+                    if "profile-bashrcs" not in profile.profile_formats:
                         continue
                     self._pbashrcdict[profile] = portage.dep.ExtendedAtomDict(dict)
                     bashrc = grabdict_package(
@@ -1685,7 +1696,7 @@ class config:
             self.settings = settings
             self.values = None
 
-        def __getitem__(self, k):
+        def __getitem__(self, k: str) -> str:
             if self.values is None:
                 self.values = self._init_values()
             return self.values[k]
@@ -2120,7 +2131,7 @@ class config:
                 allow_test = self.get("ALLOW_TEST", "").split()
                 restrict_test = (
                     "test" in restrict
-                    and not "all" in allow_test
+                    and "all" not in allow_test
                     and not ("test_network" in properties and "network" in allow_test)
                     and not (
                         "test_privileged" in properties and "privileged" in allow_test
@@ -3100,7 +3111,7 @@ class config:
         self.getvirtuals()
         return self._virtuals_manager.get_virts_p()
 
-    def getvirtuals(self):
+    def getvirtuals(self) -> dict[str, Any]:
         if self._virtuals_manager._treeVirtuals is None:
             # Hack around the fact that VirtualsManager needs a vartree
             # and vartree needs a config instance.
@@ -3113,7 +3124,7 @@ class config:
 
         return self._virtuals_manager.getvirtuals()
 
-    def _populate_treeVirtuals_if_needed(self, vartree):
+    def _populate_treeVirtuals_if_needed(self, vartree: vartree) -> None:
         """Reduce the provides into a list by CP."""
         if self._virtuals_manager._treeVirtuals is None:
             if self.local_config:
@@ -3121,10 +3132,10 @@ class config:
             else:
                 self._virtuals_manager._treeVirtuals = {}
 
-    def __delitem__(self, mykey):
+    def __delitem__(self, mykey: str) -> None:
         self.pop(mykey)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         try:
             return self._getitem(key)
         except KeyError:
@@ -3161,7 +3172,7 @@ class config:
                 )
                 return ""
 
-    def _getitem(self, mykey):
+    def _getitem(self, mykey: str) -> Any:
         if mykey in self._constant_keys:
             # These two point to temporary values when
             # portage plans to update itself.
@@ -3205,13 +3216,13 @@ class config:
 
         raise KeyError(mykey)
 
-    def get(self, k, x=None):
+    def get(self, k: str, x: Any = None) -> Any:
         try:
             return self._getitem(k)
         except KeyError:
             return x
 
-    def pop(self, key, *args):
+    def pop(self, key: str, *args: Any) -> Any:
         self.modifying()
         if len(args) > 1:
             raise TypeError(
@@ -3226,7 +3237,7 @@ class config:
             raise KeyError(key)
         return v
 
-    def __contains__(self, mykey):
+    def __contains__(self, mykey: str) -> bool:
         """Called to implement membership test operators (in and not in)."""
         try:
             self._getitem(mykey)
@@ -3235,28 +3246,28 @@ class config:
         else:
             return True
 
-    def setdefault(self, k, x=None):
+    def setdefault(self, k: str, x: Any = None) -> Any:
         v = self.get(k)
         if v is not None:
             return v
         self[k] = x
         return x
 
-    def __iter__(self):
-        keys = set()
+    def __iter__(self) -> Iterator[str]:
+        keys: set[str] = set()
         keys.update(self._constant_keys)
         for d in self.lookuplist:
             keys.update(d)
         return iter(keys)
 
-    def iterkeys(self):
+    def iterkeys(self) -> Iterator[str]:
         return iter(self)
 
-    def iteritems(self):
+    def iteritems(self) -> Iterator[tuple[str, Any]]:
         for k in self:
             yield (k, self._getitem(k))
 
-    def __setitem__(self, mykey, myvalue):
+    def __setitem__(self, mykey: str, myvalue: Any) -> None:
         "set a value; will be thrown away at reset() time"
         if not isinstance(myvalue, str):
             raise ValueError(
@@ -3271,7 +3282,7 @@ class config:
         self.modifiedkeys.append(mykey)
         self.configdict["env"][mykey] = myvalue
 
-    def environ(self):
+    def environ(self) -> dict[str, Any]:
         "return our locally-maintained environment"
         mydict = {}
         environ_filter = self._environ_filter
@@ -3420,7 +3431,7 @@ class config:
 
         return mydict
 
-    def thirdpartymirrors(self):
+    def thirdpartymirrors(self) -> dict[str, Any]:
         if getattr(self, "_thirdpartymirrors", None) is None:
             thirdparty_lists = []
             for repo_name in reversed(self.repositories.prepos_order):
@@ -3436,14 +3447,14 @@ class config:
             self._thirdpartymirrors = stack_dictlist(thirdparty_lists, incremental=True)
         return self._thirdpartymirrors
 
-    def archlist(self):
+    def archlist(self) -> list[str]:
         _archlist = []
         for myarch in self["PORTAGE_ARCHLIST"].split():
             _archlist.append(myarch)
             _archlist.append("~" + myarch)
         return _archlist
 
-    def selinux_enabled(self):
+    def selinux_enabled(self) -> int:
         if getattr(self, "_selinux_enabled", None) is None:
             self._selinux_enabled = 0
             if "selinux" in self.features:

--- a/lib/portage/tests/resolver/test_onlydeps_ideps.py
+++ b/lib/portage/tests/resolver/test_onlydeps_ideps.py
@@ -52,7 +52,7 @@ class OnlydepsIdepsTestCase(TestCase):
                     "--onlydeps-with-ideps": "y",
                 },
                 ambiguous_merge_order=True,
-                mergelist=[("dev-libs/B-1")],
+                mergelist=["dev-libs/B-1"],
             ),
             ResolverPlaygroundTestCase(
                 ["dev-libs/F"],
@@ -64,7 +64,7 @@ class OnlydepsIdepsTestCase(TestCase):
                     "--onlydeps-with-ideps": True,
                 },
                 ambiguous_merge_order=True,
-                mergelist=[("dev-libs/B-1")],
+                mergelist=["dev-libs/B-1"],
             ),
             ResolverPlaygroundTestCase(
                 ["dev-libs/F"],

--- a/lib/portage/util/_xattr.py
+++ b/lib/portage/util/_xattr.py
@@ -8,7 +8,7 @@ We do not include the functions that Python 3.3+ provides in the os module as
 the signature there is different compared to xattr.
 
 See the standard xattr module for more documentation:
-	https://pypi.python.org/pypi/pyxattr
+        https://pypi.python.org/pypi/pyxattr
 """
 
 import contextlib

--- a/lib/portage/versions.py
+++ b/lib/portage/versions.py
@@ -20,7 +20,7 @@ import typing
 import warnings
 from functools import lru_cache
 from typing import Any, Optional, Union
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 
 import portage
@@ -323,8 +323,8 @@ _missing_cat = "null"
 def catpkgsplit(
     mydata: Union[str, "_pkg_str"],
     silent: int = 1,
-    eapi: Any = None,
-) -> Optional[tuple[str, ...]]:
+    eapi: Optional[str] = None,
+) -> Optional[tuple[Optional[str], str, str, str]]:
     """
     Takes a Category/Package-Version-Rev and returns a list of each.
 
@@ -339,7 +339,7 @@ def catpkgsplit(
     3.  if rev does not exist it will be '-r0'
     """
     try:
-        return mydata.cpv_split
+        return mydata.cpv_split  # type: ignore[union-attr]
     except AttributeError:
         pass
     mysplit = mydata.split("/", 1)
@@ -373,6 +373,8 @@ class _pkg_str(str):
     is missing from the metadata dictionary.
     """
 
+    cpv_split: Optional[tuple[Optional[str], str, str, str]]
+
     def __new__(
         cls,
         cpv: str,
@@ -393,7 +395,7 @@ class _pkg_str(str):
     def __init__(
         self,
         cpv: str,
-        metadata: Optional[dict[str, Any]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
         settings: Any = None,
         eapi: Any = None,
         repo: Optional[str] = None,

--- a/lib/portage/versions.py
+++ b/lib/portage/versions.py
@@ -338,10 +338,8 @@ def catpkgsplit(
     2.  If cat is not specificed in mydata, cat will be "null"
     3.  if rev does not exist it will be '-r0'
     """
-    try:
-        return mydata.cpv_split  # type: ignore[union-attr]
-    except AttributeError:
-        pass
+    if isinstance(mydata, _pkg_str):
+        return mydata.cpv_split
     mysplit = mydata.split("/", 1)
     p_split = None
     if len(mysplit) == 1:
@@ -373,6 +371,7 @@ class _pkg_str(str):
     is missing from the metadata dictionary.
     """
 
+    cp: str
     cpv_split: Optional[tuple[Optional[str], str, str, str]]
 
     def __new__(

--- a/lib/portage/xml/metadata.py
+++ b/lib/portage/xml/metadata.py
@@ -3,29 +3,29 @@
 
 """Provides an easy-to-use python interface to Gentoo's metadata.xml file.
 
-	Example usage:
-		>>> from portage.xml.metadata import MetaDataXML
-		>>> pkg_md = MetaDataXML('/var/db/repos/gentoo/app-misc/gourmet/metadata.xml')
-		>>> pkg_md
-		<MetaDataXML '/var/db/repos/gentoo/app-misc/gourmet/metadata.xml'>
-		>>> pkg_md.herds()
-		['no-herd']
-		>>> for maint in pkg_md.maintainers():
-		...     print "{0} ({1})".format(maint.email, maint.name)
-		...
-		nixphoeni@gentoo.org (Joe Sapp)
-		>>> for flag in pkg_md.use():
-		...     print flag.name, "->", flag.description
-		...
-		rtf -> Enable export to RTF
-		gnome-print -> Enable printing support using gnome-print
-		>>> upstream = pkg_md.upstream()
-		>>> upstream
-		[<_Upstream {'docs': [], 'remoteid': [], 'maintainer':
-		 [<_Maintainer 'Thomas_Hinkle@alumni.brown.edu'>], 'bugtracker': [],
-		 'changelog': []}>]
-		>>> upstream[0].maintainer[0].name
-		'Thomas Mills Hinkle'
+Example usage:
+        >>> from portage.xml.metadata import MetaDataXML
+        >>> pkg_md = MetaDataXML('/var/db/repos/gentoo/app-misc/gourmet/metadata.xml')
+        >>> pkg_md
+        <MetaDataXML '/var/db/repos/gentoo/app-misc/gourmet/metadata.xml'>
+        >>> pkg_md.herds()
+        ['no-herd']
+        >>> for maint in pkg_md.maintainers():
+        ...     print "{0} ({1})".format(maint.email, maint.name)
+        ...
+        nixphoeni@gentoo.org (Joe Sapp)
+        >>> for flag in pkg_md.use():
+        ...     print flag.name, "->", flag.description
+        ...
+        rtf -> Enable export to RTF
+        gnome-print -> Enable printing support using gnome-print
+        >>> upstream = pkg_md.upstream()
+        >>> upstream
+        [<_Upstream {'docs': [], 'remoteid': [], 'maintainer':
+         [<_Maintainer 'Thomas_Hinkle@alumni.brown.edu'>], 'bugtracker': [],
+         'changelog': []}>]
+        >>> upstream[0].maintainer[0].name
+        'Thomas Mills Hinkle'
 """
 
 __all__ = ("MetaDataXML", "parse_metadata_use")


### PR DESCRIPTION
Checked with `mypy lib/portage/dbapi/porttree.py | grep -F porttree.py:`. Zero issues.

Also included are some other changes to match [portage-stubs](https://github.com/Tatsh/portage-stubs).

The rest of the changes are done by Black.