### PR TITLE
Introduce PORTAGE_SHOW_HTTP_TRACE functionality

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,9 @@ Features:
 * Portage will now show statistics about its internal LRU caches if the
   PORTAGE_SHOW_LRU_CACHE_INFO environment variable is set.
 
+* Portage will show a HTTP trace if the PORTAGE_SHOW_HTTP_TRACE environment
+  variable is set.
+
 * Introduce PORTAGE_LOG_FILE_SEP, allowing to configure the separator between
   the components of the log files produced by portage.
 

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -1186,6 +1186,12 @@ def emerge_main(args: Optional[list[str]] = None):
     # EMERGE_DEFAULT_OPTS has been parsed).
     portage.output.havecolor = 0
 
+    if os.environ.get("PORTAGE_SHOW_HTTP_TRACE"):
+        import http.client
+
+        http.client.HTTPConnection.debuglevel = 1
+        http.client.HTTPSConnection.debuglevel = 1
+
     # This first pass is just for options that need to be known as early as
     # possible, such as --config-root.  They will be parsed again later,
     # together with EMERGE_DEFAULT_OPTS (which may vary depending on the

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1451,6 +1451,9 @@ prior notice.
 .BR PORTAGE_SHOW_LRU_CACHE_INFO
 If this environment variable is set, then Portage will display
 statistics about its internal LRU caches.
+.BR PORTAGE_SHOW_HTTP_TRACE
+If this environment variable is set, then Portage will show
+a trace of all HTTP request.
 .SH "REPORTING BUGS"
 Please report any bugs you encounter through our website:
 .LP


### PR DESCRIPTION
The HTTP trace comes in handy to debug issues with e.g., a binhost, or to analyse and optimize portage's HTTP request handling.