### PR TITLE
fetch: add FETCH_WRAPPER support for command wrapping

### DIFF
--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -287,6 +287,7 @@ environ_filter = frozenset(
         "EMERGE_DEFAULT_OPTS",
         "EMERGE_LOG_DIR",
         "EMERGE_WARNING_DELAY",
+        "FETCH_WRAPPER",
         "FETCHCOMMAND",
         "FETCHCOMMAND_FTP",
         "FETCHCOMMAND_HTTP",

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -1813,8 +1813,16 @@ async def async_fetch(
                         if v is not None:
                             variables[k] = v
 
-                    myfetch = varexpand(locfetch, mydict=variables)
-                    myfetch = shlex.split(myfetch)
+                    fetch_wrapper = mysettings.get("FETCH_WRAPPER")
+                    if fetch_wrapper:
+                        wrapper_args = shlex.split(
+                            varexpand(fetch_wrapper, mydict=variables)
+                        )
+                        fetch_args = shlex.split(varexpand(locfetch, mydict=variables))
+                        myfetch = wrapper_args + [shlex.join(fetch_args)]
+                    else:
+                        myfetch = varexpand(locfetch, mydict=variables)
+                        myfetch = shlex.split(myfetch)
 
                     myret = -1
                     try:

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -936,6 +936,27 @@ Placeholder	Meaning	Example
 .TE
 .RE
 .TP
+.B FETCH_WRAPPER
+An optional command prefix prepended to \fBFETCHCOMMAND\fR and
+\fBRESUMECOMMAND\fR at fetch time.  When set, the fetch command is
+expanded, each argument is individually shell\-quoted, and the result is
+passed as a single string argument to the wrapper.  This ensures that
+wrappers which re\-interpret arguments through a shell \(em most commonly
+\fBssh\fR(1), which concatenates post\-hostname arguments into a remote
+command string \(em receive a properly quoted command.
+.RS
+.PP
+Without \fBFETCH_WRAPPER\fR, an ssh\-based \fBFETCHCOMMAND\fR breaks when
+the command contains shell metacharacters such as the parentheses in the
+default user\-agent string.  Setting \fBFETCH_WRAPPER\fR avoids this and
+allows \fBFETCHCOMMAND\fR and \fBRESUMECOMMAND\fR to remain at their
+\fImake.globals\fR defaults.
+.PP
+.nf
+FETCH_WRAPPER="ssh \-i ~/.ssh/id_ed25519 user@host"
+.fi
+.RE
+.TP
 .B FFLAGS FCFLAGS
 Use these variables to set the desired optimization/CPU instruction settings
 for applications that you compile with a FORTRAN compiler. FFLAGS is usually
@@ -1434,6 +1455,7 @@ have been partially downloaded.  It should be defined using the same format
 as \fBFETCHCOMMAND\fR, and must include any additional option(s) that may
 be necessary in order to continue a partially downloaded file located at
 \\${DISTDIR}/\\${FILE}.
+Also see \fBFETCH_WRAPPER\fR.
 .TP
 \fBROOT\fR = \fI[path]\fR
 Use \fBROOT\fR to specify the target root filesystem to be used for merging


### PR DESCRIPTION
When `FETCHCOMMAND` contains a wrapper that re-interprets its arguments through a shell (most commonly ssh) the fetch breaks with a shell syntax error.

ssh joins all post-hostname arguments with spaces to form the remote command string, then passes that string to the remote shell. Arguments that were separate tokens when passed to execve() end up concatenated without quoting. The default `FETCHCOMMAND` includes:

```
  -U "Portage (Gentoo, https://www.gentoo.org) distfile-fetch"
```

After `shlex.split()`, the user-agent is correctly one argument, but once ssh joins everything for the remote shell the parentheses are unquoted:

```
  wget ... -U Portage (Gentoo, ...) distfile-fetch -O ...
```

The remote shell then fails with:

```
  bash: -c: line 1: syntax error near unexpected token `('
```

A `FETCHCOMMAND` such as the following worked before the user-agent was added in commit 421ab5457 ("Add User-Agent to default FETCHCOMMAND/RESUMECOMMAND and emirrordist"):
```
  FETCHCOMMAND="ssh -i ~/.ssh/id_ed25519 user@host ${FETCHCOMMAND}"
```
When `FETCH_WRAPPER` is set, the `FETCHCOMMAND` is expanded and each argument individually shell-quoted via `shlex.quote()`, then joined into a single string passed as one argument to the wrapper. The wrapper (e.g. ssh) forwards this single string to the remote shell, which parses it correctly.

Example make.conf usage:
```
  FETCH_WRAPPER="ssh -i ~/.ssh/id_ed25519 user@host"
```
`FETCHCOMMAND` and `RESUMECOMMAND` can then be left as their `make.globals` defaults, including any future changes to the user-agent string.