### PR TITLE
github ci: run CI also with Python 3.14 forkserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         start-method:
-          - 'fork'
+          - 'fork-or-forkserver'
           - 'spawn'
         python-version:
           - '3.9'
@@ -32,8 +32,6 @@ jobs:
             start-method: 'spawn'
           - python-version: '3.13'
             start-method: 'spawn'
-          - python-version: '3.14-dev'
-            start-method: 'fork'
           - python-version: 'pypy-3.11'
             start-method: 'spawn'
       fail-fast: false


### PR DESCRIPTION
Python 3.14 uses the forkserver multiprocessing start method per default. However, our current CI configuration only ran with the 'spawn' method when using Python 3.14.

This adjusts the CI configuration matrix to also run with Python 3.14 and the forkserver start method.