### PR TITLE
Deduplicate the ld.so.conf.d include

### DIFF
--- a/lib/portage/util/env_update.py
+++ b/lib/portage/util/env_update.py
@@ -195,11 +195,7 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env, writemsg_lev
 
     ldsoconf_path = os.path.join(eroot, "etc", "ld.so.conf")
 
-    newld = list(specials["LDPATH"])
-    if os.path.isdir(os.path.join(eroot, "etc", "ld.so.conf.d")):
-        # Preserve include directive so ldconfig picks up ld.so.conf.d/*.conf
-        newld.append(f"include {eprefix}/etc/ld.so.conf.d/*.conf")
-
+    newld = specials["LDPATH"]
     if grabfile(ldsoconf_path) != newld:
         # ld.so.conf needs updating and ldconfig needs to be run
         with atomic_ofstream(ldsoconf_path) as myfd:


### PR DESCRIPTION
Regression was introduced during iteration. An earlier iteration of 4e154adc45136c040308e536367bf92e142f4c5b had attempted to solve the problem differently, and these lines were an artifact of an inferior approach.

During visual inspection of /etc/ld.so.conf after changes I misread the prepended include as part of the initial comment block, and inspected all lines beginning with /usr and afterward.

Part-of: #1592