### PR TITLE
bintree: Suppress up-to-date message if it isn't true

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1580,16 +1580,18 @@ class binarytree:
                         )
             except UseCachedCopyOfRemoteIndex:
                 changed = False
-                desc = "frozen" if repo.frozen else "up-to-date"
-                writemsg_stdout("\n")
-                writemsg_stdout(
-                    colorize(
-                        "GOOD",
-                        _("Local copy of remote index is %s and will be used.") % desc,
-                    )
-                    + "\n"
-                )
                 rmt_idx = pkgindex
+                if getbinpkg_refresh or repo.frozen:
+                    desc = "frozen" if repo.frozen else "up-to-date"
+                    writemsg_stdout("\n")
+                    writemsg_stdout(
+                        colorize(
+                            "GOOD",
+                            _("Local copy of remote index is %s and will be used.")
+                            % desc,
+                        )
+                        + "\n"
+                    )
             except OSError as e:
                 # This includes URLError which is raised for SSL
                 # certificate errors when PEP 476 is supported.


### PR DESCRIPTION
Portage would emit a message claiming that the local copy of the remote index is up-to-date when getbinpkg_refresh=False. However, if getbinpkg_refresh is set to False, then this doesn't mean that the local copy is up-to-date. It means that we didn't check if it's up-to-date.

Since populate() is potentially multiple times, typically the second time with getbinpkg_refresh set to False, this leads to multiple "Local copy of remote index is up-to-date" messages, even if just one binhost is configured.

To avoid this potentially confusing behavior, suppress the message in case getbinpkg_refresh is set to False.