### PR TITLE
Implement FEATURE `suppress-bindist-buildpkg`

### DIFF
--- a/.builds/ci.yml
+++ b/.builds/ci.yml
@@ -9,7 +9,6 @@ repositories:
   # pypy: https://ppa.launchpadcontent.net/pypy/ppa/ubuntu jammy main "251104D968854915"
 environment:
   PYTHON_VERSIONS:
-    - '3.9'
     - '3.10'
     - '3.11'
     # Python 3.12 seems to (at least sometimes) timeout

--- a/.builds/lint.yml
+++ b/.builds/lint.yml
@@ -7,7 +7,6 @@ repositories:
   deadsnakes: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main "BA6932366A755776"
 environment:
   PYTHON_VERSIONS:
-    - '3.9'
     - '3.10'
     - '3.11'
 tasks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           - 'fork'
           - 'spawn'
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
@@ -23,8 +22,6 @@ jobs:
           - '3.14-dev'
           - 'pypy-3.11'
         exclude:
-          - python-version: '3.9'
-            start-method: 'spawn'
           - python-version: '3.10'
             start-method: 'spawn'
           - python-version: '3.11'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/DEVELOPING
+++ b/DEVELOPING
@@ -9,7 +9,7 @@ bad habits that exist in the current codebase.
 Python Version
 --------------
 
-Python 3.9 is the minimum supported version.
+Python 3.10 is the minimum supported version.
 
 Dependencies
 ------------

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@ portage-3.0.69 (UNRELEASED)
 Bug fixes:
 * _global_updates: Skip if vardb lock raises PermissionDenied (bug #953449).
 
+Breaking changes:
+* The minimum supported Python version is now >= Python 3.10.
+
 portage-3.0.68 (2025-04-12)
 --------------
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 Dependencies
 ============
 
-Python and Bash should be the only hard dependencies. Python 3.9 is the
+Python and Bash should be the only hard dependencies. Python 3.10 is the
 minimum supported version.
 
 Native Extensions

--- a/lib/_emerge/EbuildBuild.py
+++ b/lib/_emerge/EbuildBuild.py
@@ -356,10 +356,16 @@ class EbuildBuild(CompositeTask):
         live_ebuild = "live" in self.settings.get("PROPERTIES", "").split()
         buildpkg_live_disabled = live_ebuild and not buildpkg_live
 
+        # Check if binary package creation should be suppressed for RESTRICT=bindist packages
+        suppress_bindist = (
+            "suppress-bindist-buildpkg" in features and "bindist" in self.pkg.restrict
+        )
+
         if (
             ("buildpkg" in features or self._issyspkg)
             and not buildpkg_live_disabled
             and not self.opts.buildpkg_exclude.findAtomForPackage(pkg)
+            and not suppress_bindist
         ):
             self._buildpkg = True
 

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -234,6 +234,7 @@ SUPPORTED_FEATURES = frozenset(
         "strict",
         "strict-keepdir",
         "stricter",
+        "suppress-bindist-buildpkg",
         "suidctl",
         "test",
         "test-fail-continue",

--- a/lib/portage/tests/emerge/meson.build
+++ b/lib/portage/tests/emerge/meson.build
@@ -1,12 +1,13 @@
 py.install_sources(
     [
         'test_actions.py',
+        'test_baseline.py',
         'test_binpkg_fetch.py',
+        'test_buildpkg.py',
         'test_config_protect.py',
         'test_emerge_blocker_file_collision.py',
         'test_emerge_slot_abi.py',
         'test_global_updates.py',
-        'test_baseline.py',
         'test_libc_dep_inject.py',
         '__init__.py',
         '__test__.py',

--- a/lib/portage/tests/emerge/test_buildpkg.py
+++ b/lib/portage/tests/emerge/test_buildpkg.py
@@ -1,0 +1,482 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import subprocess
+import sys
+
+import portage
+from portage import _unicode_decode, os
+from portage.const import (
+    PORTAGE_PYM_PATH,
+    USER_CONFIG_PATH,
+    SUPPORTED_GENTOO_BINPKG_FORMATS,
+)
+from portage.process import find_binary
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+from portage.util import ensure_dirs
+from portage.output import colorize
+
+
+# We test the buildpkg functionality at a basic level with all binary package formats,
+# but avoid repeating the same tests for each format to avoid redundancy (just use gpkg / the fastest).
+class BuildpkgTestCase(TestCase):
+    """
+    Test suite for binary package creation using the 'buildpkg' feature in Portage.
+
+    This class focuses on verifying the correct behavior of binary package
+    creation in various scenarios, including:
+
+    - Basic binary package creation with the 'buildpkg' feature enabled.
+    - Handling of packages with RESTRICT=bindist.
+    - The 'suppress-bindist-buildpkg' feature, which prevents binary package
+        creation for packages with RESTRICT=bindist.
+    - Integration between 'suppress-bindist-buildpkg' and package installation.
+
+    The tests use a ResolverPlayground to simulate a Portage environment and
+    assert that binary packages are created or not created as expected based
+    on the configuration and package restrictions.
+    """
+
+    def testBasicBuildpkg(self):
+        """
+        Test basic binary package creation with FEATURES=buildpkg flag.
+        Verify that binary packages are actually created.
+        """
+        debug = False
+
+        from portage.tests.emerge.conftest import _INSTALL_SOMETHING
+
+        ebuilds = {
+            "dev-libs/test-basic-1::test": {
+                "EAPI": "8",
+                "SLOT": "0",
+                "KEYWORDS": "x86",
+                "MISC_CONTENT": _INSTALL_SOMETHING,
+            },
+        }
+
+        for binpkg_format in SUPPORTED_GENTOO_BINPKG_FORMATS:
+            with self.subTest(binpkg_format=binpkg_format):
+                print(
+                    colorize("HILITE", f"Testing basic buildpkg with {binpkg_format}"),
+                    end=" ... ",
+                )
+                sys.stdout.flush()
+
+                user_config = {
+                    "make.conf": (
+                        f'BINPKG_FORMAT="{binpkg_format}"',
+                        'FEATURES="buildpkg"',
+                    ),
+                }
+
+                playground = ResolverPlayground(
+                    ebuilds=ebuilds, user_config=user_config, debug=debug
+                )
+                try:
+                    self._run_buildpkg_test(
+                        playground,
+                        "dev-libs/test-basic",
+                        expected_binpkg=True,
+                        binpkg_format=binpkg_format,
+                    )
+
+                finally:
+                    playground.cleanup()
+
+    def testBuildpkgWithRestrictBindist(self):
+        """
+        Test binary package creation with RESTRICT=bindist packages.
+        This should always create a binary package, even if the package
+        has restricted bindist.
+        """
+        debug = False
+
+        from portage.tests.emerge.conftest import _INSTALL_SOMETHING
+
+        ebuilds = {
+            "dev-libs/test-bindist-1::test": {
+                "EAPI": "8",
+                "SLOT": "0",
+                "KEYWORDS": "x86",
+                "RESTRICT": "bindist",
+                "MISC_CONTENT": _INSTALL_SOMETHING,
+            },
+        }
+
+        binpkg_format = "gpkg"
+        with self.subTest(binpkg_format=binpkg_format):
+            print(
+                colorize("HILITE", f"Testing RESTRICT=bindist with {binpkg_format}"),
+                end=" ... ",
+            )
+            sys.stdout.flush()
+
+            user_config = {
+                "make.conf": (
+                    f'BINPKG_FORMAT="{binpkg_format}"',
+                    'FEATURES="buildpkg"',
+                ),
+            }
+
+            playground = ResolverPlayground(
+                ebuilds=ebuilds, user_config=user_config, debug=debug
+            )
+            try:
+                self._run_buildpkg_test(
+                    playground,
+                    "dev-libs/test-bindist",
+                    expected_binpkg=True,  # Should create binpkg
+                    binpkg_format=binpkg_format,
+                )
+
+            finally:
+                playground.cleanup()
+
+    def testSuppressBindistBuildpkgFeature(self):
+        """
+        Test that suppress-bindist-buildpkg feature prevents creation of binary packages
+        for packages with RESTRICT=bindist.
+        """
+        debug = False
+
+        from portage.tests.emerge.conftest import _INSTALL_SOMETHING
+
+        ebuilds = {
+            "dev-libs/test-suppress-1::test": {
+                "EAPI": "8",
+                "SLOT": "0",
+                "KEYWORDS": "x86",
+                "RESTRICT": "bindist",
+                "MISC_CONTENT": _INSTALL_SOMETHING,
+            },
+            "dev-libs/test-normal-1::test": {
+                "EAPI": "8",
+                "SLOT": "0",
+                "KEYWORDS": "x86",
+                "MISC_CONTENT": _INSTALL_SOMETHING,
+            },
+        }
+
+        binpkg_format = "gpkg"
+        with self.subTest(binpkg_format=binpkg_format):
+            print(
+                colorize(
+                    "HILITE", f"Testing suppress-bindist-buildpkg with {binpkg_format}"
+                ),
+                end=" ... ",
+            )
+            sys.stdout.flush()
+
+            user_config = {
+                "make.conf": (
+                    f'BINPKG_FORMAT="{binpkg_format}"',
+                    'FEATURES="buildpkg suppress-bindist-buildpkg"',
+                ),
+            }
+
+            playground = ResolverPlayground(
+                ebuilds=ebuilds, user_config=user_config, debug=debug
+            )
+            try:
+                settings = playground.settings
+
+                self.assertIn(
+                    "suppress-bindist-buildpkg",
+                    settings.features,
+                    "suppress-bindist-buildpkg feature should be enabled",
+                )
+
+                self._run_buildpkg_test(
+                    playground,
+                    "dev-libs/test-suppress",
+                    expected_binpkg=False,  # Should NOT create binpkg due to suppress-bindist-buildpkg feature
+                    binpkg_format=binpkg_format,
+                )
+
+                self._run_buildpkg_test(
+                    playground,
+                    "dev-libs/test-normal",
+                    expected_binpkg=True,  # Should create binpkg normally, feature has no effect
+                    binpkg_format=binpkg_format,
+                )
+
+            finally:
+                playground.cleanup()
+
+    def testSuppressBindistBuildpkgIntegration(self):
+        """
+        Test the integration between suppress-bindist-buildpkg feature and
+        package installation. Packages with RESTRICT=bindist should still
+        be installable when the feature is enabled, without creating binary packages.
+        """
+        debug = False
+
+        from portage.tests.emerge.conftest import _INSTALL_SOMETHING
+
+        ebuilds = {
+            "dev-libs/test-integration-1::test": {
+                "EAPI": "8",
+                "SLOT": "0",
+                "KEYWORDS": "x86",
+                "RESTRICT": "bindist",
+                "MISC_CONTENT": _INSTALL_SOMETHING,
+            },
+        }
+
+        user_config = {
+            "make.conf": ('FEATURES="suppress-bindist-buildpkg"',),
+        }
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config, debug=debug
+        )
+        try:
+            settings = playground.settings
+            eroot = settings["EROOT"]
+
+            emerge_cmd = self._get_emerge_cmd(playground)
+            test_commands = (
+                emerge_cmd
+                + (
+                    "--oneshot",
+                    "dev-libs/test-integration",
+                ),
+            )
+
+            success = self._run_commands(playground, test_commands, debug)
+            self.assertTrue(
+                success,
+                "Without ACCEPT_RESTRICT=-bindist, package with RESTRICT=bindist should be installable with suppress-bindist-buildpkg feature",
+            )
+
+            vardb = playground.trees[eroot]["vartree"].dbapi
+            self.assertTrue(
+                vardb.match("dev-libs/test-integration"),
+                "Package should be installed in vardb",
+            )
+
+        finally:
+            playground.cleanup()
+
+    def testSuppressBindistBuildpkgFeatureDefinition(self):
+        """
+        Test that suppress-bindist-buildpkg is properly defined in SUPPORTED_FEATURES.
+        """
+        from portage.const import SUPPORTED_FEATURES
+
+        self.assertIn(
+            "suppress-bindist-buildpkg",
+            SUPPORTED_FEATURES,
+            "suppress-bindist-buildpkg should be in SUPPORTED_FEATURES",
+        )
+
+    def _run_buildpkg_test(
+        self, playground, package_atom, expected_binpkg, binpkg_format
+    ):
+        """
+        Helper method to run a buildpkg test and verify the results.
+
+        Args:
+            playground: ResolverPlayground instance
+            package_atom: Package atom to build (e.g., "dev-libs/test-basic")
+            expected_binpkg: Whether a binary package should be created
+            binpkg_format: Binary package format (xpak or gpkg)
+        """
+        emerge_cmd = self._get_emerge_cmd(playground)
+
+        test_commands = (
+            emerge_cmd
+            + (
+                "--oneshot",
+                package_atom,
+            ),
+        )
+
+        success = self._run_commands(playground, test_commands, False)
+        self.assertTrue(success, f"Emerge command should succeed for {package_atom}")
+
+        binpkg_created = self._check_binpkg_exists(
+            playground, package_atom, binpkg_format
+        )
+
+        if expected_binpkg:
+            self.assertTrue(
+                binpkg_created, f"Binary package should be created for {package_atom}"
+            )
+        else:
+            self.assertFalse(
+                binpkg_created,
+                f"Binary package should NOT be created for {package_atom}",
+            )
+
+    def _check_binpkg_exists(self, playground, package_atom, binpkg_format):
+        """
+        Check if a binary package was created for the given package atom.
+
+        Args:
+            playground: ResolverPlayground instance
+            package_atom: Package atom to check
+            binpkg_format: Binary package format (xpak or gpkg)
+
+        Returns:
+            bool: True if binary package exists, False otherwise
+        """
+        settings = playground.settings
+        eroot = settings["EROOT"]
+        trees = playground.trees
+        bindb = trees[eroot]["bintree"].dbapi
+
+        # Force bintree to update its index
+        bindb.bintree.populate(force_reindex=True)
+
+        # Check if package is in binary database
+        matches = bindb.match(package_atom)
+        if not matches:
+            return False
+
+        # Check if actual binary package file exists
+        for cpv in matches:
+            binpkg_path = bindb.bintree.getname(cpv, allocate_new=False)
+            if binpkg_path and os.path.exists(binpkg_path):
+                match binpkg_format:
+                    case "gpkg":
+                        if binpkg_path.endswith(".gpkg.tar"):
+                            return True
+                    case "xpak":
+                        if binpkg_path.endswith((".tbz2", ".xpak")):
+                            return True
+                    case _:
+                        return False
+
+        return False
+
+    def _get_emerge_cmd(self, playground):
+        """Get the emerge command for the given playground."""
+        portage_python = portage._python_interpreter
+        emerge_cmd = (
+            portage_python,
+            "-b",
+            "-Wd",
+            os.path.join(str(portage.const.PORTAGE_BIN_PATH), "emerge"),
+        )
+        return emerge_cmd
+
+    def _run_commands(self, playground, test_commands, debug):
+        """
+        Run a sequence of commands in the playground environment.
+
+        Args:
+            playground: ResolverPlayground instance
+            test_commands: Tuple of command tuples to run
+            debug: Whether to enable debug output
+
+        Returns:
+            bool: True if all commands succeeded, False otherwise
+        """
+        settings = playground.settings
+        eprefix = settings["EPREFIX"]
+        fake_bin = os.path.join(eprefix, "bin")
+        portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
+        user_config_dir = os.path.join(eprefix, USER_CONFIG_PATH)
+        var_cache_edb = os.path.join(eprefix, "var", "cache", "edb")
+
+        path = settings.get("PATH")
+        if path is not None and not path.strip():
+            path = None
+        if path is None:
+            path = ""
+        else:
+            path = ":" + path
+        path = fake_bin + path
+
+        pythonpath = os.environ.get("PYTHONPATH")
+        if pythonpath is not None and not pythonpath.strip():
+            pythonpath = None
+        if pythonpath is not None and pythonpath.split(":")[0] == PORTAGE_PYM_PATH:
+            pass
+        else:
+            if pythonpath is None:
+                pythonpath = ""
+            else:
+                pythonpath = ":" + pythonpath
+            pythonpath = PORTAGE_PYM_PATH + pythonpath
+
+        env = {
+            "PORTAGE_OVERRIDE_EPREFIX": eprefix,
+            "PATH": path,
+            "PORTAGE_PYTHON": portage._python_interpreter,
+            "PORTAGE_REPOSITORIES": settings.repositories.config_string(),
+            "PYTHONDONTWRITEBYTECODE": os.environ.get("PYTHONDONTWRITEBYTECODE", ""),
+            "PYTHONPATH": pythonpath,
+            "PORTAGE_INST_GID": str(os.getgid()),
+            "PORTAGE_INST_UID": str(os.getuid()),
+            "FEATURES": "-pkgdir-index-trusted",
+        }
+
+        dirs = [
+            playground.distdir,
+            fake_bin,
+            portage_tmpdir,
+            user_config_dir,
+            var_cache_edb,
+        ]
+
+        true_symlinks = ["chown", "chgrp"]
+        needed_binaries = {
+            "true": (find_binary("true"), True),
+        }
+
+        try:
+            for d in dirs:
+                ensure_dirs(d)
+            for x in true_symlinks:
+                true_binary = needed_binaries["true"][0]
+                if true_binary:
+                    try:
+                        os.symlink(true_binary, os.path.join(fake_bin, x))
+                    except FileExistsError:
+                        pass
+
+            with open(os.path.join(var_cache_edb, "counter"), "wb") as f:
+                f.write(b"100")
+
+            if debug:
+                stdout = None
+            else:
+                stdout = subprocess.PIPE
+
+            all_successful = True
+            for i, args in enumerate(test_commands):
+                if hasattr(args[0], "__call__"):
+                    continue
+
+                if isinstance(args[0], dict):
+                    local_env = env.copy()
+                    local_env.update(args[0])
+                    args = args[1:]
+                else:
+                    local_env = env
+
+                proc = subprocess.Popen(args, env=local_env, stdout=stdout)
+
+                if debug:
+                    proc.wait()
+                else:
+                    output = proc.stdout.readlines()
+                    proc.wait()
+                    proc.stdout.close()
+                    if proc.returncode != os.EX_OK:
+                        for line in output:
+                            sys.stderr.write(_unicode_decode(line))
+
+                if proc.returncode != os.EX_OK:
+                    all_successful = False
+                    break
+
+            return all_successful
+
+        except Exception as e:
+            print(f"Exception in _run_commands: {e}")
+            return False

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -1,6 +1,7 @@
 py.install_sources(
     [
         'ResolverPlayground.py',
+        'test_accept_restrict_bindist.py',
         'test_alternatives_gzip.py',
         'test_aggressive_backtrack_downgrade.py',
         'test_autounmask.py',

--- a/lib/portage/tests/resolver/test_accept_restrict_bindist.py
+++ b/lib/portage/tests/resolver/test_accept_restrict_bindist.py
@@ -1,0 +1,300 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class AcceptRestrictBindistTestCase(TestCase):
+    def testAcceptRestrictBindist(self):
+        """
+        Test that packages with RESTRICT=bindist are properly masked
+        when ACCEPT_RESTRICT contains -bindist.
+
+        This test focuses on make.conf-based configuration of ACCEPT_RESTRICT,
+        assuming that command-line options are appropriately tested elsewhere.
+        """
+        ebuilds = {
+            # Package without RESTRICT
+            "dev-libs/unrestricted-1": {
+                "EAPI": "7",
+            },
+            # Package with RESTRICT=bindist
+            "dev-libs/bindist-restricted-1": {
+                "EAPI": "7",
+                "RESTRICT": "bindist",
+            },
+            # Package with multiple RESTRICT tokens including bindist
+            "dev-libs/multi-restricted-1": {
+                "EAPI": "7",
+                "RESTRICT": "test bindist strip",
+            },
+            # Package that depends on bindist-restricted package
+            "dev-libs/depends-on-bindist-1": {
+                "EAPI": "7",
+                "RDEPEND": "dev-libs/bindist-restricted",
+            },
+        }
+
+        # Test default behavior (ACCEPT_RESTRICT="*" - should accept all)
+        test_cases_default = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/unrestricted"],
+                success=True,
+                mergelist=["dev-libs/unrestricted-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=True,
+                mergelist=["dev-libs/bindist-restricted-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/multi-restricted"],
+                success=True,
+                mergelist=["dev-libs/multi-restricted-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds, debug=False)
+        try:
+            for test_case in test_cases_default:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        # Test ACCEPT_RESTRICT="* -bindist" - should mask bindist packages
+        user_config_minus_bindist = {"make.conf": ('ACCEPT_RESTRICT="* -bindist"',)}
+        test_cases_minus_bindist = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/unrestricted"],
+                success=True,
+                mergelist=["dev-libs/unrestricted-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=False,
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/multi-restricted"],
+                success=False,
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/depends-on-bindist"],
+                success=False,
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_minus_bindist, debug=False
+        )
+        try:
+            for test_case in test_cases_minus_bindist:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        # Test ACCEPT_RESTRICT="-bindist" alone - should mask bindist packages
+        user_config_only_minus = {"make.conf": ('ACCEPT_RESTRICT="-bindist"',)}
+        test_cases_only_minus = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=False,
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_only_minus, debug=False
+        )
+        try:
+            for test_case in test_cases_only_minus:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        # Test ACCEPT_RESTRICT="bindist" - should explicitly allow only bindist
+        user_config_only_bindist = {"make.conf": ('ACCEPT_RESTRICT="bindist"',)}
+        test_cases_only_bindist = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=True,
+                mergelist=["dev-libs/bindist-restricted-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_only_bindist, debug=False
+        )
+        try:
+            for test_case in test_cases_only_bindist:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        # Test ACCEPT_RESTRICT="" - behaves same as "*" (accepts all restrictions)
+        user_config_empty = {"make.conf": ('ACCEPT_RESTRICT=""',)}
+        test_cases_empty = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/unrestricted"],
+                success=True,
+                mergelist=["dev-libs/unrestricted-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=True,
+                mergelist=["dev-libs/bindist-restricted-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_empty, debug=False
+        )
+        try:
+            for test_case in test_cases_empty:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        # Test that FEATURES settings don't interfere with ACCEPT_RESTRICT behavior
+        user_config_with_features = {
+            "make.conf": (
+                'ACCEPT_RESTRICT="* -bindist"',
+                'FEATURES="buildpkg splitdebug"',
+            )
+        }
+        test_cases_with_features = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/unrestricted"],
+                success=True,
+                mergelist=["dev-libs/unrestricted-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=False,
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_with_features, debug=False
+        )
+        try:
+            for test_case in test_cases_with_features:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testAcceptRestrictBindistWithFeatures(self):
+        """
+        Test that ACCEPT_RESTRICT behavior is independent of FEATURES.
+        This verifies that packages with RESTRICT=bindist are masked
+        regardless of what FEATURES are set.
+        """
+        ebuilds = {
+            "dev-libs/bindist-restricted-1": {
+                "EAPI": "7",
+                "RESTRICT": "bindist",
+            },
+        }
+
+        # Test with various FEATURES settings - should all behave the same
+        user_config_with_sandbox = {
+            "make.conf": (
+                'ACCEPT_RESTRICT="* -bindist"',
+                'FEATURES="sandbox"',
+            )
+        }
+        test_cases_sandbox = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=False,
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_with_sandbox, debug=False
+        )
+        try:
+            for test_case in test_cases_sandbox:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        user_config_with_multiple_features = {
+            "make.conf": (
+                'ACCEPT_RESTRICT="* -bindist"',
+                'FEATURES="sandbox userpriv usersandbox"',
+            )
+        }
+        test_cases_multi_features = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=False,
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_with_multiple_features, debug=False
+        )
+        try:
+            for test_case in test_cases_multi_features:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        user_config_no_features = {
+            "make.conf": (
+                'ACCEPT_RESTRICT="* -bindist"',
+                'FEATURES=""',
+            )
+        }
+        test_cases_no_features = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=False,
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_no_features, debug=False
+        )
+        try:
+            for test_case in test_cases_no_features:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+        # Verify that with ACCEPT_RESTRICT="*", FEATURES don't matter
+        user_config_accept_all = {
+            "make.conf": (
+                'ACCEPT_RESTRICT="*"',
+                'FEATURES="sandbox userpriv"',
+            )
+        }
+        test_cases_accept_all = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/bindist-restricted"],
+                success=True,
+                mergelist=["dev-libs/bindist-restricted-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, user_config=user_config_accept_all, debug=False
+        )
+        try:
+            for test_case in test_cases_accept_all:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -796,6 +796,28 @@ Have portage react strongly to conditions that may conflict with system
 security provisions (for example textrels, executable stack).  Read about
 the \fIQA_STRICT_*\fR variables in \fBmake.conf\fR(5).
 .TP
+.B suppress\-bindist\-binpkg
+When enabled, this feature prevents the creation of binary packages for
+ebuilds that have the \fIbindist\fR restriction. This allows users to
+install such packages normally while ensuring that no binary packages
+are created for them, avoiding potential licensing or redistribution issues.
+The package will be built and installed as usual; only the binary package
+creation step is skipped.
+.br
+If disabled (the default), binary package creation will occur for all ebuilds
+requested, regardless of their \fIbindist\fR restriction.
+.br
+This feature is particularly useful when using \fBFEATURES="buildpkg"\fR
+or the \fB\-\-buildpkg\fR option, as it allows automatic binary package
+creation for most packages while respecting licensing restrictions on
+redistribution\-sensitive packages.
+.br
+Note: This feature operates at the binary package creation level and does not
+impact \fBACCEPT_RESTRICT\fR settings, which operate at the package resolution
+level. If \fBACCEPT_RESTRICT\fR excludes \fIbindist\fR, packages (or USE flags
+on packages) with a \fIbindist\fR restriction will not be resolvable by
+\fBemerge\fR(1) at all, regardless of this feature setting.
+.TP
 .B suidctl
 Before merging packages to the live filesystem, automatically strip setuid
 bits from any file that is not listed in \fI/etc/portage/suidctl.conf\fR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = 'portage'
 dynamic = ['version']
 description = 'Portage is the package management and distribution system for Gentoo'
 readme = 'README.md'
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 license = {file = "LICENSE"}
 authors = [
   {name = 'Gentoo Portage Development Team', email = 'dev-portage@gentoo.org'},

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{39,310,311,312,313}-{pylint,test},pypy3-test
+envlist = py{310,311,312,313}-{pylint,test},pypy3-test
 skipsdist = True
 
 [gh-actions]
 python =
-	3.9: py39
 	3.10: py310
 	3.11: py311
 	3.12: py312


### PR DESCRIPTION
This feature combines with `buildpkg` to enable the installation of packages with "RESTRICT=bindist" without the creation of a binpkg.

This should help binhost builders improve the library of pre-packaged software without running the risk of accidentally (bin)packaging a dependency that we can't legally distribute (or don't want to pay royalties on!)

**Current Behaviour**:
FEATURES=buildpkg + RESTRICT=bindist
	=> Package is installed, binpkg created
FEATURES=buildpkg + RESTRICT=bindist + ACCEPT_RESTRICT=-bindist
	=> Package is masked, cannot be selected

**New Behaviour**:
FEATURES=buildpkg + RESTRICT=bindist
	=> Package is installed, binpkg created
FEATURES=buildpkg suppress-bindist-buildpkg + RESTRICT=bindist
	=> Package is installed, binpkg creation stage skipped
FEATURES=* + RESTRICT=bindist + ACCEPT_RESTRICT=-bindist
	=> Any combination of features and the above are masked

Bug: https://bugs.gentoo.org/542480