### PR TITLE
dep: Atom: fix TypeError in str.join() calls after removal of str subtyping

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -2477,7 +2477,7 @@ class Scheduler(PollScheduler):
             if not atoms:
                 msg += " dropped because it is masked or unavailable"
             else:
-                msg += f" dropped because it requires {', '.join(set(atoms))}"
+                msg += f" dropped because it requires {', '.join(str(a) for a in set(atoms))}"
             for line in textwrap.wrap(msg, msg_width):
                 eerror(line, phase="other", key=pkg.cpv)
             settings = self.pkgsettings[pkg.root]

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -385,7 +385,7 @@ def action_build(
                         )
                     else:
                         writemsg(
-                            f"  {task} requires {', '.join(atoms)}\n",
+                            f"  {task} requires {', '.join(str(a) for a in atoms)}\n",
                             noiselevel=-1,
                         )
 

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -2386,7 +2386,7 @@ class depgraph:
                         "_slot_operator_check_reverse_dependencies:",
                         f"   candidate package does not match atom '{atom}': {candidate_pkg}",
                         f"   parent: {parent}",
-                        f"   parent atoms: {' '.join(parent_atoms)}",
+                        f"   parent atoms: {' '.join(str(a) for a in parent_atoms)}",
                         "",
                     )
                     writemsg_level("\n".join(msg), noiselevel=-1, level=logging.DEBUG)

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1012,7 +1012,7 @@ class ResolverPlaygroundTestCase:
                             if not got.index(node1) < got.index(node2):
                                 fail_msgs.append(
                                     "atoms: ("
-                                    + ", ".join(result.atoms)
+                                    + ", ".join(str(a) for a in result.atoms)
                                     + "), key: "
                                     + (
                                         "merge_order_assertions, expected: %s"
@@ -1055,7 +1055,7 @@ class ResolverPlaygroundTestCase:
             if got != expected:
                 fail_msgs.append(
                     "atoms: ("
-                    + ", ".join(result.atoms)
+                    + ", ".join(str(a) for a in result.atoms)
                     + "), key: "
                     + key
                     + ", expected: "


### PR DESCRIPTION
After 7e15fc7fa (dep: Atom: remove str subtyping), Atom objects are no longer str instances, so any str.join() call on an iterable of Atoms raises TypeError: sequence item 0: expected str instance, Atom found. Fix four sites by adding explicit str() conversion:

- _emerge/Scheduler._calc_resume_list: --keep-going dropped-package message (bug #978486)
- _emerge/actions.action_build: same dropped-package display in a parallel code path
- _emerge/depgraph._slot_operator_check_reverse_dependencies: debug message
- tests/resolver/ResolverPlayground: test failure messages