### PR TITLE
dispatch-conf: Color on

### DIFF
--- a/cnf/dispatch-conf.conf
+++ b/cnf/dispatch-conf.conf
@@ -26,7 +26,8 @@ use-rcs=no
 # %s new file
 # If using colordiff instead of diff, the less -R option may be required
 # for correct display.
-diff="diff -Nu '%s' '%s'"
+# see https://wiki.gentoo.org/wiki/Dispatch-conf for more color options.
+diff="diff --color=always -Nu '%s' '%s'"
 
 # Set the pager for use with diff commands (this will
 # cause the PAGER environment variable to be ignored).


### PR DESCRIPTION
All the required packages are now included by default to support colour in dispatch-conf.

This commit turns on the mode supported by sys-apps/diffutils and adds a link to wiki to show other options that user to can select so there is still user choice for those that need it, and a good default choice for those unaware.