### PR TITLE
Remove dead Python <3.9 compatibility guards

### DIFF
--- a/bin/socks5-server.py
+++ b/bin/socks5-server.py
@@ -20,19 +20,6 @@ import errno
 import socket
 import struct
 
-if hasattr(asyncio, "ensure_future"):
-    # Python >=3.4.4.
-    asyncio_ensure_future = asyncio.ensure_future
-else:
-    # getattr() necessary because async is a keyword in Python >=3.7.
-    asyncio_ensure_future = getattr(asyncio, "async")
-
-try:
-    current_task = asyncio.current_task
-except AttributeError:
-    # Deprecated since Python 3.7
-    current_task = asyncio.Task.current_task
-
 
 class Socks5Server:
     """
@@ -167,8 +154,8 @@ class Socks5Server:
 
             # otherwise, start two loops:
             # remote -> local...
-            t = asyncio_ensure_future(
-                self.handle_proxied_conn(proxied_reader, writer, current_task())
+            t = asyncio.ensure_future(
+                self.handle_proxied_conn(proxied_reader, writer, asyncio.current_task())
             )
 
             # and local -> remote...

--- a/bin/xattr-helper.py
+++ b/bin/xattr-helper.py
@@ -86,11 +86,7 @@ def unquote(s):
             pos = start + 4
             a = array.array("B")
             a.append(int(s[start + 1 : pos], 8))
-            try:
-                # Python >= 3.2
-                result.append(a.tobytes())
-            except AttributeError:
-                result.append(a.tostring())
+            result.append(a.tobytes())
 
     return b"".join(result)
 

--- a/lib/_emerge/AbstractPollTask.py
+++ b/lib/_emerge/AbstractPollTask.py
@@ -46,11 +46,7 @@ class AbstractPollTask(AsynchronousTask):
                 raise
 
         if buf is not None:
-            try:
-                # Python >=3.2
-                buf = buf.tobytes()
-            except AttributeError:
-                buf = buf.tostring()
+            buf = buf.tobytes()
 
         return buf
 

--- a/lib/portage/process.py
+++ b/lib/portage/process.py
@@ -43,17 +43,6 @@ try:
 except ImportError:
     max_fd_limit = 256
 
-# Support PEP 446 for Python >=3.4
-try:
-    _set_inheritable = os.set_inheritable
-except AttributeError:
-    _set_inheritable = None
-
-try:
-    _FD_CLOEXEC = fcntl.FD_CLOEXEC
-except AttributeError:
-    _FD_CLOEXEC = None
-
 # Prefer /proc/self/fd if available (/dev/fd
 # doesn't work on solaris, see bug #474536).
 for _fd_dir in ("/proc/self/fd", "/dev/fd"):
@@ -111,21 +100,20 @@ def sanitize_fds():
     ensures that any unintentionally inherited file descriptors will
     not be inherited by child processes.
     """
-    if _set_inheritable is not None:
-        whitelist = frozenset(
-            [
-                portage._get_stdin().fileno(),
-                sys.__stdout__.fileno(),
-                sys.__stderr__.fileno(),
-            ]
-        )
+    whitelist = frozenset(
+        [
+            portage._get_stdin().fileno(),
+            sys.__stdout__.fileno(),
+            sys.__stderr__.fileno(),
+        ]
+    )
 
-        for fd in get_open_fds():
-            if fd not in whitelist:
-                try:
-                    _set_inheritable(fd, False)
-                except OSError:
-                    pass
+    for fd in get_open_fds():
+        if fd not in whitelist:
+            try:
+                os.set_inheritable(fd, False)
+            except OSError:
+                pass
 
 
 def spawn_bash(mycommand, debug=False, opt_name=None, **keywords):
@@ -1427,27 +1415,21 @@ def _setup_pipes(fd_pipes, close_fds=True, inheritable=None):
 
             if oldfd != newfd:
                 os.dup2(oldfd, newfd)
-                if _set_inheritable is not None:
-                    # Don't do this unless _set_inheritable is available,
-                    # since it's used below to ensure correct state, and
-                    # otherwise /dev/null stdin fails to inherit (at least
-                    # with Python versions from 3.1 to 3.3).
-                    if old_fdflags is None:
-                        old_fdflags = fcntl.fcntl(oldfd, fcntl.F_GETFD)
-                    fcntl.fcntl(newfd, fcntl.F_SETFD, old_fdflags)
+                if old_fdflags is None:
+                    old_fdflags = fcntl.fcntl(oldfd, fcntl.F_GETFD)
+                fcntl.fcntl(newfd, fcntl.F_SETFD, old_fdflags)
 
-            if _set_inheritable is not None:
-                inheritable_state = None
-                if not (old_fdflags is None or _FD_CLOEXEC is None):
-                    inheritable_state = not bool(old_fdflags & _FD_CLOEXEC)
+            inheritable_state = None
+            if old_fdflags is not None:
+                inheritable_state = not bool(old_fdflags & fcntl.FD_CLOEXEC)
 
-                if inheritable is not None:
-                    if inheritable_state is not inheritable:
-                        _set_inheritable(newfd, inheritable)
+            if inheritable is not None:
+                if inheritable_state is not inheritable:
+                    os.set_inheritable(newfd, inheritable)
 
-                elif newfd in (0, 1, 2):
-                    if inheritable_state is not True:
-                        _set_inheritable(newfd, True)
+            elif newfd in (0, 1, 2):
+                if inheritable_state is not True:
+                    os.set_inheritable(newfd, True)
 
         if oldfd not in fd_pipes:
             # If oldfd is not a key in fd_pipes, then it's safe

--- a/lib/portage/tests/ebuild/test_array_fromfile_eof.py
+++ b/lib/portage/tests/ebuild/test_array_fromfile_eof.py
@@ -32,11 +32,7 @@ class ArrayFromfileEofTestCase(TestCase):
             if not a:
                 eof = True
             else:
-                try:
-                    # Python >=3.2
-                    data.append(a.tobytes())
-                except AttributeError:
-                    data.append(a.tostring())
+                data.append(a.tobytes())
 
         f.close()
 

--- a/lib/portage/util/configparser.py
+++ b/lib/portage/util/configparser.py
@@ -34,15 +34,6 @@ def read_configs(parser, paths):
     @param paths: list of paths to read
     @type paths: iterable
     """
-    # use read_file/readfp in order to control decoding of unicode
-    try:
-        # Python >=3.2
-        read_file = parser.read_file
-        source_kwarg = "source"
-    except AttributeError:
-        read_file = parser.readfp
-        source_kwarg = "filename"
-
     for p in paths:
         if isinstance(p, str):
             f = None
@@ -55,18 +46,12 @@ def read_configs(parser, paths):
             except OSError:
                 pass
             else:
-                # The 'source' keyword argument is needed since otherwise
-                # ConfigParser in Python <3.3.3 may throw a TypeError
-                # because it assumes that f.name is a native string rather
-                # than binary when constructing error messages.
-                kwargs = {source_kwarg: p}
-                read_file(f, **kwargs)
+                parser.read_file(f, source=p)
             finally:
                 if f is not None:
                     f.close()
         elif isinstance(p, io.StringIO):
-            kwargs = {source_kwarg: "<io.StringIO>"}
-            read_file(p, **kwargs)
+            parser.read_file(p, source="<io.StringIO>")
         else:
             raise TypeError(
                 f"Unsupported type {type(p)!r} of element {p!r} of 'paths' argument"

--- a/lib/portage/util/mtimedb.py
+++ b/lib/portage/util/mtimedb.py
@@ -80,11 +80,6 @@ class MtimeDB(dict):
             except Exception as e:
                 try:
                     mypickle = pickle.Unpickler(io.BytesIO(content))
-                    try:
-                        mypickle.find_global = None
-                    except AttributeError:
-                        # Python >=3
-                        pass
                     d = mypickle.load()
                 except SystemExit:
                     raise

--- a/lib/portage/xpak.py
+++ b/lib/portage/xpak.py
@@ -81,11 +81,7 @@ def encodeint(myint):
     a.append((myint >> 16) & 0xFF)
     a.append((myint >> 8) & 0xFF)
     a.append(myint & 0xFF)
-    try:
-        # Python >= 3.2
-        return a.tobytes()
-    except AttributeError:
-        return a.tostring()
+    return a.tobytes()
 
 
 def decodeint(mystring):


### PR DESCRIPTION
Since portage requires Python >=3.9, several compatibility shims for
older Python versions are unreachable dead code. Remove them.

- process: `os.set_inheritable` and `fcntl.FD_CLOEXEC` are guaranteed present since 3.4; drop the `try`/`except` guards and `None`-checks
- `array.tostring()` was removed in 3.9; drop fallbacks from `tobytes()` calls in xpak, AbstractPollTask, xattr-helper, and tests
- socks5-server: `asyncio.ensure_future` (3.4.4) and `asyncio.current_task` (3.7) are always available; remove the compat aliases
- mtimedb: `Unpickler.find_global` is Python 2 only; the assignment always raised `AttributeError` in Python 3. Remove the dead `try`/`except`
- configparser: `ConfigParser.readfp()` was removed in 3.12; `read_file()` has been the right call since 3.2