### PR TITLE
Skip binpkgs when local user patches are supplied

### DIFF
--- a/bin/phase-helpers.sh
+++ b/bin/phase-helpers.sh
@@ -1139,6 +1139,7 @@ if ___eapi_has_eapply_user; then
 		local basename basedir columns tagfile hr d f
 		local -A patch_by
 		local -a dirents
+		local IFS
 
 		[[ ${EBUILD_PHASE} == prepare ]] || \
 			die "eapply_user() called during invalid phase: ${EBUILD_PHASE}"
@@ -1185,13 +1186,32 @@ if ___eapi_has_eapply_user; then
 		done
 
 		if (( ${#patch_by[@]} > 0 )); then
+			mkdir -p -- "${PORTAGE_BUILDDIR}"/build-info || die "eapply_user: could not create build-info directory"
+			local userpatch_digests="${PORTAGE_BUILDDIR}"/build-info/user_patch.digests
+			local userpatches_hash="${PORTAGE_BUILDDIR}"/build-info/USER_PATCHES
+
 			printf -v hr "%$(( columns - 3 ))s"
 			hr=${hr//?/=}
 			einfo "${PORTAGE_COLOR_INFO}${hr}${PORTAGE_COLOR_NORMAL}"
 			einfo "Applying user patches from ${basedir} ..."
+
+			local hash
+			local total=""
 			while IFS= read -rd '' basename; do
 				eapply -- "${patch_by[$basename]}"
+
+				read -r hash _ < <(sha256sum < "${patch_by[$basename]}") \
+				&& wait "$!" \
+				&& total+="${hash}" \
+				&& printf '%s\0' "${hash}" "${basename}" >> "${userpatch_digests}" \
+				|| die "eapply_user: could not generate individual user patch digests"
 			done < <(printf '%s\0' "${!patch_by[@]}" | LC_ALL=C sort -z)
+
+			read -r hash _ < <(printf '%s' "${total}" | sha256sum) \
+			&& wait "$!" \
+			&& printf '%s\n' "${hash}" > "${userpatches_hash}" \
+			|| die "eapply_user: could not generate hash over all user patches"
+
 			einfo "User patches applied."
 			einfo "${PORTAGE_COLOR_INFO}${hr}${PORTAGE_COLOR_NORMAL}"
 		fi

--- a/lib/_emerge/Binpkg.py
+++ b/lib/_emerge/Binpkg.py
@@ -5,6 +5,7 @@ import functools
 import io
 import logging
 import os
+import re
 import shutil
 import sys
 
@@ -370,6 +371,66 @@ class Binpkg(CompositeTask):
                 f.write(v + "\n")
             finally:
                 f.close()
+
+        # report any user patches applied when binary was built
+        user_patch_digests = os.path.join(infloc, "user_patch.digests")
+        if os.path.exists(user_patch_digests):
+            with open(user_patch_digests, "rb") as f:
+                tokens = f.read().strip(b"\0").split(b"\0")
+            hashes = tokens[0::2]
+            basenames = tokens[1::2]
+            hashes_ok = all(re.match(rb"^[0-9A-Fa-f]{64}$", h) for h in hashes)
+            basenames_ok = all(re.match(rb"[^/]+\.(patch|diff)$", b) for b in basenames)
+            count_ok = len(hashes) == len(basenames) == len(tokens) / 2
+
+            out = portage.output.EOutput()
+            if count_ok and hashes_ok and basenames_ok:
+                digests = {
+                    h.decode().lower(): os.fsdecode(f)
+                    for h, f in zip(hashes, basenames)
+                }
+
+                horiz_term_bar = lambda: out.ebinfo(
+                    colorize("PKG_BINARY_MERGE", (out.term_columns - 3) * "=")
+                )
+                min_digest = 8
+                min_basename = 25
+                max_basename = max(out.term_columns - min_digest - 6, min_basename)
+
+                out.ebinfo("This binary package was built with user patches applied:")
+                horiz_term_bar()
+                for digest, basename in digests.items():
+                    basename = re.sub("[\x01-\x1f\x7f]", "?", basename)
+                    max_digest = max(out.term_columns - len(basename) - 6, min_digest)
+                    basename = basename[:max_basename]
+                    digest = digest[:max_digest]
+                    out.ebinfo(
+                        "%s%*s%s"
+                        % (
+                            basename,
+                            out.term_columns - len(basename) - len(digest) - 4,
+                            "",
+                            digest,
+                        )
+                    )
+                horiz_term_bar()
+
+                if (
+                    self.pkg not in self.settings._user_patches
+                    or self.settings._user_patches[self.pkg] != pkg.user_patches
+                ):
+                    out.ewarn("")
+                    out.ewarn(
+                        "User patches in binary package different than configured for ebuild!!!"
+                    )
+                    out.ewarn("")
+                out.ebinfo("")
+            else:
+                out.ewarn("")
+                out.ewarn(
+                    "This binary package has invalid user patch digest metadata!!!"
+                )
+                out.ewarn("")
 
         # Store the md5sum in the vdb.
         if pkg_path is not None:

--- a/lib/_emerge/Binpkg.py
+++ b/lib/_emerge/Binpkg.py
@@ -5,12 +5,13 @@ import functools
 import io
 import logging
 import os
+import re
 import shutil
 import sys
 
 import portage
 from portage.eapi import eapi_exports_replace_vars
-from portage.output import colorize
+from portage.output import colorize, renderPath
 from portage.util import ensure_dirs
 from portage.util._async.AsyncTaskFuture import AsyncTaskFuture
 from portage.util._dyn_libs.dyn_libs import check_dyn_libs_inconsistent
@@ -370,6 +371,66 @@ class Binpkg(CompositeTask):
                 f.write(v + "\n")
             finally:
                 f.close()
+
+        # report any user patches applied when binary was built
+        user_patch_digests = os.path.join(infloc, "user_patch.digests")
+        if os.path.exists(user_patch_digests):
+            with open(user_patch_digests, "rb") as f:
+                tokens = f.read().strip(b"\0").split(b"\0")
+            hashes = tokens[0::2]
+            basenames = tokens[1::2]
+            hashes_ok = all(re.match(rb"^[0-9A-Fa-f]{64}$", h) for h in hashes)
+            basenames_ok = all(re.match(rb"[^/]+\.(patch|diff)$", b) for b in basenames)
+            count_ok = len(hashes) == len(basenames) == len(tokens) / 2
+
+            out = portage.output.EOutput()
+            if count_ok and hashes_ok and basenames_ok:
+                digests = {
+                    h.decode().lower(): os.fsdecode(f)
+                    for h, f in zip(hashes, basenames)
+                }
+
+                horiz_term_bar = lambda: out.ebinfo(
+                    colorize("PKG_BINARY_MERGE", (out.term_columns - 3) * "=")
+                )
+                min_digest = 8
+                min_basename = 25
+                max_basename = max(out.term_columns - min_digest - 6, min_basename)
+
+                out.ebinfo("This binary package was built with user patches applied:")
+                horiz_term_bar()
+                for digest, basename in digests.items():
+                    basename = renderPath(basename)
+                    max_digest = max(out.term_columns - len(basename) - 6, min_digest)
+                    basename = basename[:max_basename]
+                    digest = digest[:max_digest]
+                    out.ebinfo(
+                        "%s%*s%s"
+                        % (
+                            basename,
+                            out.term_columns - len(basename) - len(digest) - 4,
+                            "",
+                            digest,
+                        )
+                    )
+                horiz_term_bar()
+
+                if (
+                    self.pkg not in self.settings._user_patches
+                    or self.settings._user_patches[self.pkg] != pkg.user_patches
+                ):
+                    out.ewarn("")
+                    out.ewarn(
+                        "User patches in binary package different than configured for ebuild!!!"
+                    )
+                    out.ewarn("")
+                out.ebinfo("")
+            else:
+                out.ewarn("")
+                out.ewarn(
+                    "This binary package has invalid user patch digest metadata!!!"
+                )
+                out.ewarn("")
 
         # Store the md5sum in the vdb.
         if pkg_path is not None:

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -87,6 +87,7 @@ class Package(Task):
         "SIZE",
         "SLOT",
         "USE",
+        "USER_PATCHES",
         "_mtime_",
     ]
 
@@ -225,6 +226,10 @@ class Package(Task):
         if self._masks is None:
             self._masks = self._eval_masks()
         return self._masks
+
+    @property
+    def user_patches(self):
+        return self._metadata["USER_PATCHES"].lower()
 
     @property
     def visible(self):

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -106,6 +106,7 @@ class Package(Task):
         "SIZE",
         "SLOT",
         "USE",
+        "USER_PATCHES",
         "_mtime_",
     ]
 
@@ -235,6 +236,10 @@ class Package(Task):
         if self._masks is None:
             self._masks = self._eval_masks()
         return self._masks
+
+    @property
+    def user_patches(self):
+        return self._metadata["USER_PATCHES"].lower()
 
     @property
     def visible(self):

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7741,6 +7741,10 @@ class depgraph:
                         if in_usepkg_exclude or not in_usepkg_include:
                             break
 
+                        # do not select binpkgs if user patches exist (see bug #917047)
+                        if pkg.cpv in pkgsettings._user_patches:
+                            break
+
                     # We can choose not to install a live package from using binary
                     # cache by disabling it with option --usepkg-exclude-live in the
                     # emerge call.

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7642,6 +7642,9 @@ class depgraph:
         usepkg = "--usepkg" in self._frozen_config.myopts
         usepkgonly = "--usepkgonly" in self._frozen_config.myopts
         usepkg_exclude_live = "--usepkg-exclude-live" in self._frozen_config.myopts
+        usepkg_exclude_patches = self._frozen_config.myopts.get(
+            "--usepkg-exclude-patches", not usepkgonly
+        )
         empty = "empty" in self._dynamic_config.myparams
         selective = "selective" in self._dynamic_config.myparams
         reinstall = False
@@ -7742,7 +7745,10 @@ class depgraph:
                             break
 
                         # do not select binpkgs if user patches exist (see bug #917047)
-                        if pkg.cpv in pkgsettings._user_patches:
+                        if (
+                            usepkg_exclude_patches
+                            and pkg.cpv in pkgsettings._user_patches
+                        ):
                             break
 
                     # We can choose not to install a live package from using binary

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7994,7 +7994,7 @@ class depgraph:
                         # do not select binpkgs if user patches exist (see bug #917047)
                         if (
                             binpkg_respect_user_patches
-                            and pkg in pkgsettings._user_patches
+                            and pkg.user_patches != pkgsettings.userPatchDigest(pkg)
                         ):
                             self._dynamic_config.ignored_binaries.setdefault(
                                 pkg, {}

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7910,6 +7910,10 @@ class depgraph:
                         if in_usepkg_exclude or not in_usepkg_include:
                             break
 
+                        # do not select binpkgs if user patches exist (see bug #917047)
+                        if pkg in pkgsettings._user_patches:
+                            break
+
                     # We can choose not to install a live package from using binary
                     # cache by disabling it with option --usepkg-exclude-live in the
                     # emerge call.

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -29,7 +29,9 @@ from portage.dbapi.DummyTree import DummyTree
 from portage.dbapi.IndexedPortdb import IndexedPortdb
 from portage.dep import (
     Atom,
+    _build_id_separator,
     _repo_separator,
+    _slot_separator,
     best_match_to_list,
     check_required_use,
     extract_affecting_use,
@@ -1405,6 +1407,12 @@ class depgraph:
         if self._dynamic_config.myparams.get("binpkg_changed_deps") in ("y", "n"):
             ignored_binaries.pop("changed_deps", None)
 
+        if self._frozen_config.myopts.get("--binpkg-respect-user-patches") in (
+            "y",
+            "n",
+        ):
+            ignored_binaries.pop("user_patches", None)
+
         if not ignored_binaries:
             return
 
@@ -1415,6 +1423,9 @@ class depgraph:
 
         if "changed_deps" in ignored_binaries:
             self._show_ignored_binaries_changed_deps(ignored_binaries["changed_deps"])
+
+        if "user_patches" in ignored_binaries:
+            self._show_ignored_binaries_user_patches(ignored_binaries["user_patches"])
 
     def _show_ignored_binaries_respect_use(self, respect_use):
         seen = {}
@@ -1507,6 +1518,60 @@ class depgraph:
             "NOTE: The --binpkg-changed-deps=n option will prevent emerge",
             "      from ignoring these binary packages if possible.",
             "      Using --binpkg-changed-deps=y will silence this warning.",
+        ]
+
+        for line in msg:
+            if line:
+                line = colorize("INFORM", line)
+            writemsg(line + "\n", noiselevel=-1)
+
+    def _show_ignored_binaries_user_patches(self, user_patches):
+        merging = {
+            (pkg.root, pkg.cpv)
+            for pkg in self._dynamic_config._displayed_list or ()
+            if isinstance(pkg, Package)
+        }
+
+        messages = []
+        patchset = set()
+
+        for pkg, patches in user_patches.items():
+            msg = f"     {pkg.cpv}"
+            if hasattr(pkg.cpv, "slot") and pkg.slot != "0":
+                msg += _slot_separator + pkg.cpv.slot
+            if hasattr(pkg, "build_id") and pkg.build_id:
+                msg += _build_id_separator + str(pkg.build_id)
+            if pkg.root_config.settings["ROOT"] != "/":
+                msg += f" for {pkg.root}"
+            messages.append(f"{msg}\n")
+            if patches:
+                patchset.update(patches)
+
+        if not messages:
+            return
+
+        writemsg(
+            "\n!!! The following binary packages have been "
+            "ignored due to user patches:\n\n",
+            noiselevel=-1,
+        )
+        for line in sorted(messages):
+            writemsg(line, noiselevel=-1)
+
+        if "--verbose" in self._frozen_config.myopts and patchset:
+            writemsg(
+                "\n!!! These user patches are triggering this warning:\n\n",
+                noiselevel=-1,
+            )
+            for line in sorted(patchset):
+                writemsg(f"    {line}\n", noiselevel=-1)
+
+        msg = [
+            "",
+            "NOTE: The --binpkg-respect-user-patches=n option will prevent",
+            "      emerge from ignoring these binary packages.",
+            "      Using --binpkg-respect-user-patches=y will silence this",
+            "      warning.",
         ]
 
         for line in msg:
@@ -6630,7 +6695,6 @@ class depgraph:
                             ):
                                 required_use_unsatisfied.append(pkg)
                                 continue
-
                         root_slot = (pkg.root, pkg.slot_atom)
                         if (
                             pkg.built
@@ -6657,6 +6721,14 @@ class depgraph:
                             )
                         ):
                             mreasons = ["changed deps"]
+                        elif (
+                            pkg.built
+                            and not mreasons
+                            and self._dynamic_config.ignored_binaries.get(pkg, {}).get(
+                                "user_patches"
+                            )
+                        ):
+                            mreasons = ["user patches"]
                         elif (
                             pkg.built
                             and use_ebuild_visibility
@@ -6978,16 +7050,22 @@ class depgraph:
                 )
 
         elif masked_packages:
+            writemsg("\n!!! ")
+            if self._frozen_config.myopts.get("--usepkgonly", False):
+                writemsg(
+                    colorize("BAD", "All binary packages that could satisfy "),
+                    noiselevel=-1,
+                )
+            else:
+                writemsg(
+                    colorize("BAD", "All ebuilds that could satisfy "),
+                    noiselevel=-1,
+                )
             writemsg(
-                "\n!!! "
-                + colorize("BAD", "All ebuilds that could satisfy ")
-                + colorize("INFORM", xinfo)
+                colorize("INFORM", xinfo)
                 + colorize("BAD", " have been masked.")
-                + "\n",
-                noiselevel=-1,
-            )
-            writemsg(
-                "!!! One of the following masked packages is required to complete your request:\n",
+                + "\n"
+                + "!!! One of the following masked packages is required to complete your request:\n",
                 noiselevel=-1,
             )
             have_eapi_mask = show_masked_packages(masked_packages)
@@ -7819,6 +7897,9 @@ class depgraph:
         use_ebuild_visibility = (
             self._frozen_config.myopts.get("--use-ebuild-visibility", "n") != "n"
         )
+        binpkg_respect_user_patches = (
+            self._frozen_config.myopts.get("--binpkg-respect-user-patches", "y") != "n"
+        )
         reinstall_atoms = self._frozen_config.reinstall_atoms
         usepkg_exclude = self._frozen_config.usepkg_exclude
         usepkg_include = self._frozen_config.usepkg_include
@@ -7911,8 +7992,16 @@ class depgraph:
                             break
 
                         # do not select binpkgs if user patches exist (see bug #917047)
-                        if pkg in pkgsettings._user_patches:
-                            break
+                        if (
+                            binpkg_respect_user_patches
+                            and pkg in pkgsettings._user_patches
+                        ):
+                            self._dynamic_config.ignored_binaries.setdefault(
+                                pkg, {}
+                            ).setdefault(
+                                "user_patches", pkgsettings.userPatchFiles(pkg)
+                            )
+                            continue
 
                     # We can choose not to install a live package from using binary
                     # cache by disabling it with option --usepkg-exclude-live in the

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7926,6 +7926,10 @@ class depgraph:
                         if in_usepkg_exclude or not in_usepkg_include:
                             break
 
+                        # do not select binpkgs if user patches exist (see bug #917047)
+                        if pkg in pkgsettings._user_patches:
+                            break
+
                     # We can choose not to install a live package from using binary
                     # cache by disabling it with option --usepkg-exclude-live in the
                     # emerge call.

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -8010,7 +8010,7 @@ class depgraph:
                         # do not select binpkgs if user patches exist (see bug #917047)
                         if (
                             binpkg_respect_user_patches
-                            and pkg in pkgsettings._user_patches
+                            and pkg.user_patches != pkgsettings.userPatchDigest(pkg)
                         ):
                             self._dynamic_config.ignored_binaries.setdefault(
                                 pkg, {}

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -30,7 +30,9 @@ from portage.dbapi.DummyTree import DummyTree
 from portage.dbapi.IndexedPortdb import IndexedPortdb
 from portage.dep import (
     Atom,
+    _build_id_separator,
     _repo_separator,
+    _slot_separator,
     best_match_to_list,
     check_required_use,
     extract_affecting_use,
@@ -1421,6 +1423,12 @@ class depgraph:
         if self._dynamic_config.myparams.get("binpkg_changed_deps") in ("y", "n"):
             ignored_binaries.pop("changed_deps", None)
 
+        if self._frozen_config.myopts.get("--binpkg-respect-user-patches") in (
+            "y",
+            "n",
+        ):
+            ignored_binaries.pop("user_patches", None)
+
         if not ignored_binaries:
             return
 
@@ -1431,6 +1439,9 @@ class depgraph:
 
         if "changed_deps" in ignored_binaries:
             self._show_ignored_binaries_changed_deps(ignored_binaries["changed_deps"])
+
+        if "user_patches" in ignored_binaries:
+            self._show_ignored_binaries_user_patches(ignored_binaries["user_patches"])
 
     def _show_ignored_binaries_respect_use(self, respect_use):
         seen = {}
@@ -1523,6 +1534,60 @@ class depgraph:
             "NOTE: The --binpkg-changed-deps=n option will prevent emerge",
             "      from ignoring these binary packages if possible.",
             "      Using --binpkg-changed-deps=y will silence this warning.",
+        ]
+
+        for line in msg:
+            if line:
+                line = colorize("INFORM", line)
+            writemsg(line + "\n", noiselevel=-1)
+
+    def _show_ignored_binaries_user_patches(self, user_patches):
+        merging = {
+            (pkg.root, pkg.cpv)
+            for pkg in self._dynamic_config._displayed_list or ()
+            if isinstance(pkg, Package)
+        }
+
+        messages = []
+        patchset = set()
+
+        for pkg, patches in user_patches.items():
+            msg = f"     {pkg.cpv}"
+            if hasattr(pkg.cpv, "slot") and pkg.slot != "0":
+                msg += _slot_separator + pkg.cpv.slot
+            if hasattr(pkg, "build_id") and pkg.build_id:
+                msg += _build_id_separator + str(pkg.build_id)
+            if pkg.root_config.settings["ROOT"] != "/":
+                msg += f" for {pkg.root}"
+            messages.append(f"{msg}\n")
+            if patches:
+                patchset.update(patches)
+
+        if not messages:
+            return
+
+        writemsg(
+            "\n!!! The following binary packages have been "
+            "ignored due to user patches:\n\n",
+            noiselevel=-1,
+        )
+        for line in sorted(messages):
+            writemsg(line, noiselevel=-1)
+
+        if "--verbose" in self._frozen_config.myopts and patchset:
+            writemsg(
+                "\n!!! These user patches are triggering this warning:\n\n",
+                noiselevel=-1,
+            )
+            for line in sorted(patchset):
+                writemsg(f"    {line}\n", noiselevel=-1)
+
+        msg = [
+            "",
+            "NOTE: The --binpkg-respect-user-patches=n option will prevent",
+            "      emerge from ignoring these binary packages.",
+            "      Using --binpkg-respect-user-patches=y will silence this",
+            "      warning.",
         ]
 
         for line in msg:
@@ -6646,7 +6711,6 @@ class depgraph:
                             ):
                                 required_use_unsatisfied.append(pkg)
                                 continue
-
                         root_slot = (pkg.root, pkg.slot_atom)
                         if (
                             pkg.built
@@ -6673,6 +6737,14 @@ class depgraph:
                             )
                         ):
                             mreasons = ["changed deps"]
+                        elif (
+                            pkg.built
+                            and not mreasons
+                            and self._dynamic_config.ignored_binaries.get(pkg, {}).get(
+                                "user_patches"
+                            )
+                        ):
+                            mreasons = ["user patches"]
                         elif (
                             pkg.built
                             and use_ebuild_visibility
@@ -6994,16 +7066,22 @@ class depgraph:
                 )
 
         elif masked_packages:
+            writemsg("\n!!! ")
+            if self._frozen_config.myopts.get("--usepkgonly", False):
+                writemsg(
+                    colorize("BAD", "All binary packages that could satisfy "),
+                    noiselevel=-1,
+                )
+            else:
+                writemsg(
+                    colorize("BAD", "All ebuilds that could satisfy "),
+                    noiselevel=-1,
+                )
             writemsg(
-                "\n!!! "
-                + colorize("BAD", "All ebuilds that could satisfy ")
-                + colorize("INFORM", xinfo)
+                colorize("INFORM", xinfo)
                 + colorize("BAD", " have been masked.")
-                + "\n",
-                noiselevel=-1,
-            )
-            writemsg(
-                "!!! One of the following masked packages is required to complete your request:\n",
+                + "\n"
+                + "!!! One of the following masked packages is required to complete your request:\n",
                 noiselevel=-1,
             )
             have_eapi_mask = show_masked_packages(masked_packages)
@@ -7835,6 +7913,9 @@ class depgraph:
         use_ebuild_visibility = (
             self._frozen_config.myopts.get("--use-ebuild-visibility", "n") != "n"
         )
+        binpkg_respect_user_patches = (
+            self._frozen_config.myopts.get("--binpkg-respect-user-patches", "y") != "n"
+        )
         reinstall_atoms = self._frozen_config.reinstall_atoms
         usepkg_exclude = self._frozen_config.usepkg_exclude
         usepkg_include = self._frozen_config.usepkg_include
@@ -7927,8 +8008,16 @@ class depgraph:
                             break
 
                         # do not select binpkgs if user patches exist (see bug #917047)
-                        if pkg in pkgsettings._user_patches:
-                            break
+                        if (
+                            binpkg_respect_user_patches
+                            and pkg in pkgsettings._user_patches
+                        ):
+                            self._dynamic_config.ignored_binaries.setdefault(
+                                pkg, {}
+                            ).setdefault(
+                                "user_patches", pkgsettings.userPatchFiles(pkg)
+                            )
+                            continue
 
                     # We can choose not to install a live package from using binary
                     # cache by disabling it with option --usepkg-exclude-live in the

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -186,6 +186,7 @@ def insert_optional_args(args):
         "--usepkg": y_or_n,
         "--usepkgonly": y_or_n,
         "--usepkg-exclude-live": y_or_n,
+        "--usepkg-exclude-patches": y_or_n,
         "--verbose": y_or_n,
         "--verbose-missing-ebuilds": y_or_n,
         "--verbose-slot-rebuilds": y_or_n,
@@ -729,6 +730,10 @@ def parse_opts(tmpcmdline, silent=False):
             "help": "do not install from binary packages for live ebuilds",
             "choices": true_y_or_n,
         },
+        "--usepkg-exclude-patches": {
+            "help": "do not install from binary packages if user patches exist",
+            "choices": y_or_n,
+        },
         "--verbose": {
             "shortopt": "-v",
             "help": "verbose output",
@@ -1116,6 +1121,12 @@ def parse_opts(tmpcmdline, silent=False):
         myoptions.usepkg_exclude_live = True
     else:
         myoptions.usepkg_exclude_live = None
+
+    if myoptions.usepkg_exclude_patches is not None:
+        if myoptions.usepkg_exclude_patches in true_y:
+            myoptions.usepkg_exclude_patches = True
+        else:
+            myoptions.usepkg_exclude_patches = False
 
     if myoptions.verbose in true_y:
         myoptions.verbose = True

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -397,7 +397,9 @@ def parse_opts(tmpcmdline, silent=False):
             "choices": true_y_or_n,
         },
         "--binpkg-respect-user-patches": {
-            "help": "ignore binary packages for which user patches exist",
+            "help": "ignore binary packages that would revert user patches "
+            + "in the current configuration or were built with user patches "
+            + "not in the current configuration.",
             "choices": true_y_or_n,
         },
         "--buildpkg": {

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -148,6 +148,8 @@ def insert_optional_args(args):
         "--autounmask-unrestricted-atoms": y_or_n,
         "--autounmask-write": y_or_n,
         "--binpkg-changed-deps": y_or_n,
+        "--binpkg-respect-use": y_or_n,
+        "--binpkg-respect-user-patches": y_or_n,
         "--buildpkg": y_or_n,
         "--changed-deps": y_or_n,
         "--changed-slot": y_or_n,
@@ -156,7 +158,6 @@ def insert_optional_args(args):
         "--deep": valid_integers,
         "--depclean-lib-check": y_or_n,
         "--deselect": y_or_n,
-        "--binpkg-respect-use": y_or_n,
         "--fail-clean": y_or_n,
         "--fuzzy-search": y_or_n,
         "--getbinpkg": y_or_n,
@@ -388,7 +389,15 @@ def parse_opts(tmpcmdline, silent=False):
             "action": "store",
         },
         "--binpkg-changed-deps": {
-            "help": ("reject binary packages with outdated " "dependencies"),
+            "help": "ignore binary packages with outdated dependencies",
+            "choices": true_y_or_n,
+        },
+        "--binpkg-respect-use": {
+            "help": "ignore binary packages if their use flags don't match the current configuration",
+            "choices": true_y_or_n,
+        },
+        "--binpkg-respect-user-patches": {
+            "help": "ignore binary packages for which user patches exist",
             "choices": true_y_or_n,
         },
         "--buildpkg": {
@@ -536,11 +545,6 @@ def parse_opts(tmpcmdline, silent=False):
             + "Emerge will treat matching packages as if they are not "
             + "installed, and reinstall them if necessary. Implies --deep.",
             "action": "append",
-        },
-        "--binpkg-respect-use": {
-            "help": "discard binary packages if their use flags \
-				don't match the current configuration",
-            "choices": true_y_or_n,
         },
         "--getbinpkg": {
             "shortopt": "-g",
@@ -833,6 +837,18 @@ def parse_opts(tmpcmdline, silent=False):
         else:
             myoptions.binpkg_changed_deps = "n"
 
+    if myoptions.binpkg_respect_use is not None:
+        if myoptions.binpkg_respect_use in true_y:
+            myoptions.binpkg_respect_use = "y"
+        else:
+            myoptions.binpkg_respect_use = "n"
+
+    if myoptions.binpkg_respect_user_patches is not None:
+        if myoptions.binpkg_respect_user_patches in true_y:
+            myoptions.binpkg_respect_user_patches = "y"
+        else:
+            myoptions.binpkg_respect_user_patches = "n"
+
     if myoptions.buildpkg in true_y:
         myoptions.buildpkg = True
 
@@ -868,12 +884,6 @@ def parse_opts(tmpcmdline, silent=False):
 
     if myoptions.deselect in true_y:
         myoptions.deselect = True
-
-    if myoptions.binpkg_respect_use is not None:
-        if myoptions.binpkg_respect_use in true_y:
-            myoptions.binpkg_respect_use = "y"
-        else:
-            myoptions.binpkg_respect_use = "n"
 
     if myoptions.complete_graph in true_y:
         myoptions.complete_graph = True

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -148,6 +148,8 @@ def insert_optional_args(args):
         "--autounmask-unrestricted-atoms": y_or_n,
         "--autounmask-write": y_or_n,
         "--binpkg-changed-deps": y_or_n,
+        "--binpkg-respect-use": y_or_n,
+        "--binpkg-respect-user-patches": y_or_n,
         "--buildpkg": y_or_n,
         "--changed-deps": y_or_n,
         "--changed-slot": y_or_n,
@@ -157,7 +159,6 @@ def insert_optional_args(args):
         "--deep": valid_integers,
         "--depclean-lib-check": y_or_n,
         "--deselect": y_or_n,
-        "--binpkg-respect-use": y_or_n,
         "--fail-clean": y_or_n,
         "--fuzzy-search": y_or_n,
         "--getbinpkg": y_or_n,
@@ -389,7 +390,15 @@ def parse_opts(tmpcmdline, silent=False):
             "action": "store",
         },
         "--binpkg-changed-deps": {
-            "help": ("reject binary packages with outdated " "dependencies"),
+            "help": "ignore binary packages with outdated dependencies",
+            "choices": true_y_or_n,
+        },
+        "--binpkg-respect-use": {
+            "help": "ignore binary packages if their use flags don't match the current configuration",
+            "choices": true_y_or_n,
+        },
+        "--binpkg-respect-user-patches": {
+            "help": "ignore binary packages for which user patches exist",
             "choices": true_y_or_n,
         },
         "--buildpkg": {
@@ -543,11 +552,6 @@ def parse_opts(tmpcmdline, silent=False):
             + "Emerge will treat matching packages as if they are not "
             + "installed, and reinstall them if necessary. Implies --deep.",
             "action": "append",
-        },
-        "--binpkg-respect-use": {
-            "help": "discard binary packages if their use flags \
-				don't match the current configuration",
-            "choices": true_y_or_n,
         },
         "--getbinpkg": {
             "shortopt": "-g",
@@ -840,6 +844,18 @@ def parse_opts(tmpcmdline, silent=False):
         else:
             myoptions.binpkg_changed_deps = "n"
 
+    if myoptions.binpkg_respect_use is not None:
+        if myoptions.binpkg_respect_use in true_y:
+            myoptions.binpkg_respect_use = "y"
+        else:
+            myoptions.binpkg_respect_use = "n"
+
+    if myoptions.binpkg_respect_user_patches is not None:
+        if myoptions.binpkg_respect_user_patches in true_y:
+            myoptions.binpkg_respect_user_patches = "y"
+        else:
+            myoptions.binpkg_respect_user_patches = "n"
+
     if myoptions.buildpkg in true_y:
         myoptions.buildpkg = True
 
@@ -875,12 +891,6 @@ def parse_opts(tmpcmdline, silent=False):
 
     if myoptions.deselect in true_y:
         myoptions.deselect = True
-
-    if myoptions.binpkg_respect_use is not None:
-        if myoptions.binpkg_respect_use in true_y:
-            myoptions.binpkg_respect_use = "y"
-        else:
-            myoptions.binpkg_respect_use = "n"
 
     if myoptions.complete_graph in true_y:
         myoptions.complete_graph = True

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -398,7 +398,9 @@ def parse_opts(tmpcmdline, silent=False):
             "choices": true_y_or_n,
         },
         "--binpkg-respect-user-patches": {
-            "help": "ignore binary packages for which user patches exist",
+            "help": "ignore binary packages that would revert user patches "
+            + "in the current configuration or were built with user patches "
+            + "not in the current configuration.",
             "choices": true_y_or_n,
         },
         "--buildpkg": {

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -115,6 +115,7 @@ class bindbapi(fakedbapi):
             "SIZE",
             "SLOT",
             "USE",
+            "USER_PATCHES",
             "_mtime_",
         }
         # Keys required only when initially adding a package.

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -116,6 +116,7 @@ class bindbapi(fakedbapi):
             "SIZE",
             "SLOT",
             "USE",
+            "USER_PATCHES",
             "_mtime_",
         }
         # Keys required only when initially adding a package.

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -5,6 +5,7 @@
 
 __all__ = [
     "Atom",
+    "_build_id_separator",
     "_repo_name_re",
     "_repo_separator",
     "_slot_separator",
@@ -252,6 +253,8 @@ _repo_name_re = re.compile(rf"^{_repo_name}\Z", re.ASCII)
 _extended_cat = r"[\w+*][\w+.*-]*"
 
 _slot_dep_re_cache = {}
+
+_build_id_separator = "-"
 
 
 def _get_slot_dep_re(eapi_attrs: _eapi_attrs) -> re.Pattern:

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -5,6 +5,7 @@
 
 __all__ = [
     "Atom",
+    "_build_id_separator",
     "_repo_name_re",
     "_repo_separator",
     "_slot_separator",
@@ -251,6 +252,8 @@ _repo_name_re = re.compile(rf"^{_repo_name}\Z", re.ASCII)
 _extended_cat = r"[\w+*][\w+.*-]*"
 
 _slot_dep_re_cache = {}
+
+_build_id_separator = "-"
 
 
 def _get_slot_dep_re(eapi_attrs: _eapi_attrs) -> re.Pattern:

--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -616,6 +616,20 @@ class EOutput:
                 % ((self.term_columns - self.__last_e_len - 7), "", status_brackets),
             )
 
+    def ebinfo(self, msg):
+        """
+        Shows an informative message about a binary package operation
+
+        @param msg: A very brief (shorter than one line) informative message.
+        @type msg: StringType
+        """
+        out = sys.stdout
+        if not self.quiet:
+            if self.__last_e_cmd == "ebegin":
+                self._write(out, "\n")
+            self._write(out, colorize("PKG_BINARY_MERGE", " * ") + msg + "\n")
+        self.__last_e_cmd = "einfo"
+
     def ebegin(self, msg):
         """
         Shows a message indicating the start of a process.

--- a/lib/portage/output.py
+++ b/lib/portage/output.py
@@ -343,6 +343,20 @@ def nocolor():
     havecolor = 0
 
 
+def renderPath(path):
+    """
+    @param path: Path string to be shown to a user
+    @type path: String
+    @rtype: String
+    @return: A string which is safe to print, e.g. using EOutput, with
+             non-printables and non-utf8 replaced with '?'
+    """
+    if isinstance(path, (bytes, bytearray)):
+        path = os.fsdecode(path)
+    utf8 = path.encode(errors="replace").decode()
+    return re.sub("[\x01-\x1f\x7f]", "?", utf8)
+
+
 def resetColor():
     return codes["reset"]
 
@@ -615,6 +629,20 @@ class EOutput:
                 "%*s%s\n"
                 % ((self.term_columns - self.__last_e_len - 7), "", status_brackets),
             )
+
+    def ebinfo(self, msg):
+        """
+        Shows an informative message about a binary package operation
+
+        @param msg: A very brief (shorter than one line) informative message.
+        @type msg: StringType
+        """
+        out = sys.stdout
+        if not self.quiet:
+            if self.__last_e_cmd == "ebegin":
+                self._write(out, "\n")
+            self._write(out, colorize("PKG_BINARY_MERGE", " * ") + msg + "\n")
+        self.__last_e_cmd = "einfo"
 
     def ebegin(self, msg):
         """

--- a/lib/portage/package/ebuild/_config/UserPatches.py
+++ b/lib/portage/package/ebuild/_config/UserPatches.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+
+from portage.dep import _slot_separator
+from portage.versions import _pkg_str
+
+# must match filtering done by eapply_user() (see bin/phase-helpers.sh)
+_extensions = (".diff", ".patch")
+
+
+class UserPatches:
+    _patches = None
+
+    def __init__(self, abs_user_config):
+        patch_dir = os.path.join(abs_user_config, "patches")
+
+        if not os.path.exists(patch_dir):
+            return
+
+        categories = os.listdir(patch_dir)
+        cpvs = [
+            os.path.join(c, d)
+            for c in categories
+            for d in os.listdir(os.path.join(patch_dir, c))
+        ]
+
+        self._patches = {}
+        is_patch = lambda f: any(f.endswith(e) for e in _extensions)
+        for cpv in cpvs:
+            files = os.listdir(os.path.join(patch_dir, cpv))
+            if len(files) == 0:
+                continue
+            self._patches[cpv] = list(filter(is_patch, files))
+
+    def __contains__(self, pkg):
+        if self._patches is None:
+            return False
+
+        if not isinstance(pkg, _pkg_str):
+            raise TypeError(f"expected {_pkg_str}, got {type(pkg)}")
+
+        if pkg.cp in self._patches:
+            return True
+        if pkg.cpv in self._patches:
+            return True
+
+        if hasattr(pkg.cpv, "slot"):
+            slot = _slot_separator + pkg.cpv.slot
+            if pkg.cp + slot in self._patches:
+                return True
+            if pkg.cpv + slot in self._patches:
+                return True
+
+        return False

--- a/lib/portage/package/ebuild/_config/UserPatches.py
+++ b/lib/portage/package/ebuild/_config/UserPatches.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+
+from portage.dep import _slot_separator
+
+# must match filtering done by eapply_user() (see bin/phase-helpers.sh)
+_extensions = (".diff", ".patch")
+
+"""
+A dict-like object which reflects the user patches in portage config. Keyed by
+any type exposing cp, cpv, and (optionally) slot attributes, e.g. _pkg_str,
+Atom, Package, etc. The key need not exactly match a userpatch config path.
+
+Use 'in' operator to test for existence of user patches which would be applied
+to the corresponding ebuild.
+
+"""
+
+
+class UserPatches:
+    _patch_sets = None
+
+    def __init__(self, abs_user_config):
+        patch_dir = os.path.join(abs_user_config, "patches")
+        if not os.path.exists(patch_dir):
+            return
+
+        categories = os.listdir(patch_dir)
+        cpvs = [
+            os.path.join(c, p)
+            for c in categories
+            for p in os.listdir(os.path.join(patch_dir, c))
+        ]
+
+        self._patch_sets = {}
+        for c in cpvs:
+            location = os.path.join(patch_dir, c)
+            patch_set = self._load(location)
+            if len(patch_set) > 0:
+                self._patch_sets[c] = patch_set
+
+    def __contains__(self, key):
+        if self._patch_sets is None:
+            return False
+
+        if key.cp in self._patch_sets:
+            return True
+        if key.cpv in self._patch_sets:
+            return True
+
+        if hasattr(key.cpv, "slot"):
+            slot = _slot_separator + key.cpv.slot
+            if key.cp + slot in self._patch_sets:
+                return True
+            if key.cpv + slot in self._patch_sets:
+                return True
+
+        return False
+
+    # load a set of user patches from config directory
+    def _load(self, location):
+        files = []
+        for filename in os.listdir(location):
+            if not any(filename.endswith(e) for e in _extensions):
+                continue
+
+            # store file basenames as bytes as they need to sort in the same way
+            # as "LC_ALL=C sort" would (see phase-helpers.sh)
+            files.append(filename.encode())
+
+        return files

--- a/lib/portage/package/ebuild/_config/UserPatches.py
+++ b/lib/portage/package/ebuild/_config/UserPatches.py
@@ -71,3 +71,25 @@ class UserPatches:
             files.append(filename.encode())
 
         return files
+
+    # query using the rules in portage(5) for matching user patches
+    def _query(self, func, key):
+        result = func(key.cp).copy()  # copy() so as not to mutate
+        result |= func(key.cpv)
+        if hasattr(key.cpv, "slot"):
+            slot = _slot_separator + key.cpv.slot
+            result |= func(key.cp + slot)
+            result |= func(key.cpv + slot)
+
+        return result
+
+    # return the files that would be applied as user patches
+    def patches(self, key, default=set()):
+        if not self.__contains__(key):
+            return default
+
+        files = lambda x: {
+            os.path.join(x, f.decode()) for f in self._patch_sets.get(x, {})
+        }
+
+        return self._query(files, key)

--- a/lib/portage/package/ebuild/_config/UserPatches.py
+++ b/lib/portage/package/ebuild/_config/UserPatches.py
@@ -1,11 +1,13 @@
 # Copyright 2026 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+import hashlib
 import os
 
 from portage.dep import _slot_separator
 
 # must match filtering done by eapply_user() (see bin/phase-helpers.sh)
+_empty_hash = hashlib.sha256(b"").hexdigest()
 _extensions = (".diff", ".patch")
 
 """
@@ -14,7 +16,8 @@ any type exposing cp, cpv, and (optionally) slot attributes, e.g. _pkg_str,
 Atom, Package, etc. The key need not exactly match a userpatch config path.
 
 Use 'in' operator to test for existence of user patches which would be applied
-to the corresponding ebuild.
+to the corresponding ebuild. Use dict '[]' syntax to retrieve a hash over all
+applicable patches.
 
 """
 
@@ -59,18 +62,32 @@ class UserPatches:
 
         return False
 
+    def __getitem__(self, key):
+        if self._patch_sets is None:
+            raise KeyError
+
+        patches = self._query(lambda x: self._patch_sets.get(x, {}), key)
+        hashes = [patches[p] for p in sorted(patches)]
+        combined = "".join(h for h in hashes if h != _empty_hash).encode()
+        if len(combined) == 0:
+            return ""
+
+        return hashlib.sha256(combined).hexdigest().lower()
+
     # load a set of user patches from config directory
     def _load(self, location):
-        files = []
+        hashes = {}
+
         for filename in os.listdir(location):
             if not any(filename.endswith(e) for e in _extensions):
                 continue
 
-            # store file basenames as bytes as they need to sort in the same way
-            # as "LC_ALL=C sort" would (see phase-helpers.sh)
-            files.append(filename.encode())
+            with open(os.path.join(location, filename), "rb") as f:
+                # store file basenames as bytes as they need to sort in the same
+                # way as "LC_ALL=C sort" would (see phase-helpers.sh)
+                hashes[filename.encode()] = hashlib.sha256(f.read()).hexdigest()
 
-        return files
+        return hashes
 
     # query using the rules in portage(5) for matching user patches
     def _query(self, func, key):
@@ -82,6 +99,13 @@ class UserPatches:
             result |= func(key.cpv + slot)
 
         return result
+
+    # return digest over files that would be applied as user patches
+    def digest(self, key, default=None):
+        if not self.__contains__(key):
+            return default
+        else:
+            return self.__getitem__(key)
 
     # return the files that would be applied as user patches
     def patches(self, key, default=set()):

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -91,6 +91,7 @@ from portage.package.ebuild._config.LicenseManager import LicenseManager
 from portage.package.ebuild._config.UseManager import UseManager
 from portage.package.ebuild._config.LocationsManager import LocationsManager
 from portage.package.ebuild._config.MaskManager import MaskManager
+from portage.package.ebuild._config.UserPatches import UserPatches
 from portage.package.ebuild._config.VirtualsManager import VirtualsManager
 from portage.package.ebuild._config.helper import (
     ordered_by_atom_specificity,
@@ -328,6 +329,7 @@ class config:
             # that they're not instantiated more than once
             self._keywords_manager_obj = clone._keywords_manager
             self._mask_manager_obj = clone._mask_manager
+            self._user_patches_obj = clone._user_patches
 
             # shared mutable attributes
             self._unknown_features = clone._unknown_features
@@ -381,6 +383,7 @@ class config:
             # lazily instantiated objects
             self._keywords_manager_obj = None
             self._mask_manager_obj = None
+            self._user_patches_obj = None
             self._virtuals_manager_obj = None
 
             locations_manager = LocationsManager(
@@ -1342,6 +1345,14 @@ class config:
                 strict_umatched_removal=self._unmatched_removal,
             )
         return self._mask_manager_obj
+
+    @property
+    def _user_patches(self):
+        if self._user_patches_obj is None:
+            self._user_patches_obj = UserPatches(
+                self._locations_manager.abs_user_config
+            )
+        return self._user_patches_obj
 
     @property
     def _virtuals_manager(self):

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -69,6 +69,7 @@ from portage.package.ebuild._config.LicenseManager import LicenseManager
 from portage.package.ebuild._config.LocationsManager import LocationsManager
 from portage.package.ebuild._config.MaskManager import MaskManager
 from portage.package.ebuild._config.UseManager import UseManager
+from portage.package.ebuild._config.UserPatches import UserPatches
 from portage.package.ebuild._config.VirtualsManager import VirtualsManager
 from portage.process import fakeroot_capable, sandbox_capable
 from portage.repository.config import (
@@ -322,6 +323,7 @@ class config:
             # that they're not instantiated more than once
             self._keywords_manager_obj = clone._keywords_manager
             self._mask_manager_obj = clone._mask_manager
+            self._user_patches_obj = clone._user_patches
 
             # shared mutable attributes
             self._unknown_features = clone._unknown_features
@@ -375,6 +377,7 @@ class config:
             # lazily instantiated objects
             self._keywords_manager_obj = None
             self._mask_manager_obj = None
+            self._user_patches_obj = None
             self._virtuals_manager_obj = None
 
             locations_manager = LocationsManager(
@@ -1331,6 +1334,14 @@ class config:
                 strict_umatched_removal=self._unmatched_removal,
             )
         return self._mask_manager_obj
+
+    @property
+    def _user_patches(self):
+        if self._user_patches_obj is None:
+            self._user_patches_obj = UserPatches(
+                self._locations_manager.abs_user_config
+            )
+        return self._user_patches_obj
 
     @property
     def _virtuals_manager(self):

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1383,6 +1383,11 @@ class config:
             )
         return self._soname_provided
 
+    def userPatchFiles(self, pkg):
+        """Return the patch filenames of user patches applicable to pkg, where
+        pkg is any suitable type with cp, cpv, and slot attributes."""
+        return self._user_patches.patches(pkg)
+
     def expandLicenseTokens(self, tokens):
         """Take a token from ACCEPT_LICENSE or package.license and expand it
         if it's a group token (indicated by @) or just return it if it's not a

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1383,6 +1383,11 @@ class config:
             )
         return self._soname_provided
 
+    def userPatchDigest(self, pkg):
+        """Return the digest over all user patches applicable to pkg, where pkg
+        is any suitable type with cp, cpv, and slot attributes."""
+        return self._user_patches.digest(pkg, default="")
+
     def userPatchFiles(self, pkg):
         """Return the patch filenames of user patches applicable to pkg, where
         pkg is any suitable type with cp, cpv, and slot attributes."""

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1379,6 +1379,11 @@ class config:
             )
         return self._soname_provided
 
+    def userPatchDigest(self, pkg):
+        """Return the digest over all user patches applicable to pkg, where pkg
+        is any suitable type with cp, cpv, and slot attributes."""
+        return self._user_patches.digest(pkg, default="")
+
     def userPatchFiles(self, pkg):
         """Return the patch filenames of user patches applicable to pkg, where
         pkg is any suitable type with cp, cpv, and slot attributes."""

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1379,6 +1379,11 @@ class config:
             )
         return self._soname_provided
 
+    def userPatchFiles(self, pkg):
+        """Return the patch filenames of user patches applicable to pkg, where
+        pkg is any suitable type with cp, cpv, and slot attributes."""
+        return self._user_patches.patches(pkg)
+
     def expandLicenseTokens(self, tokens):
         """Take a token from ACCEPT_LICENSE or package.license and expand it
         if it's a group token (indicated by @) or just return it if it's not a

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -65,6 +65,7 @@ from portage.package.ebuild._config.LicenseManager import LicenseManager
 from portage.package.ebuild._config.LocationsManager import LocationsManager
 from portage.package.ebuild._config.MaskManager import MaskManager
 from portage.package.ebuild._config.UseManager import UseManager
+from portage.package.ebuild._config.UserPatches import UserPatches
 from portage.package.ebuild._config.VirtualsManager import VirtualsManager
 from portage.process import fakeroot_capable, sandbox_capable
 from portage.repository.config import (
@@ -318,6 +319,7 @@ class config:
             # that they're not instantiated more than once
             self._keywords_manager_obj = clone._keywords_manager
             self._mask_manager_obj = clone._mask_manager
+            self._user_patches_obj = clone._user_patches
 
             # shared mutable attributes
             self._unknown_features = clone._unknown_features
@@ -371,6 +373,7 @@ class config:
             # lazily instantiated objects
             self._keywords_manager_obj = None
             self._mask_manager_obj = None
+            self._user_patches_obj = None
             self._virtuals_manager_obj = None
 
             locations_manager = LocationsManager(
@@ -1327,6 +1330,14 @@ class config:
                 strict_umatched_removal=self._unmatched_removal,
             )
         return self._mask_manager_obj
+
+    @property
+    def _user_patches(self):
+        if self._user_patches_obj is None:
+            self._user_patches_obj = UserPatches(
+                self._locations_manager.abs_user_config
+            )
+        return self._user_patches_obj
 
     @property
     def _virtuals_manager(self):

--- a/lib/portage/tests/ebuild/MockUserPatches.py
+++ b/lib/portage/tests/ebuild/MockUserPatches.py
@@ -1,0 +1,57 @@
+# Copyright 2010-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import hashlib
+import os
+
+
+class MockUserPatches:
+    # for the purposes of testing, it doesn't really matter much what the actual
+    # user patch files contain. we therefore use the NIST SHA-256 test vectors
+    # and include the hashes here for reference when debugging tests.
+    #
+    # NullPatch -> e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    #
+    # Patch1 -> 28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1
+    # Patch2 -> 5ca7133fa735326081558ac312c620eeca9970d1e70a4b95533d956f072d1f98
+    # Patch3 -> dff2e73091f6c05e528896c4c831b9448653dc2ff043528f6769437bc7b975c2
+    # Patch4 -> b16aa56be3880d18cd41e68384cf1ec8c17680c45a02b1575dc1518923ae8b0e
+    # Patch5 -> f0887fe961c9cd3beab957e8222494abb969b1ce4c6557976df8b0f6d20e9166
+    # Patch6 -> eca0a060b489636225b4fa64d267dabbe44273067ac679f20820bddc6b6a90ac
+
+    # empty patch file used to cancel another patch
+    NullPatch = b""
+
+    # for use as the user patch file content for ResolverPlayground
+    Patch1 = b"\xd3"
+    Patch2 = b"\x11\xaf"
+    Patch3 = b"\xb4\x19\x0e"
+    Patch4 = b"\x74\xba\x25\x21"
+    Patch5 = b"\xc2\x99\x20\x96\x82"
+    Patch6 = b"\xe1\xdc\x72\x4d\x56\x21"
+
+    """
+    Calculate the expected hash over the specified user patch files which may
+    be a subset of the possible patches configured.
+
+    @param user_patches: dict of dicts defining patch folders, files, and text
+                         as might be passed to ResolvePlayground
+    @param files: list of relative paths defining the patches to be hashed
+    """
+
+    def expected_hash(user_patches, files):
+        patches = {
+            os.path.basename(p): user_patches[os.path.dirname(p)][os.path.basename(p)]
+            for p in files
+        }
+
+        expected = hashlib.sha256()
+        for f in sorted(patches):
+            content = patches[f]
+            if len(content) == 0:
+                continue
+            if isinstance(content, str):
+                content = content.encode()
+            expected.update(hashlib.sha256(content).hexdigest().encode())
+
+        return expected.hexdigest()

--- a/lib/portage/tests/ebuild/test_config.py
+++ b/lib/portage/tests/ebuild/test_config.py
@@ -15,6 +15,7 @@ from portage.tests.resolver.ResolverPlayground import (
     ResolverPlaygroundTestCase,
 )
 from portage.util import normalize_path
+from portage.versions import _pkg_str
 
 
 class ConfigTestCase(TestCase):
@@ -448,3 +449,39 @@ class ConfigTestCase(TestCase):
                 shutil.rmtree(eprefix)
             else:
                 playground.cleanup()
+
+    def testUserPatches(self):
+        files = ["user.patch", "random.diff"]
+        patches = {
+            "dev-libs/A": files,
+            "dev-libs/B-1": files,
+            "dev-libs/C:1": files,
+            "dev-libs/D-1:2": files,
+        }
+
+        playground = ResolverPlayground(patches=patches)
+        settings = config(clone=playground.settings)
+
+        # patches under ${PN} only applied for all versions and slots
+        self.assertTrue(_pkg_str("dev-libs/A-1") in settings._user_patches)
+        self.assertTrue(_pkg_str("dev-libs/A-1", slot="3") in settings._user_patches)
+        self.assertTrue(_pkg_str("dev-libs/A-2") in settings._user_patches)
+        self.assertTrue(_pkg_str("dev-libs/A-1", slot="3") in settings._user_patches)
+
+        # patches under ${P} applied to specified version regardless of slot
+        self.assertTrue(_pkg_str("dev-libs/B-1") in settings._user_patches)
+        self.assertTrue(_pkg_str("dev-libs/B-1", slot="3") in settings._user_patches)
+        self.assertFalse(_pkg_str("dev-libs/B-2") in settings._user_patches)
+        self.assertFalse(_pkg_str("dev-libs/B-2", slot="3") in settings._user_patches)
+
+        # ${PN}:${SLOT} applies to all versions of slot
+        self.assertFalse(_pkg_str("dev-libs/C-1") in settings._user_patches)
+        self.assertFalse(_pkg_str("dev-libs/C-1", slot="2") in settings._user_patches)
+        self.assertTrue(_pkg_str("dev-libs/C-1", slot="1") in settings._user_patches)
+        self.assertTrue(_pkg_str("dev-libs/C-2", slot="1") in settings._user_patches)
+
+        # patches under ${P}:${SLOT} applied to specific version and slot
+        self.assertTrue(_pkg_str("dev-libs/D-1", slot="2") in settings._user_patches)
+        self.assertFalse(_pkg_str("dev-libs/D-2", slot="2") in settings._user_patches)
+        self.assertFalse(_pkg_str("dev-libs/D-2", slot="1") in settings._user_patches)
+        self.assertFalse(_pkg_str("dev-libs/D-1") in settings._user_patches)

--- a/lib/portage/tests/ebuild/test_config.py
+++ b/lib/portage/tests/ebuild/test_config.py
@@ -11,6 +11,7 @@ from portage.dep import Atom
 from portage.package.ebuild._config.LicenseManager import LicenseManager
 from portage.package.ebuild.config import config
 from portage.tests import TestCase
+from portage.tests.ebuild.MockUserPatches import MockUserPatches
 from portage.tests.resolver.ResolverPlayground import (
     ResolverPlayground,
     ResolverPlaygroundTestCase,
@@ -449,13 +450,14 @@ class ConfigTestCase(TestCase):
 
     # exercise UserPatches.__contains__() directly to detect user patches
     def testUserPatchesExist(self):
-        files = ["user.patch", "random.diff"]
+        # do not care about the content of patche files *or* their hashes
+        files = {"user.patch": b"foo", "random.diff": b"bar"}
         patches = {
             "dev-libs/A": files,
             "dev-libs/B-1": files,
             "dev-libs/C:1": files,
             "dev-libs/D-1:2": files,
-            "dev-libs/E": [],
+            "dev-libs/E": {},
         }
 
         playground = ResolverPlayground(patches=patches)
@@ -486,16 +488,17 @@ class ConfigTestCase(TestCase):
         self.assertNotIn(_pkg_str("dev-libs/D-1"), user_patches)
 
         # empty user patch folder to not be visible
+
         self.assertNotIn(_pkg_str("dev-libs/E-1"), user_patches)
 
     # exercise UserPatches.patches() to query applicable user patch files
     def testUserPatchesFiles(self):
         patches = {
-            "dev-libs/A": ["user.patch", "random.diff"],
-            "dev-libs/B": ["user.patch"],
-            "dev-libs/B-1": ["random.diff"],
-            "dev-libs/C": ["random.diff"],
-            "dev-libs/C:3": ["user.patch"],
+            "dev-libs/A": {"user.patch": b"foo", "random.diff": b"bar"},
+            "dev-libs/B": {"user.patch": b"foo"},
+            "dev-libs/B-1": {"random.diff": b"bar"},
+            "dev-libs/C": {"random.diff": b"bar"},
+            "dev-libs/C:3": {"user.patch": b"foo"},
         }
 
         playground = ResolverPlayground(patches=patches)
@@ -547,3 +550,88 @@ class ConfigTestCase(TestCase):
 
         # expect empty set where no user patches exists
         self.assertSetEqual(settings.userPatchFiles(_pkg_str("dev-libs/E-1")), set())
+
+    # exercise UserPatches.__getitem__() via digest()
+    def testUserPatchesMatch(self):
+        patches = {
+            "dev-libs/A": {
+                "A.patch": MockUserPatches.Patch1,
+                "A.diff": MockUserPatches.Patch2,
+            },
+            "dev-libs/A-1": {
+                "A-1.patch": MockUserPatches.Patch3,
+            },
+            "dev-libs/A:13": {
+                "A:13.diff": MockUserPatches.Patch4,
+            },
+            "dev-libs/B": {
+                "B.diff": MockUserPatches.Patch1,
+                "B.patch": MockUserPatches.Patch5,
+            },
+            "dev-libs/B-1": {
+                "B.diff": MockUserPatches.NullPatch,
+            },
+            "dev-libs/B-1:foo": {
+                "B-1:foo.patch": MockUserPatches.Patch6,
+            },
+        }
+
+        playground = ResolverPlayground(patches=patches)
+        settings = config(clone=playground.settings)
+
+        # application of non-versioned patches only (no v2 patches)
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/A-2")),
+            MockUserPatches.expected_hash(
+                patches,
+                ["dev-libs/A/A.patch", "dev-libs/A/A.diff"],
+            ),
+        )
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/B-2")),
+            MockUserPatches.expected_hash(
+                patches,
+                ["dev-libs/B/B.patch", "dev-libs/B/B.diff"],
+            ),
+        )
+
+        # composition of non-versioned patches and versioned (v1) patches
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/A-1")),
+            MockUserPatches.expected_hash(
+                patches,
+                ["dev-libs/A/A.patch", "dev-libs/A/A.diff", "dev-libs/A-1/A-1.patch"],
+            ),
+        )
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/A-1", slot="1")),
+            MockUserPatches.expected_hash(
+                patches,
+                ["dev-libs/A/A.patch", "dev-libs/A/A.diff", "dev-libs/A-1/A-1.patch"],
+            ),
+        )
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/A-1", slot="13")),
+            MockUserPatches.expected_hash(
+                patches,
+                [
+                    "dev-libs/A/A.patch",
+                    "dev-libs/A/A.diff",
+                    "dev-libs/A-1/A-1.patch",
+                    "dev-libs/A:13/A:13.diff",
+                ],
+            ),
+        )
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/B-1", slot="foo")),
+            MockUserPatches.expected_hash(
+                patches,
+                ["dev-libs/B/B.patch", "dev-libs/B-1:foo/B-1:foo.patch"],
+            ),
+        )
+
+        # omission of non-versioned patches for empty versioned patch of matching basename
+        self.assertEqual(
+            settings.userPatchDigest(_pkg_str("dev-libs/B-1")),
+            MockUserPatches.expected_hash(patches, ["dev-libs/B/B.patch"]),
+        )

--- a/lib/portage/tests/ebuild/test_config.py
+++ b/lib/portage/tests/ebuild/test_config.py
@@ -447,6 +447,7 @@ class ConfigTestCase(TestCase):
             else:
                 playground.cleanup()
 
+    # exercise UserPatches.__contains__() directly to detect user patches
     def testUserPatchesExist(self):
         files = ["user.patch", "random.diff"]
         patches = {
@@ -486,3 +487,63 @@ class ConfigTestCase(TestCase):
 
         # empty user patch folder to not be visible
         self.assertNotIn(_pkg_str("dev-libs/E-1"), user_patches)
+
+    # exercise UserPatches.patches() to query applicable user patch files
+    def testUserPatchesFiles(self):
+        patches = {
+            "dev-libs/A": ["user.patch", "random.diff"],
+            "dev-libs/B": ["user.patch"],
+            "dev-libs/B-1": ["random.diff"],
+            "dev-libs/C": ["random.diff"],
+            "dev-libs/C:3": ["user.patch"],
+        }
+
+        playground = ResolverPlayground(patches=patches)
+        settings = config(clone=playground.settings)
+
+        files = lambda d: {os.path.join(d, f) for f in patches[d]}
+
+        # dev-libs/A has the same patches for all versions and slots
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/A-1")),
+            files("dev-libs/A"),
+        )
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/A-1", slot="3")),
+            files("dev-libs/A"),
+        )
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/A-2")),
+            files("dev-libs/A"),
+        )
+
+        # dev-libs/B has extra patches for that version 1 only (all slots)
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/B-1")),
+            files("dev-libs/B") | files("dev-libs/B-1"),
+        )
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/B-1", slot="2")),
+            files("dev-libs/B") | files("dev-libs/B-1"),
+        )
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/B-2")),
+            files("dev-libs/B"),
+        )
+
+        # dev-libs/C has extra patches for slot 3 only
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/C-1")),
+            files("dev-libs/C"),
+        )
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/C-1", slot="3")),
+            files("dev-libs/C") | files("dev-libs/C:3"),
+        )
+        self.assertSetEqual(
+            settings.userPatchFiles(_pkg_str("dev-libs/C-2", slot="3")),
+            files("dev-libs/C") | files("dev-libs/C:3"),
+        )
+
+        # expect empty set where no user patches exists
+        self.assertSetEqual(settings.userPatchFiles(_pkg_str("dev-libs/E-1")), set())

--- a/lib/portage/tests/ebuild/test_config.py
+++ b/lib/portage/tests/ebuild/test_config.py
@@ -16,6 +16,7 @@ from portage.tests.resolver.ResolverPlayground import (
     ResolverPlaygroundTestCase,
 )
 from portage.util import normalize_path
+from portage.versions import _pkg_str
 
 
 class ConfigTestCase(TestCase):
@@ -445,3 +446,43 @@ class ConfigTestCase(TestCase):
                 shutil.rmtree(eprefix)
             else:
                 playground.cleanup()
+
+    def testUserPatchesExist(self):
+        files = ["user.patch", "random.diff"]
+        patches = {
+            "dev-libs/A": files,
+            "dev-libs/B-1": files,
+            "dev-libs/C:1": files,
+            "dev-libs/D-1:2": files,
+            "dev-libs/E": [],
+        }
+
+        playground = ResolverPlayground(patches=patches)
+        user_patches = config(clone=playground.settings)._user_patches
+
+        # patches under ${PN} apply for all versions and slots
+        self.assertIn(_pkg_str("dev-libs/A-1"), user_patches)
+        self.assertIn(_pkg_str("dev-libs/A-1", slot="3"), user_patches)
+        self.assertIn(_pkg_str("dev-libs/A-2"), user_patches)
+        self.assertIn(_pkg_str("dev-libs/A-1", slot="3"), user_patches)
+
+        # patches under ${P} apply to specified version regardless of slot
+        self.assertIn(_pkg_str("dev-libs/B-1"), user_patches)
+        self.assertIn(_pkg_str("dev-libs/B-1", slot="3"), user_patches)
+        self.assertNotIn(_pkg_str("dev-libs/B-2"), user_patches)
+        self.assertNotIn(_pkg_str("dev-libs/B-2", slot="3"), user_patches)
+
+        # ${PN}:${SLOT} apply to all versions of slot
+        self.assertNotIn(_pkg_str("dev-libs/C-1"), user_patches)
+        self.assertNotIn(_pkg_str("dev-libs/C-1", slot="2"), user_patches)
+        self.assertIn(_pkg_str("dev-libs/C-1", slot="1"), user_patches)
+        self.assertIn(_pkg_str("dev-libs/C-2", slot="1"), user_patches)
+
+        # patches under ${P}:${SLOT} apply to specific version and slot
+        self.assertIn(_pkg_str("dev-libs/D-1", slot="2"), user_patches)
+        self.assertNotIn(_pkg_str("dev-libs/D-2", slot="2"), user_patches)
+        self.assertNotIn(_pkg_str("dev-libs/D-2", slot="1"), user_patches)
+        self.assertNotIn(_pkg_str("dev-libs/D-1"), user_patches)
+
+        # empty user patch folder to not be visible
+        self.assertNotIn(_pkg_str("dev-libs/E-1"), user_patches)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -150,6 +150,7 @@ class ResolverPlayground:
         world=[],
         world_sets=[],
         distfiles={},
+        patches={},
         eclasses={},
         eprefix=None,
         targetroot=False,
@@ -264,7 +265,14 @@ class ResolverPlayground:
         self._create_ebuilds(ebuilds)
         self._create_installed(installed)
         self._create_profile(
-            ebuilds, eclasses, installed, profile, repo_configs, user_config, sets
+            ebuilds,
+            eclasses,
+            installed,
+            profile,
+            repo_configs,
+            user_config,
+            sets,
+            patches,
         )
         self._create_world(world, world_sets)
 
@@ -514,7 +522,15 @@ class ResolverPlayground:
                     f.write(inputfile.read())
 
     def _create_profile(
-        self, ebuilds, eclasses, installed, profile, repo_configs, user_config, sets
+        self,
+        ebuilds,
+        eclasses,
+        installed,
+        profile,
+        repo_configs,
+        user_config,
+        sets,
+        patches,
     ):
         user_config_dir = os.path.join(self.eroot, USER_CONFIG_PATH)
 
@@ -710,6 +726,15 @@ class ResolverPlayground:
         default_sets_conf_dir = os.path.join(
             self.eroot, "usr/share/portage/config/sets"
         )
+
+        # user patches
+        for cpv, files in patches.items():
+            patch_dir = os.path.join(user_config_dir, "patches", cpv)
+            os.makedirs(patch_dir)
+            for patch in files:
+                patch_file = os.path.join(patch_dir, patch)
+                with open(patch_file, "w"):
+                    pass
 
         try:
             os.makedirs(default_sets_conf_dir)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -727,8 +727,11 @@ class ResolverPlayground:
             os.makedirs(patch_dir)
             for patch in files:
                 patch_file = os.path.join(patch_dir, patch)
-                with open(patch_file, "w"):
-                    pass
+                with open(patch_file, "wb") as f:
+                    text = files[patch]
+                    if isinstance(text, str):
+                        text = text.encode()
+                    f.write(text)
 
         try:
             os.makedirs(default_sets_conf_dir)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -150,6 +150,7 @@ class ResolverPlayground:
         world=[],
         world_sets=[],
         distfiles={},
+        patches={},
         eclasses={},
         eprefix=None,
         targetroot=False,
@@ -264,7 +265,14 @@ class ResolverPlayground:
         self._create_ebuilds(ebuilds)
         self._create_installed(installed)
         self._create_profile(
-            ebuilds, eclasses, installed, profile, repo_configs, user_config, sets
+            ebuilds,
+            eclasses,
+            installed,
+            profile,
+            repo_configs,
+            user_config,
+            sets,
+            patches,
         )
         self._create_world(world, world_sets)
 
@@ -513,7 +521,15 @@ class ResolverPlayground:
                     f.write(inputfile.read())
 
     def _create_profile(
-        self, ebuilds, eclasses, installed, profile, repo_configs, user_config, sets
+        self,
+        ebuilds,
+        eclasses,
+        installed,
+        profile,
+        repo_configs,
+        user_config,
+        sets,
+        patches,
     ):
         user_config_dir = os.path.join(self.eroot, USER_CONFIG_PATH)
 
@@ -704,6 +720,15 @@ class ResolverPlayground:
         default_sets_conf_dir = os.path.join(
             self.eroot, "usr/share/portage/config/sets"
         )
+
+        # user patches
+        for cpv, files in patches.items():
+            patch_dir = os.path.join(user_config_dir, "patches", cpv)
+            os.makedirs(patch_dir)
+            for patch in files:
+                patch_file = os.path.join(patch_dir, patch)
+                with open(patch_file, "w"):
+                    pass
 
         try:
             os.makedirs(default_sets_conf_dir)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -156,6 +156,7 @@ class ResolverPlayground:
         world=[],
         world_sets=[],
         distfiles={},
+        patches={},
         eclasses={},
         eprefix=None,
         targetroot=False,
@@ -270,7 +271,14 @@ class ResolverPlayground:
         self._create_ebuilds(ebuilds)
         self._create_installed(installed)
         self._create_profile(
-            ebuilds, eclasses, installed, profile, repo_configs, user_config, sets
+            ebuilds,
+            eclasses,
+            installed,
+            profile,
+            repo_configs,
+            user_config,
+            sets,
+            patches,
         )
         self._create_world(world, world_sets)
 
@@ -546,7 +554,15 @@ class ResolverPlayground:
                 _write_metadata_file(vdb_pkg_dir, metadata_kv)
 
     def _create_profile(
-        self, ebuilds, eclasses, installed, profile, repo_configs, user_config, sets
+        self,
+        ebuilds,
+        eclasses,
+        installed,
+        profile,
+        repo_configs,
+        user_config,
+        sets,
+        patches,
     ):
         user_config_dir = os.path.join(self.eroot, USER_CONFIG_PATH)
 
@@ -737,6 +753,15 @@ class ResolverPlayground:
         default_sets_conf_dir = os.path.join(
             self.eroot, "usr/share/portage/config/sets"
         )
+
+        # user patches
+        for cpv, files in patches.items():
+            patch_dir = os.path.join(user_config_dir, "patches", cpv)
+            os.makedirs(patch_dir)
+            for patch in files:
+                patch_file = os.path.join(patch_dir, patch)
+                with open(patch_file, "w"):
+                    pass
 
         try:
             os.makedirs(default_sets_conf_dir)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -760,8 +760,11 @@ class ResolverPlayground:
             os.makedirs(patch_dir)
             for patch in files:
                 patch_file = os.path.join(patch_dir, patch)
-                with open(patch_file, "w"):
-                    pass
+                with open(patch_file, "wb") as f:
+                    text = files[patch]
+                    if isinstance(text, str):
+                        text = text.encode()
+                    f.write(text)
 
         try:
             os.makedirs(default_sets_conf_dir)

--- a/lib/portage/tests/resolver/test_binpackage_patches.py
+++ b/lib/portage/tests/resolver/test_binpackage_patches.py
@@ -6,14 +6,14 @@ from portage.tests.resolver.test_binpackage_selection import BinPkgSelectionTest
 
 
 class BinPkgPatchTestCaseWithPatches(BinPkgSelectionTestCase):
+    files = ["user.patch", "random.diff"]
 
     def testBinPkgWithPatches(self):
         pkgs = self.pkgs_no_deps | self.pkgs_no_deps_newer | self.pkgs_with_slots
-        files = ["user.patch", "random.diff"]
         patches = {
-            "app-misc/foo": files,
-            "app-misc/bar-1.1": files,
-            "app-misc/baz:2": files,
+            "app-misc/foo": self.files,
+            "app-misc/bar-1.1": self.files,
+            "app-misc/baz:2": self.files,
         }
 
         test_cases = (
@@ -86,6 +86,39 @@ class BinPkgPatchTestCaseWithPatches(BinPkgSelectionTestCase):
                 success=True,
                 options={"--usepkg": True, "--usepkg-include": ["foo"]},
                 mergelist=["app-misc/foo-2.0"],
+            ),
+        )
+
+        self.runBinPkgSelectionTest(
+            test_cases, binpkgs=pkgs, ebuilds=pkgs, patches=patches
+        )
+
+    def testBinPkgExcludePatches(self):
+        pkgs = self.pkgs_no_deps
+        patches = {
+            "app-misc/foo": self.files,
+        }
+
+        test_cases = (
+            # --usepkg-exclude-patches=n overrides default of respecting patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True, "--usepkg-exclude-patches": False},
+                mergelist=["[binary]app-misc/foo-1.0"],
+            ),
+            # patches to be ignored with --usepkgonly
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkgonly": True},
+                mergelist=["[binary]app-misc/foo-1.0"],
+            ),
+            # --usepkg-exclude-patches=y to re-assert default even when it breaks
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=False,
+                options={"--usepkgonly": True, "--usepkg-exclude-patches": True},
             ),
         )
 

--- a/lib/portage/tests/resolver/test_binpackage_patches.py
+++ b/lib/portage/tests/resolver/test_binpackage_patches.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests.resolver.ResolverPlayground import ResolverPlaygroundTestCase
+from portage.tests.resolver.test_binpackage_selection import BinPkgSelectionTestCase
+
+
+class BinPkgPatchTestCaseWithPatches(BinPkgSelectionTestCase):
+
+    def testBinPkgWithPatches(self):
+        pkgs = self.pkgs_no_deps | self.pkgs_no_deps_newer | self.pkgs_with_slots
+        files = ["user.patch", "random.diff"]
+        patches = {
+            "app-misc/foo": files,
+            "app-misc/bar-1.1": files,
+            "app-misc/baz:2": files,
+        }
+
+        test_cases = (
+            # all binaries of app-misc/foo masked by patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/foo-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["=app-misc/foo-1.1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/foo-1.1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo:1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/foo-1.0"],
+            ),
+            # only app-misc/bar-1.1 masked by patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/bar-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["=app-misc/bar-1.1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/bar-1.1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar:1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/bar-1.0"],
+            ),
+            # only slot app-misc/baz:2 masked by patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/baz"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/baz-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["=app-misc/baz-1.1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/baz-1.1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/baz:1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/baz-1.0"],
+            ),
+            # --usepkg-exclude/include to not change this behaviour
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True, "--usepkg-exclude": ["foo"]},
+                mergelist=["app-misc/foo-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True, "--usepkg-include": ["foo"]},
+                mergelist=["app-misc/foo-2.0"],
+            ),
+        )
+
+        self.runBinPkgSelectionTest(
+            test_cases, binpkgs=pkgs, ebuilds=pkgs, patches=patches
+        )

--- a/lib/portage/tests/resolver/test_binpackage_patches.py
+++ b/lib/portage/tests/resolver/test_binpackage_patches.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests.resolver.ResolverPlayground import ResolverPlaygroundTestCase
+from portage.tests.resolver.test_binpackage_selection import BinPkgSelectionTestCase
+
+
+class BinPkgUserPatchTestCase(BinPkgSelectionTestCase):
+    files = ["user.patch", "random.diff"]
+
+    def testBinPkgUserPatchMasking(self):
+        pkgs = self.pkgs_no_deps | self.pkgs_no_deps_newer | self.pkgs_with_slots
+        patches = {
+            "app-misc/foo": self.files,
+            "app-misc/bar-1.1": self.files,
+            "app-misc/baz:2": self.files,
+        }
+
+        test_cases = (
+            # all binaries of app-misc/foo masked by patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/foo-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["=app-misc/foo-1.1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/foo-1.1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo:1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/foo-1.0"],
+            ),
+            # only app-misc/bar-1.1 masked by patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/bar-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["=app-misc/bar-1.1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/bar-1.1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar:1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/bar-1.0"],
+            ),
+            # only slot app-misc/baz:2 masked by patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/baz"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/baz-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["=app-misc/baz-1.1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/baz-1.1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/baz:1"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/baz-1.0"],
+            ),
+            # --usepkg-exclude/include to not change this behaviour
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True, "--usepkg-exclude": ["foo"]},
+                mergelist=["app-misc/foo-2.0"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True, "--usepkg-include": ["foo"]},
+                mergelist=["app-misc/foo-2.0"],
+            ),
+        )
+
+        self.runBinPkgSelectionTest(
+            test_cases, binpkgs=pkgs, ebuilds=pkgs, patches=patches
+        )

--- a/lib/portage/tests/resolver/test_binpackage_patches.py
+++ b/lib/portage/tests/resolver/test_binpackage_patches.py
@@ -1,12 +1,16 @@
 # Copyright 2026 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+from portage.tests.ebuild.MockUserPatches import MockUserPatches
 from portage.tests.resolver.ResolverPlayground import ResolverPlaygroundTestCase
 from portage.tests.resolver.test_binpackage_selection import BinPkgSelectionTestCase
 
 
 class BinPkgUserPatchTestCase(BinPkgSelectionTestCase):
-    files = ["user.patch", "random.diff"]
+    files = {
+        "user.patch": ("foo"),
+        "random.diff": ("foobaz not a patch"),
+    }
 
     def testBinPkgUserPatchMasking(self):
         pkgs = self.pkgs_no_deps | self.pkgs_no_deps_newer | self.pkgs_with_slots
@@ -94,9 +98,15 @@ class BinPkgUserPatchTestCase(BinPkgSelectionTestCase):
         )
 
     def testBinPkgUserPatchesOption(self):
-        pkgs = self.pkgs_no_deps
+        ebuilds = self.pkgs_no_deps
         patches = {
             "app-misc/foo": self.files,
+        }
+        binpkgs = {
+            "app-misc/foo-1.0": {},
+            "app-misc/bar-1.0": {
+                "USER_PATCHES": "28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1",
+            },
         }
 
         test_cases = (
@@ -106,28 +116,117 @@ class BinPkgUserPatchTestCase(BinPkgSelectionTestCase):
                 success=False,
                 options={"--usepkgonly": True},
             ),
+            # --usepkgonly has no solution when binpkgs have patches and config does not
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=False,
+                options={"--usepkgonly": True},
+            ),
             # --binpkg-respect-user-patches=y is default and behaves as above
             ResolverPlaygroundTestCase(
                 ["app-misc/foo"],
                 success=False,
                 options={"--usepkgonly": True, "--binpkg-respect-user-patches": "y"},
             ),
-            # --binpkg-respect-user-patches=n overrides above behaviour
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=False,
+                options={"--usepkgonly": True, "--binpkg-respect-user-patches": "y"},
+            ),
+            # --binpkg-respect-user-patches=n forces use of binpkgs with unmatched user patches
             ResolverPlaygroundTestCase(
                 ["app-misc/foo"],
                 success=True,
                 options={"--usepkgonly": True, "--binpkg-respect-user-patches": "n"},
                 mergelist=["[binary]app-misc/foo-1.0"],
             ),
-            # --binpkg-respect-user-patches=n permits unpatched binpkg with plain --usepkg
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=True,
+                options={"--usepkgonly": True, "--binpkg-respect-user-patches": "n"},
+                mergelist=["[binary]app-misc/bar-1.0"],
+            ),
+            # --binpkg-respect-user-patches=n allows plain --usepkg to prefer such binpkgs
             ResolverPlaygroundTestCase(
                 ["app-misc/foo"],
                 success=True,
                 options={"--usepkg": True, "--binpkg-respect-user-patches": "n"},
                 mergelist=["[binary]app-misc/foo-1.0"],
             ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=True,
+                options={"--usepkg": True, "--binpkg-respect-user-patches": "n"},
+                mergelist=["[binary]app-misc/bar-1.0"],
+            ),
         )
 
         self.runBinPkgSelectionTest(
-            test_cases, binpkgs=pkgs, ebuilds=pkgs, patches=patches
+            test_cases, binpkgs=binpkgs, ebuilds=ebuilds, patches=patches
+        )
+
+    def testBinPkgUserPatchedBinPkgs(self):
+        ebuilds = self.pkgs_no_deps
+        patches = {
+            "app-misc/foo": {
+                "user.patch": MockUserPatches.Patch1,
+                "random.diff": MockUserPatches.Patch2,
+            },
+            "app-misc/bar": {
+                "user.patch": MockUserPatches.Patch3,
+                "random.diff": MockUserPatches.Patch4,
+            },
+            "app-misc/bar-1.0": {
+                "user.patch": b"",
+            },
+        }
+
+        # add USER_PATCHES hash values to binpkg metadata, such that:
+        #  - app-misc/foo-1.0 matches playground user patches
+        #  - app-misc/bar-1.0 is missing one user patch
+        #  - app-misc/baz-1.0 has extra user patches
+        binpkgs = self.pkgs_no_deps.copy() | {
+            "app-misc/foo-1.0": {
+                "USER_PATCHES": MockUserPatches.expected_hash(
+                    patches,
+                    ["app-misc/foo/user.patch", "app-misc/foo/random.diff"],
+                ),
+            },
+            "app-misc/bar-1.0": {
+                "USER_PATCHES": MockUserPatches.expected_hash(
+                    patches,
+                    ["app-misc/bar/user.patch", "app-misc/bar/random.diff"],
+                ),
+            },
+            "app-misc/baz-1.0": {
+                "USER_PATCHES": "eca0a060b489636225b4fa64d267dabbe44273067ac679f20820bddc6b6a90ac",
+            },
+        }
+
+        test_cases = (
+            # app-misc/foo-1.0 from binpkg as binary has correct user patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["[binary]app-misc/foo-1.0"],
+            ),
+            # app-misc/bar-1.0 from ebuild as binary has different patches
+            ResolverPlaygroundTestCase(
+                ["app-misc/bar"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/bar-1.0"],
+            ),
+            # app-misc/baz-1.0 from ebuild as binary has patches (config has none)
+            ResolverPlaygroundTestCase(
+                ["app-misc/baz"],
+                success=True,
+                options={"--usepkg": True},
+                mergelist=["app-misc/baz-1.0"],
+            ),
+        )
+
+        self.runBinPkgSelectionTest(
+            test_cases, binpkgs=binpkgs, ebuilds=ebuilds, patches=patches
         )

--- a/lib/portage/tests/resolver/test_binpackage_patches.py
+++ b/lib/portage/tests/resolver/test_binpackage_patches.py
@@ -92,3 +92,42 @@ class BinPkgUserPatchTestCase(BinPkgSelectionTestCase):
         self.runBinPkgSelectionTest(
             test_cases, binpkgs=pkgs, ebuilds=pkgs, patches=patches
         )
+
+    def testBinPkgUserPatchesOption(self):
+        pkgs = self.pkgs_no_deps
+        patches = {
+            "app-misc/foo": self.files,
+        }
+
+        test_cases = (
+            # --usepkgonly has no solution when user patches mask binpkgs
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=False,
+                options={"--usepkgonly": True},
+            ),
+            # --binpkg-respect-user-patches=y is default and behaves as above
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=False,
+                options={"--usepkgonly": True, "--binpkg-respect-user-patches": "y"},
+            ),
+            # --binpkg-respect-user-patches=n overrides above behaviour
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkgonly": True, "--binpkg-respect-user-patches": "n"},
+                mergelist=["[binary]app-misc/foo-1.0"],
+            ),
+            # --binpkg-respect-user-patches=n permits unpatched binpkg with plain --usepkg
+            ResolverPlaygroundTestCase(
+                ["app-misc/foo"],
+                success=True,
+                options={"--usepkg": True, "--binpkg-respect-user-patches": "n"},
+                mergelist=["[binary]app-misc/foo-1.0"],
+            ),
+        )
+
+        self.runBinPkgSelectionTest(
+            test_cases, binpkgs=pkgs, ebuilds=pkgs, patches=patches
+        )

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1115,6 +1115,11 @@ dependencies, \fB\-\-with\-bdeps=y\fR must be specified explicitly.
 .BR "\-\-usepkg\-exclude\-live [ y | n ]"
 Tells emerge to not install from binary packages for live ebuilds.
 .TP
+.BR "\-\-usepkg\-exclude\-patches < y | n >"
+Tells emerge to not install from binary packages for ebuilds with user patches
+available (see \fBportage\fR(5)). Enabled by default unless \fB\-\-usepkgonly=y\fR
+is specified.
+.TP
 .BR "\-\-verbose [ y | n ]" ", " \-v
 Tell emerge to run in verbose mode.  Currently this flag causes emerge to print
 out GNU info errors, if any, and to show the USE flags that will be used for

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -468,8 +468,8 @@ then it implies \fB\-\-autounmask\-use=n\fR, because these options
 naturally oppose each other.
 .TP
 .BR "\-\-binpkg\-respect\-user\-patches [ y | n ]"
-Tells emerge to ignore binary packages when the corresponding ebuild has
-user patches configured (see \fBportage\fR(5)). Enabled by default (even
+Tells emerge to ignore binary packages for which user patches do not match
+the current configuration (see \fBportage\fR(5)). Enabled by default (even
 with \fB\-\-usepkgonly\fR) to prevent binary packages from potentially
 reverting user patches. If disabled, emerge can use both binary packages
 which revert user patches and those built with user patches not in the

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -467,6 +467,14 @@ If \fB\-\-binpkg\-respect\-use\fR is given explicitly,
 then it implies \fB\-\-autounmask\-use=n\fR, because these options
 naturally oppose each other.
 .TP
+.BR "\-\-binpkg\-respect\-user\-patches [ y | n ]"
+Tells emerge to ignore binary packages when the corresponding ebuild has
+user patches configured (see \fBportage\fR(5)). Enabled by default (even
+with \fB\-\-usepkgonly\fR) to prevent binary packages from potentially
+reverting user patches. If disabled, emerge can use both binary packages
+which revert user patches and those built with user patches not in the
+current configuraiton.
+.TP
 .BR "\-\-buildpkg [ y | n ]" ", " \-b
 Tells emerge to build binary packages for all ebuilds processed in
 addition to actually merging the packages.  Useful for maintainers

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -473,6 +473,14 @@ If \fB\-\-binpkg\-respect\-use\fR is given explicitly,
 then it implies \fB\-\-autounmask\-use=n\fR, because these options
 naturally oppose each other.
 .TP
+.BR "\-\-binpkg\-respect\-user\-patches [ y | n ]"
+Tells emerge to ignore binary packages when the corresponding ebuild has
+user patches configured (see \fBportage\fR(5)). Enabled by default (even
+with \fB\-\-usepkgonly\fR) to prevent binary packages from potentially
+reverting user patches. If disabled, emerge can use both binary packages
+which revert user patches and those built with user patches not in the
+current configuraiton.
+.TP
 .BR "\-\-buildpkg [ y | n ]" ", " \-b
 Tells emerge to build binary packages for all ebuilds processed in
 addition to actually merging the packages.  Useful for maintainers

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -474,8 +474,8 @@ then it implies \fB\-\-autounmask\-use=n\fR, because these options
 naturally oppose each other.
 .TP
 .BR "\-\-binpkg\-respect\-user\-patches [ y | n ]"
-Tells emerge to ignore binary packages when the corresponding ebuild has
-user patches configured (see \fBportage\fR(5)). Enabled by default (even
+Tells emerge to ignore binary packages for which user patches do not match
+the current configuration (see \fBportage\fR(5)). Enabled by default (even
 with \fB\-\-usepkgonly\fR) to prevent binary packages from potentially
 reverting user patches. If disabled, emerge can use both binary packages
 which revert user patches and those built with user patches not in the

--- a/man/portage.5
+++ b/man/portage.5
@@ -1509,6 +1509,10 @@ If package ebuild uses \fBEAPI\fR <= \fB5\fR, it must explicitly invoke
 \fBsrc_prepare\fR for apply patches. Otherwise, patches are silently
 ignored. If package ebuild uses \fBEAPI\fR >= \fB6\fR, applying user
 patches is mandatory.
+
+Digests of user patches are saved in the metadata of locally built binary
+packages, both with `emerge \-\-buildpkg` (or similar) and with
+\fBquickpkg\fR(1).
 .RE
 .TP
 .BR /var/db/repos/gentoo/

--- a/man/portage.5
+++ b/man/portage.5
@@ -1507,6 +1507,10 @@ If package ebuild uses \fBEAPI\fR <= \fB5\fR, it must explicitly invoke
 \fBsrc_prepare\fR for apply patches. Otherwise, patches are silently
 ignored. If package ebuild uses \fBEAPI\fR >= \fB6\fR, applying user
 patches is mandatory.
+
+Digests of user patches are saved in the metadata of locally built binary
+packages, both with `emerge \-\-buildpkg` (or similar) and with
+\fBquickpkg\fR(1).
 .RE
 .TP
 .BR /var/db/repos/gentoo/


### PR DESCRIPTION
Partial solution to https://bugs.gentoo.org/917047. Still draft as I intend to look also look at accommodating locally patched binpkgs, as per comments on the bug.

One open question might be how this should interact with `--usepkgonly`. Current implementation will revert to ignoring user patches, but some may prefer it to fail rather than effectively reverting user patches. Either behaviour is accessible via `--usepkg-exclude-patches=y/n`, just a question of which is the default. Falling back on the user-patched ebuild is obviously not an option with `--usepkgonly`.

Reporting a sensible reason for failure with `--usepkgonly --usepkg-exclude-patches=y` is also missing at this point.