### PR TITLE
Improve man text about disabling tests

### DIFF
--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -856,10 +856,12 @@ and \fIsrc_test()\fR in \fBebuild\fR(5). This feature implies the "test"
 \fBUSE\fR flag.
 .TP
 .B test\-fail\-continue
-If "test" is enabled \fBFEATURES\fR and the test phase of an ebuild fails,
-continue to execute the remaining phases as if the failure had not occurred.
-Note that the test phase for a specific package may be disabled by masking
-the "test" \fBUSE\fR flag in \fBpackage.use.mask\fR (see \fBportage\fR(5)).
+If \fItest\fR is enabled and the test phase of an ebuild fails, continue to
+execute the remaining phases as if the failure had not occurred.
+
+Note that the test phase for an individual package can be disabled by setting
+\%FEATURES="-test" for that package specifically. Refer to \%\fBpackage.env\fR
+in \%\fBportage\fR(5) for creating per\-package environment variable settings.
 .TP
 .B unknown\-features\-filter
 Filter out any unknown values that the FEATURES variable contains.


### PR DESCRIPTION
The old suggestion of using p.use.mask to selectively disable tests doesn't
work for packages that don't have test in IUSE.