### PR TITLE
emaint: hide failures to determine ebuild masking reasons (bug #971602)

### DIFF
--- a/lib/portage/emaint/modules/world/world.py
+++ b/lib/portage/emaint/modules/world/world.py
@@ -40,7 +40,7 @@ class WorldHandler:
         maxval = len(world_atoms)
         if onProgress:
             onProgress(maxval, 0)
-        for i, atom in enumerate(world_atoms):
+        for i, atom in enumerate(sorted(world_atoms)):
             if not isinstance(atom, portage.dep.Atom):
                 if atom.startswith(SETPREFIX):
                     s = atom[len(SETPREFIX) :]
@@ -53,22 +53,24 @@ class WorldHandler:
                 if onProgress:
                     onProgress(maxval, i + 1)
                 continue
-            okay = True
+
             installed = vardb.match(atom)
             if not portdb.xmatch("match-all", atom):
                 self.missing.append(atom)
-                okay = False
-            if okay and not portdb.xmatch("match-visible", atom):
-                reasons = ", ".join(
-                    {r for cpv in installed for r in getmaskingstatus(cpv)}
-                )
-                self.masked.append((atom, reasons))
-                okay = False
-            if okay and not installed:
+            elif not installed:
                 self.not_installed.append(atom)
-                okay = False
-            if okay:
+            elif not portdb.xmatch("match-visible", atom):
+                try:
+                    reasons = ", ".join(
+                        {r for cpv in installed for r in getmaskingstatus(cpv)}
+                    )
+                    reasons = f" [{reasons}]"
+                except:
+                    reasons = ""
+                self.masked.append((atom, reasons))
+            else:
                 self.okay.append(atom)
+
             if onProgress:
                 onProgress(maxval, i + 1)
 
@@ -77,7 +79,7 @@ class WorldHandler:
         self._check_world(onProgress)
         errors = []
         if self.found:
-            errors += [f"'{x}' has no visible ebuilds [{r}]" for x, r in self.masked]
+            errors += [f"'{x}' has no visible ebuilds{r}" for x, r in self.masked]
             errors += [f"'{x}' has no available ebuilds" for x in self.missing]
             errors += [f"'{x}' is not a valid atom" for x in self.invalid]
             errors += [f"'{x}' is not installed" for x in self.not_installed]

--- a/lib/portage/tests/__init__.py
+++ b/lib/portage/tests/__init__.py
@@ -22,7 +22,6 @@ from portage.const import PORTAGE_PYM_PATH
 from portage.output import colorize
 from portage.proxy.objectproxy import ObjectProxy
 
-
 # This remains constant when the real value is a mock.
 EPREFIX_ORIG = portage.const.EPREFIX
 
@@ -33,6 +32,7 @@ class CommandStep:
     command: tuple[str, ...]
     env: Optional[dict] = None
     cwd: Optional[str] = None
+    output: Optional[str] = None
 
 
 @dataclass

--- a/lib/portage/tests/emaint/EmaintTestCase.py
+++ b/lib/portage/tests/emaint/EmaintTestCase.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import subprocess
+import sys
+
+import portage
+from portage.tests import TestCase, FunctionStep
+
+
+class EmaintTestCase(TestCase):
+    cmds = {}
+    debug = False
+
+    def __init__(self, *pargs, **kwargs):
+        super().__init__(*pargs, **kwargs)
+
+        for cmd in ("emaint",):
+            for bindir in (self.bindir, self.sbindir):
+                path = os.path.join(str(bindir), cmd)
+                if os.path.exists(path):
+                    self.cmds[cmd] = (portage._python_interpreter, "-b", "-Wd", path)
+                    break
+            else:
+                raise AssertionError(
+                    f"{cmd} binary not found in {self.bindir} or {self.sbindir}"
+                )
+
+    def runEmaintTest(self, steps, playground):
+        settings = playground.settings
+        eprefix = settings["EPREFIX"]
+        env = settings.environ()
+        env.update(
+            {
+                "PORTAGE_OVERRIDE_EPREFIX": eprefix,
+                "HOME": eprefix,
+                "PYTHONDONTWRITEBYTECODE": os.environ.get(
+                    "PYTHONDONTWRITEBYTECODE", ""
+                ),
+            }
+        )
+
+        try:
+            if self.debug:
+                # The subprocess inherits both stdout and stderr, for
+                # debugging purposes.
+                stdout = None
+            else:
+                # The subprocess inherits stderr so that any warnings
+                # triggered by python -Wd will be visible.
+                stdout = subprocess.PIPE
+
+            for i, step in enumerate(steps):
+                if isinstance(step, FunctionStep):
+                    try:
+                        step.function(i)
+                    except Exception as e:
+                        if isinstance(e, AssertionError) and f"step {i}" in str(e):
+                            raise
+                        raise AssertionError(
+                            f"step {i} raised {e.__class__.__name__}"
+                        ) from e
+                    continue
+
+                proc = subprocess.Popen(
+                    step.command,
+                    env=dict(env.items(), **(step.env or {})),
+                    cwd=step.cwd,
+                    stdout=stdout,
+                )
+
+                if self.debug:
+                    proc.wait()
+                else:
+                    output = proc.stdout.readlines()
+                    proc.wait()
+                    proc.stdout.close()
+                    bad_returncode = proc.returncode != step.returncode
+                    bad_output = step.output is not None and output not in output
+                    if bad_returncode or bad_output:
+                        for line in output:
+                            sys.stderr.write(portage._unicode_decode(line))
+
+                self.assertEqual(
+                    step.returncode,
+                    proc.returncode,
+                    f"{step.command} (step {i}) failed with exit code {proc.returncode}",
+                )
+
+                if step.output is not None:
+                    self.assertTrue(
+                        isinstance(step.output, list) and len(step.output) > 0,
+                        f"step {i} output token(s) not in a list",
+                    )
+
+                    for line in output:
+                        if step.output[0] in line.decode():
+                            del step.output[0]
+                            if len(step.output) == 0:
+                                break
+
+                    self.assertTrue(
+                        len(step.output) == 0,
+                        f"{step.command} (step {i}) did not output {step.output}",
+                    )
+
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/emaint/test_emaint_binhost.py
+++ b/lib/portage/tests/emaint/test_emaint_binhost.py
@@ -2,19 +2,15 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import os
-import subprocess
-import sys
 import time
 
-import portage
-from portage.tests import TestCase, CommandStep, FunctionStep
+from portage.tests import CommandStep, FunctionStep
 from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+from portage.tests.emaint.EmaintTestCase import EmaintTestCase
 
 
-class EmainBinhostTestCase(TestCase):
+class EmainBinhostTestCase(EmaintTestCase):
     def testCompressedIndex(self):
-        debug = False
-
         user_config = {"make.conf": ('FEATURES="-compress-index"',)}
 
         binpkgs = {
@@ -28,40 +24,15 @@ class EmainBinhostTestCase(TestCase):
         playground = ResolverPlayground(
             binpkgs=binpkgs,
             user_config=user_config,
-            debug=debug,
-        )
-        settings = playground.settings
-        eprefix = settings["EPREFIX"]
-        eroot = settings["EROOT"]
-        bintree = playground.trees[eroot]["bintree"]
-
-        cmds = {}
-        for cmd in ("emaint",):
-            for bindir in (self.bindir, self.sbindir):
-                path = os.path.join(str(bindir), cmd)
-                if os.path.exists(path):
-                    cmds[cmd] = (portage._python_interpreter, "-b", "-Wd", path)
-                    break
-            else:
-                raise AssertionError(
-                    f"{cmd} binary not found in {self.bindir} or {self.sbindir}"
-                )
-
-        env = settings.environ()
-        env.update(
-            {
-                "PORTAGE_OVERRIDE_EPREFIX": eprefix,
-                "HOME": eprefix,
-                "PYTHONDONTWRITEBYTECODE": os.environ.get(
-                    "PYTHONDONTWRITEBYTECODE", ""
-                ),
-            }
+            debug=False,
         )
 
         def current_time(offset=0):
             t = time.time() + offset
             return (t, t)
 
+        emaint = self.cmds["emaint"]
+        bintree = playground.trees[playground.settings["EROOT"]]["bintree"]
         steps = (
             FunctionStep(
                 function=lambda i: self.assertTrue(
@@ -77,12 +48,12 @@ class EmainBinhostTestCase(TestCase):
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--fix"),
+                command=emaint + ("binhost", "--fix"),
             ),
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--check"),
+                command=emaint + ("binhost", "--check"),
             ),
             FunctionStep(
                 function=lambda i: self.assertTrue(
@@ -96,17 +67,17 @@ class EmainBinhostTestCase(TestCase):
             CommandStep(
                 returncode=1,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--check"),
+                command=emaint + ("binhost", "--check"),
             ),
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--fix"),
+                command=emaint + ("binhost", "--fix"),
             ),
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--check"),
+                command=emaint + ("binhost", "--check"),
             ),
             # Bump the timestamp of Packages so that Packages.gz becomes stale.
             FunctionStep(
@@ -118,23 +89,23 @@ class EmainBinhostTestCase(TestCase):
             CommandStep(
                 returncode=1,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--check"),
+                command=emaint + ("binhost", "--check"),
             ),
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--fix"),
+                command=emaint + ("binhost", "--fix"),
             ),
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "compress-index"},
-                command=cmds["emaint"] + ("binhost", "--check"),
+                command=emaint + ("binhost", "--check"),
             ),
             # It should delete the unwanted Packages.gz here when compress-index is disabled.
             CommandStep(
                 returncode=os.EX_OK,
                 env={"FEATURES": "-compress-index"},
-                command=cmds["emaint"] + ("binhost", "--fix"),
+                command=emaint + ("binhost", "--fix"),
             ),
             FunctionStep(
                 function=lambda i: self.assertFalse(
@@ -143,50 +114,4 @@ class EmainBinhostTestCase(TestCase):
             ),
         )
 
-        try:
-            if debug:
-                # The subprocess inherits both stdout and stderr, for
-                # debugging purposes.
-                stdout = None
-            else:
-                # The subprocess inherits stderr so that any warnings
-                # triggered by python -Wd will be visible.
-                stdout = subprocess.PIPE
-
-            for i, step in enumerate(steps):
-                if isinstance(step, FunctionStep):
-                    try:
-                        step.function(i)
-                    except Exception as e:
-                        if isinstance(e, AssertionError) and f"step {i}" in str(e):
-                            raise
-                        raise AssertionError(
-                            f"step {i} raised {e.__class__.__name__}"
-                        ) from e
-                    continue
-
-                proc = subprocess.Popen(
-                    step.command,
-                    env=dict(env.items(), **(step.env or {})),
-                    cwd=step.cwd,
-                    stdout=stdout,
-                )
-
-                if debug:
-                    proc.wait()
-                else:
-                    output = proc.stdout.readlines()
-                    proc.wait()
-                    proc.stdout.close()
-                    if proc.returncode != step.returncode:
-                        for line in output:
-                            sys.stderr.write(portage._unicode_decode(line))
-
-                self.assertEqual(
-                    step.returncode,
-                    proc.returncode,
-                    f"{step.command} (step {i}) failed with exit code {proc.returncode}",
-                )
-
-        finally:
-            playground.cleanup()
+        self.runEmaintTest(steps, playground)

--- a/lib/portage/tests/emaint/test_emaint_world.py
+++ b/lib/portage/tests/emaint/test_emaint_world.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import pytest
+
+from portage.tests import CommandStep, FunctionStep
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+from portage.tests.emaint.EmaintTestCase import EmaintTestCase
+
+
+class EmaintWorldTestCase(EmaintTestCase):
+    def in_world(self, playground, atom):
+        world_file = os.path.join(playground.eroot, "var", "lib", "portage", "world")
+        with open(world_file) as f:
+            atoms = (line.strip() for line in f.readlines())
+            return atom in atoms
+
+    def testWorldInstalled(self):
+        ebuilds = {
+            "app-misc/A-1.0": {},
+            "app-misc/B-1.0": {},
+        }
+
+        installed = {
+            "app-misc/A-1.0": {},
+        }
+
+        world = (
+            "app-misc/A",
+            "app-misc/B",
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=installed,
+            world=world,
+        )
+
+        emaint = self.cmds["emaint"]
+        steps = (
+            CommandStep(
+                returncode=1,
+                command=emaint + ("world", "--check"),
+                output=["'app-misc/B' is not installed"],
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--fix"),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertTrue(
+                    self.in_world(playground, "app-misc/A"), f"step {i}"
+                )
+            ),
+            FunctionStep(
+                function=lambda i: self.assertFalse(
+                    self.in_world(playground, "app-misc/B"), f"step {i}"
+                )
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--check"),
+            ),
+        )
+
+        self.runEmaintTest(steps, playground)
+
+    def testWorldMasked(self):
+        ebuilds = {
+            "app-misc/A-1.0": {},
+            "app-misc/B-1.0": {"KEYWORDS": "x86~"},
+            "app-misc/C-1.0": {"LICENSE": "TEST"},
+        }
+
+        world = (
+            "app-misc/A",
+            "app-misc/B",
+            "app-misc/C",
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=ebuilds,
+            world=world,
+        )
+
+        emaint = self.cmds["emaint"]
+        steps = (
+            CommandStep(
+                returncode=1,
+                command=emaint + ("world", "--check"),
+                output=[
+                    "'app-misc/B' has no visible ebuilds [missing keyword]",
+                    "'app-misc/C' has no visible ebuilds [TEST license(s)]",
+                ],
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--fix"),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertTrue(
+                    self.in_world(playground, "app-misc/A"), f"step {i}"
+                ),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertFalse(
+                    self.in_world(playground, "app-misc/B"), f"step {i}"
+                ),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertFalse(
+                    self.in_world(playground, "app-misc/C"), f"step {i}"
+                ),
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--check"),
+            ),
+        )
+
+        self.runEmaintTest(steps, playground)
+
+    def testWorldMissing(self):
+        ebuilds = {
+            "app-misc/A-1.0": {},
+        }
+
+        world = (
+            "app-misc/A",
+            "app-misc/B",
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=ebuilds,
+            world=world,
+        )
+
+        emaint = self.cmds["emaint"]
+        steps = (
+            CommandStep(
+                returncode=1,
+                command=emaint + ("world", "--check"),
+                output=["'app-misc/B' has no available ebuilds"],
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--fix"),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertTrue(
+                    self.in_world(playground, "app-misc/A"), f"step {i}"
+                ),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertFalse(
+                    self.in_world(playground, "app-misc/B"), f"step {i}"
+                ),
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--check"),
+            ),
+        )
+
+        self.runEmaintTest(steps, playground)
+
+    @pytest.mark.xfail()
+    def testWorldValid(self):
+        ebuilds = {
+            "app-misc/A-1.0": {},
+            "app-misc/B-1.0": {},
+        }
+
+        world = (
+            "app-misc/A",
+            "app/misc/B",
+        )
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds,
+            installed=ebuilds,
+            world=world,
+        )
+
+        emaint = self.cmds["emaint"]
+        steps = (
+            CommandStep(
+                returncode=1,
+                command=emaint + ("world", "--check"),
+                output=["'app/misc/B' is not a valid atom"],
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--fix"),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertTrue(
+                    self.in_world(playground, "app-misc/A"), f"step {i}"
+                ),
+            ),
+            FunctionStep(
+                function=lambda i: self.assertFalse(
+                    self.in_world(playground, "app-misc/B"), f"step {i}"
+                ),
+            ),
+            CommandStep(
+                returncode=os.EX_OK,
+                command=emaint + ("world", "--check"),
+            ),
+        )
+
+        self.runEmaintTest(steps, playground)


### PR DESCRIPTION
Try/catch band-aid for https://bugs.gentoo.org/971602. Am not particularly satisfied with this and intended to dig a bit more, but as this currently looks more like a data than a code problem this is perhaps required for robustness anyway.

Also fixes for logical error introduced by myself in [8d0633c](https://github.com/gentoo/portage/commit/8d0633c240c7d9dfd0eed459d69f521bb5d635bf) which had emaint report non-installed atoms as masked but with no masking reason given.

Note that only one issue will be reported by `emaint --check world` for each problematic entry in the world file, precedence of issues is:
 - atom is invalid (but see below)
 - missing from tree (installed or not)
 - not installed (masked or not)
 - not visible (masking reason reported)

The code has been structured such that the call to `getmaskingstatus()` is only made if higher priority problems are not found.

In the hope of not introducing another such error, I've also added tests. From this it is apparent that invalid atom strings in the world file are simply omitted from the `@selected` set in the loaded config and so are invisible to emaint. Unsure if this is as intended? Point being I haven't managed to actually trigger the original "invalid atom" path (have marked the test xfail).