### PR TITLE
util: listdir: port to os.scandir()

### DIFF
--- a/lib/portage/emaint/modules/merges/merges.py
+++ b/lib/portage/emaint/modules/merges/merges.py
@@ -105,19 +105,20 @@ class MergesHandler:
         @return: dictionary of packages that failed to merges
         """
         failed_pkgs = {}
-        for cat in os.listdir(self._vardb_path):
-            pkgs_path = os.path.join(self._vardb_path, cat)
-            if not os.path.isdir(pkgs_path):
-                continue
-            pkgs = os.listdir(pkgs_path)
-            maxval = len(pkgs)
-            for i, pkg in enumerate(pkgs):
-                if onProgress:
-                    onProgress(maxval, i + 1)
-                if MERGING_IDENTIFIER in pkg:
-                    mtime = int(os.stat(os.path.join(pkgs_path, pkg)).st_mtime)
-                    pkg = os.path.join(cat, pkg)
-                    failed_pkgs[pkg] = mtime
+        with os.scandir(self._vardb_path) as it:
+            for cat in it:
+                if not cat.is_dir():
+                    continue
+                pkgs_path = cat
+                pkgs = os.listdir(pkgs_path)
+                maxval = len(pkgs)
+                for i, pkg in enumerate(pkgs):
+                    if onProgress:
+                        onProgress(maxval, i + 1)
+                    if MERGING_IDENTIFIER in pkg:
+                        mtime = int(os.stat(os.path.join(pkgs_path, pkg)).st_mtime)
+                        pkg = os.path.join(cat, pkg)
+                        failed_pkgs[pkg] = mtime
         return failed_pkgs
 
     def _failed_pkgs(self, onProgress=None):

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -751,15 +751,17 @@ def unhardlink_lockfile(lockfilename, unlinkfile=True):
 
 def hardlock_cleanup(path, remove_all_locks=False):
     myhost = os.uname()[1]
-    mydl = os.listdir(path)
 
     results = []
     mycount = 0
 
     mylist = {}
-    for x in mydl:
-        if os.path.isfile(path + "/" + x):
-            parts = x.split(".hardlock-")
+    with os.scandir(path) as mydl:
+        for x in mydl:
+            if not x.is_file():
+                continue
+
+            parts = x.name.split(".hardlock-")
             if len(parts) == 2:
                 filename = parts[0][1:]
                 hostpid = parts[1].split("-")
@@ -774,7 +776,7 @@ def hardlock_cleanup(path, remove_all_locks=False):
 
                 mycount += 1
 
-    results.append(_("Found %(count)s locks") % {"count": mycount})
+        results.append(_("Found %(count)s locks") % {"count": mycount})
 
     for x in mylist:
         if myhost in mylist[x] or remove_all_locks:

--- a/lib/portage/package/ebuild/fetch.py
+++ b/lib/portage/package/ebuild/fetch.py
@@ -309,25 +309,28 @@ def _checksum_failure_temp_file(settings, distdir, basename):
     size = os.stat(filename).st_size
     checksum = None
     tempfile_re = re.compile(re.escape(normal_basename) + r"\._checksum_failure_\..*")
-    for temp_filename in os.listdir(distdir):
-        if not tempfile_re.match(temp_filename):
-            continue
-        temp_filename = os.path.join(distdir, temp_filename)
-        try:
-            if size != os.stat(temp_filename).st_size:
+    with os.scandir(distdir) as it:
+        for temp_filename in it:
+            if not tempfile_re.match(temp_filename.name):
                 continue
-        except OSError:
-            continue
-        try:
-            temp_checksum = perform_md5(temp_filename)
-        except FileNotFound:
-            # Apparently the temp file disappeared. Let it go.
-            continue
-        if checksum is None:
-            checksum = perform_md5(filename)
-        if checksum == temp_checksum:
-            os.unlink(filename)
-            return temp_filename
+
+            try:
+                if size != temp_filename.stat(follow_symlinks=False).st_size:
+                    continue
+            except OSError:
+                continue
+
+            try:
+                temp_checksum = perform_md5(temp_filename.path)
+            except FileNotFound:
+                # Apparently the temp file disappeared. Let it go.
+                continue
+
+            if checksum is None:
+                checksum = perform_md5(filename)
+            if checksum == temp_checksum:
+                os.unlink(filename)
+                return temp_filename.path
 
     fd, temp_filename = tempfile.mkstemp(
         "", normal_basename + "._checksum_failure_.", distdir

--- a/lib/portage/tests/emerge/test_config_protect.py
+++ b/lib/portage/tests/emerge/test_config_protect.py
@@ -4,7 +4,6 @@
 from functools import partial
 import shlex
 import shutil
-import stat
 import subprocess
 import sys
 import time
@@ -130,16 +129,17 @@ src_install() {
         config_protect = "/etc"
 
         def modify_files(dir_path):
-            for name in os.listdir(dir_path):
-                path = os.path.join(dir_path, name)
-                st = os.lstat(path)
-                if stat.S_ISREG(st.st_mode):
-                    with open(path, mode="a", encoding="utf-8") as f:
-                        f.write("modified at %d\n" % time.time())
-                elif stat.S_ISLNK(st.st_mode):
-                    old_dest = os.readlink(path)
-                    os.unlink(path)
-                    os.symlink(old_dest + " modified at %d" % time.time(), path)
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    if entry.is_file(follow_symlinks=False):
+                        with open(entry.path, mode="a", encoding="utf-8") as f:
+                            f.write("modified at %d\n" % time.time())
+                    elif entry.is_symlink():
+                        old_dest = os.readlink(entry.path)
+                        os.unlink(entry.path)
+                        os.symlink(
+                            old_dest + " modified at %d" % time.time(), entry.path
+                        )
 
         def updated_config_files(count):
             self.assertEqual(

--- a/lib/portage/update.py
+++ b/lib/portage/update.py
@@ -1,7 +1,6 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-import errno
 import re
 import stat
 import sys
@@ -10,8 +9,9 @@ import warnings
 import os
 from portage.const import USER_CONFIG_PATH, VCS_DIRS
 from portage.eapi import _get_eapi_attrs
-from portage.exception import DirectoryNotFound, InvalidAtom, PortageException
+from portage.exception import InvalidAtom, PortageException
 from portage.localization import _
+from portage.util.listdir import listdir
 
 ignored_dbentries = ("CONTENTS", "environment.bz2")
 
@@ -161,12 +161,7 @@ def grab_updates(updpath, prev_mtimes=None):
     the source package of a move that comes somewhere later in the entire
     sequence of files.
     """
-    try:
-        mylist = os.listdir(updpath)
-    except OSError as oe:
-        if oe.errno == errno.ENOENT:
-            raise DirectoryNotFound(updpath)
-        raise
+    mylist = listdir(updpath)
     if prev_mtimes is None:
         prev_mtimes = {}
 

--- a/lib/portage/update.py
+++ b/lib/portage/update.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import re
-import stat
 import sys
 import warnings
 
@@ -11,7 +10,6 @@ from portage.const import USER_CONFIG_PATH, VCS_DIRS
 from portage.eapi import _get_eapi_attrs
 from portage.exception import InvalidAtom, PortageException
 from portage.localization import _
-from portage.util.listdir import listdir
 
 ignored_dbentries = ("CONTENTS", "environment.bz2")
 
@@ -161,27 +159,27 @@ def grab_updates(updpath, prev_mtimes=None):
     the source package of a move that comes somewhere later in the entire
     sequence of files.
     """
-    mylist = listdir(updpath)
     if prev_mtimes is None:
         prev_mtimes = {}
 
     update_data = []
-    for myfile in mylist:
-        if myfile.startswith("."):
-            continue
-        file_path = os.path.join(updpath, myfile)
-        mystat = os.stat(file_path)
-        if not stat.S_ISREG(mystat.st_mode):
-            continue
-        if int(prev_mtimes.get(file_path, -1)) != mystat[stat.ST_MTIME]:
-            f = open(
-                file_path,
-                encoding="utf-8",
-                errors="replace",
-            )
-            content = f.read()
-            f.close()
-            update_data.append((file_path, mystat, content))
+    with os.scandir(updpath) as mylist:
+        for myfile in mylist:
+            if myfile.name.startswith("."):
+                continue
+            if not myfile.is_file():
+                continue
+
+            mystat = myfile.stat()
+            if int(prev_mtimes.get(myfile.path, -1)) != mystat.st_mtime:
+                f = open(
+                    myfile.path,
+                    encoding="utf-8",
+                    errors="replace",
+                )
+                content = f.read()
+                f.close()
+                update_data.append((myfile.path, mystat, content))
     return update_data
 
 

--- a/lib/portage/util/listdir.py
+++ b/lib/portage/util/listdir.py
@@ -1,56 +1,44 @@
-# Copyright 2010-2013 Gentoo Foundation
+# Copyright 2010-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = ["cacheddir", "listdir"]
 
-import errno
-import stat
-
 import os
+
 from portage.const import VCS_DIRS
 from portage.exception import DirectoryNotFound, PermissionDenied, PortageException
 from portage.util import normalize_path
 
 
 def cacheddir(my_original_path, ignorecvs, ignorelist, followSymlinks=True):
+    fpaths = []
+    ftype = []
     mypath = normalize_path(my_original_path)
+
     try:
-        pathstat = os.stat(mypath)
-        if not stat.S_ISDIR(pathstat.st_mode):
-            raise DirectoryNotFound(mypath)
+        with os.scandir(mypath) as it:
+            for entry in it:
+                fpaths.append(entry.name)
+
+                try:
+                    if entry.is_file(follow_symlinks=followSymlinks):
+                        ftype.append(0)
+                    elif entry.is_dir(follow_symlinks=followSymlinks):
+                        ftype.append(1)
+                    elif entry.is_symlink(follow_symlinks=followSymlinks):
+                        ftype.append(2)
+                    else:
+                        ftype.append(3)
+                except OSError:
+                    ftype.append(3)
+    except NotADirectoryError:
+        raise DirectoryNotFound(mypath)
     except OSError as e:
         if e.errno == PermissionDenied.errno:
             raise PermissionDenied(mypath)
-        del e
-        return [], []
+        return fpaths, ftype
     except PortageException:
-        return [], []
-    else:
-        try:
-            fpaths = os.listdir(mypath)
-        except OSError as e:
-            if e.errno != errno.EACCES:
-                raise
-            del e
-            raise PermissionDenied(mypath)
-        ftype = []
-        for x in fpaths:
-            try:
-                if followSymlinks:
-                    pathstat = os.stat(mypath + "/" + x)
-                else:
-                    pathstat = os.lstat(mypath + "/" + x)
-
-                if stat.S_ISREG(pathstat[stat.ST_MODE]):
-                    ftype.append(0)
-                elif stat.S_ISDIR(pathstat[stat.ST_MODE]):
-                    ftype.append(1)
-                elif stat.S_ISLNK(pathstat[stat.ST_MODE]):
-                    ftype.append(2)
-                else:
-                    ftype.append(3)
-            except OSError:
-                ftype.append(3)
+        return fpaths, ftype
 
     if ignorelist or ignorecvs:
         ret_list = []


### PR DESCRIPTION
Replace {os.stat(), os.listdir(), os.stat() or os.lstat()} with just
os.scandir() which will reuse cached stat calls where possible, like
where we check the file type. It's also just cleaner.

Porting consumers of os.listdir() in general will require some care
to see if it's worht the churn, as it's only worth it if the
information is actually going to be reused (nicer attributes notwithstanding).

This is a bit easier to review with `-w`.

With this on emerge -p -uvDU @world for me, we go from 17746 newfstatat
calls -> 14834 newfsstatat (16%) calls, and with a total syscall count change
of 297326 -> 294345 (1%).

Signed-off-by: Sam James <sam@gentoo.org>