### PR TITLE
bin/isolated-functions.sh: add new function __normalize_owner used then by {ins,dir,exec,lib}opts

### DIFF
--- a/bin/ebuild-helpers/fowners
+++ b/bin/ebuild-helpers/fowners
@@ -6,52 +6,7 @@ source "${PORTAGE_BIN_PATH:?}"/isolated-functions.sh || exit
 
 if ! ___eapi_has_prefix_variables; then
 	ED=${D}
-	EROOT=${ROOT}
 fi
-
-if ___eapi_has_SYSROOT && [[ ${EBUILD_PHASE} == install ]]; then
-	PWDB_ROOT=${SYSROOT}
-	PWDB_EROOT=${ESYSROOT}
-else
-	PWDB_ROOT=${ROOT%/}
-	PWDB_EROOT=${EROOT%/}
-fi
-
-__resolve_owner() {
-	local owner="${1}"
-	local pwdb_path="${PWDB_EROOT}/etc"
-	local user group uid gid pgid
-
-	IFS=':' read -r user group <<< "${owner}"
-
-	if [[ -n "${user}" ]]; then
-		if [[ "${user}" =~ ^[0-9]+$ ]]; then
-			uid="${user}"
-		else
-			read -r uid pgid <<< "$(awk -F: -v u="${user}" '$1==u { print $3, $4 }' "${pwdb_path}"/passwd)"
-			[[ "${uid}" =~ ^[0-9]+$ ]] || __helpers_die "fowners: invalid user in ${pwdb_path}/passwd: ${owner}"
-		fi
-	fi
-
-	if [[ -n "${group}" ]]; then
-		if [[ "${group}" =~ ^[0-9]+$ ]]; then
-			gid="${group}"
-		else
-			gid=$(awk -F: -v g="${group}" '$1==g{print $3}' "${pwdb_path}"/group)
-			[[ "${gid}" =~ ^[0-9]+$ ]] || __helpers_die "fowners: invalid group in ${pwdb_path}/group: ${owner}"
-		fi
-		gid=":${gid}"
-	elif [[ "${owner}" == *: ]]; then
-		# `chown uid:` is invalid with numeric-uid-gid, use the primary group defined above
-		if [[ "${pgid}" =~ ^[0-9]+$ ]]; then
-			gid=":${pgid}"
-		else
-			__helpers_die "fowners: invalid primary group for ${user} in ${pwdb_path}/passwd: ${owner}"
-		fi
-	fi
-
-	printf '%s%s' "${uid}" "${gid}"
-}
 
 args=()
 got_owner=
@@ -62,7 +17,7 @@ for arg; do
 		# the first non-option is the owner and must not be prefixed
 		got_owner=1
 		# use numeric-uid-gid from the custom target root
-		if [[ -n ${PWDB_ROOT} ]]; then
+		if [[ -n "${SYSROOT%/}" || -n "${ROOT%/}" ]]; then
 			args+=( "$(__resolve_owner "${arg}")" )
 		else
 			args+=( "${arg}" )

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -474,6 +474,55 @@ ___makeopts_jobs() {
 	printf '%s\n' "${jobs}"
 }
 
+# convert any chown-compatible user[:group] literal into numeric-uid-gid
+__resolve_owner() {
+	if ! ___eapi_has_prefix_variables; then
+		EROOT=${ROOT}
+	fi
+
+	if ___eapi_has_SYSROOT && [[ ${EBUILD_PHASE} == install ]]; then
+		PWDB_ROOT=${SYSROOT}
+		PWDB_EROOT=${ESYSROOT}
+	else
+		PWDB_ROOT=${ROOT%/}
+		PWDB_EROOT=${EROOT%/}
+	fi
+
+	local owner="${1}"
+	local pwdb_path="${PWDB_EROOT}/etc"
+	local user group uid gid pgid
+
+	IFS=':' read -r user group <<< "${owner}"
+
+	if [[ -n "${user}" ]]; then
+		if [[ "${user}" =~ ^[0-9]+$ ]]; then
+			uid="${user}"
+		else
+			read -r uid pgid <<< "$(awk -F: -v u="${user}" '$1==u { print $3, $4 }' "${pwdb_path}"/passwd)"
+			[[ "${uid}" =~ ^[0-9]+$ ]] || die "'${FUNCNAME}': invalid user in ${pwdb_path}/passwd: ${owner}"
+		fi
+	fi
+
+	if [[ -n "${group}" ]]; then
+		if [[ "${group}" =~ ^[0-9]+$ ]]; then
+			gid="${group}"
+		else
+			gid=$(awk -F: -v g="${group}" '$1==g{print $3}' "${pwdb_path}"/group)
+			[[ "${gid}" =~ ^[0-9]+$ ]] || die "'${FUNCNAME}': invalid group in ${pwdb_path}/group: ${owner}"
+		fi
+		gid=":${gid}"
+	elif [[ "${owner}" == *: ]]; then
+		# `chown uid:` is invalid with numeric-uid-gid, use the primary group defined above
+		if [[ "${pgid}" =~ ^[0-9]+$ ]]; then
+			gid=":${pgid}"
+		else
+			die "'${FUNCNAME}': invalid primary group for ${user} in ${pwdb_path}/passwd: ${owner}"
+		fi
+	fi
+
+	printf '%s%s' "${uid}" "${gid}"
+}
+
 # Considers the positional parameters as comprising a simple command, which
 # shall be executed for each null-terminated record read from the standard
 # input. For each record processed, its value shall be taken as an additional

--- a/bin/isolated-functions.sh
+++ b/bin/isolated-functions.sh
@@ -474,6 +474,70 @@ ___makeopts_jobs() {
 	printf '%s\n' "${jobs}"
 }
 
+# from a list of args using -o/--owner/-g/--group, replace literal user/group with numeric-uid-gid
+# a group must be prefixed by ':'
+__normalize_owner() {
+	local lopt normalized_opts num_uid_gid value
+	while (( $# )); do
+		num_uid_gid=
+		lopt=
+		value=
+		case "${1}" in
+			-o|--owner)
+				lopt="--owner"
+				if [[ -n "${2}" && "${2}" != -* ]]; then
+					value="${2}"
+					shift 2
+				else
+					shift
+				fi
+				;;
+			-o*)
+				lopt="--owner"
+				value="${1#-o}"
+				shift
+				;;
+			--owner=*)
+				lopt="--owner"
+				value="${1#*=}"
+				shift
+				;;
+			-g|--group)
+				lopt="--group"
+				if [[ -n "${2}" && "${2}" != -* ]]; then
+					value=":${2}"
+					shift 2
+				else
+					shift
+				fi
+				;;
+			-g*)
+				lopt="--group"
+				value=":${1#-g}"
+				shift
+				;;
+			--group=*)
+				lopt="--group"
+				value=":${1#*=}"
+				shift
+				;;
+			*)
+				normalized_opts+=" ${1}"
+				shift
+				continue
+				;;
+		esac
+
+		# pass all args even without value to get errors from do*.py
+		normalized_opts+=" ${lopt}"
+		num_uid_gid=$(__resolve_owner "${value}")
+		[[ -n "${num_uid_gid}" ]] && normalized_opts+=" ${num_uid_gid#:}"
+
+	done
+
+	printf '%s' "${normalized_opts}"
+}
+
 # convert any chown-compatible user[:group] literal into numeric-uid-gid
 __resolve_owner() {
 	if ! ___eapi_has_prefix_variables; then

--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -128,6 +128,8 @@ insopts() {
 
 	if has -s "$@"; then
 		die "Never call insopts() with -s"
+	elif [[ -n "${SYSROOT%/}" || -n "${ROOT%/}" ]]; then
+		export INSOPTIONS=$(__normalize_owner $*)
 	else
 		export INSOPTIONS=$*
 	fi
@@ -136,7 +138,11 @@ insopts() {
 diropts() {
 	local IFS
 
-	export DIROPTIONS=$*
+	if [[ -n "${SYSROOT%/}" || -n "${ROOT%/}" ]]; then
+		export DIROPTIONS=$(__normalize_owner $*)
+	else
+		export DIROPTIONS=$*
+	fi
 }
 
 exeopts() {
@@ -144,6 +150,8 @@ exeopts() {
 
 	if has -s "$@"; then
 		die "Never call exeopts() with -s"
+	elif [[ -n "${SYSROOT%/}" || -n "${ROOT%/}" ]]; then
+		export EXEOPTIONS=$(__normalize_owner $*)
 	else
 		export EXEOPTIONS=$*
 	fi
@@ -156,6 +164,8 @@ libopts() {
 		die "'${FUNCNAME}' has been banned for EAPI '${EAPI}'"
 	elif has -s "$@"; then
 		die "Never call libopts() with -s"
+	elif [[ -n "${SYSROOT%/}" || -n "${ROOT%/}" ]]; then
+		export LIBOPTIONS=$(__normalize_owner $*)
 	else
 		export LIBOPTIONS=$*
 	fi


### PR DESCRIPTION
move __resolve_owner from fowners to isolated-function so it can be used by other helpers. Use die instead of die_helpers.

add a new function __normalize_owner using __resolve_owner to replace literal -o/--owner/-g/--group with numeric-uid-gid. Use it for {ins,dir,exec,lib}opts.

Not sure things are in the right place but it’s a start.

Bug: https://bugs.gentoo.org/971120