### PR TITLE
special_env_vars.py: add QEMU_* to environ_whitelist_re

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -86,14 +86,19 @@ portage_mutable_filtered_vars=( AA HOSTNAME )
 # is to preserve various variables as they were at the time that the binary
 # package was built while protecting against the application of package renames.
 __filter_readonly_variables() {
-	local -a filtered_vars bash_vars
-	local IFS
+	local -a filtered_vars bash_vars qemu_env
+	local IFS x
+
+	# preserve QEMU vars for qemu-static
+	for x in ${!QEMU_@}; do
+		qemu_env+=( "${x}=${!x}" )
+	done
 
 	# Collect an initial list of special bash variables by instructing a
 	# hygienic instance of bash(1) to report them.
 	mapfile -t bash_vars < <(
 		# Like compgen -A variable but doesn't require readline support.
-		env -i -- "${BASH}" -c "printf %s\\\n $(printf '${!%s*} ' {A..Z} {a..z} _)" \
+		env -i -- "${qemu_env[@]}" "${BASH}" -c "printf %s\\\n $(printf '${!%s*} ' {A..Z} {a..z} _)" \
 		| grep -vx -e PATH -e SHELL
 	)
 	# Incorporate other variables that are known to either be set by or be

--- a/lib/portage/package/ebuild/_config/special_env_vars.py
+++ b/lib/portage/package/ebuild/_config/special_env_vars.py
@@ -247,7 +247,7 @@ environ_whitelist = frozenset(
     )
 )
 
-environ_whitelist_re = re.compile(r"^(CCACHE_|DISTCC_).*")
+environ_whitelist_re = re.compile(r"^(CCACHE_|DISTCC_|QEMU_).*")
 
 # Filter selected variables in the config.environ() method so that
 # they don't needlessly propagate down into the ebuild environment.


### PR DESCRIPTION
When running emerge in a cross architecture chroot via qemu-static
with extensions that are not enabled by default it fails with error:
```
Sandboxed process killed by signal: Illegal instruction
 * The ebuild phase 'unpack' has been killed by signal 4.
```
This is caused by `qemu-static` being invoked without the `QEMU_*` vars.
They have already been stripped by environ, but not yet being added
back in `_grab_pkg_env`. Thus `qemu-static` falls back to its default
settings for the target architecture and doesn't load the
needed cpu extensions.

Therefore `sandbox` (`environ`) and `bash` (`__filter_readonly_variables`)
fail, when execting in a cross arch chroot.

For qemu-static to work properly:
- allow `QEMU_*` vars through the environ filter
- add `QEMU_*` vars to the readonly vars filter environment

Closes: https://bugs.gentoo.org/978685