### PR TITLE
emerge: skip world warning with --usepkgonly

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,8 @@ Bug fixes:
 * Respect --usepkg=n and --getbinpkg=n on command line if the user has set
   FEATURES=getbinpkg (bug #759067)
 
+* emerge: Suppress world file warning for missing ebuilds with usepkgonly (bug #976362)
+
 portage-3.0.80 (2026-06-17)
 --------------
 

--- a/NEWS
+++ b/NEWS
@@ -46,6 +46,8 @@ Bug fixes:
 
 * emerge: Suppress world file warning for missing ebuilds with usepkgonly (bug #976362)
 
+* emerge: Fix typo in world file warning check.
+
 portage-3.0.80 (2026-06-17)
 --------------
 

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -5389,7 +5389,7 @@ class depgraph:
                         and pkg.installed
                         and pkg.operation == "nomerge"
                         and isinstance(arg, SetArg)
-                        and arg.name in ("selected, world")
+                        and arg.name in ("selected", "world")
                         and not self._replace_installed_atom(pkg)
                         and not self._frozen_config.excluded_pkgs.findAtomForPackage(
                             pkg

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -5325,6 +5325,7 @@ class depgraph:
         a favorite list."""
         debug = "--debug" in self._frozen_config.myopts
         onlydeps = "--onlydeps" in self._frozen_config.myopts
+        usepkgonly = self._frozen_config.myopts.get("--usepkgonly", False)
         args = self._dynamic_config._initial_arg_list[:]
 
         for arg in self._expand_set_args(args, add_to_digraph=True):
@@ -5383,6 +5384,7 @@ class depgraph:
                     if (
                         self._frozen_config.myopts.get("--verbose-missing-ebuilds", "y")
                         != "n"
+                        and not usepkgonly
                         and pkg
                         and pkg.installed
                         and pkg.operation == "nomerge"

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1884,7 +1884,7 @@ class binarytree:
                             writemsg(
                                 colorize(
                                     "WARN",
-                                    f"[{binrepo_name} Remote XPAK packages in '{remote_base_uri}' are ignored due to 'binpkg-request-signature'.\n",
+                                    f"[{binrepo_name}] Remote XPAK packages in '{remote_base_uri}' are ignored due to 'binpkg-request-signature'.\n",
                                 ),
                                 noiselevel=-1,
                             )

--- a/lib/portage/tests/resolver/test_world_warning.py
+++ b/lib/portage/tests/resolver/test_world_warning.py
@@ -54,6 +54,52 @@ class WorldWarningTestCase(TestCase):
         finally:
             playground.cleanup()
 
+    def testNoWorldWarningEmergeBinpkgOnly(self):
+        """
+        Test that we do not warn about a package in @world with no ebuild.
+        """
+        installed = {
+            "app-misc/i-do-not-exist-1": {},
+        }
+        ebuilds = {}
+
+        playground = ResolverPlayground(
+            world=["app-misc/i-do-not-exist"],
+            ebuilds=ebuilds,
+            installed=installed,
+        )
+
+        test_case = ResolverPlaygroundTestCase(
+            ["@world"],
+            mergelist=[],
+            options={
+                "--update": True,
+                "--deep": True,
+                "--usepkgonly": True,
+            },
+            success=True,
+        )
+
+        try:
+            # Just to make sure we don't freak out on the general case
+            # without worrying about the specific output first.
+            playground.run_TestCase(test_case)
+            self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+
+            # We need access to the depgraph object to check for missing_args
+            # so we run again manually.
+            depgraph = playground.run(
+                ["@world"], test_case.options, test_case.action
+            ).depgraph
+
+            self.assertIsNotNone(depgraph._dynamic_config._missing_args)
+            self.assertTrue(
+                len(depgraph._dynamic_config._missing_args) == 0,
+                "Wrongly warned with --usepkgonly",
+            )
+        finally:
+            playground.cleanup()
+
     def testWorldWarningVsSubslotRebuildEmerge(self):
         """
         Test that we warn about a package in @world with no ebuild


### PR DESCRIPTION
The check doesn't make sense as-written for --usepkgonly because
of how usepkgonly works. It's expected that some candidates may be
skipped in _replace_installed_atom.

Bug: https://bugs.gentoo.org/976362
Bug: https://bugs.gentoo.org/976699
Signed-off-by: Sam James <sam@gentoo.org>

---

The regression here is my fault, so I couldn't leave it alone.