### PR TITLE
emirrordist: fix dropping untried primary URIs

### DIFF
--- a/lib/portage/_emirrordist/FetchTask.py
+++ b/lib/portage/_emirrordist/FetchTask.py
@@ -273,7 +273,7 @@ class FetchTask(CompositeTask):
 
     def _next_uri(self):
         remaining_tries = self.config.options.tries - len(self._tried_uris)
-        if remaining_tries > 0:
+        if remaining_tries > 0 or self._primaryuri_stack:
             if remaining_tries <= self.config.options.tries // 2:
                 while self._primaryuri_stack:
                     uri = self._primaryuri_stack.pop()


### PR DESCRIPTION
When --tries is less than the number of primary URIs (e.g. emirrordist --tries=1 with kernel-2.eclass's GENPATCHES_URI), this can cause unexpected fetch failures. In this case, when remaining_tries drops to 0, _next_uri() will return None even if untried URIs remain in _primaryuri_stack.
