### PR TITLE
Add FEATURES="observability" for emerge status reporting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -183,6 +183,11 @@ Breaking changes:
 
 Features:
 
+* Add FEATURES="observability" to publish a machine-readable snapshot of the
+  running emerge process (which packages are building/merging, their current
+  ebuild phase, and elapsed time) to /run/portage/emerge-<pid>.json. Query it
+  with the new "portageq jobs" command or "emerge --status".
+
 * Add User-Agent to default wget FETCHCOMMAND and RESUMECOMMAND settings, as
   well as emirrordist, in order to avoid blocking by some web servers,
   particularly crates.io. (bug #682610)

--- a/NEWS
+++ b/NEWS
@@ -186,7 +186,8 @@ Features:
 * Add FEATURES="observability" to publish a machine-readable snapshot of the
   running emerge process (which packages are building/merging, their current
   ebuild phase, and elapsed time) to /run/portage/emerge-<pid>.json. Query it
-  with the new "portageq jobs" command or "emerge --status".
+  with the new "portageq jobs" command or "emerge --status". A Unix socket
+  streams the same snapshots live to connected clients.
 
 * Add User-Agent to default wget FETCHCOMMAND and RESUMECOMMAND settings, as
   well as emirrordist, in order to avoid blocking by some web servers,

--- a/bin/portageq
+++ b/bin/portageq
@@ -219,6 +219,25 @@ try:
 		"""
     mass_best_version.__doc__ = docstrings["mass_best_version"]
 
+    def jobs(argv):
+        import json as _json
+        from _emerge._observability import read_snapshots, format_snapshots
+        from portage.const import EPREFIX
+
+        snapshots = read_snapshots(EPREFIX)
+        if "--json" in argv:
+            print(_json.dumps(snapshots, sort_keys=True, indent=2))
+        else:
+            sys.stdout.write(format_snapshots(snapshots))
+        return 0
+
+    docstrings["jobs"] = """[--json]
+		Show packages currently being built/merged by running emerge
+		processes (requires FEATURES="observability").  With --json, emit
+		the raw status snapshots.
+		"""
+    jobs.__doc__ = docstrings["jobs"]
+
     @uses_eroot
     def metadata(argv):
         if len(argv) < 4:

--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -141,6 +141,14 @@ class EbuildPhase(CompositeTask):
     _locked_phases = ("setup", "preinst", "postinst", "prerm", "postrm")
 
     def _start(self):
+        # Notify the observability monitor (if any) that this package has
+        # entered a new ebuild phase, so "what is building?" queries reflect
+        # the live phase.  Guarded since not every SchedulerInterface that
+        # runs phases (e.g. the standalone `ebuild` command) provides it.
+        notify_phase = getattr(self.scheduler, "notifyPhase", None)
+        if notify_phase is not None:
+            notify_phase(self.settings.mycpv, self.phase)
+
         future = asyncio.ensure_future(self._async_start(), loop=self.scheduler)
         self._start_task(AsyncTaskFuture(future=future), self._async_start_exit)
 

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -54,6 +54,7 @@ from _emerge.getloadavg import getloadavg
 from _emerge._find_deep_system_runtime_deps import _find_deep_system_runtime_deps
 from _emerge._flush_elog_mod_echo import _flush_elog_mod_echo
 from _emerge.JobStatusDisplay import JobStatusDisplay
+from _emerge._observability import ObservabilityMonitor
 from _emerge.MergeListItem import MergeListItem
 from _emerge.Package import Package
 from _emerge.PackageMerge import PackageMerge
@@ -82,7 +83,7 @@ class Scheduler(PollScheduler):
     )
 
     class _iface_class(SchedulerInterface):
-        __slots__ = ("fetch", "scheduleSetup", "scheduleUnpack")
+        __slots__ = ("fetch", "scheduleSetup", "scheduleUnpack", "notifyPhase")
 
     class _fetch_iface_class(SlotObject):
         __slots__ = ("log_file", "schedule")
@@ -227,6 +228,7 @@ class Scheduler(PollScheduler):
         self._status_display = JobStatusDisplay(
             xterm_titles=("notitles" not in settings.features)
         )
+        self._observability = ObservabilityMonitor(self)
         self._max_load = myopts.get("--load-average")
         max_jobs = myopts.get("--jobs", 1)
         self._set_max_jobs(max_jobs)
@@ -261,6 +263,7 @@ class Scheduler(PollScheduler):
             fetch=fetch_iface,
             scheduleSetup=self._schedule_setup,
             scheduleUnpack=self._schedule_unpack,
+            notifyPhase=self._observability_phase,
         )
 
         self._prefetchers = weakref.WeakValueDictionary()
@@ -393,6 +396,14 @@ class Scheduler(PollScheduler):
 
         for q in self._task_queues.values():
             q.clear()
+
+    def _observability_phase(self, cpv, phase):
+        """Record that the given package has entered the named ebuild phase.
+
+        Invoked by EbuildPhase via the scheduler interface's notifyPhase
+        callback so the observability snapshot reflects the live phase.
+        """
+        self._observability.note_phase(cpv, phase)
 
     def _init_graph(self, graph_config):
         """
@@ -1492,11 +1503,13 @@ class Scheduler(PollScheduler):
 
     def _merge_exit(self, merge):
         self._running_tasks.pop(id(merge), None)
+        self._observability.note_task_finished(merge)
         self._do_merge_exit(merge)
         self._deallocate_config(merge.merge.settings)
         if merge.returncode == os.EX_OK and not merge.merge.pkg.installed:
             self._status_display.curval += 1
         self._status_display.merges = len(self._task_queues.merge)
+        self._observability.update()
         self._schedule()
 
     def _do_merge_exit(self, merge):
@@ -1562,6 +1575,7 @@ class Scheduler(PollScheduler):
 
     def _build_exit(self, build):
         self._running_tasks.pop(id(build), None)
+        self._observability.note_task_finished(build)
         self._release_job_token(id(build))
         if build.returncode == os.EX_OK and self._terminated_tasks:
             # We've been interrupted, so we won't
@@ -1577,6 +1591,7 @@ class Scheduler(PollScheduler):
             )
             # move the job token to the merge task
             self._running_tasks[id(merge)] = merge
+            self._observability.note_task_started(merge)
             # By default, merge-wait only allows merge when no builds are executing.
             # As a special exception, dependencies on system packages are frequently
             # unspecified and will therefore force merge-wait.
@@ -1610,6 +1625,7 @@ class Scheduler(PollScheduler):
         self._jobs -= 1
         self._status_display.running = self._jobs
         self._status_display.merge_wait = len(self._merge_wait_queue)
+        self._observability.update()
         self._schedule()
 
     def _extract_exit(self, build):
@@ -1720,6 +1736,7 @@ class Scheduler(PollScheduler):
             self._main_loop()
         finally:
             self._main_loop_cleanup()
+            self._observability.close()
             portage.locks._quiet = False
             portage.elog.remove_listener(self._elog_listener)
             if display_callback.handle is not None:
@@ -2233,6 +2250,7 @@ class Scheduler(PollScheduler):
             if pkg.installed:
                 merge = PackageMerge(merge=task, scheduler=self._sched_iface)
                 self._running_tasks[id(merge)] = merge
+                self._observability.note_task_started(merge)
                 self._task_queues.merge.addFront(merge)
                 merge.addExitListener(self._merge_exit)
 
@@ -2242,6 +2260,7 @@ class Scheduler(PollScheduler):
                 self._status_display.running = self._jobs
                 self._jobserver_tokens[id(task)] = token
                 self._running_tasks[id(task)] = task
+                self._observability.note_task_started(task)
                 task.scheduler = self._sched_iface
                 self._task_queues.jobs.add(task)
 
@@ -2249,6 +2268,8 @@ class Scheduler(PollScheduler):
                     task.addExitListener(self._extract_exit)
                 else:
                     task.addExitListener(self._build_exit)
+
+            self._observability.update()
 
     def _get_prefetcher(self, pkg):
         try:

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+"""
+Observability support for a running emerge process.
+
+When FEATURES="observability" is enabled, the Scheduler publishes a
+machine-readable snapshot of its current state (which packages are
+building/merging, in which phase, for how long) to a JSON status file
+under PORTAGE_RUN_PATH (e.g. /run/portage/emerge-<pid>.json).  External
+consumers can poll this file (see ``portageq jobs`` / ``emerge --status``).
+
+Every object carries a "type" field naming its kind ("snapshot" today).
+Consumers must dispatch on it and ignore kinds they do not know, so that
+other kinds can be added later without breaking them.
+
+Everything here degrades silently: if the runtime directory is not
+writable (e.g. unprivileged, no /run) emerge proceeds unaffected.
+"""
+
+import json
+import os as _os
+import time
+
+import portage
+import portage.exception
+from portage import os
+from portage.const import PORTAGE_RUN_PATH
+from portage.util import atomic_ofstream, ensure_dirs, writemsg_level
+
+_SCHEMA_VERSION = 1
+
+
+def _task_pkg(task):
+    """Return the Package associated with a running task, or None."""
+    pkg = getattr(task, "pkg", None)
+    if pkg is not None:
+        return pkg
+    merge = getattr(task, "merge", None)
+    if merge is not None:
+        return getattr(merge, "pkg", None)
+    return None
+
+
+def _task_pid(task):
+    """Return the live PID for task, or None."""
+    seen = set()
+    current = task
+    for _ in range(16):
+        if current is None or id(current) in seen:
+            break
+        seen.add(id(current))
+        pid = getattr(current, "pid", None)
+        if pid:
+            return pid
+        current = getattr(current, "_current_task", None)
+    return None
+
+
+def build_snapshot(monitor):
+    """Serialize the scheduler's current state into a plain dict."""
+    scheduler = monitor._scheduler
+    now = time.time()
+
+    tasks = []
+    for task in scheduler._running_tasks.values():
+        pkg = _task_pkg(task)
+        if pkg is None:
+            continue
+        # PackageMerge installs an already-built package; everything else
+        # represents an in-progress build/extract.
+        kind = "merge" if task.__class__.__name__ == "PackageMerge" else "build"
+        start = monitor._task_start.get(id(task))
+        tasks.append(
+            {
+                "cpv": str(pkg.cpv),
+                "category": pkg.category,
+                "pf": pkg.pf,
+                "root": pkg.root,
+                "operation": getattr(pkg, "operation", None),
+                "binary": bool(getattr(pkg, "built", False)),
+                "kind": kind,
+                "phase": monitor._phases.get(str(pkg.cpv)),
+                "pid": _task_pid(task),
+                "start_time": start,
+                "elapsed": (now - start) if start is not None else None,
+            }
+        )
+
+    tasks.sort(key=lambda t: (t["start_time"] is None, t["start_time"] or 0))
+
+    display = scheduler._status_display
+    return {
+        "type": "snapshot",
+        "schema": _SCHEMA_VERSION,
+        "emerge_pid": _os.getpid(),
+        "timestamp": now,
+        "jobs": {
+            "running": scheduler._jobs,
+            "max": scheduler._max_jobs,
+            "completed": display.curval,
+            "total": display.maxval,
+            "failed": len(scheduler._failed_pkgs),
+            "merge_wait": len(scheduler._merge_wait_queue),
+            "merges_pending": len(scheduler._task_queues.merge),
+        },
+        "tasks": tasks,
+    }
+
+
+def status_dir(eprefix=""):
+    """Directory where running emerge processes publish status files."""
+    if eprefix:
+        return os.path.join(eprefix, PORTAGE_RUN_PATH.lstrip(os.sep))
+    return PORTAGE_RUN_PATH
+
+
+def read_snapshots(eprefix=""):
+    """Read all live emerge status files; return a list of snapshot dicts."""
+    import glob
+
+    snapshots = []
+    for path in sorted(glob.glob(os.path.join(status_dir(eprefix), "emerge-*.json"))):
+        try:
+            with open(path, encoding="utf_8") as f:
+                snapshot = json.load(f)
+        except (OSError, ValueError):
+            continue
+        pid = snapshot.get("emerge_pid")
+        if not isinstance(pid, int) or pid <= 0 or not _pid_alive(pid):
+            continue
+        snapshots.append(snapshot)
+    return snapshots
+
+
+def _pid_alive(pid):
+    if pid <= 0:
+        return False
+    try:
+        _os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def format_snapshots(snapshots):
+    """Render snapshots as a human-readable table."""
+    if not snapshots:
+        return "No emerge processes are currently running.\n"
+
+    lines = []
+    for snapshot in snapshots:
+        jobs = snapshot.get("jobs", {})
+        lines.append(
+            "emerge[{pid}]: {running} running, {completed}/{total} done, "
+            "{failed} failed".format(
+                pid=snapshot.get("emerge_pid", "?"),
+                running=jobs.get("running", 0),
+                completed=jobs.get("completed", 0),
+                total=jobs.get("total", 0),
+                failed=jobs.get("failed", 0),
+            )
+        )
+        for task in snapshot.get("tasks", []):
+            elapsed = task.get("elapsed")
+            elapsed_str = f"{max(0, int(elapsed))}s" if elapsed is not None else "-"
+            phase = task.get("phase") or task.get("kind") or "-"
+            lines.append(f"  {task.get('cpv', '?'):<45} {phase:<10} {elapsed_str:>7}")
+    return "\n".join(lines) + "\n"
+
+
+class ObservabilityMonitor:
+    """Owns the status file for one Scheduler.
+
+    All public methods are no-ops when the feature is disabled, so the
+    Scheduler can call them unconditionally.
+    """
+
+    # Don't rewrite the status file more often than this (seconds), to
+    # bound IO when many short phases churn.  Mirrors JobStatusDisplay's
+    # rate-limiting intent.
+    _min_write_latency = 1.0
+
+    def __init__(self, scheduler):
+        self._scheduler = scheduler
+        settings = scheduler.settings
+
+        self.enabled = "observability" in settings.features
+
+        # id(task) -> epoch start time; str(cpv) -> current phase name.
+        self._task_start = {}
+        self._phases = {}
+
+        self._status_path = None
+        self._last_write = 0
+
+        if not self.enabled:
+            return
+
+        run_dir = status_dir(settings.get("EPREFIX", ""))
+        pid = _os.getpid()
+        self._run_dir = run_dir
+        self._status_path = os.path.join(run_dir, f"emerge-{pid}.json")
+
+    def note_task_started(self, task):
+        if not self.enabled:
+            return
+        self._task_start[id(task)] = time.time()
+
+    def note_task_finished(self, task):
+        if not self.enabled:
+            return
+        self._task_start.pop(id(task), None)
+        pkg = _task_pkg(task)
+        # Only forget the phase once nothing is running for this cpv.
+        if pkg is not None and task.__class__.__name__ == "PackageMerge":
+            self._phases.pop(str(pkg.cpv), None)
+
+    def note_phase(self, cpv, phase):
+        if not self.enabled:
+            return
+        self._phases[str(cpv)] = phase
+        self.update()
+
+    def update(self, force=False):
+        """Recompute the snapshot and publish it (rate-limited)."""
+        if not self.enabled:
+            return
+        now = time.time()
+        if not force and (now - self._last_write) < self._min_write_latency:
+            return
+        self._last_write = now
+
+        try:
+            snapshot = build_snapshot(self)
+        except Exception as e:
+            writemsg_level(
+                f"!!! observability: failed to build snapshot: {e}\n",
+                level=30,
+                noiselevel=-1,
+            )
+            self.enabled = False
+            return
+
+        self._write_status_file(snapshot)
+
+    def _write_status_file(self, snapshot):
+        try:
+            ensure_dirs(self._run_dir, mode=0o755)
+            f = atomic_ofstream(self._status_path, mode="w", encoding="utf_8")
+            json.dump(snapshot, f, sort_keys=True)
+            f.write("\n")
+            f.close()
+        except (OSError, portage.exception.PortageException) as e:
+            # Typically EACCES/EROFS for unprivileged emerge or no /run.
+            writemsg_level(
+                f"!!! observability: cannot write {self._status_path}: {e}\n",
+                level=30,
+                noiselevel=-1,
+            )
+            self._status_path = None
+            self.enabled = False
+
+    def close(self):
+        if self._status_path:
+            try:
+                _os.unlink(self._status_path)
+            except OSError:
+                pass

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -10,6 +10,10 @@ building/merging, in which phase, for how long) to a JSON status file
 under PORTAGE_RUN_PATH (e.g. /run/portage/emerge-<pid>.json).  External
 consumers can poll this file (see ``portageq jobs`` / ``emerge --status``).
 
+A Unix-domain socket at /run/portage/emerge-<pid>.sock additionally streams
+newline-delimited JSON snapshots: the current snapshot on connect, then one
+line per update.
+
 Every object carries a "type" field naming its kind ("snapshot" today).
 Consumers must dispatch on it and ignore kinds they do not know, so that
 other kinds can be added later without breaking them.
@@ -22,11 +26,14 @@ import json
 import os as _os
 import time
 
+import asyncio as _asyncio
+
 import portage
 import portage.exception
 from portage import os
 from portage.const import PORTAGE_RUN_PATH
 from portage.util import atomic_ofstream, ensure_dirs, writemsg_level
+from portage.util.futures import asyncio
 
 from _emerge.PackageMerge import PackageMerge as _PackageMerge
 
@@ -197,7 +204,7 @@ def format_snapshots(snapshots):
 
 
 class ObservabilityMonitor:
-    """Owns the status file for one Scheduler.
+    """Owns the status file and streaming socket for one Scheduler.
 
     All public methods are no-ops when the feature is disabled, so the
     Scheduler can call them unconditionally.
@@ -221,7 +228,12 @@ class ObservabilityMonitor:
         self._build_times = {}
 
         self._status_path = None
+        self._socket_path = None
+        self._server = None
+        self._writers = []
+        self._server_started = False
         self._last_write = 0
+        self._last_snapshot = None
 
         if not self.enabled:
             return
@@ -230,6 +242,7 @@ class ObservabilityMonitor:
         pid = _os.getpid()
         self._run_dir = run_dir
         self._status_path = os.path.join(run_dir, f"emerge-{pid}.json")
+        self._socket_path = os.path.join(run_dir, f"emerge-{pid}.sock")
 
     def note_task_started(self, task):
         if not self.enabled:
@@ -283,7 +296,10 @@ class ObservabilityMonitor:
             self.enabled = False
             return
 
+        self._last_snapshot = snapshot
         self._write_status_file(snapshot)
+        self._ensure_server()
+        self._broadcast(snapshot)
 
     def _write_status_file(self, snapshot):
         try:
@@ -302,9 +318,84 @@ class ObservabilityMonitor:
             self._status_path = None
             self.enabled = False
 
-    def close(self):
-        if self._status_path:
+    def _ensure_server(self):
+        if self._server_started:
+            return
+        self._server_started = True
+        try:
+            ensure_dirs(self._run_dir, mode=0o755)
             try:
-                _os.unlink(self._status_path)
+                _os.unlink(self._socket_path)
+            except FileNotFoundError:
+                pass
+            coro = _asyncio.start_unix_server(self._client_connected, self._socket_path)
+            future = asyncio.ensure_future(coro)
+            future.add_done_callback(self._server_ready)
+        except Exception as e:
+            writemsg_level(
+                f"!!! observability: socket setup failed: {e}\n",
+                level=30,
+                noiselevel=-1,
+            )
+
+    def _server_ready(self, future):
+        try:
+            self._server = future.result()
+            try:
+                _os.chmod(self._socket_path, 0o600)
             except OSError:
                 pass
+        except Exception as e:
+            writemsg_level(
+                f"!!! observability: socket server failed: {e}\n",
+                level=30,
+                noiselevel=-1,
+            )
+
+    def _client_connected(self, reader, writer):
+        self._writers.append(writer)
+        if self._last_snapshot is not None:
+            data = (json.dumps(self._last_snapshot, sort_keys=True) + "\n").encode(
+                "utf_8"
+            )
+            self._send(writer, data)
+
+    def _broadcast(self, snapshot):
+        if not self._writers:
+            return
+        data = (json.dumps(snapshot, sort_keys=True) + "\n").encode("utf_8")
+        for writer in list(self._writers):
+            if not self._send(writer, data):
+                self._writers.remove(writer)
+
+    @staticmethod
+    def _send(writer, data):
+        try:
+            writer.write(data)
+            return True
+        except Exception:
+            try:
+                writer.close()
+            except Exception:
+                pass
+            return False
+
+    def close(self):
+        for writer in self._writers:
+            try:
+                writer.close()
+            except Exception:
+                pass
+        self._writers = []
+        if self._server is not None:
+            try:
+                self._server.close()
+            except Exception:
+                pass
+            self._server = None
+        for path in (self._status_path, self._socket_path):
+            if path:
+                try:
+                    _os.unlink(path)
+                except OSError:
+                    pass

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -28,6 +28,8 @@ from portage import os
 from portage.const import PORTAGE_RUN_PATH
 from portage.util import atomic_ofstream, ensure_dirs, writemsg_level
 
+from _emerge.PackageMerge import PackageMerge as _PackageMerge
+
 _SCHEMA_VERSION = 1
 
 
@@ -62,6 +64,8 @@ def build_snapshot(monitor):
     scheduler = monitor._scheduler
     now = time.time()
 
+    merge_wait_ids = {id(t) for t in getattr(scheduler, "_merge_wait_queue", ())}
+
     tasks = []
     for task in scheduler._running_tasks.values():
         pkg = _task_pkg(task)
@@ -69,23 +73,42 @@ def build_snapshot(monitor):
             continue
         # PackageMerge installs an already-built package; everything else
         # represents an in-progress build/extract.
-        kind = "merge" if task.__class__.__name__ == "PackageMerge" else "build"
-        start = monitor._task_start.get(id(task))
-        tasks.append(
-            {
-                "cpv": str(pkg.cpv),
-                "category": pkg.category,
-                "pf": pkg.pf,
-                "root": pkg.root,
-                "operation": getattr(pkg, "operation", None),
-                "binary": bool(getattr(pkg, "built", False)),
-                "kind": kind,
-                "phase": monitor._phases.get(str(pkg.cpv)),
-                "pid": _task_pid(task),
-                "start_time": start,
-                "elapsed": (now - start) if start is not None else None,
-            }
-        )
+        cpv = str(pkg.cpv)
+        kind = "merge" if isinstance(task, _PackageMerge) else "build"
+        waiting = id(task) in merge_wait_ids
+
+        # Prefer the build's own start/finish times (continuous across the
+        # build -> merge hand-off) over the per-task start time.
+        times = monitor._build_times.get(cpv)
+        if times is not None:
+            start, build_finished = times[0], times[1]
+        else:
+            start, build_finished = monitor._task_start.get(id(task)), None
+
+        # A package waiting to merge is done building: freeze its elapsed time at
+        # build completion rather than letting the wait inflate it.
+        if waiting and build_finished is not None and start is not None:
+            elapsed = build_finished - start
+        elif start is not None:
+            elapsed = now - start
+        else:
+            elapsed = None
+
+        entry = {
+            "cpv": cpv,
+            "category": pkg.category,
+            "pf": pkg.pf,
+            "root": pkg.root,
+            "operation": getattr(pkg, "operation", None),
+            "binary": bool(getattr(pkg, "built", False)),
+            "kind": kind,
+            "phase": "merge-wait" if waiting else monitor._phases.get(cpv),
+            "merge_wait": waiting,
+            "pid": _task_pid(task),
+            "start_time": start,
+            "elapsed": elapsed,
+        }
+        tasks.append(entry)
 
     tasks.sort(key=lambda t: (t["start_time"] is None, t["start_time"] or 0))
 
@@ -194,6 +217,8 @@ class ObservabilityMonitor:
         # id(task) -> epoch start time; str(cpv) -> current phase name.
         self._task_start = {}
         self._phases = {}
+        # str(cpv) -> [build_start, build_finished or None]
+        self._build_times = {}
 
         self._status_path = None
         self._last_write = 0
@@ -209,16 +234,28 @@ class ObservabilityMonitor:
     def note_task_started(self, task):
         if not self.enabled:
             return
-        self._task_start[id(task)] = time.time()
+        now = time.time()
+        self._task_start[id(task)] = now
+        if not isinstance(task, _PackageMerge):
+            pkg = _task_pkg(task)
+            if pkg is not None:
+                self._build_times[str(pkg.cpv)] = [now, None]
 
     def note_task_finished(self, task):
         if not self.enabled:
             return
         self._task_start.pop(id(task), None)
         pkg = _task_pkg(task)
-        # Only forget the phase once nothing is running for this cpv.
-        if pkg is not None and task.__class__.__name__ == "PackageMerge":
-            self._phases.pop(str(pkg.cpv), None)
+        if pkg is None:
+            return
+        cpv = str(pkg.cpv)
+        if isinstance(task, _PackageMerge):
+            self._phases.pop(cpv, None)
+            self._build_times.pop(cpv, None)
+        else:
+            times = self._build_times.get(cpv)
+            if times is not None:
+                times[1] = time.time()
 
     def note_phase(self, cpv, phase):
         if not self.enabled:

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -311,6 +311,7 @@ def parse_opts(tmpcmdline, silent=False):
             "rage-clean",
             "regen",
             "search",
+            "status",
             "sync",
             "unmerge",
             "version",
@@ -1255,6 +1256,14 @@ def emerge_main(args: Optional[list[str]] = None):
         return os.EX_OK
     if myaction == "moo":
         print(COWSAY_MOO.format(platform.system()))
+        return os.EX_OK
+    if myaction == "status":
+        # Report what running emerge processes are currently building.
+        # (For machine-readable output, use `portageq jobs --json`.)
+        from _emerge._observability import read_snapshots, format_snapshots
+        from portage.const import EPREFIX
+
+        sys.stdout.write(format_snapshots(read_snapshots(EPREFIX)))
         return os.EX_OK
     if myaction == "sync":
         # need to set this to True now in order for the repository config

--- a/lib/_emerge/meson.build
+++ b/lib/_emerge/meson.build
@@ -92,6 +92,7 @@ py.install_sources(
         'unmerge.py',
         '_find_deep_system_runtime_deps.py',
         '_flush_elog_mod_echo.py',
+        '_observability.py',
         '__init__.py',
     ],
     subdir : '_emerge',

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -53,6 +53,10 @@ WORLD_SETS_FILE = f"{PRIVATE_PATH}/world_sets"
 CONFIG_MEMORY_FILE = f"{PRIVATE_PATH}/config"
 REPO_REVISIONS = f"{PRIVATE_PATH}/repo_revisions"
 NEWS_LIB_PATH = "var/lib/gentoo"
+# Runtime (volatile) state directory where a running emerge publishes its
+# machine-readable observability status file(s).  This lives on a tmpfs
+# (e.g. /run) rather than under EPREFIX cache, so it is kept separate.
+PORTAGE_RUN_PATH = "/run/portage"
 
 # these variables get EPREFIX prepended automagically when they are
 # translated into their lowercase variants
@@ -212,6 +216,7 @@ SUPPORTED_FEATURES = frozenset(
         "noman",
         "nostrip",
         "notitles",
+        "observability",
         "packdebug",
         "parallel-fetch",
         "parallel-install",

--- a/lib/portage/tests/emerge/meson.build
+++ b/lib/portage/tests/emerge/meson.build
@@ -10,6 +10,7 @@ py.install_sources(
         'test_baseline.py',
         'test_libc_dep_inject.py',
         'test_noreplace.py',
+        'test_observability.py',
         '__init__.py',
         '__test__.py',
     ],

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -15,6 +15,7 @@ from _emerge._observability import (
     read_snapshots,
     status_dir,
 )
+from _emerge.PackageMerge import PackageMerge as _RealPackageMerge
 
 
 class _Pkg:
@@ -32,10 +33,11 @@ class EbuildBuild:
         self.pid = pid
 
 
-class PackageMerge:
+class PackageMerge(_RealPackageMerge):
+    __slots__ = ()
+
     def __init__(self, build):
         self.merge = build
-        self.pkg = build.pkg
 
 
 class _Settings(dict):
@@ -89,6 +91,40 @@ class ObservabilitySnapshotTestCase(TestCase):
         self.assertEqual(by_cpv["dev-libs/foo-1.2"]["pid"], 4321)
         self.assertEqual(by_cpv["dev-libs/foo-1.2"]["kind"], "build")
         self.assertEqual(by_cpv["sys-apps/bar-3"]["kind"], "merge")
+
+    def test_snapshot_marks_merge_wait(self):
+        # A merge sitting in the merge-wait queue is reported as waiting, with
+        # its phase surfaced as "merge-wait".
+        waiting = PackageMerge(EbuildBuild(_Pkg("dev-libs/foo-1.2")))
+        active = EbuildBuild(_Pkg("sys-apps/bar-3"))
+        sched = _make_scheduler(tasks=[waiting, active])
+        sched._merge_wait_queue = [waiting]
+        monitor = ObservabilityMonitor(sched)
+        monitor.note_task_started(waiting)
+        monitor.note_task_started(active)
+
+        snap = build_snapshot(monitor)
+        by_cpv = {t["cpv"]: t for t in snap["tasks"]}
+        self.assertTrue(by_cpv["dev-libs/foo-1.2"]["merge_wait"])
+        self.assertEqual(by_cpv["dev-libs/foo-1.2"]["phase"], "merge-wait")
+        self.assertFalse(by_cpv["sys-apps/bar-3"]["merge_wait"])
+
+    def test_merge_wait_freezes_elapsed_at_build_done(self):
+        waiting = PackageMerge(EbuildBuild(_Pkg("dev-libs/foo-1.2")))
+        sched = _make_scheduler(tasks=[waiting])
+        sched._merge_wait_queue = [waiting]
+        monitor = ObservabilityMonitor(sched)
+        monitor.note_task_started(waiting)
+        # Build started 100s ago and finished building 40s ago: elapsed should
+        # freeze at the 60s build duration, not the ~100s since it started.
+        import time as _t
+
+        now = _t.time()
+        monitor._build_times["dev-libs/foo-1.2"] = [now - 100, now - 40]
+
+        entry = build_snapshot(monitor)["tasks"][0]
+        self.assertEqual(entry["start_time"], now - 100)
+        self.assertAlmostEqual(entry["elapsed"], 60, delta=1)
 
     def test_disabled_when_feature_absent(self):
         sched = _make_scheduler(features=(), tasks=[])

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+
+from portage.tests import TestCase
+
+from _emerge._observability import (
+    ObservabilityMonitor,
+    build_snapshot,
+    format_snapshots,
+    read_snapshots,
+    status_dir,
+)
+
+
+class _Pkg:
+    def __init__(self, cpv, built=False, operation="merge"):
+        self.cpv = cpv
+        self.category, self.pf = cpv.split("/", 1)
+        self.root = "/"
+        self.built = built
+        self.operation = operation
+
+
+class EbuildBuild:
+    def __init__(self, pkg, pid=None):
+        self.pkg = pkg
+        self.pid = pid
+
+
+class PackageMerge:
+    def __init__(self, build):
+        self.merge = build
+        self.pkg = build.pkg
+
+
+class _Settings(dict):
+    """Minimal stand-in for portage config: dict plus a ``features`` set."""
+
+    def __init__(self, features=(), **items):
+        super().__init__(items)
+        self.features = set(features)
+
+
+def _make_scheduler(features=("observability",), eprefix="", tasks=None):
+    tasks = tasks or []
+    running = {id(t): t for t in tasks}
+    return SimpleNamespace(
+        settings=_Settings(features=features, EPREFIX=eprefix),
+        _running_tasks=running,
+        _jobs=sum(1 for t in tasks if isinstance(t, EbuildBuild)),
+        _max_jobs=4,
+        _failed_pkgs=[],
+        _merge_wait_queue=[],
+        _task_queues=SimpleNamespace(merge=[]),
+        _status_display=SimpleNamespace(curval=1, maxval=5),
+        _event_loop=None,
+    )
+
+
+class ObservabilitySnapshotTestCase(TestCase):
+    def test_status_dir_default_is_absolute(self):
+        self.assertTrue(status_dir("").startswith("/"))
+        self.assertEqual(status_dir("/p"), "/p/run/portage")
+
+    def test_build_snapshot_structure(self):
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=4321)
+        merge = PackageMerge(EbuildBuild(_Pkg("sys-apps/bar-3")))
+        sched = _make_scheduler(tasks=[build, merge])
+        monitor = ObservabilityMonitor(sched)
+        monitor.note_task_started(build)
+        monitor.note_task_started(merge)
+        monitor.note_phase("dev-libs/foo-1.2", "compile")
+
+        snap = build_snapshot(monitor)
+
+        self.assertEqual(snap["type"], "snapshot")
+        self.assertEqual(snap["schema"], 1)
+        self.assertEqual(snap["jobs"]["completed"], 1)
+        self.assertEqual(snap["jobs"]["total"], 5)
+        self.assertEqual(len(snap["tasks"]), 2)
+
+        by_cpv = {t["cpv"]: t for t in snap["tasks"]}
+        self.assertEqual(by_cpv["dev-libs/foo-1.2"]["phase"], "compile")
+        self.assertEqual(by_cpv["dev-libs/foo-1.2"]["pid"], 4321)
+        self.assertEqual(by_cpv["dev-libs/foo-1.2"]["kind"], "build")
+        self.assertEqual(by_cpv["sys-apps/bar-3"]["kind"], "merge")
+
+    def test_disabled_when_feature_absent(self):
+        sched = _make_scheduler(features=(), tasks=[])
+        monitor = ObservabilityMonitor(sched)
+        self.assertFalse(monitor.enabled)
+        # All hooks must be safe no-ops.
+        monitor.note_task_started(object())
+        monitor.note_phase("a/b-1", "compile")
+        monitor.update(force=True)
+        monitor.close()
+
+    def test_write_and_read_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build])
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+            monitor.note_phase("dev-libs/foo-1.2", "install")
+            monitor.update(force=True)
+
+            path = os.path.join(status_dir(tmp), f"emerge-{os.getpid()}.json")
+            self.assertTrue(os.path.exists(path))
+            with open(path, encoding="utf_8") as f:
+                snap = json.load(f)
+            self.assertEqual(snap["tasks"][0]["cpv"], "dev-libs/foo-1.2")
+
+            # read_snapshots finds it (our own PID is alive).
+            found = read_snapshots(tmp)
+            self.assertEqual(len(found), 1)
+            self.assertIn("dev-libs/foo-1.2", format_snapshots(found))
+
+            monitor.close()
+            self.assertFalse(os.path.exists(path))
+
+    def test_stale_file_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            # Use an implausible PID that is not running.
+            with open(os.path.join(d, "emerge-2147480000.json"), "w") as f:
+                json.dump({"emerge_pid": 2147480000, "tasks": []}, f)
+            self.assertEqual(read_snapshots(tmp), [])

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -251,6 +251,13 @@ Matches the search string against the description field as well as
 the package name.  \fBTake caution\fR as the descriptions are also
 matched as regular expressions.
 .TP
+.BR \-\-status
+Displays the packages that running \fBemerge\fR processes are currently
+building or merging, including the current ebuild phase and elapsed time.
+This requires the target \fBemerge\fR to have been started with
+FEATURES="observability" (see \fBmake.conf\fR(5)). For machine\-readable
+output, use \fBportageq jobs \-\-json\fR instead.
+.TP
 .BR \-\-sync
 Updates repositories, for which auto\-sync, sync\-type and sync\-uri attributes are
 set in repos.conf. A list of repos or aliases can be specified, in which case

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -680,6 +680,15 @@ Prevents the stripping of binaries that are merged to the live filesystem.
 .B notitles
 Disables xterm titlebar updates (which contains status info).
 .TP
+.B observability
+Publish a machine\-readable snapshot of the running \fBemerge\fR(1)
+process to \fI/run/portage/emerge\-<pid>.json\fR, listing the packages
+currently being built or merged, their current ebuild phase, and elapsed
+time. The file is updated on every job state change and removed when
+emerge exits. Query it with \fBportageq jobs\fR or \fBemerge \-\-status\fR.
+This feature degrades silently when the runtime directory is not writable
+(for example, for an unprivileged emerge).
+.TP
 .B packdebug
 Create a tarball of debug information and source files for use with
 debuginfod.  Debug tarballs are placed at

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -686,8 +686,10 @@ process to \fI/run/portage/emerge\-<pid>.json\fR, listing the packages
 currently being built or merged, their current ebuild phase, and elapsed
 time. The file is updated on every job state change and removed when
 emerge exits. Query it with \fBportageq jobs\fR or \fBemerge \-\-status\fR.
-This feature degrades silently when the runtime directory is not writable
-(for example, for an unprivileged emerge).
+A \fI/run/portage/emerge\-<pid>.sock\fR Unix socket additionally streams
+newline\-delimited JSON snapshots to connected clients. This feature
+degrades silently when the runtime directory is not writable (for
+example, for an unprivileged emerge).
 .TP
 .B packdebug
 Create a tarball of debug information and source files for use with


### PR DESCRIPTION
I've been playing with writing an external portage monitoring utility. This PR adds `FEATURES="observability"` that lets external tools inspect a running emerge process without instrumenting emerge itself.

When enabled, the Scheduler publishes a machine-readable JSON snapshot of its current state to `/run/portage/emerge-<pid>.json` on every job state change, listing packages being built or merged, their current ebuild phase, elapsed time, and packages waiting to merge. The file is removed when emerge exits.

A Unix-domain socket at `/run/portage/emerge-<pid>.sock` streams JSON snapshots to connected clients: the current snapshot on connect, then one line per update.

Two new query interfaces are added:
- `emerge --status`: human-readable table of active builds across all running emerge processes
- `portageq jobs [--json]`: same data in machine-readable form
