### PR TITLE
whirlpool.c: fix -Wpointer-sign warnings in whirlpool C extension

### DIFF
--- a/src/portage_util__whirlpool.c
+++ b/src/portage_util__whirlpool.c
@@ -1074,7 +1074,7 @@ Whirlpool_update(WhirlpoolObject *self, PyObject *buf)
         return NULL;
     }
 
-    NESSIEadd(data, length * 8, &self->state);
+    NESSIEadd((const unsigned char *)data, length * 8, &self->state);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -1085,7 +1085,7 @@ Whirlpool_digest(WhirlpoolObject *self, PyObject *unused_obj)
 {
     char result[DIGESTBYTES];
 
-    NESSIEfinalize(&self->state, result);
+    NESSIEfinalize(&self->state, (unsigned char *)result);
 
     return PyBytes_FromStringAndSize(result, DIGESTBYTES);
 }


### PR DESCRIPTION
The C implementation of the whirlpool hash algorithm (NESSIEadd and NESSIEfinalize) expects pointers to unsigned char arrays. Passing char* or char[] without a cast triggers -Wpointer-sign warnings during compilation.

Suppress the warning by explicitly cast the pointer arguments in Whirlpool_update() and Whirlpool_digest() to const unsigned char * and unsigned char * respectively.