### PR TITLE
EbuildExecuter: fix _can_skip_source_phases() checking SRC_URI instead of A

### DIFF
--- a/lib/_emerge/EbuildExecuter.py
+++ b/lib/_emerge/EbuildExecuter.py
@@ -48,9 +48,11 @@ class EbuildExecuter(CompositeTask):
         if "live" in settings.get("PROPERTIES", "").split():
             return False
 
-        metadata = self.pkg._metadata
-        if metadata.get("SRC_URI", "").strip():
+        # A is the USE-resolved, variable-expanded list of files to fetch;
+        # pkg._metadata["SRC_URI"] is not populated in this context.
+        if self.settings.configdict["pkg"].get("A", "").strip():
             return False
+        metadata = self.pkg._metadata
         defined_phases = frozenset(metadata.get("DEFINED_PHASES", "").split())
         if defined_phases.intersection(self._skippable_src_phases):
             return False


### PR DESCRIPTION
pkg._metadata["SRC_URI"] is not populated in the emerge build context, so the check always returned "" (falsy), causing _can_skip_source_phases() to skip unpack for any package with DEFINED_PHASES not containing a skippable phase -- even packages with real source to unpack.

Use settings.configdict["pkg"]["A"] instead: it holds the USE-resolved, variable-expanded list of files to fetch, matching what EbuildPhase uses for the same purpose, and is populated before pkg_setup exits.

Bug: https://bugs.gentoo.org/978737
Bug: https://bugs.gentoo.org/978808
Fixes: 126553a76 ("EbuildExecuter: skip no-op src phases for sourceless packages")