### PR TITLE
bintree: Improve UseCachedCopyOfRemoteIndex handling, report if TTL

### DIFF
--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1666,7 +1666,7 @@ class binarytree:
                             colorize(
                                 "GOOD",
                                 _(
-                                    " [%s] Local copy of remote index is %s and will be used%s."
+                                    "[%s] Local copy of remote index is %s and will be used%s."
                                 )
                                 % (binrepo_name, exc.desc, extra_info),
                             )


### PR DESCRIPTION
Move the logic where parts of the user-exposed message is constructed from the except block to right before we raise the UseCachedCopyOfRemoteIndex exception. This means we can get rid of some logic in the except block, which tried to determine what the cause of the UseCachedCopyOfRemoteIndex exception was.

As benefit, we will no report if the use the cached copy if it is within its TTL.