### PR TITLE
Print coreutils version

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2031,6 +2031,21 @@ def action_info(settings, trees, myopts, myfiles):
 
     append(f"sh {sh_str}")
 
+    try:
+        proc = subprocess.Popen(
+            ["install", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+    except OSError:
+        pass
+    else:
+        output = _unicode_decode(proc.communicate()[0]).splitlines()
+        if proc.wait() == os.EX_OK and output:
+            pos = output[0].find("install ")
+            if pos == -1:
+                append(f"coreutils: {output[0]}")
+            else:
+                append(f"coreutils: {output[0][pos+8:]}")
+
     ld_names = []
     if chost:
         ld_names.append(chost + "-ld")

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2029,7 +2029,7 @@ def action_info(settings, trees, myopts, myfiles):
     else:
         sh_str = basename
 
-    append(f"sh {sh_str}")
+    append(f"sh: {sh_str}")
 
     try:
         proc = subprocess.Popen(
@@ -2059,9 +2059,8 @@ def action_info(settings, trees, myopts, myfiles):
             pass
         else:
             output = _unicode_decode(proc.communicate()[0]).splitlines()
-            proc.wait()
             if proc.wait() == os.EX_OK and output:
-                append(f"ld {output[0]}")
+                append(f"ld: {output[0]}")
                 break
 
     try:

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2022,7 +2022,7 @@ def action_info(settings, trees, myopts, myfiles):
     else:
         sh_str = basename
 
-    append(f"sh {sh_str}")
+    append(f"sh: {sh_str}")
 
     try:
         proc = subprocess.Popen(
@@ -2061,7 +2061,7 @@ def action_info(settings, trees, myopts, myfiles):
         else:
             output = proc.communicate()[0].splitlines()
             if proc.wait() == os.EX_OK and output:
-                append(f"ld {output[0]}")
+                append(f"ld: {output[0]}")
                 break
 
     try:

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2024,6 +2024,25 @@ def action_info(settings, trees, myopts, myfiles):
 
     append(f"sh {sh_str}")
 
+    try:
+        proc = subprocess.Popen(
+            ["install", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError:
+        pass
+    else:
+        output = proc.communicate()[0].splitlines()
+        if proc.wait() == os.EX_OK and output:
+            pos = output[0].find("install ")
+            if pos == -1:
+                append(f"coreutils: {output[0]}")
+            else:
+                append(f"coreutils: {output[0][pos+8:]}")
+
     ld_names = []
     if chost:
         ld_names.append(chost + "-ld")


### PR DESCRIPTION
This was [requested on gentoo-dev](https://archives.gentoo.org/gentoo-dev/CANQow5JxmP8P=XGG7E92AotLyyBpn4NX+RDHfjOCUxbba4zKhg@mail.gmail.com/T/#m3b3128f9d522921e291417869052e078a1b19390) in the context of eventually introducing `app-alternatives/coreutils`, but it seems interesting in its own right.

@arthurzam 