### PR TITLE
Replace FEATURES=export-pms-vars with PORTAGE_DO_NOT_EXPORT_PMS_VARS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@ Bug fixes:
 Cleanups:
 
 * Drop legacy USE=test hacks.
+* Replace FEATURES=export-pms-vars with Portage development feature
+  PORTAGE_DO_NOT_EXPORT_PMS_VARS (bug #953842)
 
 portage-3.0.69.1 (2025-09-15)
 --------------

--- a/cnf/make.globals
+++ b/cnf/make.globals
@@ -81,7 +81,7 @@ FEATURES="assume-digests binpkg-docompress binpkg-dostrip binpkg-logs
           network-sandbox news parallel-fetch pkgdir-index-trusted pid-sandbox
           preserve-libs protect-owned qa-unresolved-soname-deps sandbox strict
           unknown-features-warn unmerge-logs unmerge-orphans userfetch
-          userpriv usersandbox usersync export-pms-vars"
+          userpriv usersandbox usersync"
 
 # Ignore file collisions in /lib/modules since files inside this directory
 # are never unmerged, and therefore collisions must be ignored in order for

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -183,7 +183,6 @@ SUPPORTED_FEATURES = frozenset(
         "distlocks",
         "downgrade-backup",
         "ebuild-locks",
-        "export-pms-vars",
         "fail-clean",
         "fakeroot",
         "fixlafiles",

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -2184,12 +2184,14 @@ def spawn(
     eapi = mysettings["EAPI"]
 
     unexported_env_vars = None
-    if "export-pms-vars" not in mysettings.features or not eapi_exports_pms_vars(eapi):
+    if not eapi_exports_pms_vars(eapi) or os.environ.get(
+        "PORTAGE_DO_NOT_EXPORT_PMS_VARS"
+    ):
         unexported_env_vars = _unexported_pms_vars
 
     if unexported_env_vars:
-        # Starting with EAPI 9 (or if FEATURES="-export-pms-vars"),
-        # PMS variables should not longer be exported.
+        # Starting with EAPI 9 (or if the PORTAGE_DO_NOT_EXPORT_PMS_VARS env
+        # variable is set) PMS variables should not longer be exported.
 
         phase = mysettings.get("EBUILD_PHASE")
         is_pms_ebuild_phase = phase in _phase_func_map.keys()

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1446,6 +1446,14 @@ statistics about its internal LRU caches.
 .BR PORTAGE_SHOW_HTTP_TRACE
 If this environment variable is set, then Portage will show
 a trace of all HTTP request.
+.TP
+.BR PORTAGE_DO_NOT_EXPORT_PMS_VARS
+If this environment variable is set, then Portage will not export PMS
+variables regardless of the EAPI.  The variables are still available
+to ebuilds; however, they are not exported and therefore not available
+to child processes of the ebuild.  Since EAPI 9, Portage will never
+export PMS variables.  This setting allows testing EAPI < 9 ebuilds
+with the new behavior.
 .SH "REPORTING BUGS"
 Please report any bugs you encounter through our website:
 .LP


### PR DESCRIPTION
The toggle is primary targeted at ebuild authors, to test their ebuilds under new EAPI rules. It is not something users should care about, which is what having it in FEATURES suggests. Therefore refactor it as a toggle of "Portage Development Features".

Bug: https://bugs.gentoo.org/953842