### PR TITLE
Add support for sccache

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -121,7 +121,7 @@ export PORTAGE_BZIP2_COMMAND=${PORTAGE_BZIP2_COMMAND:-bzip2}
 
 # These two functions wrap sourcing and calling respectively.  At present they
 # perform a qa check to make sure eclasses and ebuilds and profiles don't mess
-# with shell opts (shopts).  Ebuilds/eclasses changing shopts should reset them 
+# with shell opts (shopts).  Ebuilds/eclasses changing shopts should reset them
 # when they are done.
 
 __qa_source() {
@@ -731,6 +731,13 @@ if [[ ${EBUILD_PHASE} != clean?(rm) ]]; then
 				fi
 
 				[[ -n ${CCACHE_SIZE} ]] && ccache -M ${CCACHE_SIZE} &> /dev/null
+			fi
+
+			if contains_word sccache "${FEATURES}"; then
+				if [[ -n ${SCCACHE_DIR} ]] ; then
+					addread "${SCCACHE_DIR}"
+					addwrite "${SCCACHE_DIR}"
+				fi
 			fi
 		fi
 	fi

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -1087,7 +1087,8 @@ __ebuild_main() {
 
 			local x
 			for x in ASFLAGS CCACHE_DIR CCACHE_SIZE \
-				CFLAGS CXXFLAGS LDFLAGS LIBCFLAGS LIBCXXFLAGS ; do
+				CFLAGS CXXFLAGS LDFLAGS LIBCFLAGS LIBCXXFLAGS \
+				SCCACHE_DIR SCCACHE_CACHE_SIZE ; do
 				[[ ${!x+set} = set ]] && export ${x}
 			done
 			unset x

--- a/bin/save-ebuild-env.sh
+++ b/bin/save-ebuild-env.sh
@@ -168,9 +168,10 @@ __save_ebuild_env() (
 		INSTALL_MASK
 		PKG_INSTALL_MASK
 
-		# CCACHE and DISTCC configuration variables.
+		# CCACHE, DISTCC, and SCCACHE configuration variables.
 		"${!CCACHE_@}"
 		"${!DISTCC_@}"
+		"${!SCCACHE_@}"
 	)
 
 	# Unset the collected variables before moving on to functions.

--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -131,6 +131,7 @@ class EbuildPhase(CompositeTask):
         "packdebug",
         "preserve-libs",
         "sandbox",
+        "sccache",
         "selinux",
         "sesandbox",
         "splitdebug",

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2083,6 +2083,23 @@ def action_info(settings, trees, myopts, myfiles):
             ccache_str += " [disabled]"
         append(ccache_str)
 
+    try:
+        proc = subprocess.Popen(
+            ["sccache", "-V"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+    except OSError:
+        output = (1, None)
+    else:
+        output = _unicode_decode(proc.communicate()[0]).rstrip("\n")
+        output = (proc.wait(), output)
+    if output[0] == os.EX_OK:
+        sccache_str = output[1].split("\n", 1)[0]
+        if "sccache" in settings.features:
+            sccache_str += " [enabled]"
+        else:
+            sccache_str += " [disabled]"
+        append(sccache_str)
+
     myvars = [
         "dev-build/autoconf",
         "dev-build/automake",

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -225,6 +225,7 @@ SUPPORTED_FEATURES = frozenset(
         "python-trace",
         "qa-unresolved-soname-deps",
         "sandbox",
+        "sccache",
         "selinux",
         "sesandbox",
         "sfperms",

--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -247,7 +247,7 @@ environ_whitelist = frozenset(
     )
 )
 
-environ_whitelist_re = re.compile(r"^(CCACHE_|DISTCC_).*")
+environ_whitelist_re = re.compile(r"^(S?CCACHE_|DISTCC_).*")
 
 # Filter selected variables in the config.environ() method so that
 # they don't needlessly propagate down into the ebuild environment.

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -604,8 +604,9 @@ def doebuild_environment(
         ccache = "ccache" in mysettings.features
         distcc = "distcc" in mysettings.features
         icecream = "icecream" in mysettings.features
+        sccache = "sccache" in mysettings.features
 
-        if ccache or distcc or icecream:
+        if ccache or distcc or icecream or sccache:
             libdir = None
             default_abi = mysettings.get("DEFAULT_ABI")
             if default_abi:
@@ -623,6 +624,8 @@ def doebuild_environment(
                 masquerades.append(("icecream", "icecc"))
             if ccache:
                 masquerades.append(("ccache", "ccache"))
+            if sccache:
+                masquerades.append(("sccache", "sccache"))
 
             for feature, m in masquerades:
                 for l in possible_libexecdirs:
@@ -642,6 +645,13 @@ def doebuild_environment(
                         % (m, m)
                     )
                     mysettings.features.remove(feature)
+
+        if sccache:
+            # Set to a custom default port (not the upstream default) to avoid conflicts with other users
+            # and avoid permission issue when other server has non-writable SCCACHE_DIR.
+            mysettings.setdefault("SCCACHE_SERVER_PORT", "6224")
+            mysettings["RUSTC_WRAPPER"] = "sccache"
+            mysettings["SCCACHE_BASEDIRS"] = mysettings["PORTAGE_BUILDDIR"]
 
         # MAKEOPTS conflicts with MAKEFLAGS, so skip this if MAKEFLAGS exists.
         if "MAKEOPTS" not in mysettings and "MAKEFLAGS" not in mysettings:

--- a/lib/portage/package/ebuild/prepare_build_dirs.py
+++ b/lib/portage/package/ebuild/prepare_build_dirs.py
@@ -216,6 +216,11 @@ def _prepare_features_dirs(mysettings):
             "subdirs": ("lock", "state"),
             "always_recurse": True,
         },
+        "sccache": {
+            "basedir_var": "SCCACHE_DIR",
+            "default_dir": os.path.join(mysettings["PORTAGE_TMPDIR"], "sccache"),
+            "always_recurse": False,
+        },
     }
     dirmode = 0o2070
     filemode = 0o60

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1440,6 +1440,18 @@ Defines the location where created RPM packages will be stored.
 .br
 Defaults to "/var/cache/rpm".
 .TP
+\fBSCCACHE_DIR\fR = \fI[path]\fR
+Defines the location of the sccache cache directory.
+
+Only trusted users should be granted write access to this location.
+
+Defaults to "${PORTAGE_TMPDIR}/sccache".
+.TP
+\fBSCCACHE_CACHE_SIZE\fR = \fI"size"\fR
+This controls the space use limitations for sccache.
+
+Defaults to 10G.
+.TP
 \fBSYNC\fR = \fI[RSYNC]\fR
 Insert your preferred rsync mirror here.  This rsync server
 is used to sync the local ebuild repository when `emerge \-\-sync` is run.


### PR DESCRIPTION
This depends on https://github.com/projg2/shadowman/pull/4 and a patched `sccache` ebuild.

It works exactly as the `ccache` implementation.

Docs are still missing. Maybe this can be combined with the `ccache` instructions?