### PR TITLE
fetch: Only fetch from GENTOO_MIRRORS if ebuild is in ::gentoo

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Release notes take the form of the following optional categories:
 * Bug fixes
 * Cleanups
 
+* fetch: Only fetch from GENTOO_MIRRORS if ebuild is in ::gentoo (bug #967090).
+
 portage-3.0.72 (2025-11-17)
 --------------
 

--- a/lib/_emerge/EbuildFetcher.py
+++ b/lib/_emerge/EbuildFetcher.py
@@ -249,6 +249,8 @@ class _EbuildFetcherProcess(ForkProcess):
         if nocolor is not None:
             settings["NOCOLOR"] = nocolor
 
+        use_gentoo_mirrors = self.pkg.repo == "gentoo"
+
         self._settings = settings
         self.log_filter_file = settings.get("PORTAGE_LOG_FILTER_FILE_CMD")
         self.target = functools.partial(
@@ -258,6 +260,7 @@ class _EbuildFetcherProcess(ForkProcess):
             self._uri_map,
             self.fetchonly,
             self.pre_exec,
+            use_gentoo_mirrors,
         )
         ForkProcess._start(self)
 
@@ -268,7 +271,7 @@ class _EbuildFetcherProcess(ForkProcess):
         self._settings = None
 
     @staticmethod
-    def _target(settings, manifest, uri_map, fetchonly, pre_exec):
+    def _target(settings, manifest, uri_map, fetchonly, pre_exec, use_gentoo_mirrors):
         if pre_exec is not None:
             pre_exec()
 
@@ -299,6 +302,7 @@ class _EbuildFetcherProcess(ForkProcess):
                     fetchonly=fetchonly,
                     digests=copy.deepcopy(manifest.getTypeDigests("DIST")),
                     allow_missing_digests=allow_missing,
+                    use_gentoo_mirrors=use_gentoo_mirrors,
                 )
             )
 

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -857,6 +857,7 @@ async def async_fetch(
     digests=None,
     allow_missing_digests=True,
     force=False,
+    use_gentoo_mirrors=True,
 ):
     from portage.package.ebuild.config import check_config_instance
 
@@ -1020,13 +1021,14 @@ async def async_fetch(
                 fsmirrors.append(x)
             else:
                 local_mirrors.append(x)
-        for x in mysettings["GENTOO_MIRRORS"].split():
-            if not x:
-                continue
-            if x.startswith("/"):
-                fsmirrors.append(x.rstrip("/"))
-            else:
-                public_mirrors.append(x.rstrip("/"))
+        if use_gentoo_mirrors:
+            for x in mysettings["GENTOO_MIRRORS"].split():
+                if not x:
+                    continue
+                if x.startswith("/"):
+                    fsmirrors.append(x.rstrip("/"))
+                else:
+                    public_mirrors.append(x.rstrip("/"))
 
     hash_filter = _hash_filter(mysettings.get("PORTAGE_CHECKSUM_FILTER", ""))
     if hash_filter.transparent:


### PR DESCRIPTION
Portage hits GENTOO_MIRRORS even for ebuilds within ebuild repositories other than ::gentoo. However, GENTOO_MIRRORS will only hold distfiles from ::gentoo.

To avoid unnecessary network requests and load on the mirrors only use GENTOO_MIRRORS if the ebuild's repository is ::gentoo.

Bug: https://bugs.gentoo.org/967090