### PR TITLE
Atom: drink up the string soup

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -186,6 +186,12 @@ addread "${PORTAGE_TMPDIR}/portage"
 addwrite "${PORTAGE_TMPDIR}/portage"
 [[ -n ${PORTAGE_GPG_DIR} ]] && addpredict "${PORTAGE_GPG_DIR}"
 
+if [[ -f /sys/fs/selinux/enforce ]]; then
+	addpredict /proc/self/attr/fscreate
+	addpredict /proc/thread-self/attr/fscreate
+	addpredict /proc/self/attr/current
+fi
+
 # Avoid sandbox violations in temporary directories.
 if [[ -w ${T} ]] ; then
 	export TEMP=${T}

--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -71,7 +71,8 @@ def quickpkg_atom(options, infos, arg, eout):
         eout.eerror(f"Invalid atom: {arg}")
         infos["missing"].append(arg)
         return 1
-    if atom[:1] == "=" and arg[:1] != "=":
+    # Check if dep_expand added an operator that wasn't in the original arg
+    if atom.operator == "=" and not str(arg).startswith("="):
         # dep_expand() allows missing '=' but it's really invalid
         eout.eerror(f"Invalid atom: {arg}")
         infos["missing"].append(arg)

--- a/lib/_emerge/BlockerCache.py
+++ b/lib/_emerge/BlockerCache.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import errno
+from portage.dep import Atom
 from portage.util import writemsg
 from portage.data import secpass
 import portage
@@ -99,10 +100,10 @@ class BlockerCache(portage.cache.mappings.MutableMapping):
                     continue
                 invalid_atom = False
                 for atom in atoms:
-                    if not isinstance(atom, str):
+                    if not isinstance(atom, (str, Atom)):
                         invalid_atom = True
                         break
-                    if atom[:1] != "!" or not portage.isvalidatom(
+                    if str(atom)[:1] != "!" or not portage.isvalidatom(
                         atom, allow_blockers=True
                     ):
                         invalid_atom = True

--- a/lib/_emerge/BlockerDB.py
+++ b/lib/_emerge/BlockerDB.py
@@ -76,8 +76,8 @@ class BlockerDB:
                     )
                     continue
 
-                blocker_atoms = [atom for atom in atoms if atom.startswith("!")]
-                blocker_atoms.sort()
+                blocker_atoms = [atom for atom in atoms if atom.blocker]
+                blocker_atoms.sort(key=str)
                 blocker_cache[inst_pkg.cpv] = blocker_cache.BlockerData(
                     inst_pkg.counter, blocker_atoms
                 )
@@ -113,7 +113,7 @@ class BlockerDB:
             show_invalid_depstring_notice(new_pkg, atoms)
             assert False
 
-        blocker_atoms = [atom.lstrip("!") for atom in atoms if atom[:1] == "!"]
+        blocker_atoms = [str(atom).lstrip("!") for atom in atoms if atom.blocker]
         if blocker_atoms:
             blocker_atoms = InternalPackageSet(initial_atoms=blocker_atoms)
             for inst_pkg in installed_pkgs:

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1753,8 +1753,8 @@ def action_deselect(settings, trees, opts, atoms):
         expanded_atoms = set(atoms)
 
         for atom in atoms:
-            if not atom.startswith(SETPREFIX):
-                if atom.cp.startswith("null/"):
+            if not str(atom).startswith(SETPREFIX):
+                if atom.category == "null":
                     # try to expand category from world set
                     null_cat, pn = portage.catsplit(atom.cp)
                     for world_atom in world_atoms:
@@ -1762,7 +1762,7 @@ def action_deselect(settings, trees, opts, atoms):
                         if pn == world_pn:
                             expanded_atoms.add(
                                 Atom(
-                                    atom.replace("null", cat, 1),
+                                    str(atom).replace("null", cat, 1),
                                     allow_repo=True,
                                     allow_wildcard=True,
                                 )
@@ -1775,13 +1775,13 @@ def action_deselect(settings, trees, opts, atoms):
         discard_atoms = set()
         for atom in world_set:
             for arg_atom in expanded_atoms:
-                if arg_atom.startswith(SETPREFIX):
-                    if atom.startswith(SETPREFIX) and arg_atom == atom:
+                if str(arg_atom).startswith(SETPREFIX):
+                    if str(atom).startswith(SETPREFIX) and arg_atom == atom:
                         discard_atoms.add(atom)
                         break
                 else:
                     if (
-                        not atom.startswith(SETPREFIX)
+                        not str(atom).startswith(SETPREFIX)
                         and arg_atom.intersects(atom)
                         and not (arg_atom.slot and not atom.slot)
                         and not (arg_atom.repo and not atom.repo)
@@ -1789,13 +1789,13 @@ def action_deselect(settings, trees, opts, atoms):
                         discard_atoms.add(atom)
                         break
         if discard_atoms:
-            for atom in sorted(discard_atoms):
+            for atom in sorted(discard_atoms, key=str):
                 if pretend:
                     action_desc = "Would remove"
                 else:
                     action_desc = "Removing"
 
-                if atom.startswith(SETPREFIX):
+                if str(atom).startswith(SETPREFIX):
                     filename = "world_sets"
                 else:
                     filename = "world"
@@ -2095,7 +2095,7 @@ def action_info(settings, trees, myopts, myfiles):
                 if not atom.blocker:
                     atoms.append((x, atom))
 
-    myvars = sorted(set(atoms))
+    myvars = sorted(set(atoms), key=lambda t: str(t[0]))
 
     cp_map = {}
     cp_max_len = 0
@@ -3956,11 +3956,11 @@ def run_action(emerge_config):
                     # look at the ebuilds, since EAPI 4 allows running pkg_info
                     # on non-installed packages
                     valid_atom = dep_expand(x, mydb=vardb)
-                    if valid_atom.cp.split("/")[0] == "null":
+                    if valid_atom.category == "null":
                         valid_atom = dep_expand(x, mydb=portdb)
 
                     if (
-                        valid_atom.cp.split("/")[0] == "null"
+                        valid_atom.category == "null"
                         and "--usepkg" in emerge_config.opts
                     ):
                         valid_atom = dep_expand(x, mydb=bindb)

--- a/lib/_emerge/create_world_atom.py
+++ b/lib/_emerge/create_world_atom.py
@@ -113,7 +113,7 @@ def create_world_atom(pkg, args_set, root_config, before_install=False):
         # gcc for example.
         system_atom = sets["system"].findAtomForPackage(pkg)
         if system_atom:
-            if not system_atom.cp.startswith("virtual/"):
+            if system_atom.category != "virtual":
                 return None
             # System virtuals aren't safe to exclude from world since they can
             # match multiple old-style virtuals but only one of them will be

--- a/lib/_emerge/resolver/output.py
+++ b/lib/_emerge/resolver/output.py
@@ -1,8 +1,7 @@
 # Copyright 2010-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-"""Resolver output display operation.
-"""
+"""Resolver output display operation."""
 
 __all__ = (
     "Display",
@@ -951,7 +950,7 @@ def format_unmatched_atom(pkg, atom, pkg_use_enabled):
     def perform_coloring():
         atom_str = ""
         marker_str = ""
-        for ii, x in enumerate(atom):
+        for ii, x in enumerate(str(atom)):
             if ii in highlight:
                 atom_str += colorize("BAD", x)
                 marker_str += "^"
@@ -962,7 +961,7 @@ def format_unmatched_atom(pkg, atom, pkg_use_enabled):
 
     if atom.cp != pkg.cp:
         # Highlight the cp part only.
-        ii = atom.find(atom.cp)
+        ii = str(atom).find(atom.cp)
         highlight.update(range(ii, ii + len(atom.cp)))
         return perform_coloring()
 
@@ -992,7 +991,7 @@ def format_unmatched_atom(pkg, atom, pkg_use_enabled):
             highlight.update(range(len(op)))
 
         if ver is not None:
-            start = atom.rfind(ver)
+            start = str(atom).rfind(ver)
             end = start + len(ver)
             highlight.update(range(start, end))
 
@@ -1002,7 +1001,7 @@ def format_unmatched_atom(pkg, atom, pkg_use_enabled):
             slot_str += "/" + atom.sub_slot
         if atom.slot_operator:
             slot_str += atom.slot_operator
-        start = atom.find(slot_str)
+        start = str(atom).find(slot_str)
         end = start + len(slot_str)
         highlight.update(range(start, end))
 
@@ -1025,7 +1024,7 @@ def format_unmatched_atom(pkg, atom, pkg_use_enabled):
                     )
 
     if highlight_use:
-        ii = atom.find("[") + 1
+        ii = str(atom).find("[") + 1
         for token in atom.use.tokens:
             if token.lstrip("-!").rstrip("=?") in highlight_use:
                 highlight.update(range(ii, ii + len(token)))

--- a/lib/_emerge/unmerge.py
+++ b/lib/_emerge/unmerge.py
@@ -122,8 +122,9 @@ def _unmerge_display(
                 print(f"\nNo packages to {unmerge_action} have been provided.\n")
                 return 1, {}
             for x in unmerge_files:
-                arg_parts = x.split("/")
-                if x[0] not in [".", "/"] and arg_parts[-1][-7:] != ".ebuild":
+                x_str = str(x)  # this could be an Atom, stringify
+                arg_parts = x_str.split("/")
+                if x_str[0] not in [".", "/"] and arg_parts[-1][-7:] != ".ebuild":
                     # possible cat/pkg or dep; treat as such
                     candidate_catpkgs.append(x)
                 elif unmerge_action in ["prune", "clean"]:

--- a/lib/portage/_sets/ProfilePackageSet.py
+++ b/lib/portage/_sets/ProfilePackageSet.py
@@ -40,7 +40,7 @@ class ProfilePackageSet(PackageSet):
                 ],
                 incremental=1,
             )
-            if x[:1] != "*"
+            if str(x)[:1] != "*"
         )
 
     def singleBuilder(self, options, settings, trees):

--- a/lib/portage/_sets/base.py
+++ b/lib/portage/_sets/base.py
@@ -129,7 +129,7 @@ class PackageSet:
             else:
                 rev_transform[
                     Atom(
-                        atom.replace(atom.cp, pkg.cp, 1),
+                        str(atom).replace(atom.cp, pkg.cp, 1),
                         allow_wildcard=True,
                         allow_repo=True,
                     )

--- a/lib/portage/_sets/files.py
+++ b/lib/portage/_sets/files.py
@@ -77,7 +77,10 @@ class StaticFileSet(EditablePackageSet):
     def write(self):
         write_atomic(
             self._filename,
-            "".join(f"{atom}\n" for atom in sorted(chain(self._atoms, self._nonatoms))),
+            "".join(
+                f"{atom}\n"
+                for atom in sorted(chain(self._atoms, self._nonatoms), key=str)
+            ),
         )
 
     def load(self):
@@ -305,7 +308,9 @@ class WorldSelectedPackagesSet(EditablePackageSet):
         return ValidAtomValidator(atom, allow_repo=True)
 
     def write(self):
-        write_atomic(self._filename, "".join(sorted(f"{x}\n" for x in self._atoms)))
+        write_atomic(
+            self._filename, "".join(sorted((f"{x}\n" for x in self._atoms), key=str))
+        )
 
     def load(self):
         atoms = []
@@ -401,7 +406,9 @@ class WorldSelectedSetsSet(EditablePackageSet):
         return setname.startswith(SETPREFIX)
 
     def write(self):
-        write_atomic(self._filename, "".join(sorted(f"{x}\n" for x in self._nonatoms)))
+        write_atomic(
+            self._filename, "".join(sorted((f"{x}\n" for x in self._nonatoms), key=str))
+        )
 
     def load(self):
         atoms_changed = False

--- a/lib/portage/_sets/profiles.py
+++ b/lib/portage/_sets/profiles.py
@@ -66,7 +66,7 @@ class PackagesSystemSet(PackageSet):
                 noiselevel=-1,
             )
 
-        self._setAtoms([x[1:] for x in mylist if x[0] == "*"])
+        self._setAtoms([str(x)[1:] for x in mylist if str(x)[0] == "*"])
 
     def singleBuilder(self, options, settings, trees):
         debug = get_boolean(options, "debug", False)

--- a/lib/portage/dbapi/_expand_new_virt.py
+++ b/lib/portage/dbapi/_expand_new_virt.py
@@ -16,7 +16,7 @@ def expand_new_virt(vardb, atom):
     if not isinstance(atom, Atom):
         atom = Atom(atom)
 
-    if not atom.cp.startswith("virtual/"):
+    if atom.category != "virtual":
         yield atom
         return
 
@@ -25,7 +25,7 @@ def expand_new_virt(vardb, atom):
 
     while stack:
         atom = stack.pop()
-        if atom.blocker or not atom.cp.startswith("virtual/"):
+        if atom.blocker or atom.category != "virtual":
             yield atom
             continue
 

--- a/lib/portage/dbapi/dep_expand.py
+++ b/lib/portage/dbapi/dep_expand.py
@@ -47,7 +47,7 @@ def dep_expand(mydep, mydb=None, use_cache=1, settings=None):
 
     if has_cat:
         # Optimize most common cases to avoid calling cpv_expand.
-        if not mydep.cp.startswith("virtual/"):
+        if mydep.category != "virtual":
             return mydep
         if not hasattr(mydb, "cp_list") or mydb.cp_list(mydep.cp):
             return mydep
@@ -55,4 +55,4 @@ def dep_expand(mydep, mydb=None, use_cache=1, settings=None):
         mydep = mydep.cp
 
     expanded = cpv_expand(mydep, mydb=mydb, use_cache=use_cache, settings=settings)
-    return Atom(orig_dep.replace(mydep, expanded, 1), allow_repo=True)
+    return Atom(str(orig_dep).replace(mydep, expanded, 1), allow_repo=True)

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -1919,7 +1919,7 @@ class dblink:
         # Sort atoms so that locks are acquired in a predictable
         # order, preventing deadlocks with competitors that may
         # be trying to acquire overlapping locks.
-        slot_atoms.sort()
+        slot_atoms.sort(key=str)
         for slot_atom in slot_atoms:
             self.vartree.dbapi._slot_lock(slot_atom)
             self._slot_locks.append(slot_atom)

--- a/lib/portage/emaint/modules/world/world.py
+++ b/lib/portage/emaint/modules/world/world.py
@@ -38,7 +38,7 @@ class WorldHandler:
             onProgress(maxval, 0)
         for i, atom in enumerate(world_atoms):
             if not isinstance(atom, portage.dep.Atom):
-                if atom.startswith(SETPREFIX):
+                if str(atom).startswith(SETPREFIX):
                     s = atom[len(SETPREFIX) :]
                     if s in sets:
                         self.okay.append(atom)

--- a/lib/portage/env/validators.py
+++ b/lib/portage/env/validators.py
@@ -14,7 +14,7 @@ def PackagesFileValidator(atom):
     Args:
         atom: a string representing an atom such as sys-apps/portage-2.1
     """
-    if atom.startswith("*") or atom.startswith("-"):
+    if str(atom).startswith("*") or str(atom).startswith("-"):
         atom = atom[1:]
     if not isvalidatom(atom):
         return False

--- a/lib/portage/package/ebuild/_config/MaskManager.py
+++ b/lib/portage/package/ebuild/_config/MaskManager.py
@@ -71,14 +71,14 @@ class MaskManager:
             lines = []
             repo_lines = grab_pmask(repo.location, repo)
             removals = frozenset(
-                line[0][1:] for line in repo_lines if line[0][:1] == "-"
+                str(line[0])[1:] for line in repo_lines if str(line[0])[:1] == "-"
             )
             matched_removals = set()
             for master in repo.masters:
                 master_lines = grab_pmask(master.location, master)
                 for line in master_lines:
-                    if line[0] in removals:
-                        matched_removals.add(line[0])
+                    if str(line[0]) in removals:
+                        matched_removals.add(str(line[0]))
                 # Since we don't stack masters recursively, there aren't any
                 # atoms earlier in the stack to be matched by negative atoms in
                 # master_lines. Also, repo_lines may contain negative atoms

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -863,10 +863,10 @@ class ResolverPlaygroundTestCase:
                     if got:
                         new_got = []
                         for cpv in got:
-                            if cpv[:1] == "!":
+                            if str(cpv)[:1] == "!":
                                 new_got.append(cpv)
                                 continue
-                            new_got.append(cpv.split(_repo_separator)[0])
+                            new_got.append(str(cpv).split(_repo_separator)[0])
                         got = new_got
                     if expected:
                         new_expected = []

--- a/lib/portage/update.py
+++ b/lib/portage/update.py
@@ -104,7 +104,7 @@ def update_dbentry(update_cmd, mycontent, eapi=None, parent=None):
                 if atom.slot_operator is not None:
                     slot_part += atom.slot_operator
 
-                split_content[i] = atom.with_slot(slot_part)
+                split_content[i] = str(atom.with_slot(slot_part))
                 modified = True
 
             if modified:

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -344,19 +344,20 @@ def stack_lists(
             if incremental:
                 if token == "-*":
                     new_list.clear()
-                elif token[:1] == "-":
+                elif str(token).startswith("-"):
                     matched = False
                     if ignore_repo and not "::" in token:
                         # Let -cat/pkg remove cat/pkg::repo.
                         to_be_removed = []
-                        token_slice = token[1:]
+                        token_str = str(token)
+                        token_slice = token_str[1:]
                         for atom in new_list:
                             atom_without_repo = atom
                             if atom.repo is not None:
                                 # Atom.without_repo instantiates a new Atom,
                                 # which is unnecessary here, so use string
                                 # replacement instead.
-                                atom_without_repo = atom.replace(
+                                atom_without_repo = str(atom).replace(
                                     "::" + atom.repo, "", 1
                                 )
                             if atom_without_repo == token_slice:
@@ -367,7 +368,7 @@ def stack_lists(
                                 new_list.pop(atom)
                     else:
                         try:
-                            new_list.pop(token[1:])
+                            new_list.pop(str(token)[1:])
                             matched = True
                         except KeyError:
                             pass

--- a/lib/portage/versions.py
+++ b/lib/portage/versions.py
@@ -19,9 +19,11 @@ import re
 import typing
 import warnings
 from functools import lru_cache
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from collections.abc import Sequence
 
+if TYPE_CHECKING:
+    from portage.dep import Atom
 
 import portage
 
@@ -608,8 +610,11 @@ def cpv_sort_key(eapi: Any = None) -> Any:
     return cmp_sort_key(cmp_cpv)
 
 
-def catsplit(mydep: str) -> list[str]:
-    return mydep.split("/", 1)
+# it would be better to fix the call sites,
+# but most of them are completely untyped,
+# and themselves use something like `str | Atom | OtherMonstrosity`
+def catsplit(mydep: "Union[str, Atom]") -> list[str]:
+    return str(mydep).split("/", 1)
 
 
 def best(mymatches: Sequence[Any], eapi: Any = None) -> Any:


### PR DESCRIPTION
First step to making `portage.dep.Atom` properly typed.

It still retains a `__str__` method, as that will always be useful. Some call sites will still do something like `str(atom).split(...)`, because they usually operate on variant types of `str | Atom | foo` and are completely untyped :(

Some properties of `Atom` should probably be dropped entirely, and some more be added. For memory efficiency, we may also want to synthesize some of them from the string representation as needed, instead of storing them.

Also, it seems that `depgraph.py` is more cursed than previously thought possible, and writes to `Atom._orig_atom`. I've just added it as a field for now...

Ultimately there's still a lot more `str(atom)` users than I'd like, hence this is just a draft.
There are a few remaining test failures that I am working on right now.

Note that there's also a selinux sandbox commit to fix some tests locally, that's ofc not related and I'll drop the commit later. Working with @WavyEbuilder to figure out why this only appears in tests.