### PR TITLE
bintree: Prefer 'Last-Modified' over 'timestamp' header

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,10 @@ Release notes take the form of the following optional categories:
 portage-3.0.70 (UNRELEASED)
 --------------
 
-TODO
+Features
+
+* Prefer the 'Last-Modified' over the 'timestamp' HTTP header when
+  querying binhosts.
 
 portage-3.0.69 (2025-09-14)
 --------------

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1469,7 +1469,7 @@ class binarytree:
                                     if f.headers.get("timestamp", ""):
                                         remote_timestamp = f.headers.get("timestamp")
                                     elif f.headers.get("Last-Modified", ""):
-                                        last_modified = err.headers.get("Last-Modified")
+                                        last_modified = f.headers.get("Last-Modified")
                                         remote_timestamp = http_to_timestamp(
                                             last_modified
                                         )

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1466,13 +1466,13 @@ class binarytree:
                                     proxies=proxies,
                                 )
                                 if hasattr(f, "headers"):
-                                    if f.headers.get("timestamp", ""):
-                                        remote_timestamp = f.headers.get("timestamp")
-                                    elif f.headers.get("Last-Modified", ""):
+                                    if f.headers.get("Last-Modified", ""):
                                         last_modified = f.headers.get("Last-Modified")
                                         remote_timestamp = http_to_timestamp(
                                             last_modified
                                         )
+                                    elif f.headers.get("timestamp", ""):
+                                        remote_timestamp = f.headers.get("timestamp")
                                 if (
                                     remote_timestamp
                                     and local_timestamp


### PR DESCRIPTION
The Last-Modified header is a standard header and seems to be more in sync accross different mirrors than 'timestamp'. Prefer it over 'timestamp'.