### PR TITLE
emerge: fix AttributeError when Atom object used where str expected

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -853,7 +853,7 @@ def action_depclean(
                 matched_packages = True
             else:
                 writemsg_level(
-                    f"--- Couldn't find '{x.replace('null/', '')}' to {action}.\n",
+                    f"--- Couldn't find '{str(x).replace('null/', '')}' to {action}.\n",
                     level=logging.WARN,
                     noiselevel=-1,
                 )

--- a/lib/_emerge/unmerge.py
+++ b/lib/_emerge/unmerge.py
@@ -229,7 +229,7 @@ def _unmerge_display(
                 mymatch = vartree.dep_match(x)
             if not mymatch:
                 portage.writemsg(
-                    f"\n--- Couldn't find '{x.replace('null/', '')}' to {unmerge_action}.\n",
+                    f"\n--- Couldn't find '{str(x).replace('null/', '')}' to {unmerge_action}.\n",
                     noiselevel=-1,
                 )
                 continue


### PR DESCRIPTION
Atom no longer inherits from str, so calling .replace() directly on an Atom object fails. Cast to str() before calling .replace().

Fixes: 7e15fc7fa ("dep: Atom: remove str subtyping")