### PR TITLE
emaint: report masking reasons from porttree rather than vartree

### DIFF
--- a/lib/portage/emaint/modules/world/world.py
+++ b/lib/portage/emaint/modules/world/world.py
@@ -55,16 +55,20 @@ class WorldHandler:
                 continue
 
             installed = vardb.match(atom)
-            if not portdb.xmatch("match-all", atom):
+            existing = portdb.xmatch("match-all", atom)
+            if not existing:
                 self.missing.append(atom)
             elif not installed:
                 self.not_installed.append(atom)
             elif not portdb.xmatch("match-visible", atom):
                 try:
-                    reasons = ", ".join(
-                        {r for cpv in installed for r in getmaskingstatus(cpv)}
-                    )
-                    reasons = f" [{reasons}]"
+                    reasons = {
+                        r
+                        for cpv in existing
+                        for r in getmaskingstatus(cpv)
+                        if "live" not in cpv._metadata.get("PROPERTIES", "").split()
+                    }
+                    reasons = f" [{', '.join(sorted(reasons))}]"
                 except:
                     reasons = ""
                 self.masked.append((atom, reasons))

--- a/lib/portage/tests/emaint/test_emaint_world.py
+++ b/lib/portage/tests/emaint/test_emaint_world.py
@@ -70,7 +70,15 @@ class EmaintWorldTestCase(EmaintTestCase):
         ebuilds = {
             "app-misc/A-1.0": {},
             "app-misc/B-1.0": {"KEYWORDS": "x86~"},
+            # same masking reason - to be reported only once for all ebuilds
             "app-misc/C-1.0": {"LICENSE": "TEST"},
+            "app-misc/C-2.0": {"LICENSE": "TEST"},
+            # live ebuild - to be omitted from reported masking reasons
+            "app-misc/C-9999": {"KEYWORDS": "", "PROPERTIES": "live"},
+        }
+
+        user_config = {
+            "package.mask": (">=app-misc/C-2.0",),
         }
 
         world = (
@@ -82,6 +90,7 @@ class EmaintWorldTestCase(EmaintTestCase):
         playground = ResolverPlayground(
             ebuilds=ebuilds,
             installed=ebuilds,
+            user_config=user_config,
             world=world,
         )
 
@@ -92,7 +101,7 @@ class EmaintWorldTestCase(EmaintTestCase):
                 command=emaint + ("world", "--check"),
                 output=[
                     "'app-misc/B' has no visible ebuilds [missing keyword]",
-                    "'app-misc/C' has no visible ebuilds [TEST license(s)]",
+                    "'app-misc/C' has no visible ebuilds [TEST license(s), package.mask]",
                 ],
             ),
             CommandStep(


### PR DESCRIPTION
See https://bugs.gentoo.org/971602 for details