### PR TITLE
doebuild: Allow BROOT, ESYSROOT, and SYSROOT to be exported under EAPI 9

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,12 @@ Features:
   that have no (usable) binary package, even if those packages are already
   installed. (bug #976083)
 
+Bug fixes:
+
+* Allow BROOT, ESYSROOT, and SYSROOT to be exported again under EAPI 9 because
+  they are required by crossdev's cross-pkg-config and a Gentoo GCC patch when
+  cross-compiling with a SYSROOT other than /usr/${CHOST}. (bug #977170)
+
 portage-3.0.79 (2026-05-22)
 --------------
 

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2025 Gentoo Authors
+# Copyright 2010-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ["doebuild", "doebuild_environment", "spawn", "spawnebuild"]
@@ -196,9 +196,9 @@ _unexported_pms_vars = frozenset(
         "ECLASSDIR",
         "ROOT",
         "EROOT",
-        "SYSROOT",
-        "ESYSROOT",
-        "BROOT",
+#        "SYSROOT",       # EXPORTED: used by crossdev's cross-pkg-config
+#        "ESYSROOT",      # EXPORTED: used by a Gentoo GCC patch and crossdev's cross-pkg-config
+#        "BROOT",         # EXPORTED: used by a Gentoo GCC patch
         "T",
 #        "TMPDIR",        # EXPORTED: often assumed to be exported and available to child processes
 #        "HOME",          # EXPORTED: often assumed to be exported and available to child processes


### PR DESCRIPTION
They are required by crossdev's cross-pkg-config and a Gentoo GCC patch when cross-compiling with a `SYSROOT` other than `/usr/${CHOST}`.

I'm currently doing a Flatcar build with this change to ensure no other variables are commonly needed.

Bug: https://bugs.gentoo.org/977170