### PR TITLE
spawn: move process supervisor code from pid-ns-init

### DIFF
--- a/bin/pid-ns-init
+++ b/bin/pid-ns-init
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2018-2021 Gentoo Authors
+# Copyright 2018-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import locale
@@ -24,36 +24,22 @@ import termios
 
 from pathlib import Path
 
-KILL_SIGNALS = (
+FORWARD_SIGNALS = (
     signal.SIGINT,
     signal.SIGTERM,
     signal.SIGHUP,
-)
-
-SIGTSTP_SIGCONT = (
     signal.SIGTSTP,
     signal.SIGCONT,
 )
 
 
-def forward_kill_signal(pid, signum, frame):
-    if pid == 0:
-        # Avoid a signal feedback loop, since signals sent to the
-        # process group are also sent to the current process.
-        signal.signal(signum, signal.SIG_DFL)
-    os.kill(pid, signum)
-
-
-def forward_sigtstp_sigcont(pid, signum, frame):
-    handler = None
-    if pid == 0:
-        # Temporarily disable the handler in order to prevent it from
-        # being called recursively, since the signal will also be sent
-        # to the current process.
-        handler = signal.signal(signum, signal.SIG_DFL)
-    os.kill(pid, signum)
-    if handler is not None:
-        signal.signal(signum, handler)
+def forward_signal(signum, frame):
+    # Temporarily disable the handler in order to prevent it from
+    # being called recursively, since the signal will also be sent
+    # to the current process.
+    handler = signal.signal(signum, signal.SIG_DFL)
+    os.kill(0, signum)
+    signal.signal(signum, handler)
 
 
 def preexec_fn(uid, gid, groups, umask):
@@ -79,87 +65,64 @@ def preexec_fn(uid, gid, groups, umask):
 
 
 def main(argv):
-    if len(argv) < 2:
-        return "Usage: {} <main-child-pid> or <uid> <gid> <groups> <umask> <pass_fds> <binary> <argv0> [arg]..".format(
-            argv[0]
-        )
+    if len(argv) < 8:
+        return f"Usage: {argv[0]} <uid> <gid> <groups> <umask> <pass_fds> <binary> <argv0> [arg]..."
 
-    if len(argv) == 2:
-        # The child process is init (pid 1) in a child pid namespace, and
-        # the current process supervises from within the global pid namespace
-        # (forwarding signals to init and forwarding exit status to the parent
-        # process).
-        main_child_pid = int(argv[1])
-        setsid = False
-        proc = None
-    else:
-        # The current process is init (pid 1) in a child pid namespace.
-        uid, gid, groups, umask, pass_fds, binary, args = (
-            argv[1],
-            argv[2],
-            argv[3],
-            argv[4],
-            tuple(int(fd) for fd in argv[5].split(",")),
-            argv[6],
-            argv[7:],
-        )
-        uid = int(uid) if uid else None
-        gid = int(gid) if gid else None
-        groups = tuple(int(group) for group in groups.split(",")) if groups else None
-        umask = int(umask) if umask else None
+    # The current process is init (pid 1) in a child pid namespace.
+    uid, gid, groups, umask, pass_fds, binary, args = (
+        argv[1],
+        argv[2],
+        argv[3],
+        argv[4],
+        tuple(int(fd) for fd in argv[5].split(",")),
+        argv[6],
+        argv[7:],
+    )
+    uid = int(uid) if uid else None
+    gid = int(gid) if gid else None
+    groups = tuple(int(group) for group in groups.split(",")) if groups else None
+    umask = int(umask) if umask else None
 
-        popen_kwargs = {
-            "preexec_fn": functools.partial(preexec_fn, uid, gid, groups, umask),
-            "pass_fds": pass_fds,
-        }
+    popen_kwargs = {
+        "preexec_fn": functools.partial(preexec_fn, uid, gid, groups, umask),
+        "pass_fds": pass_fds,
+    }
 
-        # Obtain the current nice value, which will be potentially be
-        # used as the newly created session's autogroup nice value.
-        nice_value = os.nice(0)
+    # Obtain the current nice value, which will be potentially be
+    # used as the newly created session's autogroup nice value.
+    nice_value = os.nice(0)
 
-        # Isolate parent process from process group SIGSTOP (bug 675870)
-        setsid = True
-        os.setsid()
+    # Isolate parent process from process group SIGSTOP (bug 675870)
+    os.setsid()
 
-        # Set the previously obtained autogroup nice value again,
-        # since we created a new session with os.setsid() above.
+    # Set the previously obtained autogroup nice value again,
+    # since we created a new session with os.setsid() above.
+    try:
+        Path("/proc/self/autogroup").write_text(str(nice_value))
+    except OSError as e:
+        # The process is likely not allowed to set the autogroup
+        # value (Linux employs a rate limiting for unprivileged
+        # changes to the autogroup value) or autogroups are not
+        # enabled. Nothing we can do here, so we simply carry on.
+        pass
+
+    if sys.stdout.isatty():
         try:
-            Path("/proc/self/autogroup").write_text(str(nice_value))
+            fcntl.ioctl(sys.stdout, termios.TIOCSCTTY, 0)
         except OSError as e:
-            # The process is likely not allowed to set the autogroup
-            # value (Linux employs a rate limiting for unprivileged
-            # changes to the autogroup value) or autogroups are not
-            # enabled. Nothing we can do here, so we simply carry on.
-            pass
+            if e.errno == errno.EPERM:
+                # This means that stdout refers to the controlling terminal
+                # of the parent process, and in this case we do not want to
+                # steal it.
+                pass
+            else:
+                raise
 
-        if sys.stdout.isatty():
-            try:
-                fcntl.ioctl(sys.stdout, termios.TIOCSCTTY, 0)
-            except OSError as e:
-                if e.errno == errno.EPERM:
-                    # This means that stdout refers to the controlling terminal
-                    # of the parent process, and in this case we do not want to
-                    # steal it.
-                    pass
-                else:
-                    raise
-        proc = subprocess.Popen(args, executable=binary, **popen_kwargs)
-        main_child_pid = proc.pid
+    for signum in FORWARD_SIGNALS:
+        signal.signal(signum, forward_signal)
 
-    # If setsid has been called, use kill(0, signum) to
-    # forward signals to the entire process group.
-    sig_handler = functools.partial(
-        forward_kill_signal, 0 if setsid else main_child_pid
-    )
-    for signum in KILL_SIGNALS:
-        signal.signal(signum, sig_handler)
-
-    # For correct operation of Ctrl+Z, forward SIGTSTP and SIGCONT.
-    sigtstp_sigcont_handler = functools.partial(
-        forward_sigtstp_sigcont, 0 if setsid else main_child_pid
-    )
-    for signum in SIGTSTP_SIGCONT:
-        signal.signal(signum, sigtstp_sigcont_handler)
+    proc = subprocess.Popen(args, executable=binary, **popen_kwargs)
+    main_child_pid = proc.pid
 
     # wait for child processes
     while True:
@@ -170,10 +133,9 @@ def main(argv):
                 continue
             raise
         if pid == main_child_pid:
-            if proc is not None:
-                # Suppress warning messages like this:
-                # ResourceWarning: subprocess 1234 is still running
-                proc.returncode = 0
+            # Suppress warning messages like this:
+            # ResourceWarning: subprocess 1234 is still running
+            proc.returncode = 0
 
             if os.WIFEXITED(status):
                 return os.WEXITSTATUS(status)

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -1,5 +1,5 @@
 # portage.py -- core Portage functionality
-# Copyright 1998-2025 Gentoo Authors
+# Copyright 1998-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import asyncio as _asyncio
@@ -937,6 +937,19 @@ def _exec_wrapper(
         raise
 
 
+_FORWARD_SIGNALS = (
+    signal.SIGINT,
+    signal.SIGTERM,
+    signal.SIGHUP,
+    signal.SIGTSTP,
+    signal.SIGCONT,
+)
+
+
+def _forward_signal(pid, signum, frame):
+    os.kill(pid, signum)
+
+
 def _exec(
     binary,
     mycommand,
@@ -1104,6 +1117,9 @@ def _exec(
         groups = None
         umask = None
 
+        # Mask signals until we can set up our handlers
+        signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, _FORWARD_SIGNALS)
+
         # Use _start_fork for os.fork() error handling, ensuring
         # that if exec fails then the child process will display
         # a traceback before it exits via os._exit to suppress any
@@ -1128,21 +1144,24 @@ def _exec(
             ),
             fd_pipes=None,
             close_fds=False,
+            signal_mask=signal_mask,
         )
 
-        # Execute a supervisor process which will forward
-        # signals to init and forward exit status to the
-        # parent process. The supervisor process runs in
-        # the global pid namespace, so skip /proc remount
-        # and other setup that's intended only for the
-        # init process.
-        binary, myargs = portage._python_interpreter, [
-            portage._python_interpreter,
-            os.path.join(portage._bin_path, "pid-ns-init"),
-            str(main_child_pid),
-        ]
+        # Forward signals to child
+        handler = partial(_forward_signal, main_child_pid)
+        for signum in _FORWARD_SIGNALS:
+            signal.signal(signum, handler)
+        signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
 
-        os.execve(binary, myargs, env)
+        # Wait for child, exit with same result
+        pid, status = os.wait()
+        ec = os.waitstatus_to_exitcode(status)
+        if ec < 0:
+            signum = -ec
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+            os._exit(127)
+        os._exit(ec)
 
     # Reachable only if unshare_pid is False.
     _exec2(
@@ -1456,6 +1475,7 @@ def _start_fork(
     kwargs: Optional[dict[str, Any]] = {},
     fd_pipes: Optional[dict[int, int]] = None,
     close_fds: Optional[bool] = True,
+    signal_mask=None,
 ) -> int:
     """
     Execute the target function in a fork. The fd_pipes and
@@ -1480,6 +1500,8 @@ def _start_fork(
         if pid == 0:
             try:
                 _setup_pipes(fd_pipes, close_fds=close_fds, inheritable=True)
+                if signal_mask is not None:
+                    signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
                 target(*args, **kwargs)
             except Exception:
                 # We need to catch _any_ exception and display it since the child


### PR DESCRIPTION
This works around an error when Portage is run using qemu-user.

qemu calls pthread_create() in its startup code, which ends up invoking clone() with CLONE_THREAD in the flags parameter. This will fail in a process which has previously called unshare() with CLONE_NEWPID.

We can avoid triggering the qemu startup code by avoiding any execve() calls in the process that called unshare(). Practically, this means copying the relevant "supervisor" code from pid-ns-init.

Bug: https://bugs.gentoo.org/703278