### PR TITLE
emaint -c world should warn about missing or masked ebuilds in world file (bug #970742)

### DIFF
--- a/lib/portage/emaint/modules/world/world.py
+++ b/lib/portage/emaint/modules/world/world.py
@@ -14,6 +14,8 @@ class WorldHandler:
 
     def __init__(self):
         self.invalid = []
+        self.masked = []
+        self.missing = []
         self.not_installed = []
         self.okay = []
         from portage._sets import load_default_config
@@ -28,8 +30,10 @@ class WorldHandler:
         self.world_file = os.path.join(eroot, portage.const.WORLD_FILE)
         self.found = os.access(self.world_file, os.R_OK)
         vardb = portage.db[eroot]["vartree"].dbapi
+        portdb = portage.db[eroot]["porttree"].dbapi
 
         from portage._sets import SETPREFIX
+        from portage.package.ebuild.getmaskingstatus import getmaskingstatus
 
         sets = self._sets
         world_atoms = list(sets["selected"])
@@ -50,7 +54,17 @@ class WorldHandler:
                     onProgress(maxval, i + 1)
                 continue
             okay = True
-            if not vardb.match(atom):
+            installed = vardb.match(atom)
+            if not portdb.xmatch("match-all", atom):
+                self.missing.append(atom)
+                okay = False
+            if okay and not portdb.xmatch("match-visible", atom):
+                reasons = ", ".join(
+                    {r for cpv in installed for r in getmaskingstatus(cpv)}
+                )
+                self.masked.append((atom, reasons))
+                okay = False
+            if okay and not installed:
                 self.not_installed.append(atom)
                 okay = False
             if okay:
@@ -63,6 +77,8 @@ class WorldHandler:
         self._check_world(onProgress)
         errors = []
         if self.found:
+            errors += [f"'{x}' has no visible ebuilds [{r}]" for x, r in self.masked]
+            errors += [f"'{x}' has no available ebuilds" for x in self.missing]
             errors += [f"'{x}' is not a valid atom" for x in self.invalid]
             errors += [f"'{x}' is not installed" for x in self.not_installed]
         else:


### PR DESCRIPTION
Adding the following checks to `emaint -c world`:
 - missing from porttree entire, i.e. package retired
 - all ebuilds masked for whatever reason

Note conditional chain with `okay` such that only the first problem found is reported - differs from prior behaviour. Example output after rudimentary testing with manually masked packages or commenting ACCEPT_LICENSE in make.conf, etc:

```
Emaint: check world        100% [============================================>]

'sys-devel/icecream' is has no visible ebuilds [~amd64 keyword]
'media-video/mpv' is has no visible ebuilds [package.mask]
'sys-firmware/intel-microcode' is has no visible ebuilds [intel-ucode license(s)]
```

Or if we recklessly manually edit world to simulate tree removal:

```
Emaint: check world        100% [============================================>]

'app-misc/foo' is has no available ebuilds
```

Have tried to keep this simple. Is not perfect, for example more complex ebuild LICENSE settings can make a bit of noise, e.g.:

```
Emaint: check world        100% [============================================>]

'sys-kernel/linux-firmware' is has no visible ebuilds [|| ( ) ( linux-fw-redistributable ) ( ) license(s)]
```

I did have a look at fixing that one, but the way it's implemented looks like the retention of the parens and operators is deliberate so decided to leave that alone. See https://gitweb.gentoo.org/proj/portage.git/tree/lib/portage/package/ebuild/getmaskingstatus.py#n150.