### PR TITLE
Fix missed Atom str-subtyping call sites

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -504,7 +504,9 @@ def action_build(
                         x
                         for x in favorites
                         if not (
-                            x.startswith(SETPREFIX) and not sets[x[1:]].world_candidate
+                            isinstance(x, str)
+                            and x.startswith(SETPREFIX)
+                            and not sets[x[1:]].world_candidate
                         )
                     ]
 

--- a/lib/_emerge/create_world_atom.py
+++ b/lib/_emerge/create_world_atom.py
@@ -102,7 +102,9 @@ def create_world_atom(pkg, args_set, root_config, before_install=False):
             if len(matched_slots) == 1:
                 new_world_atom = slot_atom
                 if arg_atom.repo:
-                    new_world_atom += _repo_separator + arg_atom.repo
+                    new_world_atom = (
+                        str(new_world_atom) + _repo_separator + arg_atom.repo
+                    )
 
     if new_world_atom == sets["selected"].findAtomForPackage(pkg):
         # Both atoms would be identical, so there's nothing to add.

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -11135,7 +11135,7 @@ class depgraph:
 
             if not skip:
                 for a in all_added:
-                    if a.startswith(SETPREFIX):
+                    if isinstance(a, str) and a.startswith(SETPREFIX):
                         filename = "world_sets"
                     else:
                         filename = "world"

--- a/lib/portage/tests/emerge/test_actions.py
+++ b/lib/portage/tests/emerge/test_actions.py
@@ -1,9 +1,10 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 from unittest.mock import MagicMock, patch
 
 from _emerge.actions import get_libc_version, run_action
+from _emerge.create_world_atom import create_world_atom
 
 from portage.const import LIBC_PACKAGE_ATOM
 from portage.dbapi.virtual import fakedbapi
@@ -49,6 +50,43 @@ class RunActionTestCase(TestCase):
         bt.populate.assert_called_once_with(
             getbinpkgs=False, getbinpkg_refresh=True, pretend=False, verbose=False
         )
+
+    def testCreateWorldAtomSlottedWithRepo(self):
+        pkg = MagicMock()
+        pkg.slot_atom = Atom("dev-libs/foo:1")
+        pkg.slot = "1"
+
+        arg_atom = Atom("=dev-libs/foo-1::gentoo", allow_repo=True)
+
+        args_set = MagicMock()
+        args_set.findAtomForPackage.return_value = arg_atom
+
+        portdb = MagicMock()
+        portdb.porttrees = ["/usr/portage"]
+        portdb.repositories.get_name_for_location.return_value = "gentoo"
+        portdb.match.side_effect = lambda a: (
+            ["dev-libs/foo-1"] if str(a) == "dev-libs/foo" else ["dev-libs/foo-1:1"]
+        )
+        slot_pkg_str = MagicMock()
+        slot_pkg_str.slot = "1"
+        portdb._pkg_str.return_value = slot_pkg_str
+
+        vardb = MagicMock()
+        vardb.match.return_value = ["dev-libs/foo-1"]
+
+        root_config = MagicMock()
+        root_config.trees = {
+            "porttree": MagicMock(dbapi=portdb),
+            "vartree": MagicMock(dbapi=vardb),
+        }
+        root_config.sets["selected"].findAtomForPackage.return_value = None
+        root_config.sets["system"].findAtomForPackage.return_value = None
+
+        result = create_world_atom(pkg, args_set, root_config, before_install=True)
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, str)
+        self.assertIn("::gentoo", result)
 
     def testGetSystemLibc(self):
         """

--- a/lib/portage/tests/emerge/test_noreplace.py
+++ b/lib/portage/tests/emerge/test_noreplace.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import subprocess
+
+import portage
+from portage.const import PORTAGE_PYM_PATH
+from portage.process import find_binary
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+from portage.util import ensure_dirs
+
+
+class NoreplaceEmergeTestCase(TestCase):
+    def testNoreplaceAlreadyInstalled(self):
+        ebuilds = {
+            "dev-libs/A-1": {"KEYWORDS": "x86"},
+        }
+        installed = {
+            "dev-libs/A-1": {"KEYWORDS": "x86"},
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds, installed=installed)
+        settings = playground.settings
+        eprefix = settings["EPREFIX"]
+
+        portage_python = portage._python_interpreter
+        emerge_cmd = (
+            portage_python,
+            "-b",
+            "-Wd",
+            os.path.join(str(self.bindir), "emerge"),
+        )
+
+        fake_bin = os.path.join(eprefix, "bin")
+        var_cache_edb = os.path.join(eprefix, "var", "cache", "edb")
+
+        path = settings.get("PATH")
+        if not path or not path.strip():
+            path = ""
+        else:
+            path = ":" + path
+        path = fake_bin + path
+
+        pythonpath = os.environ.get("PYTHONPATH")
+        if pythonpath is not None and not pythonpath.strip():
+            pythonpath = None
+        if pythonpath is None or pythonpath.split(":")[0] != PORTAGE_PYM_PATH:
+            pythonpath = PORTAGE_PYM_PATH + (":" + pythonpath if pythonpath else "")
+
+        env = {
+            "PORTAGE_OVERRIDE_EPREFIX": eprefix,
+            "PATH": path,
+            "PORTAGE_PYTHON": portage_python,
+            "PORTAGE_REPOSITORIES": settings.repositories.config_string(),
+            "PYTHONDONTWRITEBYTECODE": os.environ.get("PYTHONDONTWRITEBYTECODE", ""),
+            "PYTHONPATH": pythonpath,
+            "PORTAGE_INST_GID": str(os.getgid()),
+            "PORTAGE_INST_UID": str(os.getuid()),
+        }
+
+        if "__PORTAGE_TEST_HARDLINK_LOCKS" in os.environ:
+            env["__PORTAGE_TEST_HARDLINK_LOCKS"] = os.environ[
+                "__PORTAGE_TEST_HARDLINK_LOCKS"
+            ]
+
+        true_binary = find_binary("true")
+        self.assertIsNotNone(true_binary, "true command not found")
+
+        try:
+            ensure_dirs(fake_bin)
+            ensure_dirs(var_cache_edb)
+            for x in ("chown", "chgrp"):
+                os.symlink(true_binary, os.path.join(fake_bin, x))
+            with open(os.path.join(var_cache_edb, "counter"), "wb") as f:
+                f.write(b"100")
+
+            proc = subprocess.Popen(
+                emerge_cmd + ("--noreplace", "--verbose", "dev-libs/A"),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            _, stderr = proc.communicate()
+
+            self.assertEqual(
+                proc.returncode,
+                os.EX_OK,
+                f"emerge --noreplace --verbose crashed:\n{stderr.decode()}",
+            )
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
Three call sites missed by the 7e15fc7fa ("dep: Atom: remove str subtyping") audit:

- actions: Atom.startswith() in world_candidates filtering (bug 978088)
- create_world_atom: Atom += str when recording slotted atom to world
- depgraph: Atom.startswith() in saveNomergeFavorites

Regression tests for the first two bugs. (Third would require actual emerging, I think)

Bug: https://bugs.gentoo.org/978088