### PR TITLE
resolver: speed up _serialize_tasks with an incremental leaf frontier

### DIFF
--- a/lib/_emerge/_serialize_frontier.py
+++ b/lib/_emerge/_serialize_frontier.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+"""
+Incrementally-maintained leaf frontier for depgraph._serialize_tasks.
+
+_serialize_tasks repeatedly asks digraph.leaf_nodes() which nodes are leaves
+under an ignore_priority filter. Each query is an O(V) scan, and the selection
+loop issues many of them.
+
+The frontier keeps, per node and per level, a count of how many children have an
+edge surviving that level's filter; the node is a leaf under level L iff its
+count for L is zero. Removing a node decrements its parents' counts; adding an
+edge increments the parent's counts.
+
+Each level owns a min-heap of the order-indices of its current leaves, so leaves
+can be enumerated in mygraph.order without an O(V) walk. Heaps use lazy deletion:
+an entry is valid iff the node is still in the graph, still leaf under the level,
+and the entry's index is the node's current order-index.
+
+order-index is a node's position in mygraph.order; a node introduced later
+(uninstall reversal / blocker edges) gets an appended index, as in digraph.add().
+
+PORTAGE_SERIALIZE_FRONTIER_DISABLE makes _serialize_tasks fall back to the
+digraph.leaf_nodes() path (frontier not built).
+"""
+
+from heapq import heappop, heappush
+
+from _emerge.DepPriorityNormalRange import DepPriorityNormalRange
+from _emerge.DepPrioritySatisfiedRange import DepPrioritySatisfiedRange
+from portage.util.digraph import digraph
+
+
+def _build_levels():
+    """Return (filters, level_of) for the union of ignore_priority filters used
+    by the DepPriorityNormalRange and DepPrioritySatisfiedRange leaf scans.
+
+    Level 0 is the None filter (leaf iff no children). Filters are deduplicated
+    by object identity; the ignore_priority entries are stable singletons.
+    """
+    filters = [None]
+    seen = {id(None)}
+    for rng in (DepPriorityNormalRange, DepPrioritySatisfiedRange):
+        for f in rng.ignore_priority:
+            if id(f) not in seen:
+                seen.add(id(f))
+                filters.append(f)
+    level_of = {id(f): i for i, f in enumerate(filters)}
+    return tuple(filters), level_of
+
+
+class _SerializeFrontier:
+    """Per-node, per-level surviving-child counts and per-level ready heaps.
+
+    A node is a leaf under level L iff surv[node][L] == 0. Counts and heaps are
+    maintained incrementally as the graph is mutated (see remove/add_edge).
+    """
+
+    def __init__(self, graph):
+        self._graph = graph
+        self._filters, self._level_of = _build_levels()
+        self._nlevels = nlevels = len(self._filters)
+        # node -> list[int]: surviving-child count per level
+        self._surv = {}
+        # (parent, child) -> survival bitmask over levels
+        self._edge_mask = {}
+        # node -> current order-index; index -> node
+        self._index = {}
+        self._by_index = {}
+        # per-level min-heap of order-indices for nodes currently leaf under it
+        self._ready = [[] for _ in range(nlevels)]
+
+        for i, node in enumerate(graph.order):
+            self._index[node] = i
+            self._by_index[i] = node
+        self._next_index = len(graph.order)
+
+        for node in graph.order:
+            counts = [0] * nlevels
+            for child, priorities in graph.nodes[node][0].items():
+                mask = self._compute_mask(priorities)
+                self._edge_mask[(node, child)] = mask
+                m = mask
+                while m:
+                    lb = m & -m
+                    counts[lb.bit_length() - 1] += 1
+                    m ^= lb
+            self._surv[node] = counts
+
+        # Seed each level's ready heap with its initial leaves. Appending in
+        # order-index order yields a valid min-heap without heapify.
+        for node in graph.order:
+            counts = self._surv[node]
+            idx = self._index[node]
+            for L in range(nlevels):
+                if counts[L] == 0:
+                    self._ready[L].append(idx)
+
+    def _compute_mask(self, priorities):
+        """Bitmask of the levels whose filter this edge survives.
+
+        Level 0 (None) is always set: an edge always has at least one priority.
+        For level L>0 with filter f, the edge survives iff some priority p has
+        ``not f(p)``, as in digraph.leaf_nodes().
+        """
+        mask = 1
+        filters = self._filters
+        for L in range(1, self._nlevels):
+            f = filters[L]
+            for p in priorities:
+                if not f(p):
+                    mask |= 1 << L
+                    break
+        return mask
+
+    def level_of(self, ignore_priority):
+        """Level index for an ignore_priority filter, or None if untracked."""
+        return self._level_of.get(id(ignore_priority))
+
+    def is_leaf(self, node, level):
+        counts = self._surv.get(node)
+        return counts is not None and counts[level] == 0
+
+    def ready_nodes(self, level):
+        """Return the nodes that are leaves under `level`, in mygraph.order.
+
+        Drains the level's heap, discarding stale/duplicate entries, and rebuilds
+        it from the survivors. Entries pop in ascending order-index order, so the
+        result is in mygraph.order and the rebuilt heap needs no heapify.
+        """
+        heap = self._ready[level]
+        surv = self._surv
+        index = self._index
+        by_index = self._by_index
+        result = []
+        seen_idx = set()
+        while heap:
+            idx = heappop(heap)
+            if idx in seen_idx:
+                continue
+            seen_idx.add(idx)
+            node = by_index.get(idx)
+            if node is None:
+                continue
+            counts = surv.get(node)
+            # Valid iff still in graph, still leaf here, and this is the node's
+            # current index.
+            if counts is None or counts[level] != 0 or index.get(node) != idx:
+                continue
+            result.append(node)
+        self._ready[level] = [index[node] for node in result]
+        return result
+
+    def remove(self, node):
+        """Account for `node` leaving the graph. Must be called while the graph
+        still contains `node` and its edges, i.e. before the digraph mutation.
+        """
+        node_data = self._graph.nodes.get(node)
+        if node_data is None:
+            return
+        children, parents, _ = node_data
+        edge_mask = self._edge_mask
+        surv = self._surv
+        index = self._index
+        ready = self._ready
+        for parent in parents:
+            mask = edge_mask.pop((parent, node), None)
+            if mask is None:
+                continue
+            pcounts = surv.get(parent)
+            if pcounts is None:
+                continue
+            pidx = index.get(parent)
+            m = mask
+            while m:
+                lb = m & -m
+                L = lb.bit_length() - 1
+                pcounts[L] -= 1
+                if pcounts[L] == 0 and pidx is not None:
+                    heappush(ready[L], pidx)
+                m ^= lb
+        for child in children:
+            edge_mask.pop((node, child), None)
+        surv.pop(node, None)
+        # Leave index/by_index in place; ready_nodes filters the stale entries.
+        # Re-adding the node assigns it a fresh index.
+
+    def difference_update(self, nodes):
+        for node in nodes:
+            self.remove(node)
+
+    def _assign_index(self, node):
+        """Ensure `node` has an order-index; assign a fresh appended one if it is
+        new or being reintroduced after removal."""
+        if node not in self._surv:
+            idx = self._next_index
+            self._next_index += 1
+            self._index[node] = idx
+            self._by_index[idx] = node
+            self._surv[node] = [0] * self._nlevels
+            # A reintroduced node starts isolated, so it is a leaf everywhere.
+            for L in range(self._nlevels):
+                heappush(self._ready[L], idx)
+
+    def add_edge(self, node, parent, priority):
+        """Account for digraph.add(node, parent, priority), an edge from graph
+        parent `parent` to graph child `node`. Must be called after the digraph
+        mutation, so the parent's priorities list is already updated.
+
+        Adding a priority only makes an edge survive more levels, so the parent's
+        counts only increase. A parent may leave a level's ready set; that is
+        handled lazily on pop.
+        """
+        self._assign_index(node)
+        if not parent:
+            return
+        self._assign_index(parent)
+        priorities = self._graph.nodes[parent][0].get(node)
+        if priorities is None:
+            return
+        new_mask = self._compute_mask(priorities)
+        old_mask = self._edge_mask.get((parent, node), 0)
+        if new_mask == old_mask:
+            return
+        self._edge_mask[(parent, node)] = new_mask
+        delta = new_mask & ~old_mask
+        pcounts = self._surv[parent]
+        m = delta
+        while m:
+            lb = m & -m
+            pcounts[lb.bit_length() - 1] += 1
+            m ^= lb
+
+
+class _FrontierDigraph(digraph):
+    """digraph that keeps an attached _SerializeFrontier in sync on every
+    mutation."""
+
+    frontier = None
+
+    def remove(self, node):
+        if self.frontier is not None:
+            self.frontier.remove(node)
+        super().remove(node)
+
+    def difference_update(self, t):
+        if self.frontier is not None:
+            if isinstance(t, (list, tuple)) or not hasattr(t, "__contains__"):
+                t = frozenset(t)
+            self.frontier.difference_update(t)
+        super().difference_update(t)
+
+    def add(self, node, parent, priority=0):
+        super().add(node, parent, priority=priority)
+        if self.frontier is not None:
+            self.frontier.add_edge(node, parent, priority)

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -80,6 +80,7 @@ from _emerge.DependencyArg import DependencyArg
 from _emerge.DepPriority import DepPriority
 from _emerge.DepPriorityNormalRange import DepPriorityNormalRange
 from _emerge.DepPrioritySatisfiedRange import DepPrioritySatisfiedRange
+from _emerge._serialize_frontier import _FrontierDigraph, _SerializeFrontier
 from _emerge.EbuildMetadataPhase import EbuildMetadataPhase
 from _emerge.FakeVartree import FakeVartree
 from _emerge._find_deep_system_runtime_deps import _find_deep_system_runtime_deps
@@ -9461,6 +9462,17 @@ class depgraph:
 
         mygraph = self._dynamic_config.digraph.copy()
 
+        # Wrap mygraph so an incremental leaf frontier stays in sync with every
+        # mutation, then drive the asap/leaf-scan selection from it instead of
+        # O(V) leaf_nodes() scans. PORTAGE_SERIALIZE_FRONTIER_DISABLE falls back
+        # to leaf_nodes(). See _serialize_frontier.
+        use_frontier = "PORTAGE_SERIALIZE_FRONTIER_DISABLE" not in os.environ
+        if use_frontier:
+            fdg = _FrontierDigraph()
+            fdg.nodes = mygraph.nodes
+            fdg.order = mygraph.order
+            mygraph = fdg
+
         removed_nodes = set()
 
         # Prune off all DependencyArg instances since they aren't
@@ -9505,6 +9517,10 @@ class depgraph:
         ignore_world = self._dynamic_config.myparams.get("ignore_world", False)
         asap_nodes = []
 
+        # Set to a _SerializeFrontier just before the selection loop, unless the
+        # frontier is disabled.
+        frontier = None
+
         def get_nodes(**kwargs):
             """
             Returns leaf nodes excluding Uninstall instances
@@ -9513,6 +9529,19 @@ class depgraph:
             return [
                 node
                 for node in mygraph.leaf_nodes(**kwargs)
+                if isinstance(node, Package)
+                and (node.operation != "uninstall" or node in scheduled_uninstalls)
+            ]
+
+        def frontier_leaves(ignore_priority):
+            """
+            Frontier equivalent of get_nodes(ignore_priority=...): the eligible
+            leaf nodes under `ignore_priority`, in mygraph.order.
+            """
+            level = frontier.level_of(ignore_priority)
+            return [
+                node
+                for node in frontier.ready_nodes(level)
                 if isinstance(node, Package)
                 and (node.operation != "uninstall" or node in scheduled_uninstalls)
             ]
@@ -9658,6 +9687,10 @@ class depgraph:
         # If no nodes are selected on the last iteration, it is due to
         # unresolved blockers or circular dependencies.
 
+        if use_frontier:
+            frontier = _SerializeFrontier(mygraph)
+            mygraph.frontier = frontier
+
         while mygraph:
             selected_nodes = None
             ignore_priority = None
@@ -9673,10 +9706,19 @@ class depgraph:
                 asap_nodes = [node for node in asap_nodes if mygraph.contains(node)]
                 for i in range(priority_range.SOFT, priority_range.MEDIUM_SOFT + 1):
                     ignore_priority = priority_range.ignore_priority[i]
+                    level = (
+                        frontier.level_of(ignore_priority)
+                        if frontier is not None
+                        else None
+                    )
                     for node in asap_nodes:
-                        if not mygraph.child_nodes(
-                            node, ignore_priority=ignore_priority
-                        ):
+                        if level is not None:
+                            is_leaf = frontier.is_leaf(node, level)
+                        else:
+                            is_leaf = not mygraph.child_nodes(
+                                node, ignore_priority=ignore_priority
+                            )
+                        if is_leaf:
                             selected_nodes = [node]
                             asap_nodes.remove(node)
                             break
@@ -9686,7 +9728,10 @@ class depgraph:
             if not selected_nodes and not (prefer_asap and asap_nodes):
                 for i in range(priority_range.NONE, priority_range.MEDIUM_SOFT + 1):
                     ignore_priority = priority_range.ignore_priority[i]
-                    nodes = get_nodes(ignore_priority=ignore_priority)
+                    if frontier is not None:
+                        nodes = frontier_leaves(ignore_priority)
+                    else:
+                        nodes = get_nodes(ignore_priority=ignore_priority)
                     if nodes:
                         # If there is a mixture of merges and uninstalls,
                         # do the uninstalls first.

--- a/lib/_emerge/meson.build
+++ b/lib/_emerge/meson.build
@@ -93,6 +93,7 @@ py.install_sources(
         '_find_deep_system_runtime_deps.py',
         '_flush_elog_mod_echo.py',
         '_observability.py',
+        '_serialize_frontier.py',
         '__init__.py',
     ],
     subdir : '_emerge',

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1502,6 +1502,13 @@ statistics about its internal LRU caches.
 If this environment variable is set, then Portage will show
 a trace of all HTTP request.
 .TP
+.BR PORTAGE_SERIALIZE_FRONTIER_DISABLE
+If this environment variable is set, then Portage will disable the
+incremental leaf-frontier optimization in the task serialization step of
+dependency resolution and fall back to the previous implementation.
+This variable is internal and experimental; it may be removed or changed
+in a future release.
+.TP
 .BR PORTAGE_DO_NOT_EXPORT_PMS_VARS
 If this environment variable is set, then Portage will not export PMS
 variables regardless of the EAPI.  The variables are still available


### PR DESCRIPTION
The merge-order calculation in _serialize_tasks repeatedly asks the digraph which nodes are leaves under a given ignore_priority filter, via digraph.leaf_nodes(). Each such query is an O(V) scan of the whole graph, and the asap/leaf-scan selection loop issues many of them, so the leaf-finding cost grows quadratically on large graphs.

Add lib/_emerge/_serialize_frontier.py, a Kahn-style leaf frontier. For every node it keeps a per-level count of how many of its children have an edge surviving that level's filter; a node is a leaf under level L iff its count for L is zero. Removing a node decrements its parents' counts, and adding an edge (the uninstall-reversal and blocker paths) increments the parent's counts, computed from a per-edge survival bitmask. Each level also owns a min-heap of the order-indices of its current leaves, so leaves can be enumerated in mygraph.order without an O(V) walk. A _FrontierDigraph wrapper keeps the frontier in sync on every mutation.

_serialize_tasks now drives the asap child-test (frontier.is_leaf) and the leaf-scan level loop (frontier.ready_nodes) from the frontier instead of leaf_nodes(). The selection logic downstream of the leaf list is unchanged, so the chosen node, and thus the merge order, is identical. Set PORTAGE_SERIALIZE_FRONTIER_DISABLE to fall back to the leaf_nodes() path.

Merge order is unchanged, verified byte-identical against emerge -uDNp @world (307-package graph, PYTHONHASHSEED=0). On that graph _serialize_tasks drops from ~9.09s to ~8.22s total across its 4 calls (~9.5%). The win scales with graph size; _serialize_tasks is only ~16% of the ~52s @world resolution, so total wall-clock moves little here.