### PR TITLE
emerge: add hidden --ponder alias

### DIFF
--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -586,6 +586,10 @@ def parse_opts(tmpcmdline, silent=False):
             "help": "modify interpretation of dependencies",
             "choices": true_y_or_n,
         },
+        "--ponder": {
+            "help": argparse.SUPPRESS,
+            "action": "store_true",
+        },
         "--rebuild-exclude": {
             "help": "A space separated list of package names or slot atoms. "
             + "Emerge will not rebuild these packages due to the "
@@ -802,6 +806,8 @@ def parse_opts(tmpcmdline, silent=False):
         myoptions.alert = None
 
     if myoptions.ask in true_y:
+        myoptions.ask = True
+    elif myoptions.ponder and not myoptions.ask:
         myoptions.ask = True
     else:
         myoptions.ask = None
@@ -1103,6 +1109,8 @@ def parse_opts(tmpcmdline, silent=False):
 
     if myoptions.verbose in true_y:
         myoptions.verbose = True
+    elif myoptions.ponder and not myoptions.verbose:
+        myoptions.verbose = True
     else:
         myoptions.verbose = None
 
@@ -1134,6 +1142,9 @@ def parse_opts(tmpcmdline, silent=False):
 
     if myaction is None and myoptions.deselect is True:
         myaction = "deselect"
+
+    if myoptions.ponder:
+        myoptions.ponder = None
 
     return myaction, myopts, myoptions.positional_args
 


### PR DESCRIPTION
Undocumented `--ponder` as a shorthand notation for `--ask --verbose`.

If either `--ask` or `--verbose` is passed explicitly, those take precedence. Meant to be an easter egg, referencing the pondering the orb meme, but is somewhat useful.