### PR TITLE
util: drop stale unicode comment

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1836,11 +1836,9 @@ class _info_pkgs_ver:
     def __lt__(self, other):
         return portage.versions.vercmp(self.ver, other.ver) < 0
 
-    def toString(self):
+    def __str__(self):
         """
         This may return unicode if repo_name contains unicode.
-        Don't use __str__ and str() since unicode triggers compatibility
-        issues between python 2.x and 3.x.
         """
         return self.ver + self.repo_suffix + self.provide_suffix
 
@@ -2138,7 +2136,7 @@ def action_info(settings, trees, myopts, myfiles):
 
     for cp in sorted(cp_map):
         versions = sorted(cp_map[cp].values())
-        versions = ", ".join(ver.toString() for ver in versions)
+        versions = ", ".join(str(ver) for ver in versions)
         append(f"{(cp + ':').ljust(cp_max_len + 1)} {versions}")
 
     append("Repositories:\n")

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -835,16 +835,11 @@ def has_ipv6():
                 # With ipv6.disable=0 and ipv6.disable_ipv6=1, socket creation
                 # succeeds, but then the bind call fails with this error:
                 # [Errno 99] Cannot assign requested address.
-                sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-                sock.bind(("::1", 0))
+                with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
+                    sock.bind(("::1", 0))
             except OSError:
                 __has_ipv6 = False
-            else:
-                __has_ipv6 = True
-            finally:
-                # python2.7 sockets do not support context management protocol
-                if sock is not None:
-                    sock.close()
+            __has_ipv6 = True
         else:
             __has_ipv6 = False
 

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -782,10 +782,6 @@ def getconfig(
         if f is not None:
             f.close()
 
-    # Since this file has unicode_literals enabled, and Python 2's
-    # shlex implementation does not support unicode, the following code
-    # uses _native_string() to encode unicode literals when necessary.
-
     # Workaround for avoiding a silent error in shlex that is
     # triggered by a source statement at the end of the file
     # without a trailing newline after the source statement.


### PR DESCRIPTION
Fixes: 30bbecf
Signed-off-by: Sam James <sam@gentoo.org>