### PR TITLE
Add FEATURES="buildpkg-proactive" to rebuild missing/unusable binpkgs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,14 @@ Release notes take the form of the following optional categories:
 portage-3.0.80 (UNRELEASED)
 --------------
 
+Breaking changes:
+
+* Drop the @unavailable-binaries set in favour of FEATURES="buildpkg-proactive"
+  (see below) because the former cannot check whether an existing binary package
+  is usable or whether a given ebuild will actually produce a binary package or
+  not. This set is broken anyway and probably has been for 11 years since
+  Portage 2.2.19. (bug #976083)
+
 Features:
 
 * Add User-Agent to default wget FETCHCOMMAND and RESUMECOMMAND settings, as

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@ Features:
   well as emirrordist, in order to avoid blocking by some web servers,
   particularly crates.io. (bug #682610)
 
+* Add FEATURES="buildpkg-proactive" to proactively rebuild matching packages
+  that have no (usable) binary package, even if those packages are already
+  installed. (bug #976083)
+
 portage-3.0.79 (2026-05-22)
 --------------
 

--- a/cnf/sets/portage.conf
+++ b/cnf/sets/portage.conf
@@ -100,11 +100,6 @@ class = portage.sets.dbapi.DowngradeSet
 [unavailable]
 class = portage.sets.dbapi.UnavailableSet
 
-# Installed packages for which corresponding binary packages
-# are not available.
-[unavailable-binaries]
-class = portage.sets.dbapi.UnavailableBinaries
-
 # Installed packages for which vdb *DEPEND entries are outdated compared
 # to the matching portdb entry.
 [changed-deps]

--- a/lib/_emerge/EbuildBuild.py
+++ b/lib/_emerge/EbuildBuild.py
@@ -327,40 +327,15 @@ class EbuildBuild(CompositeTask):
         self._build_dir.clean_log()
         pkg = self.pkg
         logger = self.logger
-        opts = self.opts
         pkg_count = self.pkg_count
         scheduler = self.scheduler
         settings = self.settings
-        features = settings.features
         ebuild_path = self._ebuild_path
-        system_set = pkg.root_config.sets["system"]
 
         # buildsyspkg: Check if we need to _force_ binary package creation
-        self._issyspkg = (
-            "buildsyspkg" in features
-            and system_set.findAtomForPackage(pkg)
-            and "buildpkg" not in features
-            and opts.buildpkg != "n"
-        )
+        self._issyspkg = pkg.syspkg_wanted()
 
-        # Do not build binary cache for packages from volatile sources.
-        # For volatile sources (eg., git), the PROPERTIES parameter in
-        # the ebuild is set to 'live'.
-
-        # The default behavior is to build binary cache for all pkgs.
-        # "buildpkg-live" is a FEATURE that is enabled by default.
-        # To not build binary cache for live pkgs, we disable it by
-        # specifying FEATURES="-buildpkg-live"
-
-        buildpkg_live = "buildpkg-live" in features
-        live_ebuild = "live" in self.settings.get("PROPERTIES", "").split()
-        buildpkg_live_disabled = live_ebuild and not buildpkg_live
-
-        if (
-            ("buildpkg" in features or self._issyspkg)
-            and not buildpkg_live_disabled
-            and not self.opts.buildpkg_exclude.findAtomForPackage(pkg)
-        ):
+        if pkg.binpkg_wanted(self.opts.buildpkg_exclude):
             self._buildpkg = True
 
             msg = " === ({} of {}) Compiling/Packaging ({}::{})".format(

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -607,6 +607,34 @@ class Package(Task):
         s += ")"
         return s
 
+    def syspkg_wanted(self):
+        """Tests whether this is a system package to build a binary package for
+        (buildsyspkg), assuming it isn't already covered by buildpkg."""
+        features = self.root_config.settings.features
+        return (
+            "buildsyspkg" in features
+            and "buildpkg" not in features
+            and self.root_config.sets["system"].findAtomForPackage(self)
+        )
+
+    def binpkg_wanted(self, exclude):
+        """Tests whether this is a package to build a binary package for, taking
+        account of FEATURES, PROPERTIES, and the given excluded set."""
+        # Do not build binary cache for packages from volatile sources.
+        # For volatile sources (eg., git), the PROPERTIES parameter in
+        # the ebuild is set to 'live'.
+        #
+        # The default behavior is to build binary cache for all pkgs.
+        # "buildpkg-live" is a FEATURE that is enabled by default.
+        # To not build binary cache for live pkgs, we disable it by
+        # specifying FEATURES="-buildpkg-live"
+        features = self.root_config.settings.features
+        return (
+            ("buildpkg-live" in features or not "live" in self.properties)
+            and not exclude.findAtomForPackage(self)
+            and ("buildpkg" in features or self.syspkg_wanted())
+        )
+
     class _use_class:
         __slots__ = ("enabled", "_expand", "_expand_hidden", "_force", "_pkg", "_mask")
 

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -207,6 +207,12 @@ class _frozen_depgraph_config:
         atoms = " ".join(myopts.get("--rebuild-ignore", [])).split()
         self.rebuild_ignore = WildcardPackageSet(atoms)
 
+        self.buildpkg_exclude = InternalPackageSet(
+            initial_atoms=" ".join(myopts.get("--buildpkg-exclude", [])).split(),
+            allow_wildcard=True,
+            allow_repo=True,
+        )
+
         for repo in settings.repositories:
             self.usepkg_exclude.update(
                 a + _repo_separator + repo.name for a in repo.usepkg_exclude.getAtoms()
@@ -7850,6 +7856,24 @@ class depgraph:
                                 pkg, autounmask_level=autounmask_level
                             ):
                                 continue
+                            # Also reject built instances if we want a binary
+                            # package, but none exist or all the existing ones
+                            # are now masked (e.g. accepted keywords changed).
+                            elif (
+                                myeb
+                                and "buildpkg-proactive"
+                                in root_config.settings.features
+                                and myeb.binpkg_wanted(
+                                    self._frozen_config.buildpkg_exclude
+                                )
+                            ):
+                                for binpkg in self._iter_match_pkgs_atom(
+                                    root_config, "binary", Atom(f"={myeb.cpv}")
+                                ):
+                                    if not binpkg.masks:
+                                        break
+                                else:
+                                    continue
 
                     # Calculation of USE for unbuilt ebuilds is relatively
                     # expensive, so it is only performed lazily, after the

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7859,7 +7859,7 @@ class depgraph:
                             # Also reject built instances if we want a binary
                             # package, but none exist, all the existing ones are
                             # now masked (e.g. accepted keywords changed), or we
-                            # care that the USE flags have changed.
+                            # care that the USE flags or deps have changed.
                             elif (
                                 myeb
                                 and "buildpkg-proactive"
@@ -7887,6 +7887,10 @@ class depgraph:
                                             bin_iuse,
                                             pkg_use,
                                             pkg_iuse,
+                                        )
+                                        and not (
+                                            binpkg_changed_deps
+                                            and self._changed_deps(binpkg)
                                         )
                                     ):
                                         break

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -7857,8 +7857,9 @@ class depgraph:
                             ):
                                 continue
                             # Also reject built instances if we want a binary
-                            # package, but none exist or all the existing ones
-                            # are now masked (e.g. accepted keywords changed).
+                            # package, but none exist, all the existing ones are
+                            # now masked (e.g. accepted keywords changed), or we
+                            # care that the USE flags have changed.
                             elif (
                                 myeb
                                 and "buildpkg-proactive"
@@ -7870,7 +7871,24 @@ class depgraph:
                                 for binpkg in self._iter_match_pkgs_atom(
                                     root_config, "binary", Atom(f"={myeb.cpv}")
                                 ):
-                                    if not binpkg.masks:
+                                    forced_flags = set(
+                                        chain(myeb.use.force, myeb.use.mask)
+                                    )
+                                    bin_use = binpkg.use.enabled
+                                    bin_iuse = binpkg.iuse.all
+                                    pkg_use = self._pkg_use_enabled(myeb)
+                                    pkg_iuse = myeb.iuse.all
+                                    if (
+                                        not binpkg.masks
+                                        and not self._reinstall_for_flags(
+                                            binpkg,
+                                            forced_flags,
+                                            bin_use,
+                                            bin_iuse,
+                                            pkg_use,
+                                            pkg_iuse,
+                                        )
+                                    ):
                                         break
                                 else:
                                     continue

--- a/lib/portage/_sets/dbapi.py
+++ b/lib/portage/_sets/dbapi.py
@@ -356,41 +356,6 @@ class UnavailableSet(EverythingSet):
     singleBuilder = classmethod(singleBuilder)
 
 
-class UnavailableBinaries(EverythingSet):
-    _operations = (
-        "merge",
-        "unmerge",
-    )
-
-    description = (
-        "Package set which contains all installed "
-        + "packages for which corresponding binary packages "
-        + "are not available."
-    )
-
-    def __init__(self, vardb, metadatadb=None):
-        super().__init__(vardb)
-        self._metadatadb = metadatadb
-
-    def _filter(self, atom):
-        inst_pkg = self._db.match(atom)
-        if not inst_pkg:
-            return False
-        inst_cpv = inst_pkg[0]
-        return not self._metadatadb.cpv_exists(inst_cpv)
-
-    def singleBuilder(cls, options, settings, trees):
-        metadatadb = options.get("metadata-source", "bintree")
-        if not metadatadb in trees:
-            raise SetConfigError(
-                _("invalid value '%s' for option " "metadata-source") % (metadatadb,)
-            )
-
-        return cls(trees["vartree"].dbapi, metadatadb=trees[metadatadb].dbapi)
-
-    singleBuilder = classmethod(singleBuilder)
-
-
 class CategorySet(PackageSet):
     _operations = ["merge", "unmerge"]
 

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -167,6 +167,7 @@ SUPPORTED_FEATURES = frozenset(
         "binpkg-signing",
         "buildpkg",
         "buildpkg-live",
+        "buildpkg-proactive",
         "buildsyspkg",
         "candy",
         "case-insensitive-fs",

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -19,6 +19,7 @@ py.install_sources(
         'test_blocker.py',
         'test_broken_deps.py',
         'test_bootstrap_deps.py',
+        'test_buildpkg.py',
         'test_changed_deps.py',
         'test_circular_choices.py',
         'test_circular_choices_rust.py',

--- a/lib/portage/tests/resolver/test_buildpkg.py
+++ b/lib/portage/tests/resolver/test_buildpkg.py
@@ -19,6 +19,11 @@ class BuildPkgTestCase(TestCase):
             "dev-libs/F-1": {"IUSE": "static"},
             "dev-libs/G-1": {"IUSE": "static"},
             "dev-libs/H-1": {"IUSE": "doc"},
+            "app-misc/A-0": {
+                "DEPEND": "app-misc/B",
+                "RDEPEND": "app-misc/B",
+            },
+            "app-misc/B-0": {},
         }
 
         installed = {
@@ -29,6 +34,7 @@ class BuildPkgTestCase(TestCase):
             "dev-libs/F-1": {"IUSE": "static"},
             "dev-libs/G-1": {"IUSE": "static", "USE": "static"},
             "dev-libs/H-1": {"IUSE": "static", "USE": "static"},
+            "app-misc/A-0": {},
         }
 
         binpkgs = {
@@ -64,6 +70,10 @@ class BuildPkgTestCase(TestCase):
                 "USE": "static",
             },
             "dev-libs/X-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+            },
+            "app-misc/A-0": {
                 "BUILD_ID": "1",
                 "BUILD_TIME": "1",
             },
@@ -146,6 +156,18 @@ class BuildPkgTestCase(TestCase):
                 success=True,
                 options={"--update": True, "--binpkg-respect-use": "n"},
                 mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/A"],
+                success=True,
+                options={"--update": True, "--binpkg-changed-deps": "n"},
+                mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["app-misc/A"],
+                success=True,
+                options={"--update": True, "--binpkg-changed-deps": "y"},
+                mergelist=["app-misc/B-0", "app-misc/A-0"],
             ),
         )
 

--- a/lib/portage/tests/resolver/test_buildpkg.py
+++ b/lib/portage/tests/resolver/test_buildpkg.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class BuildPkgTestCase(TestCase):
+    def testBuildPkgProactive(self):
+        ebuilds = {
+            "dev-libs/A-1": {},
+            "dev-libs/B-1": {},
+            "dev-libs/C-1": {},
+            "dev-libs/D-1": {"KEYWORDS": "amd64"},
+        }
+
+        installed = {
+            "dev-libs/B-1": {},
+            "dev-libs/C-1": {},
+            "dev-libs/D-1": {},
+        }
+
+        binpkgs = {
+            "dev-libs/C-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+            },
+            "dev-libs/D-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+                "KEYWORDS": "~amd64",
+            },
+            "dev-libs/X-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+            },
+        }
+
+        user_config = {
+            "make.conf": ('FEATURES="buildpkg buildpkg-proactive"',),
+            "package.accept_keywords": ("dev-libs/D amd64",),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                success=True,
+                options={"--update": True},
+                mergelist=["dev-libs/A-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/B"],
+                success=True,
+                options={"--update": True},
+                mergelist=["dev-libs/B-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/C"],
+                success=True,
+                options={"--update": True},
+                mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/D"],
+                success=True,
+                options={"--update": True},
+                mergelist=["dev-libs/D-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(
+            debug=False,
+            binpkgs=binpkgs,
+            ebuilds=ebuilds,
+            installed=installed,
+            user_config=user_config,
+        )
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.debug = False
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_buildpkg.py
+++ b/lib/portage/tests/resolver/test_buildpkg.py
@@ -15,12 +15,20 @@ class BuildPkgTestCase(TestCase):
             "dev-libs/B-1": {},
             "dev-libs/C-1": {},
             "dev-libs/D-1": {"KEYWORDS": "amd64"},
+            "dev-libs/E-1": {"IUSE": "static"},
+            "dev-libs/F-1": {"IUSE": "static"},
+            "dev-libs/G-1": {"IUSE": "static"},
+            "dev-libs/H-1": {"IUSE": "doc"},
         }
 
         installed = {
             "dev-libs/B-1": {},
             "dev-libs/C-1": {},
             "dev-libs/D-1": {},
+            "dev-libs/E-1": {"IUSE": "static"},
+            "dev-libs/F-1": {"IUSE": "static"},
+            "dev-libs/G-1": {"IUSE": "static", "USE": "static"},
+            "dev-libs/H-1": {"IUSE": "static", "USE": "static"},
         }
 
         binpkgs = {
@@ -33,6 +41,28 @@ class BuildPkgTestCase(TestCase):
                 "BUILD_TIME": "1",
                 "KEYWORDS": "~amd64",
             },
+            "dev-libs/E-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+                "IUSE": "static",
+            },
+            "dev-libs/F-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+                "IUSE": "static",
+                "USE": "static",
+            },
+            "dev-libs/G-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+                "IUSE": "static",
+            },
+            "dev-libs/H-1": {
+                "BUILD_ID": "1",
+                "BUILD_TIME": "1",
+                "IUSE": "static",
+                "USE": "static",
+            },
             "dev-libs/X-1": {
                 "BUILD_ID": "1",
                 "BUILD_TIME": "1",
@@ -40,7 +70,7 @@ class BuildPkgTestCase(TestCase):
         }
 
         user_config = {
-            "make.conf": ('FEATURES="buildpkg buildpkg-proactive"',),
+            "make.conf": ('FEATURES="buildpkg buildpkg-proactive"', 'USE="static"'),
             "package.accept_keywords": ("dev-libs/D amd64",),
         }
 
@@ -68,6 +98,54 @@ class BuildPkgTestCase(TestCase):
                 success=True,
                 options={"--update": True},
                 mergelist=["dev-libs/D-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/E"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "y"},
+                mergelist=["dev-libs/E-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/E"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "n"},
+                mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "y"},
+                mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/F"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "n"},
+                mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/G"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "y"},
+                mergelist=["dev-libs/G-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/G"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "n"},
+                mergelist=[],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/H"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "y"},
+                mergelist=["dev-libs/H-1"],
+            ),
+            ResolverPlaygroundTestCase(
+                ["dev-libs/H"],
+                success=True,
+                options={"--update": True, "--binpkg-respect-use": "n"},
+                mergelist=[],
             ),
         )
 

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -414,6 +414,12 @@ When this option is enabled (the default), \fBbuildpkg\fR will exhibit
 the default behavior of building binary cache for all packages. When
 it is disabled, binary packages will not be created for live ebuilds.
 .TP
+.B buildpkg\-proactive
+Proactively rebuild packages that have no (usable) binary package. This only
+applies to installed packages that Portage is already checking but would
+otherwise not consider rebuilding, e.g. because they're already up-to-date.
+This does nothing unless \fBbuildpkg\fR or \fBbuildsyspkg\fR is also enabled.
+.TP
 .B buildsyspkg
 Build binary packages for just packages in the system set.
 .TP

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -419,6 +419,8 @@ Proactively rebuild packages that have no (usable) binary package. This only
 applies to installed packages that Portage is already checking but would
 otherwise not consider rebuilding, e.g. because they're already up-to-date.
 This does nothing unless \fBbuildpkg\fR or \fBbuildsyspkg\fR is also enabled.
+When \fBemerge\fR(1) \fB--binpkg-respect-use\fR is enabled (it usually is),
+binary packages will also be rebuilt if the USE flags have changed.
 .TP
 .B buildsyspkg
 Build binary packages for just packages in the system set.

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -419,8 +419,9 @@ Proactively rebuild packages that have no (usable) binary package. This only
 applies to installed packages that Portage is already checking but would
 otherwise not consider rebuilding, e.g. because they're already up-to-date.
 This does nothing unless \fBbuildpkg\fR or \fBbuildsyspkg\fR is also enabled.
-When \fBemerge\fR(1) \fB--binpkg-respect-use\fR is enabled (it usually is),
-binary packages will also be rebuilt if the USE flags have changed.
+When \fBemerge\fR(1) \fB--binpkg-respect-use\fR or \fB--binpkg-changed-deps\fR
+are enabled (they usually are), binary packages will also be rebuilt if the USE
+flags or dependencies have changed.
 .TP
 .B buildsyspkg
 Build binary packages for just packages in the system set.


### PR DESCRIPTION
If you build binary packages in order to do a `--usepkgonly` build later, you want to be sure that no packages are missing and that the packages you do have will actually be visible, e.g. they were not built when a now stable package was previously unstable.

This will proactively rebuild matching packages that have no (usable) binary package, even if those packages are already installed.

This required some refactoring of the logic around whether to build a binary package or not. Note that it is not necessary to check whether `--buildpkg=n` was given because `adjust_config()` already takes care of that.

I thought about automatically enabling `buildpkg-proactive` when `--buildpkgonly` is given, but that option applies to / as well as ROOT, so this would have been unhelpful.

Bug: https://bugs.gentoo.org/976083