### PR TITLE
.github, tox.ini: update for latest python and github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-          - '3.14-dev'
+          - '3.14'
+          - '3.15-dev'
           - 'pypy-3.11'
         exclude:
           - python-version: '3.9'
@@ -33,13 +34,15 @@ jobs:
             start-method: 'spawn'
           - python-version: '3.13'
             start-method: 'spawn'
+          - python-version: '3.14'
+            start-method: 'spawn'
           - python-version: 'pypy-3.11'
             start-method: 'spawn'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: "Collect stragglers that Black misses"
         id: stragglers
         run: |
@@ -28,11 +28,14 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
+          - '3.14'
+          # no pylint for py315 available
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install python dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - uses: pre-commit/action@v3.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313}-{pylint,test},pypy3-test
+envlist = py{39,310,311,312,313,314,315}-{pylint,test},pypy3-test
 skipsdist = True
 
 [gh-actions]
@@ -9,6 +9,8 @@ python =
 	3.11: py311
 	3.12: py312
 	3.13: py313
+	3.14: py314
+	3.15: py315
 	pypy-3: pypy3
 
 [gh-actions:env]


### PR DESCRIPTION
Python 3.13 has been cleaned for me, prompting a look at `tox.ini`.

Was requested on IRC that github workflows be updated too. That part is new to me so I've skim read some docs, had a glance at the repos for the _checkout_ and _setup-python_ actions, and done my best to make sense of it. Doesn't look like the ubuntu runner has pylint for py315.

One thing I didn't 100% understand was why the "spawn" start method is currently only used on py314-dev, but have followed that pattern and set py315-dev up similarly.