### PR TITLE
Only populate bintree once

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -156,24 +156,21 @@ def action_build(
         and emerge_config.opts.get("--quickpkg-direct", "n") == "y"
         and emerge_config.target_config.settings["ROOT"] != quickpkg_root
     )
-    if "--getbinpkg" in emerge_config.opts or quickpkg_direct:
+    if quickpkg_direct:
         kwargs = {}
-        if quickpkg_direct:
-            if quickpkg_root == emerge_config.running_config.settings["ROOT"]:
-                quickpkg_vardb = emerge_config.running_config.trees["vartree"].dbapi
-            else:
-                quickpkg_settings = portage.config(
-                    config_root=emerge_config.target_config.settings[
-                        "PORTAGE_CONFIGROOT"
-                    ],
-                    target_root=quickpkg_root,
-                    env=emerge_config.target_config.settings.backupenv.copy(),
-                    sysroot=emerge_config.target_config.settings["SYSROOT"],
-                    eprefix=emerge_config.target_config.settings["EPREFIX"],
-                )
-                quickpkg_vardb = portage.vartree(settings=quickpkg_settings).dbapi
-            kwargs["add_repos"] = (quickpkg_vardb,)
+        if quickpkg_root == emerge_config.running_config.settings["ROOT"]:
+            quickpkg_vardb = emerge_config.running_config.trees["vartree"].dbapi
+        else:
+            quickpkg_settings = portage.config(
+                config_root=emerge_config.target_config.settings["PORTAGE_CONFIGROOT"],
+                target_root=quickpkg_root,
+                env=emerge_config.target_config.settings.backupenv.copy(),
+                sysroot=emerge_config.target_config.settings["SYSROOT"],
+                eprefix=emerge_config.target_config.settings["EPREFIX"],
+            )
+            quickpkg_vardb = portage.vartree(settings=quickpkg_settings).dbapi
 
+        kwargs["add_repos"] = (quickpkg_vardb,)
         try:
             kwargs["pretend"] = "--pretend" in emerge_config.opts
             emerge_config.target_config.trees["bintree"].populate(


### PR DESCRIPTION
Portage would previously unnecessarily invoke "bintree" populate() twice, causing an avoidable delay for binpkg users.

The stack traces of the two populate() invocations are:

```
  /home/dev/repos/gentoo/portage/bin/emerge(88)<module>()
-> main()
  /home/dev/repos/gentoo/portage/bin/emerge(57)main()
-> retval = emerge_main()
  /home/dev/repos/gentoo/portage/lib/_emerge/main.py(1308)emerge_main()
-> return run_action(emerge_config)
  /home/dev/repos/gentoo/portage/lib/_emerge/actions.py(3524)run_action()
-> mytrees["bintree"].populate(
  /home/dev/repos/gentoo/portage/lib/portage/dbapi/bintree.py(961)populate()
-> self._populate_remote(
> /home/dev/repos/gentoo/portage/lib/portage/dbapi/bintree.py(1538)_populate_remote()
  -> f = GzipFile(fileobj=f, mode='rb')
```

```
  /home/dev/repos/gentoo/portage/bin/emerge(88)<module>()
-> main()
  /home/dev/repos/gentoo/portage/bin/emerge(57)main()
-> retval = emerge_main()
  /home/dev/repos/gentoo/portage/lib/_emerge/main.py(1308)emerge_main()
-> return run_action(emerge_config)
  /home/dev/repos/gentoo/portage/lib/_emerge/actions.py(4059)run_action()
-> retval = action_build(emerge_config, spinner=spinner)
  /home/dev/repos/gentoo/portage/lib/_emerge/actions.py(179)action_build()
-> emerge_config.target_config.trees["bintree"].populate(
  /home/dev/repos/gentoo/portage/lib/portage/dbapi/bintree.py(961)populate()
-> self._populate_remote(
> /home/dev/repos/gentoo/portage/lib/portage/dbapi/bintree.py(1538)_populate_remote()
  -> f = GzipFile(fileobj=f, mode='rb')
```

This changes the latter from being only invoked if --getbinpkg is in emerge_config.opts, as in this case, the former has already populated the bintree(s).

**Note that** I am not 100% sure if this change is sound. It appears so to me, but I would appreciate another set of eyes.