### PR TITLE
util: listdir: drop old, (nearly-)unused stub

### DIFF
--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -83,8 +83,11 @@ portage.process.atexit_register(close_portdbapi_caches)
 
 class _dummy_list(list):
     def remove(self, item):
-        # TODO: Trigger a DeprecationWarning here, after stable portage
-        # has dummy portdbapi_instances.
+        warnings.warn(
+            "_dummy_list.remove() is no longer necessary for portdbapi_instances; drop the call",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         try:
             list.remove(self, item)
         except ValueError:

--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -1130,9 +1130,7 @@ class portdbapi(dbapi):
             trees = self.porttrees
         for x in categories:
             for oroot in trees:
-                for y in listdir(
-                    oroot + "/" + x, EmptyOnError=1, ignorecvs=1, dirsonly=1
-                ):
+                for y in listdir(oroot + "/" + x, ignorecvs=1, dirsonly=1):
                     try:
                         atom = Atom(f"{x}/{y}")
                     except InvalidAtom:

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -600,15 +600,12 @@ class vardbapi(dbapi):
         self._clear_pkg_cache(pkg_dblink)
 
     def _clear_pkg_cache(self, pkg_dblink):
-        from portage.util.listdir import dircache
-
         # Due to 1 second mtime granularity in <python-2.5, mtime checks
         # are not always sufficient to invalidate vardbapi caches. Therefore,
         # the caches need to be actively invalidated here.
         self.mtdircache.pop(pkg_dblink.cat, None)
         self.matchcache.pop(pkg_dblink.cat, None)
         self.cpcache.pop(pkg_dblink.mysplit[0], None)
-        dircache.pop(pkg_dblink.dbcatdir, None)
 
     def match(self, origdep, use_cache=1):
         "caching match function"

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -536,7 +536,7 @@ class vardbapi(dbapi):
                     del e
                     return []
 
-        catdirs = listdir(basepath, EmptyOnError=1, ignorecvs=1, dirsonly=1)
+        catdirs = listdir(basepath, ignorecvs=1, dirsonly=1)
         if sort:
             catdirs.sort()
 
@@ -546,7 +546,7 @@ class vardbapi(dbapi):
             if not self._category_re.match(x):
                 continue
 
-            pkgdirs = listdir(basepath + x, EmptyOnError=1, dirsonly=1)
+            pkgdirs = listdir(basepath + x, dirsonly=1)
             if sort:
                 pkgdirs.sort()
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -506,35 +506,22 @@ class vardbapi(dbapi):
             del self.cpcache[mycp]
         return returnme
 
-    def cpv_all(self, use_cache=1):
-        """
-        Set use_cache=0 to bypass the portage.cachedir() cache in cases
-        when the accuracy of mtime staleness checks should not be trusted
-        (generally this is only necessary in critical sections that
-        involve merge or unmerge of packages).
-        """
-        return list(self._iter_cpv_all(use_cache=use_cache))
+    def cpv_all(self):
+        return list(self._iter_cpv_all())
 
-    def _iter_cpv_all(self, use_cache=True, sort=False):
+    def _iter_cpv_all(self, use_cache=None, sort=False):
         from portage.versions import _pkg_str
+        from portage import listdir
 
         returnme = []
         basepath = os.path.join(self._eroot, VDB_PATH) + os.path.sep
 
         if use_cache:
-            from portage import listdir
-        else:
-
-            def listdir(p, **kwargs):
-                try:
-                    return [
-                        x for x in os.listdir(p) if os.path.isdir(os.path.join(p, x))
-                    ]
-                except OSError as e:
-                    if e.errno == PermissionDenied.errno:
-                        raise PermissionDenied(p)
-                    del e
-                    return []
+            warnings.warn(
+                "_iter_cpv_all's use_cache param is a noop and is always false, please remove it",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         catdirs = listdir(basepath, ignorecvs=1, dirsonly=1)
         if sort:
@@ -563,10 +550,10 @@ class vardbapi(dbapi):
 
                 yield subpath
 
-    def cp_all(self, use_cache=1, sort=False):
+    def cp_all(self, sort=False):
         from portage.versions import catpkgsplit
 
-        mylist = self.cpv_all(use_cache=use_cache)
+        mylist = self.cpv_all()
         d = {}
         for y in mylist:
             if y[0] == "*":

--- a/lib/portage/util/env_update.py
+++ b/lib/portage/util/env_update.py
@@ -108,7 +108,7 @@ def _env_update(makelinks, target_root, prev_mtimes, contents, env, writemsg_lev
     )
     envd_dir = os.path.join(eroot, "etc", "env.d")
     ensure_dirs(envd_dir, mode=0o755)
-    fns = listdir(envd_dir, EmptyOnError=1)
+    fns = listdir(envd_dir)
     fns.sort()
     templist = []
     for x in fns:

--- a/lib/portage/util/listdir.py
+++ b/lib/portage/util/listdir.py
@@ -12,9 +12,7 @@ from portage.exception import DirectoryNotFound, PermissionDenied, PortageExcept
 from portage.util import normalize_path
 
 
-def cacheddir(
-    my_original_path, ignorecvs, ignorelist, EmptyOnError, followSymlinks=True
-):
+def cacheddir(my_original_path, ignorecvs, ignorelist, followSymlinks=True):
     mypath = normalize_path(my_original_path)
     try:
         pathstat = os.stat(mypath)
@@ -80,7 +78,6 @@ def listdir(
     ignorecvs=False,
     ignorelist=[],
     followSymlinks=True,
-    EmptyOnError=False,
     dirsonly=False,
 ):
     """
@@ -98,17 +95,13 @@ def listdir(
     @type ignorelist: List
     @param followSymlinks: Follow Symlink'd files and directories
     @type followSymlinks: Boolean
-    @param EmptyOnError: Return [] if an error occurs (deprecated, always True)
-    @type EmptyOnError: Boolean
     @param dirsonly: Only return directories.
     @type dirsonly: Boolean
     @rtype: List
     @return: A list of files and directories (or just files or just directories) or an empty list.
     """
 
-    fpaths, ftype = cacheddir(
-        mypath, ignorecvs, ignorelist, EmptyOnError, followSymlinks
-    )
+    fpaths, ftype = cacheddir(mypath, ignorecvs, ignorelist, followSymlinks)
 
     if fpaths is None:
         fpaths = []
@@ -131,7 +124,6 @@ def listdir(
                     os.path.join(mypath, file_path),
                     ignorecvs,
                     ignorelist,
-                    EmptyOnError,
                     followSymlinks,
                 )
                 stack.extend(

--- a/lib/portage/util/listdir.py
+++ b/lib/portage/util/listdir.py
@@ -11,14 +11,6 @@ from portage.const import VCS_DIRS
 from portage.exception import DirectoryNotFound, PermissionDenied, PortageException
 from portage.util import normalize_path
 
-# The global dircache is no longer supported, since it could
-# be a memory leak for API consumers. Any cacheddir callers
-# should use higher-level caches instead, when necessary.
-# TODO: Remove dircache variable after stable portage does
-# not use is (keep it for now, in case API consumers clear
-# it manually).
-dircache = {}
-
 
 def cacheddir(
     my_original_path, ignorecvs, ignorelist, EmptyOnError, followSymlinks=True


### PR DESCRIPTION
This is unused since 0196031 (2013), with
the exception of a part of Portage. Address the TODO by dropping it.

Signed-off-by: Sam James <sam@gentoo.org>