### PR TITLE
regression fixes for 3.0.69.1

### DIFF
--- a/bin/misc-functions.sh
+++ b/bin/misc-functions.sh
@@ -531,14 +531,14 @@ __dyn_package() {
 
 		[[ ${PORTAGE_VERBOSE} = 1 ]] && tar_options+=" -v"
 		if contains_word xattr "${FEATURES}" \
-			&& tar --help 2>/dev/null | grep -q -- --xattrs
+			&& gtar --help 2>/dev/null | grep -q -- --xattrs
 		then
 			tar_options+=" --xattrs"
 		fi
 
 		[[ -z "${PORTAGE_COMPRESSION_COMMAND}" ]] && die "PORTAGE_COMPRESSION_COMMAND is unset"
 
-		tar ${tar_options} -cf - ${PORTAGE_BINPKG_TAR_OPTS} -C "${D}" . | \
+		gtar ${tar_options} -cf - ${PORTAGE_BINPKG_TAR_OPTS} -C "${D}" . | \
 			${PORTAGE_COMPRESSION_COMMAND} > "${PORTAGE_BINPKG_TMPFILE}"
 		assert "failed to pack binary package: '${PORTAGE_BINPKG_TMPFILE}'"
 
@@ -584,7 +584,7 @@ __dyn_spec() {
 	mkdir -p "${sources_dir}"
 	declare -a tar_args=("${EBUILD}")
 	[[ -d ${FILESDIR} ]] && tar_args=("${EBUILD}" "${FILESDIR}")
-	tar czf "${sources_dir}/${PF}.tar.gz" \
+	gtar czf "${sources_dir}/${PF}.tar.gz" \
 		"${tar_args[@]}" || \
 		die "Failed to create base rpm tarball."
 

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -480,17 +480,17 @@ unpack() {
 				unrar x -idq -o+ "${srcdir}${f}"
 				;;
 			tar.bz|tar.bz2|tbz|tbz2)
-				tar -I "${bzip2_cmd-bzip2} -c" -xof "${srcdir}${f}"
+				gtar -I "${bzip2_cmd-bzip2} -c" -xof "${srcdir}${f}"
 				;;
 			tar|tar.*|tgz)
 				# GNU tar recognises various file suffixes, for
 				# which it is able to execute the appropriate
 				# decompressor. They are documented by the
 				# (info) manual for the -a option.
-				tar --warning=decompress-program -xof "${srcdir}${f}"
+				gtar --warning=decompress-program -xof "${srcdir}${f}"
 				;;
 			txz)
-				tar -xJof "${srcdir}${f}"
+				gtar -xJof "${srcdir}${f}"
 				;;
 			xz)
 				xz -dc -- "${srcdir}${f}" > "${basename%.*}"

--- a/lib/_emerge/BinpkgExtractorAsync.py
+++ b/lib/_emerge/BinpkgExtractorAsync.py
@@ -39,7 +39,7 @@ class BinpkgExtractorAsync(SpawnProcess):
         tar_options = ""
         if "xattr" in self.features:
             process = subprocess.Popen(
-                ["tar", "--help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                ["gtar", "--help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             output = process.communicate()[0]
             if b"--xattrs" in output:
@@ -121,7 +121,7 @@ class BinpkgExtractorAsync(SpawnProcess):
                 f"""
                     cmd0=(head -c {pkg_xpak.filestat.st_size - pkg_xpak.xpaksize} -- {shlex.quote(self.pkg_path)})
                     cmd1=({decomp_cmd})
-                    cmd2=(tar -xp {tar_options} -C {shlex.quote(self.image_dir)} -f -);
+                    cmd2=(gtar -xp {tar_options} -C {shlex.quote(self.image_dir)} -f -);
                 """
                 """
                     "${cmd0[@]}" | "${cmd1[@]}" | "${cmd2[@]}";

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1506,6 +1506,7 @@ class binarytree:
                             if (
                                 hasattr(err, "code") and err.code == 304
                             ):  # not modified (since local_timestamp)
+                                extra_info = ""
                                 if hasattr(err, "headers") and err.headers.get(
                                     "Last-Modified", ""
                                 ):

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -1094,7 +1094,7 @@ class vardbapi(dbapi):
             "BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0]
         )
         if binpkg_format == "xpak":
-            tar_cmd = ("tar", "-x", "--xattrs", "--xattrs-include=*", "-C", dest_dir)
+            tar_cmd = ("gtar", "-x", "--xattrs", "--xattrs-include=*", "-C", dest_dir)
             pr, pw = multiprocessing.Pipe(duplex=False)
             proc = await asyncio.create_subprocess_exec(*tar_cmd, stdin=pr)
             pr.close()

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -179,7 +179,7 @@ class ResolverPlayground:
                 "rm",
                 "sed",
                 "sort",
-                "tar",
+                "gtar",
                 "tr",
                 "uname",
                 "uniq",

--- a/misc/emerge-delta-webrsync
+++ b/misc/emerge-delta-webrsync
@@ -278,7 +278,7 @@ do_tar() {
 		*.gz)   decompressor="zcat"  ;;
 		*)      decompressor="cat"   ;;
 	esac
-	${decompressor} "${file}" | tar "$@"
+	${decompressor} "${file}" | gtar "$@"
 	_pipestatus=${PIPESTATUS[*]}
 	[[ ${_pipestatus// /} -eq 0 ]]
 }


### PR DESCRIPTION
Full changes for https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=eab82293826d44a0835a08efa436d9b9b8b4b2ff

- ensure GNU tar is used in most places

  Portage makes certain assumptions in various places, such as --xattrs enabling FEATURES=xattr and its lack *unconditionally* disabling it. Or, --wildcard existing.
    
  PMS mandates "GNU Tar" be used to extract files in `unpack`, and a recent fix went "all in" and used GNU Tar options to improve the function.
  
  All this is quite reasonable, but nowhere have we ever enforced that "gtar" is used. libarchive is a valid app-alternatives/tar, on Gentoo, has been broken subtly in the past, and now breaks src_unpack.
    
  emerge-webrsync alone has "is_gnu" support code introduced since commit 23ce89c761c080e7d3163165dded94241a9a9eea, so leave it alone.
    
  Fixes: 3e89139fae34c9bd2e2b4c0490512f71d1d78546

- fix crash when using binhost due to using conditionally defined variable
  
  extra_info didn't always exist, so if you get http 304 but no Last-Modified, portage errors out with:
  ```
    File "/usr/lib/python3.13/site-packages/portage/dbapi/bintree.py", line 1519, in _populate_remote
      "up-to-date", extra_info
                    ^^^^^^^^^^
  UnboundLocalError: cannot access local variable 'extra_info' where it is not associated with a value
  ```

  Fixes: c83466a50efdee2cac81a5ed6a660c11b9ac746e