### PR TITLE
ebuild.sh: run depend phase under sandbox

### DIFF
--- a/bin/ebuild.sh
+++ b/bin/ebuild.sh
@@ -641,6 +641,40 @@ if [[ ${EBUILD_PHASE} != clean?(rm) ]]; then
 		unset E_RESTRICT PROVIDES_EXCLUDE REQUIRES_EXCLUDE
 		unset PORTAGE_EXPLICIT_INHERIT
 
+		pre_source_sandbox() {
+			export SANDBOX_ON=1
+			# DENY seems to take priority over READ+WRITE so
+			# don't use it.
+			#export SANDBOX_DENY="/"
+			export SANDBOX_PREDICT=""
+			export SANDBOX_READ="${EBUILD}:${SANDBOX_LOG}"
+			export SANDBOX_WRITE="${SANDBOX_LOG}:/dev/null"
+			[[ ${PORTAGE_DEBUG} != 1 ]] || export SANDBOX_DEBUG=1
+
+			# We need inherit to work
+			for repo_location in "${PORTAGE_ECLASS_LOCATIONS[@]}"; do
+				local potential_location="${repo_location}/eclass"
+				if [[ -d ${potential_location} ]]; then
+					SANDBOX_READ+=":${potential_location}"
+				fi
+			done
+
+			# Give a nicer error message in case someone is confused
+			adddeny() { die "External commands disallowed while sourcing ebuild: ${FUNCNAME}" ; }
+			addpredict() { die "External commands disallowed while sourcing ebuild: ${FUNCNAME}" ; }
+			addread() { die "External commands disallowed while sourcing ebuild: ${FUNCNAME}" ; }
+			addwrite() { die "External commands disallowed while sourcing ebuild: ${FUNCNAME}" ; }
+
+			# Disallow any tampering
+			readonly SANDBOX_{ALLOW,ACTIVE,DENY,DEBUG,ON,PREDICT,READ,WRITE}
+		}
+
+		# We can't unset these post-sourcing because of `readonly`
+		# as we don't want the sourced ebuild to be able to modify
+		# the SANDBOX_* vars, but it's okay as the process shouldn't
+		# need to do anything interesting post-sourcing anyway.
+		[[ ${EBUILD_PHASE} = depend ]] && pre_source_sandbox
+
 		if [[ ${PORTAGE_DEBUG} != 1 || $- == *x* ]] ; then
 			source "${EBUILD}" || die "error sourcing ebuild"
 		else
@@ -741,7 +775,6 @@ if contains_word nostrip "${FEATURES} ${PORTAGE_RESTRICT}" || contains_word stri
 fi
 
 if [[ ${EBUILD_PHASE} = depend ]] ; then
-	export SANDBOX_ON="0"
 	set -f
 
 	metadata_keys=(


### PR DESCRIPTION
It's been this way since the start, it seems, but there's no need for it to be unsandboxed. Since 40da7ee19c4c195da35083bf2d2fcbd852ad3846, Portage already forbids cases that rely on PATH lookups, but didn't prevent absolute paths to commands. Fix that by using sandbox with no paths allowed except to read the ebuild, eclasses, and to write to /dev/null and sandbox.log.

Some inconvenience arises from the fact that die() wants to call sed which results in an ugly error, but I don't think that's a blocker for changing this given that of course only happens when we found a problem.

Bug: https://bugs.gentoo.org/543774
Bug: https://bugs.gentoo.org/734650
Bug: https://bugs.gentoo.org/978846