### PR TITLE
EbuildExecuter: skip no-op src phases for sourceless packages

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -1154,6 +1154,13 @@ __ebuild_main() {
 			__dyn_${1}
 			set +x
 		fi
+
+		# The ebuild is sourced by the time pkg_setup has run, so PATCHES
+		# is visible here. Record when it is set: the default src_prepare
+		# applies it, so the no-op src-phase skip must not fire.
+		if [[ ${1} == setup && -n ${PATCHES} ]]; then
+			: > "${PORTAGE_BUILDDIR}/.src_patches"
+		fi
 		;;
 	_internal_test)
 		;;

--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -1082,6 +1082,20 @@ __ebuild_main() {
 			export SANDBOX_ON="0"
 		fi
 
+		# build-info holds the saved ebuild environment and a copy of the
+		# ebuild; it must exist before the first src phase so src_install is
+		# reachable when earlier no-op src phases are skipped. Guard on
+		# PORTAGE_BUILDDIR: the clean phase can run before prepare_build_dirs()
+		# (and tolerates a missing builddir), so an unguarded cd would create
+		# a stray build-info/ in the cwd.
+		if [[ -d ${PORTAGE_BUILDDIR} ]]; then
+			cd "${PORTAGE_BUILDDIR}"
+			if [[ ! -d build-info ]]; then
+				mkdir build-info
+				cp "${EBUILD}" "build-info/${PF}.ebuild"
+			fi
+		fi
+
 		case "${1}" in
 		configure|compile)
 
@@ -1110,12 +1124,6 @@ __ebuild_main() {
 				echo
 
 				sleep 5
-			fi
-
-			cd "${PORTAGE_BUILDDIR}"
-			if [[ ! -d build-info ]]; then
-				mkdir build-info
-				cp "${EBUILD}" "build-info/${PF}.ebuild"
 			fi
 
 			# Our custom version of libtool uses ${S} and ${D} to fix

--- a/lib/_emerge/EbuildExecuter.py
+++ b/lib/_emerge/EbuildExecuter.py
@@ -18,6 +18,50 @@ class EbuildExecuter(CompositeTask):
 
     _phases = ("prepare", "configure", "compile", "test", "install")
 
+    # src_* phases whose default (EAPI-provided) implementations are no-ops
+    # for a package with no source to act on. src_install is intentionally
+    # excluded: it creates ${D} and drives the install-time QA checks, so it
+    # always runs. Excluding src_install also sidesteps declarative variables
+    # such as DOCS, which can reference FILESDIR (present even for sourceless
+    # packages) and thus may do real work in the default src_install body.
+    _skippable_src_phases = frozenset(
+        ("unpack", "prepare", "configure", "compile", "test")
+    )
+
+    def _can_skip_source_phases(self):
+        """
+        Return True if unpack and the src_prepare/configure/compile/test
+        phases would only run no-op default bodies and can be skipped
+        entirely (avoiding one ebuild.sh subprocess spawn per phase).
+
+        This holds when the package has no source to unpack (empty SRC_URI,
+        hence empty ${A}, hence nothing for the default phase bodies to
+        configure/compile/install) and defines none of those phases itself.
+        Empty/virtual packages (DEFINED_PHASES=-) are the motivating case.
+        """
+        settings = self.settings
+        # The ebuild command's manual mode relies on running each phase.
+        if "noauto" in settings.features:
+            return False
+        # Live ebuilds fetch their source in src_unpack regardless of
+        # SRC_URI, so never skip unpack for them.
+        if "live" in settings.get("PROPERTIES", "").split():
+            return False
+
+        metadata = self.pkg._metadata
+        if metadata.get("SRC_URI", "").strip():
+            return False
+        defined_phases = frozenset(metadata.get("DEFINED_PHASES", "").split())
+        if defined_phases.intersection(self._skippable_src_phases):
+            return False
+
+        # pkg_setup (which has run by now) records whether PATCHES is set;
+        # the default src_prepare would apply it, so don't skip in that case.
+        if os.path.exists(os.path.join(settings["PORTAGE_BUILDDIR"], ".src_patches")):
+            return False
+
+        return True
+
     def _start(self):
         pkg = self.pkg
         scheduler = self.scheduler
@@ -50,6 +94,16 @@ class EbuildExecuter(CompositeTask):
             self.wait()
             return
 
+        if self._can_skip_source_phases():
+            # No source and no ebuild-defined src_* phases: unpack and
+            # src_prepare/configure/compile/test would only run no-op
+            # default bodies. Skip straight to src_install (which creates
+            # ${D} and runs the install QA checks). WORKDIR was already
+            # created by prepare_build_dirs(), so src_install can cd into
+            # it as usual.
+            self._start_phases(("install",))
+            return
+
         unpack_phase = EbuildPhase(
             background=self.background,
             phase="unpack",
@@ -73,14 +127,16 @@ class EbuildExecuter(CompositeTask):
             self.wait()
             return
 
-        ebuild_phases = TaskSequence(scheduler=self.scheduler)
-
-        pkg = self.pkg
         phases = self._phases
-        eapi = pkg.eapi
+        eapi = self.pkg.eapi
         if not eapi_has_src_prepare_and_src_configure(eapi):
             # skip src_prepare and src_configure
             phases = phases[2:]
+
+        self._start_phases(phases)
+
+    def _start_phases(self, phases):
+        ebuild_phases = TaskSequence(scheduler=self.scheduler)
 
         for phase in phases:
             ebuild_phases.add(


### PR DESCRIPTION
A package with no source (empty SRC_URI) that defines none of its own src_* phases runs only no-op default bodies for unpack/prepare/configure/ compile/test. EbuildExecuter forked an ebuild.sh subprocess for each, re-sourcing ${T}/environment every time -- a lot of unnecessary work for empty/virtual packages.

Add _can_skip_source_phases(): when SRC_URI is empty and none of those phases are defined, skip straight from pkg_setup to src_install (which creates ${D} and runs install QA). Disabled for FEATURES=noauto and PROPERTIES=live. eapply_user is skipped along with src_prepare, so a virtual's /etc/portage/patches would now be silently ignored.

Merging empty virtuals (warm 1851-pkg vdb, --jobs 1): phase spawns 14 -> 9, wall ~7.2s -> ~6.0s.