### PR TITLE
FEATURES: add merge-use-vdb to bypass identical file rewrites

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,11 @@ Breaking changes:
 
 Features:
 
+* Add FEATURES="merge-use-vdb" to bypass identical file rewrites during
+  package merges. When enabled, Portage uses hashes and mtimes from the
+  VDB (var database) to skip writing files that are already identical on
+  disk, which saves I/O and reduces filesystem cache pressure.
+
 * Add FEATURES="cgroup" to account each source build's CPU time, peak memory,
   and I/O in a per-build cgroup v2. No limits are imposed. Totals are written
   to the build log and, with FEATURES="observability", included in the live

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -202,6 +202,7 @@ SUPPORTED_FEATURES = frozenset(
         "keepwork",
         "lmirror",
         "merge-sync",
+        "merge-use-vdb",
         "merge-wait",
         "metadata-transfer",
         "mirror",

--- a/lib/portage/const.py
+++ b/lib/portage/const.py
@@ -201,6 +201,7 @@ SUPPORTED_FEATURES = frozenset(
         "keepwork",
         "lmirror",
         "merge-sync",
+        "merge-use-vdb",
         "merge-wait",
         "metadata-transfer",
         "mirror",

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -25,6 +25,7 @@ import tempfile
 import textwrap
 import time
 import warnings
+from enum import Enum, auto
 from itertools import chain
 
 from _emerge.EbuildBuildDir import EbuildBuildDir
@@ -345,6 +346,23 @@ def _explode_metadata_file(dbdir):
 
     os.unlink(path)
     return missing
+
+
+class MoveReason(Enum):
+    # Falsy reasons (Move not needed)
+    VDB_HASH_MATCHES = auto()
+    CONTENT_MATCHES = auto()
+
+    # Truthy reasons (Move needed)
+    FILE_MISSING_OR_NOT_REGULAR = auto()
+    MODE_DIFFERS = auto()
+    VDB_HASH_DIFFERS = auto()
+    XATTR_DIFFERS = auto()
+    CONTENT_DIFFERS = auto()
+    COMPARISON_EXCEPTION = auto()
+
+    def __bool__(self):
+        return self.value >= self.__class__.FILE_MISSING_OR_NOT_REGULAR.value
 
 
 class vardbapi(dbapi):
@@ -5623,7 +5641,26 @@ class dblink:
                         ).hexdigest()
 
                     elif stat.S_ISREG(mydmode):
-                        destmd5 = perform_md5(mydest)
+                        destmd5 = None
+                        # If the file hasn't been modified since it was installed, we can safely
+                        # reuse the MD5 hash recorded in the var database (VDB) instead of
+                        # reading the file from disk to compute it.
+                        if (
+                            "merge-use-vdb" in self.settings.features
+                            and self._installed_instance is not None
+                        ):
+                            k = self._installed_instance._match_contents(myrealdest)
+                            if k is not False:
+                                data = self._installed_instance.getcontents()[k]
+                                if data[0] == "obj":
+                                    vdb_mtime = data[1]
+                                    if (
+                                        str(mydstat.st_mtime_ns // 1000000000)
+                                        == vdb_mtime
+                                    ):
+                                        destmd5 = data[2]
+                        if destmd5 is None:
+                            destmd5 = perform_md5(mydest)
             except (FileNotFound, OSError) as e:
                 if isinstance(e, OSError) and e.errno != errno.ENOENT:
                     raise
@@ -5916,7 +5953,10 @@ class dblink:
                 # same way.  Unless moveme=0 (blocking directory)
                 if moveme:
                     # only replace the existing file if it differs, see #722270
-                    if self._needs_move(mysrc, mydest, mymode, mydmode):
+                    needs_move_reason = self._needs_move(
+                        mysrc, mydest, mymode, mydmode, mymd5, myrealdest
+                    )
+                    if needs_move_reason:
                         # Create hardlinks only for source files that already exist
                         # as hardlinks (having identical st_dev and st_ino).
                         hardlink_key = (mystat.st_dev, mystat.st_ino)
@@ -5945,7 +5985,11 @@ class dblink:
                         except OSError:
                             # utime can fail here with EPERM
                             pass
-                        zing = "==="
+                        zing = (
+                            "=V="
+                            if needs_move_reason == MoveReason.VDB_HASH_MATCHES
+                            else "==="
+                        )
 
                     try:
                         self._merged_path(mydest, os.lstat(mydest))
@@ -6362,7 +6406,7 @@ class dblink:
         finally:
             self.unlockdb()
 
-    def _needs_move(self, mysrc, mydest, mymode, mydmode):
+    def _needs_move(self, mysrc, mydest, mymode, mydmode, mymd5=None, myrealdest=None):
         """
         Checks whether the given file at |mysrc| needs to be moved to |mydest| or if
         they are identical.
@@ -6373,13 +6417,42 @@ class dblink:
         from portage.util import writemsg
         from portage.util.movefile import _cmpxattr
 
-        if mydmode is None or not stat.S_ISREG(mydmode) or mymode != mydmode:
-            return True
+        if mydmode is None or not stat.S_ISREG(mydmode):
+            return MoveReason.FILE_MISSING_OR_NOT_REGULAR
+        if mymode != mydmode:
+            return MoveReason.MODE_DIFFERS
+
+        # Instead of doing a full file content comparison, we can check if the file's
+        # modification time matches the one recorded in the var database (VDB).
+        # If it does, we assume the file hasn't been modified and can simply compare
+        # the incoming file's MD5 hash with the one in the VDB.
+        if (
+            "merge-use-vdb" in self.settings.features
+            and myrealdest is not None
+            and mymd5 is not None
+            and self._installed_instance is not None
+        ):
+            k = self._installed_instance._match_contents(myrealdest)
+            if k is not False:
+                data = self._installed_instance.getcontents()[k]
+                if data[0] == "obj":
+                    vdb_mtime = data[1]
+                    try:
+                        mydest_mtime = str(os.lstat(mydest).st_mtime_ns // 1000000000)
+                    except OSError:
+                        mydest_mtime = None
+                    if mydest_mtime == vdb_mtime:
+                        vdb_md5 = data[2]
+                        return (
+                            MoveReason.VDB_HASH_DIFFERS
+                            if mymd5 != vdb_md5
+                            else MoveReason.VDB_HASH_MATCHES
+                        )
 
         if "xattr" in self.settings.features:
             excluded_xattrs = self.settings.get("PORTAGE_XATTR_EXCLUDE", "")
             if not _cmpxattr(mysrc, mydest, exclude=excluded_xattrs):
-                return True
+                return MoveReason.XATTR_DIFFERS
 
         try:
             files_equal = filecmp.cmp(mysrc, mydest, shallow=False)
@@ -6391,9 +6464,13 @@ class dblink:
                 % (e, mysrc, mydest),
                 noiselevel=-1,
             )
-            return True
+            return MoveReason.COMPARISON_EXCEPTION
 
-        return not files_equal
+        return (
+            MoveReason.CONTENT_DIFFERS
+            if not files_equal
+            else MoveReason.CONTENT_MATCHES
+        )
 
 
 def merge(

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -26,6 +26,7 @@ import tempfile
 import textwrap
 import time
 import warnings
+from enum import Enum, auto
 from itertools import chain
 
 from _emerge.EbuildBuildDir import EbuildBuildDir
@@ -70,6 +71,23 @@ from ._ContentsCaseSensitivityManager import ContentsCaseSensitivityManager
 # https://bugs.gentoo.org/970375
 from ._SyncfsProcess import SyncfsProcess
 from ._VdbMetadataDelta import VdbMetadataDelta
+
+
+class MoveReason(Enum):
+    # Falsy reasons (Move not needed)
+    VDB_HASH_MATCHES = auto()
+    CONTENT_MATCHES = auto()
+
+    # Truthy reasons (Move needed)
+    FILE_MISSING_OR_NOT_REGULAR = auto()
+    MODE_DIFFERS = auto()
+    VDB_HASH_DIFFERS = auto()
+    XATTR_DIFFERS = auto()
+    CONTENT_DIFFERS = auto()
+    COMPARISON_EXCEPTION = auto()
+
+    def __bool__(self):
+        return self.value >= self.__class__.FILE_MISSING_OR_NOT_REGULAR.value
 
 
 class vardbapi(dbapi):
@@ -5416,7 +5434,23 @@ class dblink:
                         ).hexdigest()
 
                     elif stat.S_ISREG(mydmode):
-                        destmd5 = perform_md5(mydest)
+                        destmd5 = None
+                        if (
+                            "merge-use-vdb" in self.settings.features
+                            and self._installed_instance is not None
+                        ):
+                            k = self._installed_instance._match_contents(myrealdest)
+                            if k is not False:
+                                data = self._installed_instance.getcontents()[k]
+                                if data[0] == "obj":
+                                    vdb_mtime = data[1]
+                                    if (
+                                        str(mydstat.st_mtime_ns // 1000000000)
+                                        == vdb_mtime
+                                    ):
+                                        destmd5 = data[2]
+                        if destmd5 is None:
+                            destmd5 = perform_md5(mydest)
             except (FileNotFound, OSError) as e:
                 if isinstance(e, OSError) and e.errno != errno.ENOENT:
                     raise
@@ -5709,7 +5743,10 @@ class dblink:
                 # same way.  Unless moveme=0 (blocking directory)
                 if moveme:
                     # only replace the existing file if it differs, see #722270
-                    if self._needs_move(mysrc, mydest, mymode, mydmode):
+                    needs_move_reason = self._needs_move(
+                        mysrc, mydest, mymode, mydmode, mymd5, myrealdest
+                    )
+                    if needs_move_reason:
                         # Create hardlinks only for source files that already exist
                         # as hardlinks (having identical st_dev and st_ino).
                         hardlink_key = (mystat.st_dev, mystat.st_ino)
@@ -5738,7 +5775,11 @@ class dblink:
                         except OSError:
                             # utime can fail here with EPERM
                             pass
-                        zing = "==="
+                        zing = (
+                            "=V="
+                            if needs_move_reason == MoveReason.VDB_HASH_MATCHES
+                            else "==="
+                        )
 
                     try:
                         self._merged_path(mydest, os.lstat(mydest))
@@ -6161,7 +6202,7 @@ class dblink:
         finally:
             self.unlockdb()
 
-    def _needs_move(self, mysrc, mydest, mymode, mydmode):
+    def _needs_move(self, mysrc, mydest, mymode, mydmode, mymd5=None, myrealdest=None):
         """
         Checks whether the given file at |mysrc| needs to be moved to |mydest| or if
         they are identical.
@@ -6172,13 +6213,38 @@ class dblink:
         from portage.util import writemsg
         from portage.util.movefile import _cmpxattr
 
-        if mydmode is None or not stat.S_ISREG(mydmode) or mymode != mydmode:
-            return True
+        if mydmode is None or not stat.S_ISREG(mydmode):
+            return MoveReason.FILE_MISSING_OR_NOT_REGULAR
+        if mymode != mydmode:
+            return MoveReason.MODE_DIFFERS
+
+        if (
+            "merge-use-vdb" in self.settings.features
+            and myrealdest is not None
+            and mymd5 is not None
+            and self._installed_instance is not None
+        ):
+            k = self._installed_instance._match_contents(myrealdest)
+            if k is not False:
+                data = self._installed_instance.getcontents()[k]
+                if data[0] == "obj":
+                    vdb_mtime = data[1]
+                    try:
+                        mydest_mtime = str(os.lstat(mydest).st_mtime_ns // 1000000000)
+                    except OSError:
+                        mydest_mtime = None
+                    if mydest_mtime == vdb_mtime:
+                        vdb_md5 = data[2]
+                        return (
+                            MoveReason.VDB_HASH_DIFFERS
+                            if mymd5 != vdb_md5
+                            else MoveReason.VDB_HASH_MATCHES
+                        )
 
         if "xattr" in self.settings.features:
             excluded_xattrs = self.settings.get("PORTAGE_XATTR_EXCLUDE", "")
             if not _cmpxattr(mysrc, mydest, exclude=excluded_xattrs):
-                return True
+                return MoveReason.XATTR_DIFFERS
 
         try:
             files_equal = filecmp.cmp(mysrc, mydest, shallow=False)
@@ -6190,9 +6256,13 @@ class dblink:
                 % (e, mysrc, mydest),
                 noiselevel=-1,
             )
-            return True
+            return MoveReason.COMPARISON_EXCEPTION
 
-        return not files_equal
+        return (
+            MoveReason.CONTENT_DIFFERS
+            if not files_equal
+            else MoveReason.CONTENT_MATCHES
+        )
 
 
 def merge(

--- a/lib/portage/tests/emerge/test_merge_use_vdb.py
+++ b/lib/portage/tests/emerge/test_merge_use_vdb.py
@@ -1,0 +1,198 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import subprocess
+import time
+
+import portage
+from portage.const import PORTAGE_PYM_PATH
+from portage.process import find_binary
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+from portage.util import ensure_dirs
+
+
+class MergeUseVdbTestCase(TestCase):
+    def testMergeUseVdb(self):
+        """
+        Verify that FEATURES="merge-use-vdb" uses the VDB hashes and avoids replacing
+        files on the live filesystem if the new file's hash matches the VDB hash.
+        """
+
+        debug = False
+
+        content_A_1 = """
+S="${WORKDIR}"
+src_install() {
+    insinto /usr/lib/A
+    echo original_content > "${T}"/foo
+    doins "${T}"/foo
+}
+"""
+
+        ebuilds = {
+            "dev-libs/A-1": {
+                "EAPI": "5",
+                "IUSE": "+flag",
+                "KEYWORDS": "x86",
+                "LICENSE": "GPL-2",
+                "MISC_CONTENT": content_A_1,
+            },
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds, debug=debug)
+        settings = playground.settings
+        eprefix = settings["EPREFIX"]
+        eroot = settings["EROOT"]
+        var_cache_edb = os.path.join(eprefix, "var", "cache", "edb")
+
+        portage_python = portage._python_interpreter
+        emerge_cmd = (
+            portage_python,
+            "-b",
+            "-Wd",
+            os.path.join(str(self.bindir), "emerge"),
+        )
+
+        foo_path = os.path.join(eroot, "usr", "lib", "A", "foo")
+
+        def modify_file(path, spoof_mtime=None):
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("modified_content_at_%d\n" % time.time())
+            if spoof_mtime is not None:
+                os.utime(path, (spoof_mtime, spoof_mtime))
+
+        def verify_file_content(path, expected):
+            with open(path, encoding="utf-8") as f:
+                content = f.read().strip()
+                self.assertEqual(content, expected)
+
+        distdir = playground.distdir
+        fake_bin = os.path.join(eprefix, "bin")
+        portage_tmpdir = os.path.join(eprefix, "var", "tmp", "portage")
+
+        path = settings.get("PATH")
+        if path is not None and not path.strip():
+            path = None
+        if path is None:
+            path = ""
+        else:
+            path = ":" + path
+        path = fake_bin + path
+
+        pythonpath = os.environ.get("PYTHONPATH")
+        if pythonpath is not None and not pythonpath.strip():
+            pythonpath = None
+        if pythonpath is not None and pythonpath.split(":")[0] == PORTAGE_PYM_PATH:
+            pass
+        else:
+            if pythonpath is None:
+                pythonpath = ""
+            else:
+                pythonpath = ":" + pythonpath
+            pythonpath = PORTAGE_PYM_PATH + pythonpath
+
+        env = {
+            "PORTAGE_OVERRIDE_EPREFIX": eprefix,
+            "CLEAN_DELAY": "0",
+            "DISTDIR": distdir,
+            "EMERGE_DEFAULT_OPTS": "-v",
+            "EMERGE_WARNING_DELAY": "0",
+            "PATH": path,
+            "PORTAGE_INST_GID": str(os.getgid()),
+            "PORTAGE_INST_UID": str(os.getuid()),
+            "PORTAGE_PYTHON": portage_python,
+            "PORTAGE_REPOSITORIES": settings.repositories.config_string(),
+            "PORTAGE_TMPDIR": portage_tmpdir,
+            "PYTHONDONTWRITEBYTECODE": os.environ.get("PYTHONDONTWRITEBYTECODE", "1"),
+            "PYTHONPATH": pythonpath,
+            "__PORTAGE_TEST_PATH_OVERRIDE": fake_bin,
+        }
+
+        if "__PORTAGE_TEST_HARDLINK_LOCKS" in os.environ:
+            env["__PORTAGE_TEST_HARDLINK_LOCKS"] = os.environ[
+                "__PORTAGE_TEST_HARDLINK_LOCKS"
+            ]
+
+        dirs = [distdir, fake_bin, portage_tmpdir, var_cache_edb]
+        true_symlinks = ["prepstrip", "scanelf"]
+        true_binary = find_binary("true")
+        self.assertEqual(true_binary is None, False, "true command not found")
+
+        try:
+            for d in dirs:
+                ensure_dirs(d)
+            for x in true_symlinks:
+                os.symlink(true_binary, os.path.join(fake_bin, x))
+            with open(os.path.join(var_cache_edb, "counter"), "wb") as f:
+                f.write(b"100")
+
+            if debug:
+                stdout = None
+            else:
+                stdout = subprocess.PIPE
+
+            def run_cmd(args, extra_env=None):
+                local_env = env.copy()
+                if extra_env:
+                    local_env.update(extra_env)
+
+                proc = subprocess.Popen(args, env=local_env, stdout=stdout)
+                if debug:
+                    proc.wait()
+                else:
+                    output = proc.stdout.readlines()
+                    proc.wait()
+                    proc.stdout.close()
+                    if proc.returncode != os.EX_OK:
+                        import sys
+
+                        for line in output:
+                            sys.stderr.write(line.decode("utf-8", "replace"))
+
+                self.assertEqual(os.EX_OK, proc.returncode, f"cmd failed: {args}")
+
+            # Install package normally
+            run_cmd(emerge_cmd + ("-1", "=dev-libs/A-1"))
+            verify_file_content(foo_path, "original_content")
+
+            # Record original mtime
+            original_mtime = os.stat(foo_path).st_mtime
+
+            # Modify the installed file (changes mtime naturally)
+            modify_file(foo_path)
+
+            with open(foo_path, encoding="utf-8") as f:
+                modified_content = f.read().strip()
+
+            # Re-install with feature disabled (default behavior)
+            # The manual modification should be replaced by original content
+            run_cmd(emerge_cmd + ("-1", "=dev-libs/A-1"))
+            verify_file_content(foo_path, "original_content")
+
+            # Modify the installed file again, but don't spoof mtime
+            modify_file(foo_path)
+
+            # Re-install with feature enabled. Even though feature is
+            # enabled, mtime differs, so it falls back to reading file
+            # and overwrites it.
+            run_cmd(emerge_cmd + ("-1", "=dev-libs/A-1"), {"FEATURES": "merge-use-vdb"})
+            verify_file_content(foo_path, "original_content")
+
+            # Record original mtime again
+            original_mtime = os.stat(foo_path).st_mtime
+
+            # Modify the installed file and spoof mtime to match original
+            modify_file(foo_path, spoof_mtime=original_mtime)
+            with open(foo_path, encoding="utf-8") as f:
+                modified_content = f.read().strip()
+
+            # Re-install with feature enabled. The manual modification
+            # should be preserved because both mtime AND VDB hash
+            # match
+            run_cmd(emerge_cmd + ("-1", "=dev-libs/A-1"), {"FEATURES": "merge-use-vdb"})
+            verify_file_content(foo_path, modified_content)
+
+        finally:
+            playground.cleanup()

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -625,6 +625,16 @@ failures for greater parallelism.
 The queue can be flushed by sending the SIGUSR2 signal to \fBemerge\fR(1).
 This feature is enabled by default.
 .TP
+.B merge\-use\-vdb
+When this feature is enabled, Portage uses the file hashes and modification
+times recorded in the package database to determine if a file needs to be
+replaced on the live filesystem.  This avoids reading the live filesystem files
+directly, saving disk I/O, unless the file's mtime differs from the time it was
+installed.  Note that this feature must be disabled if Portage is being used to
+repair corrupted files.  Otherwise, Portage will trust the package database and
+fail to overwrite the corrupted files on the live filesystem.  This feature is
+disabled by default.
+.TP
 .B metadata\-transfer
 Automatically perform a metadata transfer when `emerge \-\-sync` is run.
 In versions of portage >=2.1.5, this feature is disabled by

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -615,6 +615,16 @@ failures for greater parallelism.
 The queue can be flushed by sending the SIGUSR2 signal to \fBemerge\fR(1).
 This feature is enabled by default.
 .TP
+.B merge\-use\-vdb
+When this feature is enabled, Portage uses the file hashes and modification
+times recorded in the package database to determine if a file needs to be
+replaced on the live filesystem.  This avoids reading the live filesystem files
+directly, saving disk I/O, unless the file's mtime differs from the time it was
+installed.  Note that this feature must be disabled if Portage is being used to
+repair corrupted files.  Otherwise, Portage will trust the package database and
+fail to overwrite the corrupted files on the live filesystem.  This feature is
+disabled by default.
+.TP
 .B metadata\-transfer
 Automatically perform a metadata transfer when `emerge \-\-sync` is run.
 In versions of portage >=2.1.5, this feature is disabled by


### PR DESCRIPTION
When FEATURES="merge-use-vdb" is enabled, Portage will use the hashes and mtimes recorded in VDB for installed packages. If the mtime on the live filesystem matches the VDB, it trusts the VDB hash rather than reading the live file and computing a new hash.

This allows portage to skip rewriting files that are identical, saving disk I/O and reduces pressure on the filesystem cache, while still correctly falling back to checking live hashes if the user has touched or modified the file.

Also update dblink._needs_move() to return a MoveReason Enum indicating why a file should be moved or not. This allows the caller to inspect the specific reason while maintaining compatibility with boolean checks via a custom __bool__ implementation.

When a file is skipped specifically because of a VDB hash match, mergeme() now outputs an '=V=' prefix instead of '==='.

This is similar to what @chewi proposed in https://github.com/chewi/portage/commit/f7e3e3753ab3a808865c2e351898b3054fd638ec but has an additional optimization to not compute `destmd5` if enabled, not only avoiding disk writes, but also unnecessary disk reads.

@floppym raised the concern that this feature, if enabled, prevents the restoration of corrupted package installs, since portage would not merge and override corrupted files when it relies only on the VDB entry. This is a valid concern. However, the feature is *disabled by default*. The tradeoff is also explicitly documented in the man page so users can make an informed choice before opting *in.*