### PR TITLE
porttree: hoist pkgsplit import out of findname2

### DIFF
--- a/lib/portage/dbapi/porttree.py
+++ b/lib/portage/dbapi/porttree.py
@@ -21,6 +21,7 @@ from portage.exception import (
 from portage.localization import _
 
 from portage import eclass_cache, eapi_is_supported, _eapi_is_deprecated
+from portage.versions import pkgsplit
 from portage.util.futures import asyncio
 from portage.util.futures.iter_completed import iter_gather
 from _emerge.EbuildMetadataPhase import EbuildMetadataPhase
@@ -521,8 +522,6 @@ class portdbapi(dbapi):
         the file we wanted.
         If myrepo is not None it will find packages from this repository(overlay)
         """
-        from portage.versions import pkgsplit
-
         if not mycpv:
             return (None, 0)
 
@@ -1661,8 +1660,6 @@ class portagetree:
 
     def getname(self, pkgname):
         """Deprecated. Use the portdbapi findname method instead."""
-        from portage.versions import pkgsplit
-
         warnings.warn(
             "The getname method of "
             "portage.dbapi.porttree.portagetree is deprecated. "


### PR DESCRIPTION
findname2 is on the resolver hot path (called once per candidate cpv, tens of thousands of times per `@world` resolve) and did 'from portage.versions import pkgsplit' on every call. The import is cheap not free at that call volume. Import pkgsplit at module scope instead; there is no circular-import risk (portage.versions does not import porttree).

Also drop the now-redundant in-function import in the deprecated getname().