### PR TITLE
dispatch-conf: fix AttributeError in massage() on str from newconfigs

### DIFF
--- a/bin/dispatch-conf
+++ b/bin/dispatch-conf
@@ -514,9 +514,7 @@ class dispatch:
         newconfigs.sort()
 
         for nconf in newconfigs:
-            # Use strict mode here, because we want to know if it fails,
-            # and portage only merges files with valid UTF-8 encoding.
-            nconf = nconf.decode("utf-8", "strict").rstrip()
+            nconf = nconf.rstrip()
             conf = re.sub(r"\._cfg\d+_", "", nconf)
             dirname = os.path.dirname(nconf)
             conf_map = {


### PR DESCRIPTION
path_list is decoded to str before splitlines(), so nconf elements are already str. The .decode() call added in commit 30bbecfbc is wrong; drop it.

Fixes: 30bbecfbc ("Remove Python 2 unicode compatibility layer")