### PR TITLE
EbuildPhase: prefer C.UTF-8 for LC_COLLATE

### DIFF
--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -53,11 +53,11 @@ async def _setup_locale(settings):
     eapi_attrs = _get_eapi_attrs(settings["EAPI"])
     if eapi_attrs.posixish_locale:
         split_LC_ALL(settings)
-        settings["LC_COLLATE"] = "C"
         # check_locale() returns None when check can not be executed.
         if await async_check_locale(silent=True, env=settings.environ()) is False:
             # try another locale
-            for l in ("C.UTF-8", "en_US.UTF-8", "en_GB.UTF-8", "C"):
+            for l in ("C.UTF-8", "C"):
+                settings["LC_COLLATE"] = l
                 settings["LC_CTYPE"] = l
                 if await async_check_locale(silent=True, env=settings.environ()):
                     # TODO: output the following only once


### PR DESCRIPTION
EbuildPhase: prefer C.UTF-8 for LC_COLLATE

Prefer C.UTF-8 for LC_COLLATE over C and set LC_COLLATE in the validation
loop if required.

Modern glibc (>=2.35) guarantees C.UTF-8 (though Gentoo had it patched
in before) and musl always has C.UTF-8.

This should still comply with the spec:
> The package manager must ensure that the LC_CTYPE and LC_COLLATE locale
> categories are equivalent to the POSIX locale, as far as characters in the ASCII
> range (U+0000 to U+007F) are concerned.

We would previously try for LC_CTYPE:
1) C.UTF-8
2) en_US.UTF-8
3) en_GB.UTF-8
4) C

but 3) and 4) aren't equivalent to C in the ASCII range for LC_COLLATE
which we want to add now, so change the iteration list to:
1) C.UTF-8
2) C
and we can maybe add the other two en_* if required at the end, but I
don't think those would satisfy the spec requirement.

Bug: https://bugs.gentoo.org/913903
Signed-off-by: Sam James <sam@gentoo.org>
