### PR TITLE
DRAFT: Add RESTRICT=binpkg support

### DIFF
--- a/lib/_emerge/EbuildBuild.py
+++ b/lib/_emerge/EbuildBuild.py
@@ -355,11 +355,13 @@ class EbuildBuild(CompositeTask):
         buildpkg_live = "buildpkg-live" in features
         live_ebuild = "live" in self.settings.get("PROPERTIES", "").split()
         buildpkg_live_disabled = live_ebuild and not buildpkg_live
+        restrict_binpkg = "binpkg" in self.settings.get("RESTRICT", "").split()
 
         if (
             ("buildpkg" in features or self._issyspkg)
             and not buildpkg_live_disabled
             and not self.opts.buildpkg_exclude.findAtomForPackage(pkg)
+            and not restrict_binpkg
         ):
             self._buildpkg = True
 

--- a/man/ebuild.5
+++ b/man/ebuild.5
@@ -754,6 +754,9 @@ see the \fBQA CONTROL VARIABLES\fR section for more specific exemptions.
 .I bindist
 Distribution of built packages is restricted.
 .TP
+.I binpkg
+Do not build a binary package of this ebuild.
+.TP
 .I dedupdebug
 Disables dedupdebug for specific packages.
 .TP


### PR DESCRIPTION
With the continuing success the Gentoo binhost, it becomes important mark certain packages as unsuitable for the binhost. Typical examples include acct-user/*, acct-group/*, or virtual/* packages.

This introduces a new RESTRICT key: binpkg. If set by the ebuild, portage will not build a binary package for it.

Implementing RESTRICT=binpkg was easy. This could reduce the number of (unnecessary) binary packages on the Gentoo binhost significantly, which would reduce the pressure on the mirrors and probably even speed up things for the users. RESTRICT=binpkg was also requested in https://bugs.gentoo.org/542480#c1

However, then I read sam's comment at https://bugs.gentoo.org/911825#c1 about how not creating all binpkgs would break FEATURES=usepkgonly.

What we need is to add logic to the dependency resolution to consider a non-binary emerge of a RESTRICT=binpkg ebuild, *even if FEATURES=usepkgonly is active*. I think depgraph.py is probably the place where this should be added, but I couldn't determine the right location. @zmedico (or others): any suggestion would be welcome.