### PR TITLE
check for /usr/lib/distcc/bin or /usr/lib/distcc

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -631,7 +631,10 @@ def doebuild_environment(
 
             for feature, m in masquerades:
                 for l in possible_libexecdirs:
-                    p = os.path.join(os.sep, eprefix_lstrip, "usr", l, m, "bin")
+                    masqdir = os.path.join(os.sep, eprefix_lstrip, "usr", l, m)
+                    p = os.path.join(masqdir, "bin")
+                    if not os.path.isdir(p):
+                        p = masqdir
                     if os.path.isdir(p):
                         mysettings["PATH"] = p + ":" + mysettings["PATH"]
                         break


### PR DESCRIPTION
The distcc masquerade directory was moved from for better upstream compat.

Bug: https://bugs.gentoo.org/650986