### PR TITLE
Respect --usepkg=n and --getbinpkg=n on command line if FEATURES=getbinpkg

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,9 @@ Bug fixes:
   reduced-privilege phases can source them where the process TMPDIR is not
   traversable by the portage user. (bug #977245)
 
+* Respect --usepkg=n and --getbinpkg=n on command line if the user has set
+  FEATURES=getbinpkg (bug #759067)
+
 portage-3.0.79 (2026-05-22)
 --------------
 

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -849,7 +849,7 @@ class Scheduler(PollScheduler):
 
         elif (
             pkg.type_name == "binary"
-            and "--getbinpkg" in self.myopts
+            and self.myopts.get("--getbinpkg") is True
             and pkg.root_config.trees["bintree"].download_required(pkg.cpv)
         ):
             prefetcher = BinpkgPrefetcher(

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -145,7 +145,7 @@ def action_build(
         + os.path.sep
     )
     quickpkg_direct = (
-        "--usepkg" in emerge_config.opts
+        emerge_config.opts.get("--usepkg") is True
         and emerge_config.opts.get("--quickpkg-direct", "n") == "y"
         and emerge_config.target_config.settings["ROOT"] != quickpkg_root
     )
@@ -171,7 +171,7 @@ def action_build(
             if "--getbinpkg-include" in emerge_config.opts:
                 kwargs["getbinpkg_include"] = emerge_config.opts["--getbinpkg-include"]
             emerge_config.target_config.trees["bintree"].populate(
-                getbinpkgs="--getbinpkg" in emerge_config.opts, **kwargs
+                getbinpkgs=emerge_config.opts.get("--getbinpkg") is True, **kwargs
             )
         except ParseError as e:
             writemsg(f"\n\n!!!{e}.\nSee make.conf(5) for more info.\n", noiselevel=-1)
@@ -426,7 +426,7 @@ def action_build(
             # instances need to load remote metadata if --getbinpkg
             # is enabled. Use getbinpkg_refresh=False to use cached
             # metadata, since the cache is already fresh.
-            if "--getbinpkg" in emerge_config.opts or quickpkg_direct:
+            if emerge_config.opts.get("--getbinpkg") is True or quickpkg_direct:
                 for root_trees in emerge_config.trees.values():
                     kwargs = {}
                     if quickpkg_direct:
@@ -1917,7 +1917,7 @@ def action_info(settings, trees, myopts, myfiles):
                 dbs = [IndexedVardb(vardb) if search_index else vardb]
                 # if "--usepkgonly" not in myopts:
                 dbs.append(IndexedPortdb(portdb) if search_index else portdb)
-                if "--usepkg" in myopts:
+                if myopts.get("--usepkg") is True:
                     dbs.append(bindb)
 
                 matches = similar_name_search(dbs, x)
@@ -2427,8 +2427,8 @@ def action_search(root_config, myopts, myfiles, spinner):
             spinner,
             "--searchdesc" in myopts,
             "--quiet" not in myopts,
-            "--usepkg" in myopts,
-            "--usepkgonly" in myopts,
+            myopts.get("--usepkg") is True,
+            myopts.get("--usepkgonly") is True,
             search_index=myopts.get("--search-index", "y") != "n",
             search_similarity=myopts.get("--search-similarity"),
             fuzzy=myopts.get("--fuzzy-search") != "n",
@@ -2703,7 +2703,7 @@ def adjust_configs(myopts, trees):
         # For --usepkgonly mode, propagate settings from the binary package
         # database, so that it's possible to operate without dependence on
         # a local ebuild repository and profile.
-        if "--usepkgonly" in myopts and mytrees["bintree"]._propagate_config(
+        if myopts.get("--usepkgonly") is True and mytrees["bintree"]._propagate_config(
             mysettings
         ):
             # Also propagate changes to the portdbapi doebuild_settings
@@ -3680,18 +3680,19 @@ def run_action(emerge_config):
         emerge_config.opts["--buildpkg"] = True
 
     if "getbinpkg" in emerge_config.target_config.settings.features:
+        if emerge_config.opts.get("--getbinpkg") is not False:
+            emerge_config.opts["--getbinpkg"] = True
+
+    if emerge_config.opts.get("--getbinpkgonly") is True:
         emerge_config.opts["--getbinpkg"] = True
 
-    if "--getbinpkgonly" in emerge_config.opts:
-        emerge_config.opts["--getbinpkg"] = True
-
-    if "--getbinpkgonly" in emerge_config.opts:
+    if emerge_config.opts.get("--getbinpkgonly") is True:
         emerge_config.opts["--usepkgonly"] = True
 
-    if "--getbinpkg" in emerge_config.opts:
+    if emerge_config.opts.get("--getbinpkg") is True:
         emerge_config.opts["--usepkg"] = True
 
-    if "--usepkgonly" in emerge_config.opts:
+    if emerge_config.opts.get("--usepkgonly") is True:
         emerge_config.opts["--usepkg"] = True
 
     # Populate the bintree with current --getbinpkg setting.
@@ -3699,7 +3700,10 @@ def run_action(emerge_config):
     # * expand_set_arguments, in case any sets use the bintree
     # * adjust_configs and profile_check, in order to propagate settings
     #   implicit IUSE and USE_EXPAND settings from the binhost(s)
-    if emerge_config.action in ("search", None) and "--usepkg" in emerge_config.opts:
+    if (
+        emerge_config.action in ("search", None)
+        and emerge_config.opts.get("--usepkg") is True
+    ):
         for mytrees in emerge_config.trees.values():
             kwargs = {}
             if (
@@ -3719,7 +3723,7 @@ def run_action(emerge_config):
 
             try:
                 mytrees["bintree"].populate(
-                    getbinpkgs="--getbinpkg" in emerge_config.opts,
+                    getbinpkgs=emerge_config.opts.get("--getbinpkg") is True,
                     getbinpkg_refresh=True,
                     verbose="--verbose" in emerge_config.opts,
                     **kwargs,
@@ -4161,7 +4165,7 @@ def run_action(emerge_config):
 
                     if (
                         valid_atom.cp.split("/")[0] == "null"
-                        and "--usepkg" in emerge_config.opts
+                        and emerge_config.opts.get("--usepkg") is True
                     ):
                         valid_atom = dep_expand(x, mydb=bindb)
 

--- a/lib/_emerge/create_depgraph_params.py
+++ b/lib/_emerge/create_depgraph_params.py
@@ -186,7 +186,7 @@ def create_depgraph_params(myopts, myaction):
     if (
         rebuilt_binaries is True
         or rebuilt_binaries != "n"
-        and "--usepkgonly" in myopts
+        and myopts.get("--usepkgonly") is True
         and myopts.get("--deep") is True
         and "--update" in myopts
     ):

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -154,7 +154,7 @@ class _frozen_depgraph_config:
         # no soname data. Therefore, only enable soname dependency
         # resolution if --usepkgonly is enabled, or for removal actions.
         self.soname_deps_enabled = (
-            "--usepkgonly" in myopts or "remove" in params
+            myopts.get("--usepkgonly") is True or "remove" in params
         ) and params.get("ignore_soname_deps") != "y"
         dynamic_deps = "dynamic_deps" in params
         ignore_built_slot_operator_deps = (
@@ -310,7 +310,7 @@ class _rebuild_config:
             if self._needs_rebuild(dep_pkg):
                 self.rebuild_list.add(root_slot)
                 return True
-            if "--usepkg" in self._frozen_config.myopts and (
+            if self._frozen_config.myopts.get("--usepkg") is True and (
                 dep_root_slot in self.reinstall_list
                 or dep_root_slot in self.rebuild_list
                 or not dep_pkg.installed
@@ -640,7 +640,7 @@ class _dynamic_depgraph_config:
                     db_keys = list(portdb._aux_cache_keys)
                     dbs.append((portdb, "ebuild", False, False, db_keys))
 
-                if "--usepkg" in depgraph._frozen_config.myopts:
+                if depgraph._frozen_config.myopts.get("--usepkg") is True:
                     bindb = depgraph._frozen_config.trees[myroot]["bintree"].dbapi
                     db_keys = list(bindb._aux_cache_keys)
                     dbs.append((bindb, "binary", True, False, db_keys))
@@ -2841,7 +2841,7 @@ class depgraph:
         graph_pkg itself may be yielded only if it's not installed.
         """
 
-        usepkgonly = "--usepkgonly" in self._frozen_config.myopts
+        usepkgonly = self._frozen_config.myopts.get("--usepkgonly") is True
         useoldpkg_atoms = self._frozen_config.useoldpkg_atoms
         use_ebuild_visibility = (
             self._frozen_config.myopts.get("--use-ebuild-visibility", "n") != "n"
@@ -6873,7 +6873,7 @@ class depgraph:
                 dbs = [vardb]
                 if "--usepkgonly" not in self._frozen_config.myopts:
                     dbs.append(IndexedPortdb(portdb) if search_index else portdb)
-                if "--usepkg" in self._frozen_config.myopts:
+                if self._frozen_config.myopts.get("--usepkg") is True:
                     # bindbapi is indexed
                     dbs.append(bindb)
 
@@ -7645,8 +7645,8 @@ class depgraph:
         existing_node = None
         myeb = None
         rebuilt_binaries = "rebuilt_binaries" in self._dynamic_config.myparams
-        usepkg = "--usepkg" in self._frozen_config.myopts
-        usepkgonly = "--usepkgonly" in self._frozen_config.myopts
+        usepkg = self._frozen_config.myopts.get("--usepkg") is True
+        usepkgonly = self._frozen_config.myopts.get("--usepkgonly") is True
         usepkg_exclude_live = "--usepkg-exclude-live" in self._frozen_config.myopts
         empty = "empty" in self._dynamic_config.myparams
         selective = "selective" in self._dynamic_config.myparams
@@ -11697,7 +11697,7 @@ class _dep_check_composite_db(dbapi):
                 "--update" not in myopts
                 and "remove" not in self._depgraph._dynamic_config.myparams
             )
-            usepkgonly = "--usepkgonly" in myopts
+            usepkgonly = myopts.get("--usepkgonly") is True
             if not avoid_update:
                 if not use_ebuild_visibility and usepkgonly:
                     return False
@@ -11822,8 +11822,8 @@ def ambiguous_package_name(arg, atoms, root_config, spinner, myopts):
         spinner,
         "--searchdesc" in myopts,
         "--quiet" not in myopts,
-        "--usepkg" in myopts,
-        "--usepkgonly" in myopts,
+        myopts.get("--usepkg") is True,
+        myopts.get("--usepkgonly") is True,
         search_index=False,
     )
     null_cp = portage.dep_getkey(insert_category_into_atom(arg, "null"))

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -320,6 +320,7 @@ def parse_opts(tmpcmdline, silent=False):
     y_or_n = ("y", "n")
     true_y_or_n = ("True", "y", "n")
     true_y = ("True", "y")
+    false_n = ("False", "n")
     argument_options = {
         "--alert": {
             "shortopt": "-A",
@@ -913,11 +914,15 @@ def parse_opts(tmpcmdline, silent=False):
 
     if myoptions.getbinpkg in true_y:
         myoptions.getbinpkg = True
+    elif myoptions.getbinpkg in false_n:
+        myoptions.getbinpkg = False
     else:
         myoptions.getbinpkg = None
 
     if myoptions.getbinpkgonly in true_y:
         myoptions.getbinpkgonly = True
+    elif myoptions.getbinpkgonly in false_n:
+        myoptions.getbinpkgonly = False
     else:
         myoptions.getbinpkgonly = None
 
@@ -1104,11 +1109,15 @@ def parse_opts(tmpcmdline, silent=False):
 
     if myoptions.usepkg in true_y:
         myoptions.usepkg = True
+    elif myoptions.usepkg in false_n:
+        myoptions.usepkg = False
     else:
         myoptions.usepkg = None
 
     if myoptions.usepkgonly in true_y:
         myoptions.usepkgonly = True
+    elif myoptions.usepkgonly in false_n:
+        myoptions.usepkgonly = False
     else:
         myoptions.usepkgonly = None
 

--- a/lib/_emerge/resolver/slot_collision.py
+++ b/lib/_emerge/resolver/slot_collision.py
@@ -243,7 +243,7 @@ class slot_conflict_handler:
         Print all slot conflicts in a human readable way.
         """
         _pkg_use_enabled = self.depgraph._pkg_use_enabled
-        usepkgonly = "--usepkgonly" in self.myopts
+        usepkgonly = self.myopts.get("--usepkgonly") is True
         need_rebuild = {}
         verboseconflicts = "--verbose-conflicts" in self.myopts
         any_omitted_parents = False

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -788,14 +788,14 @@ class ResolverPlayground:
             elif options.get("--prune"):
                 action = "prune"
 
-        if "--getbinpkgonly" in options:
+        if options.get("--getbinpkgonly") is True:
             options["--getbinpkg"] = True
             options["--usepkgonly"] = True
 
-        if "--getbinpkg" in options:
+        if options.get("--getbinpkg") is True:
             options["--usepkg"] = True
 
-        if "--usepkgonly" in options:
+        if options.get("--usepkgonly") is True:
             options["--usepkg"] = True
 
         binpkg_selection_config(options, self.settings)


### PR DESCRIPTION
Portage would ignore --usepkg=n or --getbinpkg=n on the command line, if the user has FEATURES=getbinpkg in their make.conf. So, instead of

    emerge --usepkg=n <package>

users with FEATURES=getbinpkg in make.conf would need to use

    FEATURES=-getbinpkg emerge <package>

to perform a source-based emerge.

This was caused by Portage's option parser converting 'n' to None, which prevented it from being added to myopts, because None values are ignored.

Fix this by converting 'n' to False instead of None. This ensures that the users intend is recored in myopts.

As a consequence, all value retrieval checks need to be adjusted, to check of True, instead of the sole existences of the option in myopts.

Finally, the configuration override via features only kicks in if the command line option does not disaggree with it.

Closes: https://bugs.gentoo.org/759067