### PR TITLE
fix missing shlex import in error path

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -4,6 +4,7 @@
 
 import argparse
 import os
+import shlex
 import stat
 import sys
 import subprocess


### PR DESCRIPTION
Regression in commit 002cd09b455eae1790f113438a030828edf3ef14. Since the function we need isn't invisibly exposed via portage.*, we need to distinctly import it. We did in most cases, but not here.

Caught by flake8's missing imports linter. Unfortunately, the overall usefulness of flake8 here is effectively nil, because lazyimport means *all* imports are "missing". It is too noisy to believe. But I actually spotted this error, it's not a false positive, and we might as well fix it immediately.

Fixes: 002cd09b455eae1790f113438a030828edf3ef14