### PR TITLE
LocationsManager: Initialize profiles and profiles_complex

### DIFF
--- a/lib/portage/package/ebuild/_config/LocationsManager.py
+++ b/lib/portage/package/ebuild/_config/LocationsManager.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2021 Gentoo Authors
+# Copyright 2010-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ("LocationsManager",)
@@ -64,6 +64,8 @@ class LocationsManager:
         self.target_root = target_root
         self.sysroot = sysroot
         self._user_config = local_config
+        self.profiles = []
+        self.profiles_complex = []
 
         if self.eprefix is None:
             self.eprefix = portage.const.EPREFIX


### PR DESCRIPTION
This fixes a failure when creating an instance of LicenseManager without prior call to load_profiles().

Seen with app-portage/elicense:

   Traceback (most recent call last):
     ...
     File "/local/home/ulm/git/elicense/elicense", line 48, in main
       license_manager = LicenseManager(locations_manager, user_config=True)
     File "/usr/lib/python3.14/site-packages/portage/package/ebuild/_config/LicenseManager.py", line 31, in __init__
       for profile in locations_manager.profiles_complex:
		      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   AttributeError: 'LocationsManager' object has no attribute 'profiles_complex'