### PR TITLE
util: listdir: drop invalid follow_symlinks kwarg from is_symlink()

### DIFF
--- a/lib/portage/util/listdir.py
+++ b/lib/portage/util/listdir.py
@@ -25,7 +25,7 @@ def cacheddir(my_original_path, ignorecvs, ignorelist, followSymlinks=True):
                         ftype.append(0)
                     elif entry.is_dir(follow_symlinks=followSymlinks):
                         ftype.append(1)
-                    elif entry.is_symlink(follow_symlinks=followSymlinks):
+                    elif entry.is_symlink():
                         ftype.append(2)
                     else:
                         ftype.append(3)


### PR DESCRIPTION
Python's is_symlink() method takes no arguments, unlike is_dir() and is_file(). Passing the 'follow_symlinks' keyword argument results in a TypeError.

This bug surfaces during package tree traversals, notably crashing "eclean distfiles" with:

  TypeError: is_symlink() takes no arguments
      elif entry.is_symlink(follow_symlinks=followSymlinks):

Fix this by removing the invalid argument.

Fixes: ef82d7e97385c7d7f377c0adf6f9cec21f0856bb