### PR TITLE
Hostname support in titles for all titles

### DIFF
--- a/lib/_emerge/JobStatusDisplay.py
+++ b/lib/_emerge/JobStatusDisplay.py
@@ -296,11 +296,5 @@ class JobStatusDisplay:
             self._update(color_output.getvalue())
 
         if self.xterm_titles:
-            # If the HOSTNAME variable is exported, include it
-            # in the xterm title, just like emergelog() does.
-            # See bug #390699.
             title_str = " ".join(plain_output.split())
-            hostname = os.environ.get("HOSTNAME")
-            if hostname is not None:
-                title_str = f"{hostname}: {title_str}"
             xtermTitle(title_str)

--- a/lib/_emerge/emergelog.py
+++ b/lib/_emerge/emergelog.py
@@ -27,8 +27,6 @@ def emergelog(xterm_titles, mystr, short_msg=None):
         short_msg = _unicode_decode(short_msg)
 
     if xterm_titles and short_msg:
-        if "HOSTNAME" in os.environ:
-            short_msg = os.environ["HOSTNAME"] + ": " + short_msg
         xtermTitle(short_msg)
     try:
         file_path = os.path.join(_emerge_log_dir, "emerge.log")

--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -282,6 +282,9 @@ def xtermTitle(mystr, raw=False):
         )
 
     if dotitles and not _disable_xtermTitle:
+        if "HOSTNAME" in os.environ and not raw:
+            hostname = os.environ["HOSTNAME"]
+            mystr = f"{hostname}: {mystr}"
         # If the title string is too big then the terminal can
         # misbehave. Therefore, truncate it if it's too big.
         if len(mystr) > _max_xtermTitle_len:


### PR DESCRIPTION
Move hostname support to the xtermTitle function, instead of (only two of) the places that call it. Notably, this adds the hostname to the initial static "emerge" display when syncing or calculating dependencies. It also removes duplicated code.

You could also pull my master branch which goes a step further and doesn't require people to export HOSTNAME from their shell.