### PR TITLE
Fixed a minor bug in writemsg() from lib/portage/util

### DIFF
--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -112,7 +112,7 @@ def writemsg(mystr: str, noiselevel: int = 0, fd: Optional[TextIO] = None) -> No
         fd = sys.stderr
     if noiselevel <= noiselimit:
         # avoid potential UnicodeEncodeError
-        if isinstance(fd, io.StringIO):
+        if isinstance(fd, io.TextIOBase):
             mystr = _unicode_decode(
                 mystr, encoding=_encodings["content"], errors="replace"
             )


### PR DESCRIPTION
When passing a regular text file descriptor to writemsg(), some bug-avoidance code was not identifying all of the file descriptor types that don't need Unicode encoding. The file descriptor was being tested for being an instance of io.StringIO instead of the base class for text streams (io.TextIOBase). As such, passing a file descriptor that was opened in the most natural way for a text file, for example

    fd = open(logfile, "w")

would cause an exception because Unicode encoding would be applied unnecessarily, creating a binary object on which fd.write() would raise an exception.