### PR TITLE
dep: hoist per-call imports out of dependency hot paths

### DIFF
--- a/lib/_emerge/resolver/package_tracker.py
+++ b/lib/_emerge/resolver/package_tracker.py
@@ -4,6 +4,10 @@
 import bisect
 import collections
 
+from portage.dep import Atom, match_from_list
+from portage.util import cmp_sort_key
+from portage.versions import vercmp
+
 _PackageConflict = collections.namedtuple(
     "_PackageConflict", ["root", "pkgs", "atom", "description"]
 )
@@ -229,9 +233,6 @@ class PackageTracker:
         If 'installed' is True, installed non-replaced
         packages may also be returned.
         """
-        from portage.dep import match_from_list
-        from portage.util import cmp_sort_key
-        from portage.versions import vercmp
 
         if atom.soname:
             return iter(self._provides_index.get((root, atom), []))
@@ -375,8 +376,6 @@ class PackageTrackerDbapiWrapper:
         self._package_tracker.add_pkg(pkg)
 
     def match_pkgs(self, atom):
-        from portage.util import cmp_sort_key
-        from portage.versions import vercmp
 
         ret = sorted(
             self._package_tracker.match(self._root, atom),
@@ -391,6 +390,5 @@ class PackageTrackerDbapiWrapper:
         return self.match_pkgs(atom)
 
     def cp_list(self, cp):
-        from portage.dep import Atom
 
         return self.match_pkgs(Atom(cp))

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -2525,8 +2525,6 @@ def best_match_to_list(mypkg: Union[str, Atom], mylist: list) -> Optional[Atom]:
             - cp:slot with extended syntax	0
             - cp with extended syntax	-1
     """
-    from portage.util import cmp_sort_key
-
     operator_values = {
         "=": 6,
         "~": 5,
@@ -2583,6 +2581,8 @@ def best_match_to_list(mypkg: Union[str, Atom], mylist: list) -> Optional[Atom]:
                     v1 = getattr(cpv1, "version", None) or cpv_getversion(str(cpv1))
                     v2 = getattr(cpv2, "version", None) or cpv_getversion(str(cpv2))
                     return vercmp(v1, v2)
+
+                from portage.util import cmp_sort_key
 
                 cpv_list.sort(key=cmp_sort_key(cmp_cpv))
                 if cpv_list[0] is mypkg_cpv or cpv_list[-1] is mypkg_cpv:

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -2606,8 +2606,6 @@ def match_from_list(mydep: Union[str, Atom], candidate_list):
     @rtype: List
     @return: A list of package atoms that match the given package atom
     """
-    from portage.util import writemsg
-
     if not candidate_list:
         return []
 
@@ -2635,6 +2633,8 @@ def match_from_list(mydep: Union[str, Atom], candidate_list):
     if ver and rev:
         operator = mydep.operator
         if not operator:
+            from portage.util import writemsg
+
             writemsg(f"!!! Invalid atom: {mydep}\n", noiselevel=-1)
             return []
     else:
@@ -2800,6 +2800,8 @@ def match_from_list(mydep: Union[str, Atom], candidate_list):
             try:
                 result = vercmp(pkg.version, mydep.version)
             except ValueError:  # pkgcmp may return ValueError during int() conversion
+                from portage.util import writemsg
+
                 writemsg(_("\nInvalid package name: %s\n") % x, noiselevel=-1)
                 raise
             if result is None:

--- a/lib/portage/update.py
+++ b/lib/portage/update.py
@@ -8,6 +8,12 @@ import warnings
 
 import os
 from portage.const import USER_CONFIG_PATH, VCS_DIRS
+from portage.dep import (
+    Atom,
+    dep_getkey,
+    isvalidatom,
+    match_from_list,
+)
 from portage.eapi import _get_eapi_attrs
 from portage.exception import InvalidAtom, PortageException
 from portage.localization import _
@@ -16,7 +22,6 @@ ignored_dbentries = ("CONTENTS", "environment.bz2")
 
 
 def update_dbentry(update_cmd, mycontent, eapi=None, parent=None):
-    from portage.dep import Atom, isvalidatom, match_from_list
 
     if parent is not None:
         eapi = parent.eapi
@@ -186,7 +191,6 @@ def grab_updates(updpath, prev_mtimes=None):
 
 def parse_updates(mycontent):
     """Valid updates are returned as a list of split update commands."""
-    from portage.dep import Atom
     from portage.versions import _get_slot_re
 
     eapi_attrs = _get_eapi_attrs(None)
@@ -279,7 +283,6 @@ def update_config_files(
     match_callback - a callback which will be called with three arguments:
             match_callback(repo_name, old_atom, new_atom)
     and should return boolean value determining whether to perform the update"""
-    from portage.dep import isvalidatom
     from portage.util import (
         ConfigProtect,
         new_protect_filename,
@@ -440,7 +443,6 @@ def update_config_files(
 
 
 def dep_transform(mydep, oldkey, newkey):
-    from portage.dep import dep_getkey
 
     if dep_getkey(mydep) == oldkey:
         return mydep.replace(oldkey, newkey, 1)


### PR DESCRIPTION
Several hot functions in the dependency-resolution path ran a `from ... import ...` statement on every call. Once the real per-call work is cheap, that import machinery (`importlib._bootstrap._handle_fromlist`) becomes a measurable share of the cost. This series moves those imports so the common path skips them, either to module scope or into the rare branch that actually uses the symbol.

Three independent changes:

- `match_from_list` (~1M calls/resolve): `writemsg` is used only on two cold error paths. Moved the import into those branches. Kept function-level (not module scope) to avoid a circular import at load time.
- `best_match_to_list` (~858k calls): `cmp_sort_key` is used only on the rare tie-break path that sorts candidate cpvs. Moved into that branch.
- `update_dbentry` (~1.15M calls) and `PackageTracker.match` (~815k calls, where the imports ran even before the result-cache check): moved the `portage.dep` imports to module scope. `portage.update` is lazy-loaded, so `portage.dep` is always ready by call time, and module-level `from portage.dep import` is already common elsewhere.

Effect on a profiled `emerge -uDNp @world`: `_handle_fromlist` drops from ~3.13M calls to ~180k, and total resolution goes from 115.6s to 110.7s.

No behavior change. The `@world` merge list is byte-identical to master under a fixed PYTHONHASHSEED, and the resolver/dep/update test suites pass.
