### PR TITLE
emergelog: truncate fractional seconds

### DIFF
--- a/lib/_emerge/emergelog.py
+++ b/lib/_emerge/emergelog.py
@@ -45,7 +45,7 @@ def emergelog(xterm_titles, mystr, short_msg=None):
             )
         mylock = portage.locks.lockfile(file_path)
         try:
-            mylogfile.write(f"{time.time():.0f}: {mystr}\n")
+            mylogfile.write(f"{int(time.time())}: {mystr}\n")
             mylogfile.close()
         finally:
             portage.locks.unlockfile(mylock)

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -2685,7 +2685,7 @@ def _post_src_install_write_metadata(settings):
         encoding=_encodings["repo.content"],
         errors="strict",
     ) as f:
-        f.write(f"{time.time():.0f}\n")
+        f.write(f"{int(time.time())}\n")
 
     use = frozenset(settings["PORTAGE_USE"].split())
     for k in _vdb_use_conditional_keys:


### PR DESCRIPTION
The ".0f" format will result in the timestamp being rounded to the nearest second, which would give some messages a timestamp in the future.

Truncating the fractional seconds gives behavior that is more consistent.