### PR TITLE
lib: Consolidate multiple sys.stderr.write calls

### DIFF
--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -31,24 +31,15 @@ try:
     del shutil
 
 except ImportError as e:
-    sys.stderr.write("\n\n")
     sys.stderr.write(
+        "\n\n"
         "!!! Failed to complete python imports. These are internal modules for\n"
-    )
-    sys.stderr.write(
         "!!! python and failure here indicates that you have a problem with python\n"
-    )
-    sys.stderr.write(
         "!!! itself and thus portage is not able to continue processing.\n\n"
-    )
-
-    sys.stderr.write(
         "!!! You might consider starting python with verbose flags to see what has\n"
-    )
-    sys.stderr.write(
         "!!! gone wrong. Here is the information we got for this exception:\n"
+        f"    {e}\n\n"
     )
-    sys.stderr.write(f"    {e}\n\n")
     raise
 
 try:


### PR DESCRIPTION
Combine consecutive sys.stderr.write calls into a single call using implicit string literal concatenation. This improves code readability.