### PR TITLE
Fix two regressions from skip-no-op-src-phases

### DIFF
--- a/bin/phase-functions.sh
+++ b/bin/phase-functions.sh
@@ -1088,12 +1088,14 @@ __ebuild_main() {
 		# reachable when earlier no-op src phases are skipped. Guard on
 		# PORTAGE_BUILDDIR: the clean phase can run before prepare_build_dirs()
 		# (and tolerates a missing builddir), so an unguarded cd would create
-		# a stray build-info/ in the cwd.
+		# a stray build-info/ in the cwd. Guard the cp on EBUILD existing:
+		# for binary merges EBUILD points inside build-info/ and is extracted
+		# later by unpack_metadata(), so it does not exist at clean time.
 		if [[ -d ${PORTAGE_BUILDDIR} ]]; then
 			cd "${PORTAGE_BUILDDIR}"
 			if [[ ! -d build-info ]]; then
 				mkdir build-info
-				cp "${EBUILD}" "build-info/${PF}.ebuild"
+				[[ -e ${EBUILD} ]] && cp "${EBUILD}" "build-info/${PF}.ebuild"
 			fi
 		fi
 

--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -320,6 +320,12 @@ class EbuildPhase(CompositeTask):
             alist = self.settings.configdict["pkg"].get("A", "").split()
             _prepare_fake_distdir(self.settings, alist)
             _prepare_fake_filesdir(self.settings)
+        elif self.phase == "install":
+            # Ensure FILESDIR symlink exists for install phase, which may
+            # reference files via DOCS or other declarative variables.
+            # Skip if already set up by unpack phase.
+            if not os.path.islink(self.settings.get("FILESDIR", "")):
+                _prepare_fake_filesdir(self.settings)
 
         fd_pipes = self.fd_pipes
         if fd_pipes is None:


### PR DESCRIPTION
Two bugs introduced by the sourceless-package phase-skip work:

- EbuildPhase: missing FILESDIR symlink: When `_can_skip_source_phases()` bypasses unpack, `_prepare_fake_filesdir` never runs. The `${PORTAGE_BUILDDIR}/files` → `${O}/files` symlink is absent at install time, breaking any ebuild that references `${FILESDIR}` in `src_install` (e.g. `newins "${FILESDIR}/...`"). Fixed by calling `_prepare_fake_filesdir` at the top of the install phase when the symlink is absent.
- phase-functions.sh: spurious cp failure during binary merge: move the build-info creation block to the outer src-phase case so it covers all src phases including clean. For binary merges `Binpkg.__init__` sets `EBUILD` to the not-yet-extracted `build-info/${PF}.ebuild`; when the clean phase fires before `unpack_metadata()` the cp fails with "cannot stat". Fixed by guarding the cp with `[[ -e ${EBUILD} ]]`.