### PR TITLE
doebuild: Re-export SYSROOT, ESYSROOT, and BROOT in EAPI 9

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -196,9 +196,9 @@ _unexported_pms_vars = frozenset(
         "ECLASSDIR",
         "ROOT",
         "EROOT",
-        "SYSROOT",
-        "ESYSROOT",
-        "BROOT",
+#        "SYSROOT",       # EXPORTED: required for cross-compiling
+#        "ESYSROOT",      # EXPORTED: required for cross-compiling
+#        "BROOT",         # EXPORTED: required for cross-compiling
         "T",
 #        "TMPDIR",        # EXPORTED: often assumed to be exported and available to child processes
 #        "HOME",          # EXPORTED: often assumed to be exported and available to child processes


### PR DESCRIPTION
It turns out that SYSROOT, ESYSROOT, and BROOT need to be exported for cross compilation. Re-export those PMS variables again in EAPI 9.

Bug: https://bugs.gentoo.org/977170