### PR TITLE
dep: add a native C dependency-string parser

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,10 @@ Features:
 * Introduce FETCH_WRAPPER for use with FETCHCOMMAND and RESUMECOMMAND,
   see make.conf(5) for details.
 
+* dep: Add a native C dependency-string parser, used by use_reduce() and
+  Atom construction. Set PORTAGE_NATIVE_DEP_PARSER=0 in the environment to
+  fall back to the pure-Python implementation; see emerge(1) for details.
+
 Bug fixes:
 
 * man: make.conf(5): Improve man text about disabling tests to not wrongly

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -200,9 +200,24 @@ def _c_normalize_seq(seq, empty_always_true, under_anyof=False):
     return out
 
 
-def _c_fast_use_reduce(depstr, uselist, matchall, eapi):
+def _c_flatten_result(items, out, eapi, eapi_attrs, uselist, matchall):
+    """Recursively flatten the C parse tree into use_reduce(flat=True) form.
+    Nested || groups produce repeated '||' tokens, matching the Python path."""
+    for item in items:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, list):
+            _c_flatten_result(item, out, eapi, eapi_attrs, uselist, matchall)
+        else:
+            out.append(_c_atom_from_c(item, eapi, eapi_attrs, uselist, matchall))
+    return out
+
+
+def _c_fast_use_reduce(depstr, uselist, matchall, eapi, flat):
     raw = _c_dep_parser.parse(depstr, uselist=uselist, matchall=matchall)
     eapi_attrs = _get_eapi_attrs(eapi)
+    if flat:
+        return _c_flatten_result(raw, [], eapi, eapi_attrs, uselist, matchall)
     result = _c_convert_result(raw, eapi, eapi_attrs, uselist, matchall)
     return _c_normalize_seq(result, eapi_attrs.empty_groups_always_true)
 
@@ -1109,7 +1124,6 @@ def use_reduce(
         and token_class is Atom
         and not is_src_uri
         and not opconvert
-        and not flat
         and is_valid_flag is None
         and subset is None
         and not matchnone
@@ -1119,7 +1133,7 @@ def use_reduce(
         and (eapi is None or _get_eapi_attrs(eapi).slot_operator)
     ):
         try:
-            return _c_fast_use_reduce(depstr, uselist, matchall, eapi)
+            return _c_fast_use_reduce(depstr, uselist, matchall, eapi, flat)
         except ValueError as e:
             raise InvalidDependString(str(e)) from e
 

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -1826,7 +1826,23 @@ class Atom:
         def __init__(self, forbid_overlap=False):
             self.overlap = self._overlap(forbid=forbid_overlap)
 
-    def _c_fast_init(self, catom, eapi, eapi_attrs, unevaluated_atom):
+    def _validate_conditional_flags(self, is_valid_flag):
+        """Raise if a USE-conditional flag in this atom is not in IUSE.
+
+        Mirrors the check the regex path performs in __init__.
+        """
+        for conditional_type, flags in self._use.conditional.items():
+            for flag in flags:
+                if is_valid_flag(flag):
+                    continue
+                conditional_str = _use_dep._conditional_strings[conditional_type]
+                raise InvalidAtom(
+                    f"USE flag '{flag}' referenced in conditional "
+                    f"'{conditional_str % flag}' in atom '{self}' is not in IUSE",
+                    category="IUSE.missing",
+                )
+
+    def _c_fast_init(self, catom, eapi, eapi_attrs, is_valid_flag, unevaluated_atom):
         """Populate this Atom from a C scan_atom result.
 
         Raises InvalidAtom/TypeError for the same cases as the regex path.
@@ -1868,6 +1884,8 @@ class Atom:
                     f"Use dep defaults are not allowed in EAPI {eapi}: '{self}'",
                     category="EAPI.incompatible",
                 )
+            if is_valid_flag is not None and self._use.conditional:
+                self._validate_conditional_flags(is_valid_flag)
 
         if (
             self._blocker_obj
@@ -1918,17 +1936,13 @@ class Atom:
             if allow_build_id is None:
                 allow_build_id = True
 
-        # Fast path: parse the atom in C for the common case. scan_atom is
-        # byte-exact with the regex path or raises ValueError (repo specs,
-        # build-ids, wildcards, anything invalid), in which case we fall
-        # through to the pure-Python regex path below. Wildcards, an injected
-        # _use, flag validation, and virtual-expansion originals are handled
-        # only by the regex path.
+        # Try the C fast path. scan_atom raises ValueError for anything it
+        # can't handle (wildcards, repo specs, build-ids); we fall through to
+        # the regex path. allow_wildcard is safe: __init__ tries strict regex
+        # first, so actual wildcard atoms fail scan_atom and fall back naturally.
         if (
             _c_dep_parser is not None
-            and not allow_wildcard
             and _use is None
-            and is_valid_flag is None
             and orig_atom is None
             and (eapi is None or eapi_attrs.slot_operator)
         ):
@@ -1937,7 +1951,9 @@ class Atom:
             except ValueError:
                 catom = None
             if catom is not None:
-                self._c_fast_init(catom, eapi, eapi_attrs, unevaluated_atom)
+                self._c_fast_init(
+                    catom, eapi, eapi_attrs, is_valid_flag, unevaluated_atom
+                )
                 return
 
         if s[:1] == "!":

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "use_reduce",
 ]
 
+import os
 import re
 import warnings
 from functools import lru_cache
@@ -57,6 +58,10 @@ try:
     # extension has not been built, as in the lint-only CI job.
     import portage.dep._parser as _c_dep_parser
 except ImportError:
+    _c_dep_parser = None
+
+# PORTAGE_NATIVE_DEP_PARSER=0 forces the pure-Python path.  See emerge(1).
+if os.environ.get("PORTAGE_NATIVE_DEP_PARSER") == "0":
     _c_dep_parser = None
 
 if TYPE_CHECKING:

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -130,10 +130,81 @@ def _c_convert_result(items, eapi, eapi_attrs, uselist, matchall):
     return result
 
 
+def _c_normalize_alts(group, empty_always_true):
+    """Reduce the alternatives of one || group to use_reduce's non-flat form."""
+    alts = []
+    i = 0
+    n = len(group)
+    while i < n:
+        item = group[i]
+        if isinstance(item, str):  # a nested '||'
+            i += 1
+            nested = _c_normalize_alts(group[i], empty_always_true)
+            if nested:
+                alts.extend(nested)
+            elif not empty_always_true:
+                # empty nested || -> placeholder atom (EAPI 7+)
+                alts.append([Atom("__const__/empty-any-of")])
+        elif isinstance(item, list):
+            # conjunction: normalize under_anyof to suppress bracket removal
+            sub = _c_normalize_seq(item, empty_always_true, under_anyof=True)
+            if len(sub) == 1:
+                # ( X ) alternative -> X
+                alts.append(sub[0])
+            elif len(sub) == 2 and sub[0] == "||":
+                # ( || ( ... ) ) alternative -> its alternatives flatten into
+                # the enclosing any-of.
+                alts.extend(sub[1])
+            elif sub:
+                alts.append(sub)
+        else:
+            alts.append(item)
+        i += 1
+    return alts
+
+
+def _c_normalize_seq(seq, empty_always_true, under_anyof=False):
+    """Reduce a C parse (sub)tree to use_reduce's non-flat form.
+
+    under_anyof: this sequence is an alternative of an enclosing || group;
+    use_reduce keeps redundant brackets there, suppressing conjunction inlining."""
+    out = []
+    i = 0
+    n = len(seq)
+    while i < n:
+        item = seq[i]
+        if isinstance(item, str):  # '||'
+            i += 1
+            alts = _c_normalize_alts(seq[i], empty_always_true)
+            if not alts:
+                # || ( ) -> dropped (EAPI < 7) or a const placeholder (EAPI 7+).
+                if not empty_always_true:
+                    out.append(Atom("__const__/empty-any-of"))
+            elif len(alts) == 1:
+                # || ( X ) -> X
+                alt = alts[0]
+                if isinstance(alt, list) and not under_anyof:
+                    out.extend(alt)
+                else:
+                    out.append(alt)
+            else:
+                out.append("||")
+                out.append(alts)
+        elif isinstance(item, list):
+            out.extend(
+                _c_normalize_seq(item, empty_always_true, under_anyof=under_anyof)
+            )
+        else:
+            out.append(item)
+        i += 1
+    return out
+
+
 def _c_fast_use_reduce(depstr, uselist, matchall, eapi):
     raw = _c_dep_parser.parse(depstr, uselist=uselist, matchall=matchall)
     eapi_attrs = _get_eapi_attrs(eapi)
-    return _c_convert_result(raw, eapi, eapi_attrs, uselist, matchall)
+    result = _c_convert_result(raw, eapi, eapi_attrs, uselist, matchall)
+    return _c_normalize_seq(result, eapi_attrs.empty_groups_always_true)
 
 
 # \w is [a-zA-Z0-9_]

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -68,34 +68,46 @@ if TYPE_CHECKING:
     from _emerge.Package import Package
 
 
-def _c_atom_from_c(catom, eapi, eapi_attrs, uselist, matchall):
-    """Construct a portage.dep.Atom from a _parser.Atom, bypassing __init__ regex."""
-    a = Atom.__new__(Atom)
-    a._string = str(catom)
-    a._cp = catom.cp
-    a._repo = None
-    a._slot = catom.slot
-    a._sub_slot = catom.sub_slot
-    a._slot_operator = catom.slot_operator
-    ver = catom.version
+def _c_fill_atom_fields(atom, catom, eapi):
+    """Copy the scalar fields of a _parser.Atom onto a portage.dep.Atom.
+
+    Everything except _string, _use and _unevaluated_atom, which the two
+    callers set differently.  The C scanner reports the "=*" glob as operator
+    "=" with a trailing "*" on the version, so undo that here.
+    """
     op = catom.operator
+    ver = catom.version
+    cpv = catom.cpv
     if op == "=" and ver is not None and ver.endswith("*"):
         op = "=*"
         ver = ver[:-1]
-    a._operator = op
-    a._version = ver
-    a._cpv = catom.cpv[:-1] if op == "=*" else catom.cpv
-    a._eapi = eapi
-    a._extended_syntax = False
-    a._build_id = None
-    a._unevaluated_atom = a
-    a._orig_atom = None
+        cpv = cpv[:-1]
+    atom._cp = catom.cp
+    atom._cpv = cpv
+    atom._version = ver
+    atom._operator = op
+    atom._slot = catom.slot
+    atom._sub_slot = catom.sub_slot
+    atom._slot_operator = catom.slot_operator
+    atom._repo = None
+    atom._eapi = eapi
+    atom._extended_syntax = False
+    atom._build_id = None
+    atom._orig_atom = None
     blocker_str = catom.blocker
-    a._blocker_obj = (
+    atom._blocker_obj = (
         Atom._blocker(forbid_overlap=blocker_str == "!!")
         if blocker_str is not None
         else None
     )
+
+
+def _c_atom_from_c(catom, eapi, eapi_attrs, uselist, matchall):
+    """Construct a portage.dep.Atom from a _parser.Atom, bypassing __init__ regex."""
+    a = Atom.__new__(Atom)
+    a._string = str(catom)
+    _c_fill_atom_fields(a, catom, eapi)
+    a._unevaluated_atom = a
     use_tokens = catom.use
     if use_tokens is not None:
         en, dis, miss_en, miss_dis, cond, req = _c_dep_parser.classify_use_deps(
@@ -1814,6 +1826,59 @@ class Atom:
         def __init__(self, forbid_overlap=False):
             self.overlap = self._overlap(forbid=forbid_overlap)
 
+    def _c_fast_init(self, catom, eapi, eapi_attrs, unevaluated_atom):
+        """Populate this Atom from a C scan_atom result.
+
+        Raises InvalidAtom/TypeError for the same cases as the regex path.
+        """
+        use_tokens = catom.use
+        if use_tokens is not None:
+            # _use_dep validates conflicting flags, same as the regex path.
+            self._use = _use_dep(list(use_tokens), eapi_attrs)
+        else:
+            self._use = None
+
+        _c_fill_atom_fields(self, catom, eapi)
+        self._unevaluated_atom = unevaluated_atom if unevaluated_atom else self
+
+        if eapi is None:
+            return
+
+        if not isinstance(eapi, str):
+            raise TypeError(
+                f"expected eapi argument of {str}, got {type(eapi)}: {eapi}"
+            )
+
+        if self._slot and not eapi_attrs.slot_deps:
+            raise InvalidAtom(
+                f"Slot deps are not allowed in EAPI {eapi}: '{self}'",
+                category="EAPI.incompatible",
+            )
+
+        if self._use:
+            if not eapi_attrs.use_deps:
+                raise InvalidAtom(
+                    f"Use deps are not allowed in EAPI {eapi}: '{self}'",
+                    category="EAPI.incompatible",
+                )
+            if not eapi_attrs.use_dep_defaults and (
+                self._use.missing_enabled or self._use.missing_disabled
+            ):
+                raise InvalidAtom(
+                    f"Use dep defaults are not allowed in EAPI {eapi}: '{self}'",
+                    category="EAPI.incompatible",
+                )
+
+        if (
+            self._blocker_obj
+            and self._blocker_obj.overlap.forbid
+            and not eapi_attrs.strong_blocks
+        ):
+            raise InvalidAtom(
+                f"Strong blocks are not allowed in EAPI {eapi}: '{self}'",
+                category="EAPI.incompatible",
+            )
+
     def __init__(
         self,
         s,
@@ -1852,6 +1917,28 @@ class Atom:
                 allow_repo = True
             if allow_build_id is None:
                 allow_build_id = True
+
+        # Fast path: parse the atom in C for the common case. scan_atom is
+        # byte-exact with the regex path or raises ValueError (repo specs,
+        # build-ids, wildcards, anything invalid), in which case we fall
+        # through to the pure-Python regex path below. Wildcards, an injected
+        # _use, flag validation, and virtual-expansion originals are handled
+        # only by the regex path.
+        if (
+            _c_dep_parser is not None
+            and not allow_wildcard
+            and _use is None
+            and is_valid_flag is None
+            and orig_atom is None
+            and (eapi is None or eapi_attrs.slot_operator)
+        ):
+            try:
+                catom = _c_dep_parser.scan_atom(s)
+            except ValueError:
+                catom = None
+            if catom is not None:
+                self._c_fast_init(catom, eapi, eapi_attrs, unevaluated_atom)
+                return
 
         if s[:1] == "!":
             blocker = self._blocker(forbid_overlap=s[1:2] == "!")

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -52,8 +52,84 @@ from portage.versions import (
     ververify,
 )
 
+try:
+    # Not "from . import _parser": pylint reports import-self for that when the
+    # extension has not been built, as in the lint-only CI job.
+    import portage.dep._parser as _c_dep_parser
+except ImportError:
+    _c_dep_parser = None
+
 if TYPE_CHECKING:
     from _emerge.Package import Package
+
+
+def _c_atom_from_c(catom, eapi, eapi_attrs, uselist, matchall):
+    """Construct a portage.dep.Atom from a _parser.Atom, bypassing __init__ regex."""
+    a = Atom.__new__(Atom)
+    a._string = str(catom)
+    a._cp = catom.cp
+    a._repo = None
+    a._slot = catom.slot
+    a._sub_slot = catom.sub_slot
+    a._slot_operator = catom.slot_operator
+    ver = catom.version
+    op = catom.operator
+    if op == "=" and ver is not None and ver.endswith("*"):
+        op = "=*"
+        ver = ver[:-1]
+    a._operator = op
+    a._version = ver
+    a._cpv = catom.cpv[:-1] if op == "=*" else catom.cpv
+    a._eapi = eapi
+    a._extended_syntax = False
+    a._build_id = None
+    a._unevaluated_atom = a
+    a._orig_atom = None
+    blocker_str = catom.blocker
+    a._blocker_obj = (
+        Atom._blocker(forbid_overlap=blocker_str == "!!")
+        if blocker_str is not None
+        else None
+    )
+    use_tokens = catom.use
+    if use_tokens is not None:
+        en, dis, miss_en, miss_dis, cond, req = _c_dep_parser.classify_use_deps(
+            use_tokens
+        )
+        a._use = _use_dep(
+            use_tokens,
+            eapi_attrs,
+            enabled_flags=en,
+            disabled_flags=dis,
+            missing_enabled=miss_en,
+            missing_disabled=miss_dis,
+            conditional=cond,
+            required=req,
+        )
+        if not matchall and a._use.conditional:
+            a = a.evaluate_conditionals(uselist)
+    else:
+        a._use = None
+    return a
+
+
+def _c_convert_result(items, eapi, eapi_attrs, uselist, matchall):
+    result = []
+    for item in items:
+        if isinstance(item, str):
+            result.append(item)
+        elif isinstance(item, list):
+            result.append(_c_convert_result(item, eapi, eapi_attrs, uselist, matchall))
+        else:
+            result.append(_c_atom_from_c(item, eapi, eapi_attrs, uselist, matchall))
+    return result
+
+
+def _c_fast_use_reduce(depstr, uselist, matchall, eapi):
+    raw = _c_dep_parser.parse(depstr, uselist=uselist, matchall=matchall)
+    eapi_attrs = _get_eapi_attrs(eapi)
+    return _c_convert_result(raw, eapi, eapi_attrs, uselist, matchall)
+
 
 # \w is [a-zA-Z0-9_]
 
@@ -949,6 +1025,27 @@ def use_reduce(
         excludeall = frozenset(excludeall)
     if subset is not None:
         subset = frozenset(subset)
+
+    if (
+        _c_dep_parser is not None
+        # The fast path builds portage.dep.Atom directly, so it cannot serve
+        # a caller that asked for some other token class.
+        and token_class is Atom
+        and not is_src_uri
+        and not opconvert
+        and not flat
+        and is_valid_flag is None
+        and subset is None
+        and not matchnone
+        and not masklist
+        and not excludeall
+        # C grammar is EAPI 5+ only; eapi=None is permissive.
+        and (eapi is None or _get_eapi_attrs(eapi).slot_operator)
+    ):
+        try:
+            return _c_fast_use_reduce(depstr, uselist, matchall, eapi)
+        except ValueError as e:
+            raise InvalidDependString(str(e)) from e
 
     result = _use_reduce_cached(
         depstr,

--- a/lib/portage/tests/dep/meson.build
+++ b/lib/portage/tests/dep/meson.build
@@ -2,6 +2,7 @@ py.install_sources(
     [
         'test_atom.py',
         'test_check_required_use.py',
+        'test_c_parser.py',
         'test_extended_atom_dict.py',
         'test_extract_affecting_use.py',
         'test_standalone.py',

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -719,6 +719,45 @@ class TestCFastVsPython(TestCase):
     def test_slot_operator_bare_eq(self):
         self._compare("dev-libs/foo:=", matchall=True)
 
+    def test_anyof_conjunction_alternative(self):
+        # ( a b ) inside || is a conjunction and must stay nested, not flattened.
+        self._compare("|| ( ( dev-libs/a dev-libs/b ) dev-libs/c )", matchall=True)
+
+    def test_anyof_conjunction_second(self):
+        self._compare("|| ( dev-libs/a ( dev-libs/b dev-libs/c ) )", matchall=True)
+
+    def test_anyof_two_conjunctions(self):
+        self._compare(
+            "|| ( ( dev-libs/a dev-libs/b ) ( dev-libs/c dev-libs/d ) )",
+            matchall=True,
+        )
+
+    def test_anyof_active_conditional_conjunction(self):
+        # An active USE-conditional group inside || is also a conjunction.
+        self._compare(
+            "|| ( foo? ( dev-libs/a dev-libs/b ) dev-libs/c )", uselist=["foo"]
+        )
+
+    def test_anyof_nested_anyof_flattens(self):
+        self._compare("|| ( dev-libs/a || ( dev-libs/b dev-libs/c ) )", matchall=True)
+
+    def test_anyof_naked_wrapping_anyof(self):
+        # ( || ( b c ) ) inside || flattens its alternatives up.
+        self._compare(
+            "|| ( ( || ( dev-libs/b dev-libs/c ) ) dev-libs/a )", matchall=True
+        )
+
+    def test_anyof_deeply_nested_conjunctions(self):
+        self._compare(
+            "|| ( ( dev-libs/a ( dev-libs/b dev-libs/c ) ) dev-libs/e )",
+            matchall=True,
+        )
+
+    def test_anyof_empty_conditional_eapi7(self):
+        # Empty || after USE evaluation yields a placeholder atom in EAPI 7+.
+        self._compare("|| ( foo? ( dev-libs/a ) )", uselist=[], eapi="8")
+        self._compare("|| ( foo? ( dev-libs/a ) )", uselist=[], eapi="6")
+
     def test_invalid_raises_same_exception(self):
         bad_cases = [
             "|| ( dev-libs/a dev-libs/b",
@@ -753,6 +792,15 @@ class TestDeepNesting(TestCase):
         for depth in (1, 8, 31, 32, 33, 64, 65, 200):
             with self.subTest(depth=depth):
                 depstr = "( " * depth + "dev-libs/a" + " )" * depth
+                self.assertEqual(
+                    self._reduce(depstr, use_c=True),
+                    self._reduce(depstr, use_c=False),
+                )
+
+    def test_nesting_parity_any_of(self):
+        for depth in (1, 8, 31, 32, 33, 64, 65, 200):
+            with self.subTest(depth=depth):
+                depstr = "|| ( " * depth + "dev-libs/a" + " )" * depth
                 self.assertEqual(
                     self._reduce(depstr, use_c=True),
                     self._reduce(depstr, use_c=False),

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -8,6 +8,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+try:
+    import _testcapi
+except ImportError:
+    _testcapi = None
+else:
+    # PyPy ships a _testcapi module, but not the allocator hooks that the
+    # allocation-failure sweep needs.
+    if not all(hasattr(_testcapi, x) for x in ("set_nomemory", "remove_mem_hooks")):
+        _testcapi = None
+
 import portage
 import portage.dep as _dep_mod
 from portage.dep import Atom, _get_eapi_attrs, _use_dep, use_reduce
@@ -1469,3 +1479,134 @@ class TestKillSwitch(TestCase):
         for value in ("1", "", "no"):
             with self.subTest(value=value):
                 self.assertEqual(self._probe(value), "False")
+
+
+class TestCParserAllocFailure(TestCase):
+    """Every allocation the C parser makes can fail, and each failure has its
+    own cleanup path that no ordinary test reaches.  _testcapi.set_nomemory(n,
+    n + 1) makes the nth allocation fail, so sweeping n over a whole call
+    exercises those paths one at a time.
+
+    A failed allocation must surface as MemoryError, must not crash, and must
+    not leave the parser unusable: the group-frame stack and the half-built
+    Atom of the aborted call have to be released.
+
+    set_nomemory() hooks CPython's own allocator, so these tests skip wherever
+    it is unavailable: _testcapi is a test-support module that is not installed
+    everywhere, and PyPy provides the module without the memory hooks."""
+
+    # Large enough that the sweep runs past the last allocation of every case
+    # here; _sweep() fails if a case ever outgrows it.
+    SWEEP_LIMIT = 400
+
+    PARSE_CASES = (
+        ("dev-libs/a", (), False),
+        ("=sys-apps/portage-2.1-r1:0/1=[doc,a=,!b=,c?,!d?,-e]", (), True),
+        ("|| ( dev-libs/a dev-libs/b )", (), True),
+        ("|| ( ( dev-libs/a dev-libs/b ) dev-libs/c )", (), True),
+        ("foo? ( dev-libs/a dev-libs/b )", ("foo",), False),
+        ("foo? ( dev-libs/a )", (), False),
+        (
+            "dev-libs/A >=dev-libs/B-2.0 || ( dev-libs/C dev-libs/D ) "
+            "foo? ( =dev-libs/E-1.0:0[bar,baz?] )",
+            ("foo",),
+            False,
+        ),
+        # Long enough to miss the on-stack buffer in join_atom_string().
+        ("=cat/" + "a" * 300 + "-1.0", (), True),
+        # Deeper than PY_PARSE_INLINE_DEPTH, so the group-frame stack moves to
+        # the heap (PyMem_New) and then grows again (PyMem_Realloc).
+        ("( " * 40 + "dev-libs/a" + " )" * 40, (), True),
+        ("( " * 70 + "dev-libs/a" + " )" * 70, (), True),
+    )
+
+    ATOM_CASES = (
+        "sys-apps/portage",
+        ">=dev-libs/foo-1.2.3-r1:0/1=[a,-b,c?,!d?,e=]",
+        "!!media-libs/x:2",
+        "=cat/pkg-1.2*",
+    )
+
+    USE_DEP_CASES = (
+        ("foo",),
+        ("foo", "-bar", "!baz?", "qux=", "quux(+)"),
+        ("a", "b?", "!c?", "d=", "!e=", "-f", "g(+)", "h(-)"),
+    )
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+        if _testcapi is None:
+            self.skipTest("_testcapi memory hooks not available")
+        self._parser = _orig_c_dep_parser
+
+    def _sweep(self, fn, *args, **kwargs):
+        """Call fn(*args, **kwargs) once per allocation index, failing that
+        allocation."""
+        failed = []
+        for n in range(self.SWEEP_LIMIT):
+            _testcapi.set_nomemory(n, n + 1)
+            try:
+                fn(*args, **kwargs)
+            except MemoryError:
+                failed.append(n)
+            finally:
+                _testcapi.remove_mem_hooks()
+        self.assertTrue(failed, "no allocation failure was injected")
+        # A failure in the last stretch of the sweep means the call allocates
+        # more than SWEEP_LIMIT times, so its deepest error paths were never
+        # reached and the limit needs raising.
+        self.assertLess(
+            failed[-1],
+            self.SWEEP_LIMIT - 50,
+            f"SWEEP_LIMIT={self.SWEEP_LIMIT} too low for this case",
+        )
+
+    def test_parse(self):
+        for depstr, uselist, matchall in self.PARSE_CASES:
+            with self.subTest(depstr=depstr):
+                kw = dict(uselist=uselist, matchall=matchall)
+                expected = self._parser.parse(depstr, **kw)
+                self._sweep(self._parser.parse, depstr, **kw)
+                self.assertEqual(self._parser.parse(depstr, **kw), expected)
+
+    def test_scan_atom(self):
+        for s in self.ATOM_CASES:
+            with self.subTest(s=s):
+                expected = str(self._parser.scan_atom(s))
+                self._sweep(self._parser.scan_atom, s)
+                self.assertEqual(str(self._parser.scan_atom(s)), expected)
+
+    def test_classify_use_deps(self):
+        for tokens in self.USE_DEP_CASES:
+            with self.subTest(tokens=tokens):
+                expected = self._parser.classify_use_deps(tokens)
+                self._sweep(self._parser.classify_use_deps, tokens)
+                self.assertEqual(self._parser.classify_use_deps(tokens), expected)
+
+    def test_bad_argument_types(self):
+        """Argument conversion failures are error paths of their own, and no
+        allocation sweep reaches them."""
+        for arg in (42, None, b"dev-libs/a", ["dev-libs/a"]):
+            with self.subTest(arg=arg):
+                with self.assertRaises(TypeError):
+                    self._parser.parse(arg)
+                with self.assertRaises(TypeError):
+                    self._parser.scan_atom(arg)
+        # classify_use_deps() wants a sequence, and its items must be strings.
+        for arg in (42, None):
+            with self.subTest(arg=arg):
+                with self.assertRaises(TypeError):
+                    self._parser.classify_use_deps(arg)
+        with self.assertRaises(TypeError):
+            self._parser.classify_use_deps((42,))
+
+    def test_atom_fast_path(self):
+        """Atom() drives scan_atom() plus _c_fast_init(), so a failure here
+        can also leave a partly initialized portage.dep.Atom behind."""
+        for s in self.ATOM_CASES:
+            with self.subTest(s=s):
+                expected = Atom(s, eapi="8")
+                self._sweep(Atom, s, eapi="8")
+                ok, msg = _atoms_equal(Atom(s, eapi="8"), expected)
+                self.assertTrue(ok, f"{s!r}: {msg}")

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -1,0 +1,1072 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import contextlib
+import operator
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import portage
+import portage.dep as _dep_mod
+from portage.dep import Atom, _get_eapi_attrs, _use_dep, use_reduce
+from portage.exception import InvalidDependString
+from portage.tests import TestCase
+
+_orig_c_dep_parser = _dep_mod._c_dep_parser
+
+
+@contextlib.contextmanager
+def _use_c_parser(enabled):
+    """Select the parser used by portage.dep for the duration of the block.
+
+    portage.dep._c_dep_parser is module state, so a test may not leave it
+    toggled and two tests may not toggle it concurrently in one interpreter.
+    Every toggle in this file goes through here, and always around a single
+    call, so a failing assertion cannot leak the setting into the next test.
+    pytest-xdist distributes over processes rather than threads, so each
+    worker has its own copy of the module and cannot race with another."""
+    _dep_mod._c_dep_parser = _orig_c_dep_parser if enabled else None
+    try:
+        yield
+    finally:
+        _dep_mod._c_dep_parser = _orig_c_dep_parser
+
+
+def _c_parser():
+    try:
+        from portage.dep import _parser
+
+        return _parser
+    except ImportError:
+        return None
+
+
+def _atoms_equal(a, b):
+    for f in (
+        "_string",
+        "_cp",
+        "_cpv",
+        "_version",
+        "_operator",
+        "_slot",
+        "_sub_slot",
+        "_slot_operator",
+        "_eapi",
+        "_extended_syntax",
+        "_build_id",
+    ):
+        av, bv = getattr(a, f), getattr(b, f)
+        if av != bv:
+            return False, f"{f}: {av!r} != {bv!r}"
+
+    ab, bb = a._blocker_obj, b._blocker_obj
+    if bool(ab) != bool(bb):
+        return False, f"_blocker_obj presence: {ab!r} != {bb!r}"
+    if ab and bb and ab.overlap.forbid != bb.overlap.forbid:
+        return False, "_blocker_obj.overlap.forbid mismatch"
+
+    au, bu = a._use, b._use
+    if (au is None) != (bu is None):
+        return False, f"_use presence: {au!r} != {bu!r}"
+    if au is not None and bu is not None:
+        for attr in (
+            "tokens",
+            "enabled",
+            "disabled",
+            "required",
+            "missing_enabled",
+            "missing_disabled",
+        ):
+            av2, bv2 = getattr(au, attr), getattr(bu, attr)
+            if av2 != bv2:
+                return False, f"_use.{attr}: {av2!r} != {bv2!r}"
+        ac, bc = au.conditional, bu.conditional
+        if (ac is None) != (bc is None):
+            return False, f"_use.conditional presence: {ac!r} != {bc!r}"
+        if ac is not None and bc is not None:
+            for k in ("enabled", "disabled", "equal", "not_equal"):
+                av2, bv2 = getattr(ac, k), getattr(bc, k)
+                if av2 != bv2:
+                    return False, f"_use.conditional.{k}: {av2!r} != {bv2!r}"
+    return True, ""
+
+
+def _result_equal(c_result, py_result):
+    if len(c_result) != len(py_result):
+        return False, f"length {len(c_result)} != {len(py_result)}"
+    for i, (ci, pi) in enumerate(zip(c_result, py_result)):
+        if isinstance(ci, list) and isinstance(pi, list):
+            ok, msg = _result_equal(ci, pi)
+            if not ok:
+                return False, f"[{i}]: {msg}"
+        elif isinstance(ci, str) and isinstance(pi, str):
+            if ci != pi:
+                return False, f"[{i}]: {ci!r} != {pi!r}"
+        elif isinstance(ci, Atom) and isinstance(pi, Atom):
+            ok, msg = _atoms_equal(ci, pi)
+            if not ok:
+                return False, f"[{i}] Atom mismatch: {msg}"
+        else:
+            return False, f"[{i}]: type mismatch {type(ci)} vs {type(pi)}"
+    return True, ""
+
+
+class _UseReduceTests:
+    """Mixin run with USE_C_PARSER True or False; subclasses set it."""
+
+    USE_C_PARSER = False
+
+    def setUp(self):
+        _dep_mod._c_dep_parser = _orig_c_dep_parser if self.USE_C_PARSER else None
+
+    def tearDown(self):
+        _dep_mod._c_dep_parser = _orig_c_dep_parser
+
+    def _reduce(self, depstr, uselist=None, matchall=False, eapi="8", **kw):
+        return use_reduce(
+            depstr,
+            uselist=uselist or [],
+            matchall=matchall,
+            token_class=Atom,
+            eapi=eapi,
+            **kw,
+        )
+
+    def _atom(self, depstr, **kw):
+        result = self._reduce(depstr, **kw)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], Atom)
+        return result[0]
+
+    def test_unversioned_atom_fields(self):
+        a = self._atom("dev-libs/foo", matchall=True)
+        self.assertEqual(a._cp, "dev-libs/foo")
+        self.assertEqual(a._cpv, "dev-libs/foo")
+        self.assertIsNone(a._version)
+        self.assertIsNone(a._operator)
+        self.assertIsNone(a._slot)
+        self.assertIsNone(a._sub_slot)
+        self.assertIsNone(a._slot_operator)
+        self.assertIsNone(a._use)
+        self.assertIsNone(a._blocker_obj)
+
+    def test_versioned_atom_fields(self):
+        a = self._atom("=dev-libs/foo-1.2.3-r1", matchall=True)
+        self.assertEqual(a._cp, "dev-libs/foo")
+        self.assertEqual(a._version, "1.2.3-r1")
+        self.assertEqual(a._operator, "=")
+        self.assertEqual(a._cpv, "dev-libs/foo-1.2.3-r1")
+
+    def test_all_operators(self):
+        for op in ("=", ">=", ">", "<=", "<", "~"):
+            with self.subTest(op=op):
+                a = self._atom(f"{op}cat/pkg-1.0", matchall=True)
+                self.assertEqual(a._operator, op)
+                self.assertEqual(a._version, "1.0")
+
+    def test_version_suffixes(self):
+        for ver in ("1.0_alpha1", "1.0_beta2", "1.0_pre1", "1.0_rc1", "1.0_p1"):
+            with self.subTest(ver=ver):
+                a = self._atom(f"=cat/pkg-{ver}", matchall=True)
+                self.assertEqual(a._version, ver)
+
+    def test_slot_fields(self):
+        a = self._atom("dev-libs/foo:1", matchall=True)
+        self.assertEqual(a._slot, "1")
+        self.assertIsNone(a._sub_slot)
+        self.assertIsNone(a._slot_operator)
+
+    def test_sub_slot_fields(self):
+        a = self._atom("dev-libs/foo:0/53", matchall=True)
+        self.assertEqual(a._slot, "0")
+        self.assertEqual(a._sub_slot, "53")
+        self.assertIsNone(a._slot_operator)
+
+    def test_slot_operator_eq(self):
+        a = self._atom("dev-libs/foo:0=", matchall=True)
+        self.assertEqual(a._slot, "0")
+        self.assertEqual(a._slot_operator, "=")
+
+    def test_slot_operator_star(self):
+        a = self._atom("dev-libs/foo:*", matchall=True)
+        self.assertIsNone(a._slot)
+        self.assertEqual(a._slot_operator, "*")
+
+    def test_slot_operator_bare_eq(self):
+        a = self._atom("dev-libs/foo:=", matchall=True)
+        self.assertIsNone(a._slot)
+        self.assertEqual(a._slot_operator, "=")
+
+    def test_blocker_weak(self):
+        a = self._atom("!dev-libs/foo", matchall=True)
+        self.assertIsNotNone(a._blocker_obj)
+        self.assertFalse(a._blocker_obj.overlap.forbid)
+
+    def test_blocker_strong(self):
+        a = self._atom("!!dev-libs/foo", matchall=True)
+        self.assertIsNotNone(a._blocker_obj)
+        self.assertTrue(a._blocker_obj.overlap.forbid)
+
+    def test_combined_fields(self):
+        a = self._atom(
+            "=sys-apps/portage-2.1-r1:0[doc,a=,!b=,c?,!d?,-e]",
+            matchall=True,
+        )
+        self.assertEqual(a._cp, "sys-apps/portage")
+        self.assertEqual(a._version, "2.1-r1")
+        self.assertEqual(a._operator, "=")
+        self.assertEqual(a._slot, "0")
+        self.assertIsNotNone(a._use)
+        self.assertEqual(a._use.tokens, ("doc", "a=", "!b=", "c?", "!d?", "-e"))
+
+    def test_use_enabled(self):
+        a = self._atom("dev-libs/foo[bar]", matchall=True)
+        self.assertIsNotNone(a._use)
+        self.assertIn("bar", a._use.enabled)
+        self.assertEqual(a._use.disabled, frozenset())
+
+    def test_use_disabled(self):
+        a = self._atom("dev-libs/foo[-bar]", matchall=True)
+        self.assertIn("bar", a._use.disabled)
+        self.assertEqual(a._use.enabled, frozenset())
+
+    def test_use_conditional_enabled(self):
+        a = self._atom("dev-libs/foo[bar?]", matchall=True)
+        self.assertIsNotNone(a._use.conditional)
+        self.assertIn("bar", a._use.conditional.enabled)
+
+    def test_use_conditional_disabled(self):
+        a = self._atom("dev-libs/foo[!bar?]", matchall=True)
+        self.assertIsNotNone(a._use.conditional)
+        self.assertIn("bar", a._use.conditional.disabled)
+
+    def test_use_equal(self):
+        a = self._atom("dev-libs/foo[bar=]", matchall=True)
+        self.assertIn("bar", a._use.conditional.equal)
+
+    def test_use_not_equal(self):
+        a = self._atom("dev-libs/foo[!bar=]", matchall=True)
+        self.assertIn("bar", a._use.conditional.not_equal)
+
+    def test_use_missing_enabled_default(self):
+        a = self._atom("dev-libs/foo[bar(+)]", matchall=True)
+        self.assertIn("bar", a._use.missing_enabled)
+
+    def test_use_missing_disabled_default(self):
+        a = self._atom("dev-libs/foo[bar(-)]", matchall=True)
+        self.assertIn("bar", a._use.missing_disabled)
+
+    def test_use_str(self):
+        a = self._atom("dev-libs/foo[bar,-baz]", matchall=True)
+        self.assertEqual(str(a._use), "[bar,-baz]")
+
+    def test_conditional_active(self):
+        a = self._atom("dev-libs/foo[bar?]", uselist=["bar"])
+        self.assertIsNone(a._use.conditional)
+        self.assertIn("bar", a._use.enabled)
+
+    def test_conditional_inactive(self):
+        a = self._atom("dev-libs/foo[bar?]", uselist=[])
+        self.assertIsNone(a._use)
+
+    def test_conditional_not_equal_active(self):
+        a = self._atom("dev-libs/foo[!bar=]", uselist=["bar"])
+        self.assertIsNone(a._use.conditional)
+        self.assertIn("bar", a._use.disabled)
+
+    def test_conditional_not_equal_inactive(self):
+        a = self._atom("dev-libs/foo[!bar=]", uselist=[])
+        self.assertIsNone(a._use.conditional)
+        self.assertIn("bar", a._use.enabled)
+
+    def test_or_group(self):
+        result = self._reduce("|| ( dev-libs/a dev-libs/b )", matchall=True)
+        self.assertEqual(result[0], "||")
+        self.assertIsInstance(result[1], list)
+        self.assertEqual(len(result[1]), 2)
+
+    def test_use_conditional_group_active(self):
+        result = self._reduce("foo? ( dev-libs/a dev-libs/b )", uselist=["foo"])
+        atoms = [x for x in result if isinstance(x, Atom)]
+        self.assertEqual(len(atoms), 2)
+
+    def test_use_conditional_group_inactive(self):
+        result = self._reduce("foo? ( dev-libs/a dev-libs/b )", uselist=[])
+        self.assertEqual(result, [])
+
+    def test_nested_groups(self):
+        result = self._reduce(
+            "a? ( || ( dev-libs/a1 dev-libs/a2 ) b? ( dev-libs/b ) )",
+            uselist=["a", "b"],
+        )
+        self.assertIn("||", result)
+
+    def test_matchall_expands_all(self):
+        result = self._reduce("a? ( dev-libs/A ) !b? ( dev-libs/B )", matchall=True)
+        cps = [a._cp for a in result if isinstance(a, Atom)]
+        self.assertIn("dev-libs/A", cps)
+        self.assertIn("dev-libs/B", cps)
+
+    def test_glob_version(self):
+        a = self._atom("=dev-libs/foo-1.2*", matchall=True)
+        self.assertEqual(a._cp, "dev-libs/foo")
+        self.assertEqual(a._operator, "=*")
+        self.assertIn("1.2", a._version)
+
+    def test_complex_depstr(self):
+        result = self._reduce(
+            "dev-libs/A >=dev-libs/B-2.0 || ( dev-libs/C dev-libs/D ) "
+            "foo? ( =dev-libs/E-1.0:0[bar,baz?] )",
+            uselist=["foo"],
+        )
+        cps = [a._cp for a in result if isinstance(a, Atom)]
+        self.assertIn("dev-libs/A", cps)
+        self.assertIn("dev-libs/B", cps)
+        self.assertIn("dev-libs/E", cps)
+        self.assertEqual(result[2], "||")
+        self.assertIsInstance(result[3], list)
+        or_cps = [a._cp for a in result[3] if isinstance(a, Atom)]
+        self.assertIn("dev-libs/C", or_cps)
+        self.assertIn("dev-libs/D", or_cps)
+
+    def test_opconvert(self):
+        result = use_reduce(
+            "|| ( dev-libs/a dev-libs/b )",
+            token_class=Atom,
+            matchall=True,
+            eapi="8",
+            opconvert=True,
+        )
+        self.assertIsInstance(result, list)
+
+    def test_flat(self):
+        result = use_reduce(
+            "a? ( dev-libs/a ) dev-libs/b",
+            token_class=Atom,
+            matchall=True,
+            eapi="8",
+            flat=True,
+        )
+        self.assertIsInstance(result, list)
+
+    def test_no_token_class(self):
+        result = use_reduce("dev-libs/a dev-libs/b", matchall=True, eapi="8")
+        self.assertTrue(all(isinstance(x, str) for x in result))
+
+    def test_invalid_missing_close_paren(self):
+        with self.assertRaises(InvalidDependString):
+            self._reduce("|| ( dev-libs/a dev-libs/b", matchall=True)
+
+    def test_invalid_extra_close_paren(self):
+        with self.assertRaises(InvalidDependString):
+            self._reduce("dev-libs/a )", matchall=True)
+
+    def test_invalid_atom_no_category(self):
+        with self.assertRaises(InvalidDependString):
+            self._reduce("foo", matchall=True)
+
+    def test_invalid_operator_no_version(self):
+        with self.assertRaises(InvalidDependString):
+            self._reduce(">=dev-libs/foo", matchall=True)
+
+    def test_eapi5(self):
+        a = self._atom("dev-libs/foo[bar=]", matchall=True, eapi="5")
+        self.assertIn("bar", a._use.conditional.equal)
+
+    def test_eapi6(self):
+        a = self._atom("dev-libs/foo:0/1=[bar,!baz?]", matchall=True, eapi="6")
+        self.assertEqual(a._slot, "0")
+        self.assertEqual(a._sub_slot, "1")
+
+
+class TestUseReducePythonPath(_UseReduceTests, TestCase):
+    USE_C_PARSER = False
+
+
+class TestUseReduceCPath(_UseReduceTests, TestCase):
+    USE_C_PARSER = True
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+        super().setUp()
+
+
+class TestCParserRawAtom(TestCase):
+    def setUp(self):
+        self._parser = _c_parser()
+        if self._parser is None:
+            self.skipTest("_parser extension not available")
+
+    def test_parse_returns_list(self):
+        result = self._parser.parse("cat/pkg", matchall=True)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], self._parser.Atom)
+
+    def test_raw_atom_fields(self):
+        a = self._parser.parse(
+            "=sys-apps/portage-2.1-r1:0/1=[foo,-bar]", matchall=True
+        )[0]
+        self.assertEqual(a.cp, "sys-apps/portage")
+        self.assertEqual(a.version, "2.1-r1")
+        self.assertEqual(a.operator, "=")
+        self.assertEqual(a.slot, "0")
+        self.assertEqual(a.sub_slot, "1")
+        self.assertEqual(a.slot_operator, "=")
+        self.assertEqual(tuple(a.use), ("foo", "-bar"))
+        self.assertIsNone(a.blocker)
+
+    def test_raw_atom_blocker(self):
+        a = self._parser.parse("!!dev-libs/foo", matchall=True)[0]
+        self.assertEqual(a.blocker, "!!")
+        a2 = self._parser.parse("!dev-libs/foo", matchall=True)[0]
+        self.assertEqual(a2.blocker, "!")
+
+    def test_raw_atom_glob_version(self):
+        a = self._parser.parse("=dev-libs/foo-1.2*", matchall=True)[0]
+        self.assertEqual(a.cp, "dev-libs/foo")
+        self.assertEqual(a.operator, "=")  # _c_atom_from_c converts this to "=*"
+        self.assertEqual(a.version, "1.2*")
+
+
+class TestClassifyUseDeps(TestCase):
+    def setUp(self):
+        self._parser = _c_parser()
+        if self._parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _classify(self, tokens):
+        return self._parser.classify_use_deps(tokens)
+
+    def test_enabled(self):
+        en, dis, _, _, cond, req = self._classify(("foo",))
+        self.assertEqual(en, frozenset({"foo"}))
+        self.assertEqual(dis, frozenset())
+        self.assertIsNone(cond)
+        self.assertEqual(req, frozenset({"foo"}))
+
+    def test_disabled(self):
+        en, dis, _, _, cond, req = self._classify(("-foo",))
+        self.assertEqual(en, frozenset())
+        self.assertEqual(dis, frozenset({"foo"}))
+        self.assertIsNone(cond)
+        self.assertEqual(req, frozenset({"foo"}))
+
+    def test_conditional_enabled(self):
+        _, _, _, _, cond, _ = self._classify(("foo?",))
+        self.assertIsNotNone(cond)
+        self.assertEqual(cond["enabled"], frozenset({"foo"}))
+
+    def test_conditional_disabled(self):
+        _, _, _, _, cond, _ = self._classify(("!foo?",))
+        self.assertIsNotNone(cond)
+        self.assertEqual(cond["disabled"], frozenset({"foo"}))
+
+    def test_conditional_equal(self):
+        _, _, _, _, cond, _ = self._classify(("foo=",))
+        self.assertIsNotNone(cond)
+        self.assertEqual(cond["equal"], frozenset({"foo"}))
+
+    def test_conditional_not_equal(self):
+        _, _, _, _, cond, _ = self._classify(("!foo=",))
+        self.assertIsNotNone(cond)
+        self.assertEqual(cond["not_equal"], frozenset({"foo"}))
+
+    def test_missing_enabled_default(self):
+        en, _, miss_en, miss_dis, _, req = self._classify(("foo(+)",))
+        self.assertEqual(en, frozenset({"foo"}))
+        self.assertEqual(miss_en, frozenset({"foo"}))
+        self.assertEqual(miss_dis, frozenset())
+        self.assertEqual(req, frozenset())  # has default, not required
+
+    def test_missing_disabled_default(self):
+        _, _, miss_en, miss_dis, _, req = self._classify(("foo(-)",))
+        self.assertEqual(miss_en, frozenset())
+        self.assertEqual(miss_dis, frozenset({"foo"}))
+        self.assertEqual(req, frozenset())
+
+    def test_disabled_with_default(self):
+        _, dis, miss_en, _, _, req = self._classify(("-foo(+)",))
+        self.assertEqual(dis, frozenset({"foo"}))
+        self.assertEqual(miss_en, frozenset({"foo"}))
+        self.assertEqual(req, frozenset())
+
+    def test_mixed(self):
+        en, dis, _, _, cond, req = self._classify(("foo", "-bar", "!baz?", "qux="))
+        self.assertEqual(en, frozenset({"foo"}))
+        self.assertEqual(dis, frozenset({"bar"}))
+        self.assertIsNotNone(cond)
+        self.assertEqual(cond["disabled"], frozenset({"baz"}))
+        self.assertEqual(cond["equal"], frozenset({"qux"}))
+        self.assertEqual(req, frozenset({"foo", "bar", "baz", "qux"}))
+
+    def test_flag_with_hyphen(self):
+        en, dis, _, _, cond, req = self._classify(("foo-bar",))
+        self.assertEqual(en, frozenset({"foo-bar"}))
+        self.assertEqual(req, frozenset({"foo-bar"}))
+
+    def test_disabled_flag_with_hyphen(self):
+        _, dis, _, _, _, req = self._classify(("-foo-bar",))
+        self.assertEqual(dis, frozenset({"foo-bar"}))
+        self.assertEqual(req, frozenset({"foo-bar"}))
+
+    def test_conditional_flag_with_hyphen(self):
+        _, _, _, _, cond, _ = self._classify(("foo-bar?",))
+        self.assertEqual(cond["enabled"], frozenset({"foo-bar"}))
+
+    def test_flag_with_plus(self):
+        en, _, _, _, _, _ = self._classify(("c++",))
+        self.assertEqual(en, frozenset({"c++"}))
+
+    def test_conditional_flag_with_plus(self):
+        _, _, _, _, cond, _ = self._classify(("c++?",))
+        self.assertEqual(cond["enabled"], frozenset({"c++"}))
+
+    def test_flag_with_at(self):
+        en, _, _, _, _, _ = self._classify(("LINGUAS_en@euro",))
+        self.assertEqual(en, frozenset({"LINGUAS_en@euro"}))
+
+    def test_disabled_flag_with_at(self):
+        _, dis, _, _, _, _ = self._classify(("-LINGUAS_en@euro",))
+        self.assertEqual(dis, frozenset({"LINGUAS_en@euro"}))
+
+    def test_invalid_token_raises(self):
+        for bad in ("!foo", "!!foo", "?", "=", "foo??", ""):
+            with self.subTest(token=bad):
+                with self.assertRaises(ValueError):
+                    self._parser.classify_use_deps((bad,))
+
+    def test_matches_python_use_dep(self):
+        eapi_attrs = _get_eapi_attrs("8")
+        cases = [
+            ("foo",),
+            ("-foo",),
+            ("foo?",),
+            ("!foo?",),
+            ("foo=",),
+            ("!foo=",),
+            ("foo(+)",),
+            ("foo(-)",),
+            ("-foo(+)",),
+            ("foo", "-bar", "!baz?", "qux=", "quux(+)"),
+            ("a", "b?", "!c?", "d=", "!e=", "-f", "g(+)", "h(-)"),
+            ("foo-bar",),
+            ("-foo-bar",),
+            ("foo-bar?",),
+            ("c++",),
+            ("-c++",),
+            ("c++?",),
+            ("LINGUAS_en@euro",),
+            ("-LINGUAS_en@euro",),
+        ]
+        for tokens in cases:
+            with self.subTest(tokens=tokens):
+                en, dis, miss_en, miss_dis, cond, req = self._parser.classify_use_deps(
+                    tokens
+                )
+                c_use = _use_dep(
+                    tokens,
+                    eapi_attrs,
+                    enabled_flags=en,
+                    disabled_flags=dis,
+                    missing_enabled=miss_en,
+                    missing_disabled=miss_dis,
+                    conditional=cond,
+                    required=req,
+                )
+                py_use = _use_dep(list(tokens), eapi_attrs)
+                for attr in (
+                    "enabled",
+                    "disabled",
+                    "required",
+                    "missing_enabled",
+                    "missing_disabled",
+                ):
+                    self.assertEqual(
+                        getattr(c_use, attr),
+                        getattr(py_use, attr),
+                        f"{attr} mismatch for {tokens}",
+                    )
+                if py_use.conditional is None:
+                    self.assertIsNone(c_use.conditional)
+                else:
+                    self.assertIsNotNone(c_use.conditional)
+                    for k in ("enabled", "disabled", "equal", "not_equal"):
+                        self.assertEqual(
+                            getattr(c_use.conditional, k, frozenset()),
+                            getattr(py_use.conditional, k, frozenset()),
+                            f"conditional.{k} for {tokens}",
+                        )
+
+
+class TestCFastVsPython(TestCase):
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _compare(self, depstr, uselist=None, matchall=False, eapi="8"):
+        kw = dict(token_class=Atom, matchall=matchall, eapi=eapi, uselist=uselist or [])
+        with _use_c_parser(False):
+            py_result = use_reduce(depstr, **kw)
+        c_result = use_reduce(depstr, **kw)
+        ok, msg = _result_equal(c_result, py_result)
+        self.assertTrue(ok, f"{depstr!r}: {msg}")
+
+    def test_simple_atom(self):
+        self._compare("dev-libs/foo")
+
+    def test_versioned_atom(self):
+        self._compare("=dev-libs/foo-1.2.3-r1")
+
+    def test_blocker_weak(self):
+        self._compare("!dev-libs/foo")
+
+    def test_blocker_strong(self):
+        self._compare("!!dev-libs/foo")
+
+    def test_slot(self):
+        self._compare("dev-libs/foo:1")
+
+    def test_sub_slot(self):
+        self._compare("dev-libs/foo:1/2")
+
+    def test_slot_operator(self):
+        self._compare("dev-libs/foo:=")
+
+    def test_slot_and_operator(self):
+        self._compare("dev-libs/foo:1=")
+
+    def test_use_enabled(self):
+        self._compare("dev-libs/foo[bar]", matchall=True)
+
+    def test_use_disabled(self):
+        self._compare("dev-libs/foo[-bar]", matchall=True)
+
+    def test_use_multiple(self):
+        self._compare("dev-libs/foo[a,b,c,-d]", matchall=True)
+
+    def test_use_conditional_enabled(self):
+        self._compare("dev-libs/foo[bar?]", matchall=True)
+
+    def test_use_conditional_disabled(self):
+        self._compare("dev-libs/foo[!bar?]", matchall=True)
+
+    def test_use_equal(self):
+        self._compare("dev-libs/foo[bar=]", matchall=True)
+
+    def test_use_not_equal(self):
+        self._compare("dev-libs/foo[!bar=]", matchall=True)
+
+    def test_use_miss_en_default(self):
+        self._compare("dev-libs/foo[bar(+)]", matchall=True)
+
+    def test_use_miss_dis_default(self):
+        self._compare("dev-libs/foo[bar(-)]", matchall=True)
+
+    def test_use_complex(self):
+        self._compare("=sys-apps/portage-2.1-r1:0[doc,a=,!b=,c?,!d?,-e]", matchall=True)
+
+    def test_cond_eval_active(self):
+        self._compare("dev-libs/foo[bar?]", uselist=["bar"])
+
+    def test_cond_eval_inactive(self):
+        self._compare("dev-libs/foo[bar?]", uselist=[])
+
+    def test_cond_not_eq_active(self):
+        self._compare("dev-libs/foo[!bar=]", uselist=["bar"])
+
+    def test_or_group(self):
+        self._compare("|| ( dev-libs/a dev-libs/b )", matchall=True)
+
+    def test_use_cond_group(self):
+        self._compare("foo? ( dev-libs/a dev-libs/b )", uselist=["foo"])
+
+    def test_nested_groups(self):
+        self._compare(
+            "a? ( || ( dev-libs/a1 dev-libs/a2 ) b? ( dev-libs/b ) )",
+            uselist=["a", "b"],
+        )
+
+    def test_complex(self):
+        self._compare(
+            "dev-libs/A >=dev-libs/B-2.0 || ( dev-libs/C dev-libs/D ) "
+            "foo? ( =dev-libs/E-1.0:0[bar,baz?] )",
+            uselist=["foo"],
+        )
+
+    def test_matchall(self):
+        self._compare("a? ( dev-libs/A ) !b? ( dev-libs/B )", matchall=True)
+
+    def test_eapi5(self):
+        self._compare("dev-libs/foo[bar=]", matchall=True, eapi="5")
+
+    def test_eapi6(self):
+        self._compare("dev-libs/foo:0/1=[bar,!baz?]", matchall=True, eapi="6")
+
+    # '@' in USE flag names, deprecated but allowed per PMS (old LINGUAS flags)
+    def test_use_at_sign(self):
+        self._compare("dev-libs/foo[LINGUAS_en@euro]", matchall=True)
+
+    def test_use_at_sign_disabled(self):
+        self._compare("dev-libs/foo[-LINGUAS_en@euro]", matchall=True)
+
+    def test_glob_version(self):
+        self._compare("=dev-libs/foo-1.2*", matchall=True)
+
+    def test_slot_operator_bare_eq(self):
+        self._compare("dev-libs/foo:=", matchall=True)
+
+    def test_invalid_raises_same_exception(self):
+        bad_cases = [
+            "|| ( dev-libs/a dev-libs/b",
+            "dev-libs/a )",
+            ">=dev-libs/foo",
+        ]
+        kw = dict(token_class=Atom, matchall=True, eapi="8", uselist=[])
+        for depstr in bad_cases:
+            with self.subTest(depstr=depstr):
+                with _use_c_parser(False):
+                    with self.assertRaises(InvalidDependString):
+                        use_reduce(depstr, **kw)
+                with self.assertRaises(InvalidDependString):
+                    use_reduce(depstr, **kw)
+
+
+class TestDeepNesting(TestCase):
+    """The C parser keeps its group stack on the heap, so it must not impose a
+    nesting limit the pure-Python path does not have."""
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _reduce(self, depstr, use_c):
+        with _use_c_parser(use_c):
+            return use_reduce(
+                depstr, token_class=Atom, matchall=True, eapi="8", uselist=[]
+            )
+
+    def test_nesting_parity(self):
+        for depth in (1, 8, 31, 32, 33, 64, 65, 200):
+            with self.subTest(depth=depth):
+                depstr = "( " * depth + "dev-libs/a" + " )" * depth
+                self.assertEqual(
+                    self._reduce(depstr, use_c=True),
+                    self._reduce(depstr, use_c=False),
+                )
+
+
+class TestLongAtoms(TestCase):
+    """Category and package names are not length-limited, so the C path must
+    not reject an atom that the pure-Python path accepts."""
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _reduce(self, depstr, use_c):
+        with _use_c_parser(use_c):
+            return use_reduce(
+                depstr, token_class=Atom, matchall=True, eapi="8", uselist=[]
+            )
+
+    def test_long_package_name(self):
+        for length in (8, 250, 255, 256, 300, 512, 1000):
+            with self.subTest(length=length):
+                depstr = "cat/" + "a" * length
+                self.assertEqual(
+                    self._reduce(depstr, use_c=True),
+                    self._reduce(depstr, use_c=False),
+                )
+
+    def test_long_versioned_atom(self):
+        for length in (250, 256, 600):
+            with self.subTest(length=length):
+                depstr = "=cat/" + "a" * length + "-1.0"
+                c = self._reduce(depstr, use_c=True)
+                py = self._reduce(depstr, use_c=False)
+                self.assertEqual(c, py)
+                self.assertEqual(c[0]._cpv, py[0]._cpv)
+
+    def test_long_category(self):
+        depstr = "c" * 400 + "/pkg"
+        self.assertEqual(
+            self._reduce(depstr, use_c=True), self._reduce(depstr, use_c=False)
+        )
+
+
+class TestCParserMalformedGroups(TestCase):
+    """Whitespace and delimiter errors in group syntax. Every one of these has
+    a distinct error path in scan_item()/scan_group_contents(), and each must
+    be rejected by both parsers."""
+
+    CASES = (
+        "( dev-libs/a",  # no closing paren
+        "( dev-libs/a dev-libs/b",  # no closing paren, multiple items
+        "|| ( dev-libs/a ",  # trailing whitespace, still unterminated
+        "(dev-libs/a )",  # no whitespace after '('
+        "|| (dev-libs/a )",  # no whitespace after '(' in an any-of
+        "foo? (dev-libs/a )",  # no whitespace after '(' in a conditional
+        "||( dev-libs/a )",  # no whitespace after the '||' prefix
+        "foo?( dev-libs/a )",  # no whitespace after the 'foo?' prefix
+        "|| dev-libs/a",  # any-of with no group at all
+        "foo? dev-libs/a",  # conditional with no group at all
+        "|| dev-libs/a dev-libs/b",
+        "( dev-libs/a )dev-libs/b",  # no whitespace after ')'
+        "|| (",
+        "foo?",
+        "||",
+    )
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _reduce(self, depstr, use_c):
+        with _use_c_parser(use_c):
+            return use_reduce(depstr, token_class=Atom, eapi="8", uselist=["foo"])
+
+    def test_both_paths_reject(self):
+        for depstr in self.CASES:
+            with self.subTest(depstr=depstr):
+                with self.assertRaises(InvalidDependString):
+                    self._reduce(depstr, use_c=False)
+                with self.assertRaises(InvalidDependString):
+                    self._reduce(depstr, use_c=True)
+
+
+class TestCParserWhitespace(TestCase):
+    """The C parser sees the dep string unsplit, so leading, trailing and
+    repeated whitespace is its own business rather than str.split()'s."""
+
+    CASES = (
+        "dev-libs/a ",
+        " dev-libs/a",
+        "\tdev-libs/a\n",
+        "dev-libs/a  dev-libs/b",
+        "|| ( dev-libs/a dev-libs/b )   ",
+        "\n|| (\n\tdev-libs/a\n\tdev-libs/b\n)\n",
+        "   ",
+        "",
+    )
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _reduce(self, depstr, use_c):
+        with _use_c_parser(use_c):
+            return use_reduce(depstr, token_class=Atom, eapi="8", matchall=True)
+
+    def test_parity(self):
+        for depstr in self.CASES:
+            with self.subTest(depstr=depstr):
+                py = self._reduce(depstr, use_c=False)
+                c = self._reduce(depstr, use_c=True)
+                ok, msg = _result_equal(c, py)
+                self.assertTrue(ok, f"{depstr!r}: {msg}")
+
+
+class TestCParserInactiveConditionalBodies(TestCase):
+    """The body of an inactive use conditional is not emitted, but it is still
+    parsed with the real grammar (via the skip visitor) so that syntax errors
+    inside it are still reported. Nested groups and nested conditionals inside
+    an inactive body are the interesting cases."""
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _reduce(self, depstr, use_c, uselist=()):
+        with _use_c_parser(use_c):
+            return use_reduce(depstr, token_class=Atom, eapi="8", uselist=list(uselist))
+
+    VALID = (
+        ("foo? ( ( dev-libs/a ) )", ()),
+        ("foo? ( || ( dev-libs/a dev-libs/b ) )", ()),
+        ("foo? ( bar? ( dev-libs/a ) )", ()),
+        ("foo? ( bar? ( dev-libs/a ) )", ("bar",)),
+        ("!foo? ( bar? ( dev-libs/a ) )", ("foo", "bar")),
+        ("foo? ( !bar? ( dev-libs/a ) )", ()),
+        ("foo? ( bar? ( || ( dev-libs/a dev-libs/b ) ) )", ()),
+        ("foo? ( dev-libs/a ) bar? ( dev-libs/b )", ("bar",)),
+    )
+
+    # Syntax errors that only appear inside a body that is never emitted.
+    INVALID = (
+        ("foo? ( ||( dev-libs/a ) )", ()),
+        ("foo? ( (dev-libs/a ) )", ()),
+        ("foo? ( bar? ( noslash ) )", ()),
+        ("foo? ( bar? ( dev-libs/a )", ()),
+        ("foo? ( >=dev-libs/a )", ()),
+    )
+
+    def test_inactive_bodies_parity(self):
+        for depstr, uselist in self.VALID:
+            with self.subTest(depstr=depstr, uselist=uselist):
+                py = self._reduce(depstr, use_c=False, uselist=uselist)
+                c = self._reduce(depstr, use_c=True, uselist=uselist)
+                ok, msg = _result_equal(c, py)
+                self.assertTrue(ok, f"{depstr!r} uselist={uselist}: {msg}")
+
+    def test_errors_inside_inactive_bodies_still_raise(self):
+        for depstr, uselist in self.INVALID:
+            with self.subTest(depstr=depstr, uselist=uselist):
+                with self.assertRaises(InvalidDependString):
+                    self._reduce(depstr, use_c=False, uselist=uselist)
+                with self.assertRaises(InvalidDependString):
+                    self._reduce(depstr, use_c=True, uselist=uselist)
+
+
+class TestCAtomObjectProtocol(TestCase):
+    """_parser.Atom's tp_repr/tp_str/tp_hash/tp_richcompare slots."""
+
+    def setUp(self):
+        self._parser = _c_parser()
+        if self._parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _atom(self, s):
+        return self._parser.parse(s, matchall=True)[0]
+
+    def test_str(self):
+        self.assertEqual(
+            str(self._atom(">=dev-libs/a-1:2/3=[x]")), ">=dev-libs/a-1:2/3=[x]"
+        )
+
+    def test_repr(self):
+        self.assertEqual(repr(self._atom("dev-libs/a")), "Atom('dev-libs/a')")
+
+    def test_hash_matches_string(self):
+        self.assertEqual(hash(self._atom("dev-libs/a")), hash("dev-libs/a"))
+
+    def test_hashable_in_containers(self):
+        a, b = self._atom("dev-libs/a"), self._atom("dev-libs/a")
+        self.assertEqual(len({a, b}), 1)
+        self.assertEqual({a: 1}[b], 1)
+
+    def test_equality(self):
+        a, b = self._atom("dev-libs/a"), self._atom("dev-libs/a")
+        c = self._atom("dev-libs/b")
+        self.assertTrue(a == b)
+        self.assertFalse(a != b)
+        self.assertFalse(a == c)
+        self.assertTrue(a != c)
+
+    def test_equality_with_foreign_type(self):
+        a = self._atom("dev-libs/a")
+        for other in ("dev-libs/a", 1, None, Atom("dev-libs/a")):
+            with self.subTest(other=other):
+                self.assertFalse(a == other)
+                self.assertTrue(a != other)
+
+    def test_ordering_is_not_implemented(self):
+        a, b = self._atom("dev-libs/a"), self._atom("dev-libs/b")
+        for op in (operator.lt, operator.le, operator.gt, operator.ge):
+            with self.subTest(op=op.__name__):
+                with self.assertRaises(TypeError):
+                    op(a, b)
+
+
+class TestCParserEapiGuard(TestCase):
+    """The C scanner implements the modern (EAPI 5+) atom grammar
+    unconditionally. The use_reduce fast-path guard must therefore only take
+    the C path for EAPIs whose grammar matches -- None (permissive) or
+    slot_operator-capable (EAPI 5+) -- so it never accepts atoms that the
+    pure-Python path rejects under an older EAPI."""
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _reduce(self, depstr, eapi, use_c):
+        with _use_c_parser(use_c):
+            return use_reduce(
+                depstr, token_class=Atom, matchall=True, eapi=eapi, uselist=[]
+            )
+
+    def test_slot_operator_gate_matches_expectation(self):
+        for eapi in ("0", "1", "4"):
+            self.assertFalse(_get_eapi_attrs(eapi).slot_operator, eapi)
+        for eapi in (None, "5", "6", "7", "8"):
+            self.assertTrue(_get_eapi_attrs(eapi).slot_operator, eapi)
+
+    def test_old_eapi_rejects_modern_syntax(self):
+        # Each string is invalid under the given older EAPI. The Python path
+        # rejects it; the C path is guard-skipped for these EAPIs, so it must
+        # reject identically rather than silently accept.
+        cases = [
+            ("dev-libs/foo:=", "4"),  # slot operator: EAPI 5+
+            ("dev-libs/foo:1/2", "4"),  # sub-slot: EAPI 5+
+            ("dev-libs/foo[bar]", "1"),  # use dep: EAPI 4+
+            ("dev-libs/foo:1", "0"),  # slot dep: EAPI 1+
+        ]
+        for depstr, eapi in cases:
+            with self.subTest(depstr=depstr, eapi=eapi):
+                with self.assertRaises(InvalidDependString):
+                    self._reduce(depstr, eapi, use_c=False)
+                with self.assertRaises(InvalidDependString):
+                    self._reduce(depstr, eapi, use_c=True)
+
+    def test_valid_across_eapis_parity(self):
+        cases = [
+            ("dev-libs/foo", None),
+            ("dev-libs/foo", "0"),
+            ("dev-libs/foo", "8"),
+            ("dev-libs/foo:1", "1"),
+            ("dev-libs/foo:1", "8"),
+            ("dev-libs/foo[bar]", "4"),
+            ("dev-libs/foo[bar]", "8"),
+            ("dev-libs/foo:=", "5"),
+            ("dev-libs/foo:1/2=", "8"),
+        ]
+        for depstr, eapi in cases:
+            with self.subTest(depstr=depstr, eapi=eapi):
+                py = self._reduce(depstr, eapi, use_c=False)
+                c = self._reduce(depstr, eapi, use_c=True)
+                ok, msg = _result_equal(c, py)
+                self.assertTrue(ok, f"{depstr!r} eapi={eapi}: {msg}")
+
+
+class TestKillSwitch(TestCase):
+    """PORTAGE_NATIVE_DEP_PARSER=0 must disable the C path.  It is consulted
+    when portage.dep is imported, so this has to run in a fresh process."""
+
+    PROBE = "import portage.dep; print(portage.dep._c_dep_parser is None)"
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _probe(self, value):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(Path(portage.__file__).parent.parent), env.get("PYTHONPATH", "")]
+        )
+        if value is None:
+            env.pop("PORTAGE_NATIVE_DEP_PARSER", None)
+        else:
+            env["PORTAGE_NATIVE_DEP_PARSER"] = value
+        out = subprocess.run(
+            [sys.executable, "-c", self.PROBE],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return out.stdout.strip()
+
+    def test_unset_uses_c_parser(self):
+        self.assertEqual(self._probe(None), "False")
+
+    def test_zero_disables_c_parser(self):
+        self.assertEqual(self._probe("0"), "True")
+
+    def test_other_values_do_not_disable(self):
+        # Only the exact string "0" disables it.
+        for value in ("1", "", "no"):
+            with self.subTest(value=value):
+                self.assertEqual(self._probe(value), "False")

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -607,13 +607,19 @@ class TestCFastVsPython(TestCase):
         if _orig_c_dep_parser is None:
             self.skipTest("_parser extension not available")
 
-    def _compare(self, depstr, uselist=None, matchall=False, eapi="8"):
-        kw = dict(token_class=Atom, matchall=matchall, eapi=eapi, uselist=uselist or [])
+    def _compare(self, depstr, uselist=None, matchall=False, eapi="8", flat=False):
+        kw = dict(
+            token_class=Atom,
+            matchall=matchall,
+            eapi=eapi,
+            uselist=uselist or [],
+            flat=flat,
+        )
         with _use_c_parser(False):
             py_result = use_reduce(depstr, **kw)
         c_result = use_reduce(depstr, **kw)
         ok, msg = _result_equal(c_result, py_result)
-        self.assertTrue(ok, f"{depstr!r}: {msg}")
+        self.assertTrue(ok, f"{depstr!r} (flat={flat}): {msg}")
 
     def test_simple_atom(self):
         self._compare("dev-libs/foo")
@@ -757,6 +763,60 @@ class TestCFastVsPython(TestCase):
         # Empty || after USE evaluation yields a placeholder atom in EAPI 7+.
         self._compare("|| ( foo? ( dev-libs/a ) )", uselist=[], eapi="8")
         self._compare("|| ( foo? ( dev-libs/a ) )", uselist=[], eapi="6")
+
+    def test_flat_simple(self):
+        self._compare("dev-libs/a dev-libs/b", matchall=True, flat=True)
+
+    def test_flat_or_group(self):
+        self._compare("|| ( dev-libs/a dev-libs/b )", matchall=True, flat=True)
+
+    def test_flat_nested_or(self):
+        # Nested any-of groups keep a '||' token per level in flat mode.
+        self._compare(
+            "|| ( dev-libs/a || ( dev-libs/b dev-libs/c ) )",
+            matchall=True,
+            flat=True,
+        )
+
+    def test_flat_use_conditional_active(self):
+        self._compare("foo? ( dev-libs/a dev-libs/b )", uselist=["foo"], flat=True)
+
+    def test_flat_use_conditional_inactive(self):
+        self._compare("foo? ( dev-libs/a dev-libs/b )", uselist=[], flat=True)
+
+    def test_flat_nested_conditionals(self):
+        self._compare(
+            "a? ( dev-libs/a b? ( dev-libs/b ) ) c? ( dev-libs/c )",
+            uselist=["a", "c"],
+            flat=True,
+        )
+
+    def test_flat_conditional_or_mix(self):
+        self._compare(
+            "foo? ( || ( dev-libs/a dev-libs/b ) ) dev-libs/c",
+            uselist=["foo"],
+            flat=True,
+        )
+
+    def test_flat_atoms_with_use(self):
+        self._compare(
+            "dev-libs/a[x] foo? ( =dev-libs/b-1[y?] )", uselist=["foo"], flat=True
+        )
+
+    def test_flat_matchall(self):
+        self._compare(
+            "a? ( dev-libs/a ) !b? ( dev-libs/b ) || ( dev-libs/c dev-libs/d )",
+            matchall=True,
+            flat=True,
+        )
+
+    def test_flat_complex(self):
+        self._compare(
+            "dev-libs/A >=dev-libs/B-2.0 || ( dev-libs/C dev-libs/D ) "
+            "foo? ( =dev-libs/E-1.0:0[bar,baz?] || ( dev-libs/F dev-libs/G ) )",
+            uselist=["foo"],
+            flat=True,
+        )
 
     def test_invalid_raises_same_exception(self):
         bad_cases = [

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -906,6 +906,276 @@ class TestLongAtoms(TestCase):
         )
 
 
+class _AtomParityMixin:
+    """Helpers for asserting that _parser.scan_atom + Atom._c_fast_init agrees
+    with the pure-Python regex path, both on what it accepts and on the fields
+    it produces."""
+
+    def setUp(self):
+        if _orig_c_dep_parser is None:
+            self.skipTest("_parser extension not available")
+
+    def _both(self, s, **kw):
+        with _use_c_parser(False):
+            try:
+                py = Atom(s, **kw)
+                py_exc = None
+            except Exception as e:
+                py, py_exc = None, type(e)
+        try:
+            c = Atom(s, **kw)
+            c_exc = None
+        except Exception as e:
+            c, c_exc = None, type(e)
+        return (py, py_exc), (c, c_exc)
+
+    def _assert_same(self, s, **kw):
+        (py, pe), (c, ce) = self._both(s, **kw)
+        self.assertEqual(pe, ce, f"{s!r}: exception {pe} vs {ce}")
+        if pe is None:
+            for attr in (
+                "_cp",
+                "_cpv",
+                "_version",
+                "_operator",
+                "_slot",
+                "_sub_slot",
+                "_slot_operator",
+                "_repo",
+                "_build_id",
+                "_extended_syntax",
+            ):
+                self.assertEqual(getattr(py, attr), getattr(c, attr), f"{s!r}: {attr}")
+            self.assertEqual(str(py._use or ""), str(c._use or ""), f"{s!r}: use")
+            self.assertEqual(str(py), str(c))
+
+
+class TestScanAtom(_AtomParityMixin, TestCase):
+    """Test that _parser.scan_atom + Atom._c_fast_init matches the pure-Python
+    regex path for both valid atoms and invalid ones."""
+
+    def test_valid_atoms(self):
+        for s in (
+            "sys-apps/portage",
+            "=sys-apps/portage-2.1",
+            ">=dev-libs/foo-1.2.3-r1:0/1=[a,-b,c?,!d?,e=]",
+            "!!media-libs/x:2",
+            "~cat/pkg-1.0",
+            "cat/pkg:0/1=",
+            "dev-libs/gtk+",
+        ):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+                self._assert_same(s, eapi=None)
+
+    def test_glob_only_with_equals(self):
+        self._assert_same("=cat/pkg-1.2*", eapi="8")
+        self._assert_same(">=cat/pkg-1.2*", eapi="8")  # invalid -> both reject
+        self._assert_same("<cat/pkg-1*", eapi="8")
+
+    def test_version_requires_operator(self):
+        self._assert_same("cat/pkg-1", eapi="8")  # invalid
+        self._assert_same("cat/pkg-1.2.3", eapi="8")  # invalid
+
+    def test_name_must_not_end_in_version(self):
+        for s in ("<cat/bar-2-0", "=foo/bar-1-r1-1-r1", "=cat/libc-2-9999"):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")  # invalid, both reject
+
+    def test_leading_plus_rejected(self):
+        for s in ("+cat/pkg", "cat/pkg:+slot", "cat/pkg:0/+sub"):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+
+    def test_conflicting_use_rejected(self):
+        self._assert_same("cat/pkg[a(+),-a]", eapi="8")
+        self._assert_same("cat/pkg[a,a]", eapi="8")
+
+    def test_repo_and_build_id_fall_back(self):
+        # scan_atom rejects these; the regex path handles them when allowed.
+        self._assert_same("cat/pkg::gentoo", eapi=None, allow_repo=True)
+        self._assert_same("=cat/pkg-1-3", eapi=None, allow_build_id=True)
+
+    def test_eapi_incompatibility(self):
+        self._assert_same("cat/pkg:0", eapi="0")  # slot deps invalid in EAPI 0
+        self._assert_same("cat/pkg[a]", eapi="1")  # use deps invalid in EAPI 1
+        self._assert_same("cat/pkg[a(+)]", eapi="4")  # defaults invalid in EAPI 4
+
+
+class TestScanAtomNameGrammar(_AtomParityMixin, TestCase):
+    """Category, package-name, version and revision edge cases, adapted from
+    pkgcore's tests/ebuild/test_cpv.py.
+
+    The corpus only supplies awkward shapes; it does not assert which of them
+    are valid. Portage's own regex path is the reference, and every string is
+    checked for parity against it, so a C scanner that is stricter or laxer
+    than portage anywhere in this grammar fails."""
+
+    # Names that are legal per PMS 3.1.1/3.1.2, including the ones that look
+    # like they should not be: a bare "_" category, a category with a dot in
+    # it, and package names ending in hyphens or in a hyphen-digit sequence
+    # that is not a version.
+    GOOD_CATS = (
+        "dev-util",
+        "dev+",
+        "DEV-UTIL+",
+        "aaa0",
+        "aaa-0",
+        "multi--hyphen",
+        "_dev",
+        "_",
+        "cross-hppa2.0-unknown-linux-gnu",
+    )
+    BAD_CATS = (
+        "",
+        ".reject",
+        " reject",
+        "-",
+        "+",
+        "dev-util ",
+        "multi/blah/depth",
+        "multi//depth",
+    )
+    GOOD_PKGS = (
+        "diffball",
+        "a9",
+        "a9+",
+        "a-100dpi",
+        "diff-mode-",
+        "multi--hyphen",
+        "timidity--",
+        "frob---",
+        "diffball-9-",
+        "7z",
+        "xf86-video-r128",
+        "emacs-cvs",
+    )
+    # "diffball-9" and "bar-11-r3" are rejected because an unversioned atom's
+    # name may not end in something that parses as a version.
+    BAD_PKGS = (
+        "diffball ",
+        "diffball-9",
+        "a-3D",
+        "-df",
+        "+dfa",
+        "timidity--9f",
+        "ormaybe---13_beta",
+        "bar-11-r3",
+    )
+
+    GOOD_VERS = ("1", "2.3.4", "2.3.4a", "02.3", "2.03", "3d")
+    BAD_VERS = ("2.3a.4", "2.a.3", "2.3_", "2.3 ", "2.3.", "cvs.2", "3D")
+    GOOD_REVS = ("", "-r0", "-r1", "-r300", "-r1000000000000000000")
+    BAD_REVS = ("-r", "-ra", "-R1")
+
+    SIMPLE_SUFS = ("_alpha", "_beta", "_pre", "_p", "_rc")
+    GOOD_SUFS = SIMPLE_SUFS + tuple(f"{x}{n}" for n, x in enumerate(SIMPLE_SUFS))
+    BAD_SUFS = ("_a", "_9", "_") + tuple(f"{x} " for x in SIMPLE_SUFS)
+
+    def test_category_grammar(self):
+        for cat in self.GOOD_CATS + self.BAD_CATS:
+            with self.subTest(cat=cat):
+                self._assert_same(f"{cat}/diffball", eapi="8")
+
+    def test_package_name_grammar(self):
+        for pkg in self.GOOD_PKGS + self.BAD_PKGS:
+            with self.subTest(pkg=pkg):
+                self._assert_same(f"dev-util/{pkg}", eapi="8")
+
+    def test_category_package_matrix(self):
+        for cat in self.GOOD_CATS:
+            for pkg in self.GOOD_PKGS:
+                with self.subTest(cat=cat, pkg=pkg):
+                    self._assert_same(f"{cat}/{pkg}", eapi="8")
+
+    def test_version_grammar(self):
+        for ver in self.GOOD_VERS + self.BAD_VERS:
+            with self.subTest(ver=ver):
+                self._assert_same(f"=dev-util/diffball-{ver}", eapi="8")
+                self._assert_same(f"~dev-util/diffball-{ver}", eapi="8")
+
+    def test_revision_grammar(self):
+        for rev in self.GOOD_REVS + self.BAD_REVS:
+            with self.subTest(rev=rev):
+                self._assert_same(f"=dev-util/diffball-2.3.4{rev}", eapi="8")
+
+    def test_version_suffix_grammar(self):
+        for suf in self.GOOD_SUFS + self.BAD_SUFS:
+            with self.subTest(suf=suf):
+                self._assert_same(f"=dev-util/diffball-1{suf}", eapi="8")
+                self._assert_same(f"=dev-util/diffball-1{suf}-r1", eapi="8")
+
+    def test_version_suffix_and_revision_matrix(self):
+        for ver in self.GOOD_VERS:
+            for rev in self.GOOD_REVS + self.BAD_REVS:
+                with self.subTest(ver=ver, rev=rev):
+                    self._assert_same(f"=dev-util/diffball-{ver}{rev}", eapi="8")
+
+    def test_version_glob_grammar(self):
+        for ver in self.GOOD_VERS + self.BAD_VERS:
+            with self.subTest(ver=ver):
+                self._assert_same(f"=dev-util/diffball-{ver}*", eapi="8")
+
+    def test_package_name_containing_version_like_words(self):
+        # A hyphen-digit run only terminates the name if what follows it is a
+        # complete version, so these all stay part of the package name.
+        for s in (
+            "dev-util/diffball-blah-monkeys",
+            "bah/f-100dpi",
+            "dev-ut-asdf/emacs-cvs",
+            "bbb-9/foon",
+            "dev-util/foo-123-bar",
+            "app-text/foo-2abc",
+            "app-text/foo-2_bar",
+        ):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+
+    def test_slot_grammar(self):
+        # ":=" and ":*" are whole slot deps, not sub-slots, and the "="
+        # operator only ever comes last.
+        for s in (
+            "cat/pkg:0",
+            "cat/pkg:0/53",
+            "cat/pkg:0=",
+            "cat/pkg:0/53=",
+            "cat/pkg:=",
+            "cat/pkg:*",
+            "cat/pkg:my-slot_2.1/other+sub=",
+            "cat/pkg:0/*",  # invalid
+            "cat/pkg:0/=",  # invalid
+            "cat/pkg:0=/53",  # invalid
+            "cat/pkg:0=/53=",  # invalid
+            "cat/pkg:0/",  # invalid
+            "cat/pkg:",  # invalid
+            "cat/pkg:/53",  # invalid
+            "cat/pkg:-slot",  # invalid
+            "cat/pkg:0//53",  # invalid
+            "cat/pkg:0/53/54",  # invalid
+            "cat/pkg:*=",  # invalid
+            "cat/pkg:=*",  # invalid
+        ):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+
+    def test_truncated_atoms(self):
+        for s in ("cat/", "cat/pkg[", "cat/pkg[a", "cat/pkg[]", "cat", "/pkg", "/"):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+
+    def test_pathological_name(self):
+        # https://github.com/pkgcore/pkgcore/issues/463 and the oversized name
+        # from pkgcore's test_cpv.py, which also exercises the heap fallback in
+        # join_atom_string().
+        cat = "dev-java"
+        pkg = (
+            "log5j-777777777777777777777777777777777-777777777777777777"
+            "-7777777777777777777-7777777-7dev-q!7778"
+        )
+        self._assert_same(f"{cat}/{pkg}", eapi="8")
+        self._assert_same("cross-hppa2.0-unknown-linux-gnu/gcc", eapi="8")
+
+
 class TestCParserMalformedGroups(TestCase):
     """Whitespace and delimiter errors in group syntax. Every one of these has
     a distinct error path in scan_item()/scan_group_contents(), and each must

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -1001,6 +1001,27 @@ class TestScanAtom(_AtomParityMixin, TestCase):
         self._assert_same("cat/pkg[a]", eapi="1")  # use deps invalid in EAPI 1
         self._assert_same("cat/pkg[a(+)]", eapi="4")  # defaults invalid in EAPI 4
 
+    def test_is_valid_flag(self):
+        # The conditional-flag-in-IUSE check runs in the fast path too.
+        def accept_all(flag):
+            return True
+
+        def reject_x(flag):
+            return not flag.startswith("x")
+
+        self._assert_same("cat/pkg[a?,!b?]", eapi="8", is_valid_flag=accept_all)
+        self._assert_same("cat/pkg[x?]", eapi="8", is_valid_flag=reject_x)  # invalid
+        self._assert_same("cat/pkg[x=]", eapi="8", is_valid_flag=reject_x)  # invalid
+        # Non-conditional flags are not validated by is_valid_flag.
+        self._assert_same("cat/pkg[x,-y]", eapi="8", is_valid_flag=reject_x)
+
+    def test_wildcard_falls_back(self):
+        # Extended/wildcard atoms fail scan_atom and use the regex path;
+        # results (extended_syntax etc.) must still match.
+        for s in ("*/*", "cat/*", "*/pkg", "dev-*/foo", "=cat/pkg-*1*"):
+            with self.subTest(s=s):
+                self._assert_same(s, allow_wildcard=True)
+
 
 class TestScanAtomNameGrammar(_AtomParityMixin, TestCase):
     """Category, package-name, version and revision edge cases, adapted from

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1509,6 +1509,17 @@ dependency resolution and fall back to the previous implementation.
 This variable is internal and experimental; it may be removed or changed
 in a future release.
 .TP
+.BR PORTAGE_NATIVE_DEP_PARSER
+If this environment variable is set to \fI0\fR, then Portage will not use
+the native C dependency\-string parser and will fall back to the
+pure\-Python implementation.  Both paths are expected to produce identical
+results; the variable exists to verify that, and to work around a defect in
+the native parser should one be found.  It is read once, when the
+\fBportage.dep\fR module is imported, so it must be set in the environment
+before Portage starts.
+This variable is internal and experimental; it may be removed or changed
+in a future release.
+.TP
 .BR PORTAGE_DO_NOT_EXPORT_PMS_VARS
 If this environment variable is set, then Portage will not export PMS
 variables regardless of the EAPI.  The variables are still available

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -57,3 +57,7 @@ option('rsync-verify', type : 'boolean', value : true,
 option('xattr', type : 'boolean', value : false,
     description : 'Preserve extended attributes when installing files'
 )
+
+option('fuzzing', type : 'boolean', value : false,
+    description : 'Build the libFuzzer harness for the native dependency parser'
+)

--- a/src/dep_atom.h
+++ b/src/dep_atom.h
@@ -1,0 +1,154 @@
+/* Copyright 2026 Gentoo Authors
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "dep_parser_core.h"
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *str;          /* original dep token string, used for __hash__/__eq__ */
+    PyObject *cp;
+    PyObject *cpv;
+    PyObject *version;
+    PyObject *operator;
+    PyObject *blocker;
+    PyObject *slot;
+    PyObject *sub_slot;
+    PyObject *slot_operator;
+    PyObject *use;
+} AtomObject;
+
+/* Forward declaration so Atom_richcompare can reference AtomType. */
+static PyTypeObject AtomType;
+
+static void Atom_dealloc(AtomObject *self)
+{
+    Py_XDECREF(self->str);
+    Py_XDECREF(self->cp);
+    Py_XDECREF(self->cpv);
+    Py_XDECREF(self->version);
+    Py_XDECREF(self->operator);
+    Py_XDECREF(self->blocker);
+    Py_XDECREF(self->slot);
+    Py_XDECREF(self->sub_slot);
+    Py_XDECREF(self->slot_operator);
+    Py_XDECREF(self->use);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyObject *Atom_repr(AtomObject *self)
+{
+    return PyUnicode_FromFormat("Atom(%R)", self->str);
+}
+
+static PyObject *Atom_str(AtomObject *self)
+{
+    return Py_NewRef(self->str);
+}
+
+static Py_hash_t Atom_hash(AtomObject *self)
+{
+    return PyObject_Hash(self->str);
+}
+
+static PyObject *Atom_richcompare(AtomObject *self, PyObject *other, int op)
+{
+    if (op != Py_EQ && op != Py_NE)
+        Py_RETURN_NOTIMPLEMENTED;
+
+    if (Py_TYPE(other) != &AtomType) {
+        if (op == Py_EQ) {
+            Py_RETURN_FALSE;
+        } else {
+            Py_RETURN_TRUE;
+        }
+    }
+
+    return PyObject_RichCompare(self->str, ((AtomObject *)other)->str, op);
+}
+
+#define ATOM_GETTER(field) \
+    static PyObject *Atom_get_##field(AtomObject *self, UNUSED void *closure) \
+    { return Py_NewRef(self->field); }
+
+ATOM_GETTER(cp)
+ATOM_GETTER(cpv)
+ATOM_GETTER(version)
+ATOM_GETTER(operator)
+ATOM_GETTER(blocker)
+ATOM_GETTER(slot)
+ATOM_GETTER(sub_slot)
+ATOM_GETTER(slot_operator)
+ATOM_GETTER(use)
+
+static PyGetSetDef Atom_getset[] = {
+    { "cp",            (getter)Atom_get_cp,            NULL, NULL, NULL },
+    { "cpv",           (getter)Atom_get_cpv,           NULL, NULL, NULL },
+    { "version",       (getter)Atom_get_version,       NULL, NULL, NULL },
+    { "operator",      (getter)Atom_get_operator,      NULL, NULL, NULL },
+    { "blocker",       (getter)Atom_get_blocker,       NULL, NULL, NULL },
+    { "slot",          (getter)Atom_get_slot,          NULL, NULL, NULL },
+    { "sub_slot",      (getter)Atom_get_sub_slot,      NULL, NULL, NULL },
+    { "slot_operator", (getter)Atom_get_slot_operator, NULL, NULL, NULL },
+    { "use",           (getter)Atom_get_use,           NULL, NULL, NULL },
+    { NULL }
+};
+
+static PyTypeObject AtomType = {
+    .ob_base        = PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name        = "portage.dep._parser.Atom",
+    .tp_basicsize   = sizeof(AtomObject),
+    .tp_dealloc     = (destructor)Atom_dealloc,
+    .tp_repr        = (reprfunc)Atom_repr,
+    .tp_hash        = (hashfunc)Atom_hash,
+    .tp_str         = (reprfunc)Atom_str,
+    .tp_richcompare = (richcmpfunc)Atom_richcompare,
+    .tp_flags       = Py_TPFLAGS_DEFAULT,
+    .tp_getset      = Atom_getset,
+};
+
+/* Allocate an AtomObject and populate it.  Steals all refs.  Returns the
+ * object, or NULL if the allocation failed (refs NOT consumed on NULL). */
+static inline PyObject *atom_new(
+    PyObject *str,
+    PyObject *cp, PyObject *cpv, PyObject *version,
+    PyObject *operator, PyObject *blocker,
+    PyObject *slot, PyObject *sub_slot, PyObject *slot_operator,
+    PyObject *use)
+{
+    AtomObject *obj = PyObject_New(AtomObject, &AtomType);
+
+    if (!obj)
+        return NULL;
+
+    obj->str           = str;
+    obj->cp            = cp;
+    obj->cpv           = cpv;
+    obj->version       = version;
+    obj->operator      = operator;
+    obj->blocker       = blocker;
+    obj->slot          = slot;
+    obj->sub_slot      = sub_slot;
+    obj->slot_operator = slot_operator;
+    obj->use           = use;
+
+    return (PyObject *)obj;
+}
+
+/* Register AtomType with a module.  Call after PyType_Ready. */
+static inline int atom_add_to_module(PyObject *m)
+{
+    Py_INCREF(&AtomType);
+    if (PyModule_AddObject(m, "Atom", (PyObject *)&AtomType) < 0) {
+        Py_DECREF(&AtomType);
+        return -1;
+    }
+    return 0;
+}
+
+/* vim: set ts=4 sw=4 et: */

--- a/src/dep_atom.h
+++ b/src/dep_atom.h
@@ -143,12 +143,7 @@ static inline PyObject *atom_new(
 /* Register AtomType with a module.  Call after PyType_Ready. */
 static inline int atom_add_to_module(PyObject *m)
 {
-    Py_INCREF(&AtomType);
-    if (PyModule_AddObject(m, "Atom", (PyObject *)&AtomType) < 0) {
-        Py_DECREF(&AtomType);
-        return -1;
-    }
-    return 0;
+    return PyModule_AddType(m, &AtomType);
 }
 
 /* vim: set ts=4 sw=4 et: */

--- a/src/dep_parser.c
+++ b/src/dep_parser.c
@@ -699,41 +699,45 @@ static PyMethodDef methods[] = {
     { NULL, NULL, 0, NULL },
 };
 
+static int module_exec(PyObject *m)
+{
+    if (!init_globals())
+        return -1;
+
+    return atom_add_to_module(m);
+}
+
+static PyModuleDef_Slot slots[] = {
+    { Py_mod_exec, (void *)module_exec },
+#ifdef Py_mod_multiple_interpreters
+    /* The interned strings and the Atom type are process-wide statics, so the
+     * module must only ever be loaded into the main interpreter. */
+    { Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED },
+#endif
+#ifdef Py_mod_gil
+    /* Safe to run without the GIL: the character-class table and the interned
+     * strings are written once during module exec and only read afterwards,
+     * the scanner keeps all of its state on the stack or in a per-call
+     * context, and Atom is an ordinary refcounted object with no mutable
+     * fields. */
+    { Py_mod_gil, Py_MOD_GIL_NOT_USED },
+#endif
+    { 0, NULL },
+};
+
 static struct PyModuleDef module = {
     .m_base    = PyModuleDef_HEAD_INIT,
     .m_name    = MODULE_NAME,
     .m_doc     = NULL,
-    .m_size    = -1,
+    .m_size    = 0,
     .m_methods = methods,
+    .m_slots   = slots,
 };
 
 PyMODINIT_FUNC
 PyInit__parser(void)
 {
-    if (!init_globals())
-        return NULL;
-
-    PyObject *m = PyModule_Create(&module);
-    if (!m)
-        return NULL;
-
-    if (atom_add_to_module(m) < 0) {
-        Py_DECREF(m);
-        return NULL;
-    }
-
-#ifdef Py_GIL_DISABLED
-    /* Safe to run without the GIL: the character-class table and the interned
-     * strings are written once here and only read afterwards, the scanner
-     * keeps all of its state on the stack or in a per-call context, and Atom
-     * is an ordinary refcounted object with no mutable fields. */
-    if (PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED) < 0) {
-        Py_DECREF(m);
-        return NULL;
-    }
-#endif
-
-    return m;
+    return PyModuleDef_Init(&module);
 }
 
 /* vim: set ts=4 sw=4 et: */

--- a/src/dep_parser.c
+++ b/src/dep_parser.c
@@ -627,7 +627,11 @@ py_parse(UNUSED PyObject *self, PyObject *args, PyObject *kwargs)
 
     AUTO_PY useset = NULL;
     if (py_uselist != Py_None) {
-        useset = PyFrozenSet_New(py_uselist);
+        /* use_reduce() has already frozen its uselist, so the common case is
+         * a frozenset that can be reused instead of copied. */
+        useset = PyFrozenSet_CheckExact(py_uselist)
+            ? Py_NewRef(py_uselist)
+            : PyFrozenSet_New(py_uselist);
         if (!useset) {
             return NULL;
         }

--- a/src/dep_parser.c
+++ b/src/dep_parser.c
@@ -1,0 +1,715 @@
+/* Copyright 2026 Gentoo Authors
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+#include "dep_atom.h"
+#include "dep_parser_core.h"
+#include <assert.h>
+#include <string.h>
+
+#define MODULE_NAME "portage.dep._parser"
+
+typedef struct {
+    PyObject *useset;   /* frozenset of active USE flags, or NULL */
+    int       matchall;
+} UseContext;
+
+static inline void py_decref_p(PyObject **p) {
+    Py_XDECREF(*p);
+}
+#define AUTO_PY __attribute__((cleanup(py_decref_p))) PyObject *
+
+static struct {
+    /* operator strings */
+    PyObject *op_lt, *op_gt, *op_le, *op_ge, *op_eq, *op_tilde;
+    /* blocker strings */
+    PyObject *blocker_weak, *blocker_strong;   /* "!" weak, "!!" strong */
+    /* slot operator strings */
+    PyObject *slot_op_eq, *slot_op_star;
+} interned;
+
+static int init_globals(void)
+{
+    init_cc_table();
+
+    if (PyType_Ready(&AtomType) < 0)
+        return 0;
+
+#define INTERN(var, s) \
+    do { interned.var = PyUnicode_InternFromString(s); if (!interned.var) return 0; } while (0)
+    INTERN(op_lt,          "<");
+    INTERN(op_gt,          ">");
+    INTERN(op_le,          "<=");
+    INTERN(op_ge,          ">=");
+    INTERN(op_eq,          "=");
+    INTERN(op_tilde,       "~");
+    INTERN(blocker_weak,   "!");
+    INTERN(blocker_strong, "!!");
+    INTERN(slot_op_eq,     "=");
+    INTERN(slot_op_star,   "*");
+#undef INTERN
+
+    return 1;
+}
+
+/* Return an interned operator string, avoiding allocation for the common cases. */
+static PyObject *op_str(const char *op, int len)
+{
+    if (len == 1) {
+        if (op[0] == '<') return Py_NewRef(interned.op_lt);
+        if (op[0] == '>') return Py_NewRef(interned.op_gt);
+        if (op[0] == '=') return Py_NewRef(interned.op_eq);
+        if (op[0] == '~') return Py_NewRef(interned.op_tilde);
+    } else if (len == 2) {
+        if (op[0] == '<') return Py_NewRef(interned.op_le);
+        if (op[0] == '>') return Py_NewRef(interned.op_ge);
+    }
+    return PyUnicode_FromStringAndSize(op, len);
+}
+
+static PyObject *blocker_str(int len)
+{
+    assert(len == 1 || len == 2);
+    return Py_NewRef(len == 1 ? interned.blocker_weak : interned.blocker_strong);
+}
+
+/* Split the raw text between ':' and the end of the slot into the three
+ * fields portage.dep.Atom keeps, following PMS 8.3.3:
+ *
+ *   "0"     -> slot "0",  sub_slot None, op None
+ *   "0/53"  -> slot "0",  sub_slot "53", op None
+ *   "0="    -> slot "0",  sub_slot None, op "="
+ *   "0/53=" -> slot "0",  sub_slot "53", op "="
+ *   "="     -> slot None, sub_slot None, op "="
+ *   "*"     -> slot None, sub_slot None, op "*"
+ *
+ * The scanner has already validated the text, so this only has to divide it.
+ * Each out parameter is set to a new reference. */
+static void parse_slot_raw(const char *raw, int rlen,
+                            PyObject **out_slot, PyObject **out_sub,
+                            PyObject **out_op)
+{
+    if (rlen == 1 && (raw[0] == '*' || raw[0] == '=')) {
+        *out_slot = Py_NewRef(Py_None);
+        *out_sub  = Py_NewRef(Py_None);
+        *out_op   = raw[0] == '=' ? Py_NewRef(interned.slot_op_eq) : Py_NewRef(interned.slot_op_star);
+        return;
+    }
+
+    const char *slash = memchr(raw, '/', rlen);
+    char slot_op = 0;
+
+    if (!slash) {
+        int slen = rlen;
+        if (slen > 0 && raw[slen - 1] == '=') {
+            slot_op = '=';
+            slen--;
+        }
+        *out_slot = PyUnicode_FromStringAndSize(raw, slen);
+        *out_sub  = Py_NewRef(Py_None);
+    } else {
+        int main_len = (int)(slash - raw);
+        if (main_len > 0 && raw[main_len - 1] == '=') {
+            slot_op = '=';
+            main_len--;
+        }
+        *out_slot = PyUnicode_FromStringAndSize(raw, main_len);
+
+        const char *sub = slash + 1;
+        int sub_len = rlen - (int)(sub - raw);
+        if (sub_len == 1 && (sub[0] == '*' || sub[0] == '=')) {
+            *out_sub = Py_NewRef(Py_None);
+            slot_op = sub[0];
+        } else {
+            if (sub_len > 0 && sub[sub_len - 1] == '=') {
+                slot_op = '=';
+                sub_len--;
+            }
+            *out_sub = PyUnicode_FromStringAndSize(sub, sub_len);
+        }
+    }
+
+    if (slot_op == '=') {
+        *out_op = Py_NewRef(interned.slot_op_eq);
+    } else if (slot_op == '*') {
+        *out_op = Py_NewRef(interned.slot_op_star);
+    } else {
+        *out_op = Py_NewRef(Py_None);
+    }
+}
+
+/* Split the raw text between '[' and ']' into one string per flag:
+ *
+ *   "foo,-bar,baz?" -> ("foo", "-bar", "baz?")
+ *
+ * The prefixes and suffixes are left on; _use_dep (or classify_use_deps)
+ * interprets them.  The scanner has already validated the text, so a ',' here
+ * can only be a separator. */
+static PyObject *parse_use_raw(const char *raw, int rlen)
+{
+    int count = 1;
+    for (int i = 0; i < rlen; i++) {
+        if (raw[i] == ',') {
+            count++;
+        }
+    }
+
+    PyObject *tup = PyTuple_New(count);
+    if (!tup)
+        return NULL;
+
+    int idx = 0, start = 0;
+    for (int j = 0; j <= rlen; j++) {
+        if (j == rlen || raw[j] == ',') {
+            PyObject *flag = PyUnicode_FromStringAndSize(raw + start, j - start);
+            if (!flag) {
+                Py_DECREF(tup);
+                return NULL;
+            }
+
+            PyTuple_SET_ITEM(tup, idx++, flag);
+            start = j + 1;
+        }
+    }
+    return tup;
+}
+
+/* Join the pieces of an atom into one string:
+ *
+ *   ("dev-libs", "foo", NULL)  -> "dev-libs/foo"
+ *   ("dev-libs", "foo", "1.2") -> "dev-libs/foo-1.2"
+ *
+ * The scanner reports spans into the caller's dep string rather than
+ * NUL-terminated pieces, so they have to be copied to be joined.  Category and
+ * package names are unbounded, so a stack buffer big enough for every real
+ * atom is used where it fits and the heap otherwise; rejecting a long atom
+ * here would make the C path refuse a dep string the regex path accepts. */
+static PyObject *join_atom_string(const char *cat, int cat_len,
+                                  const char *pkg, int pkg_len,
+                                  const char *ver, int ver_len)
+{
+    char  stack_buf[256];
+    char *buf = stack_buf;
+    int   len = cat_len + 1 + pkg_len + (ver ? 1 + ver_len : 0);
+
+    if (len > (int)sizeof(stack_buf)) {
+        buf = PyMem_Malloc(len);
+        if (!buf)
+            return PyErr_NoMemory();
+    }
+
+    char *w = buf;
+    memcpy(w, cat, cat_len);
+    w += cat_len;
+    *w++ = '/';
+    memcpy(w, pkg, pkg_len);
+    w += pkg_len;
+    if (ver) {
+        *w++ = '-';
+        memcpy(w, ver, ver_len);
+    }
+
+    PyObject *result = PyUnicode_FromStringAndSize(buf, len);
+    if (buf != stack_buf)
+        PyMem_Free(buf);
+    return result;
+}
+
+static PyObject *build_atom_obj(const AtomInfo *a, const char *tok, int tok_len)
+{
+    PyObject *py_str = PyUnicode_FromStringAndSize(tok, tok_len);
+    if (!py_str)
+        return NULL;
+
+    PyObject *py_cp = join_atom_string(a->cat, a->cat_len,
+                                       a->pkg, a->pkg_len, NULL, 0);
+    if (!py_cp) {
+        Py_DECREF(py_str);
+        return NULL;
+    }
+
+    PyObject *py_ver, *py_cpv;
+    if (a->ver) {
+        py_ver = PyUnicode_FromStringAndSize(a->ver, a->ver_len);
+        py_cpv = py_ver ? join_atom_string(a->cat, a->cat_len, a->pkg,
+                                           a->pkg_len, a->ver, a->ver_len)
+                        : NULL;
+        if (!py_cpv) {
+            Py_DECREF(py_str);
+            Py_DECREF(py_cp);
+            Py_XDECREF(py_ver);
+            return NULL;
+        }
+    } else {
+        py_ver = Py_NewRef(Py_None);
+        py_cpv = Py_NewRef(py_cp);
+    }
+
+    PyObject *py_operator = a->op ?
+        op_str(a->op, a->op_len)  : Py_NewRef(Py_None);
+    PyObject *py_blocker  = a->block ?
+        blocker_str(a->block_len) : Py_NewRef(Py_None);
+
+    PyObject *py_slot, *py_sub, *py_slot_op;
+    if (a->slot_raw) {
+        parse_slot_raw(a->slot_raw, a->slot_raw_len,
+                       &py_slot, &py_sub, &py_slot_op);
+    } else {
+        py_slot    = Py_NewRef(Py_None);
+        py_sub     = Py_NewRef(Py_None);
+        py_slot_op = Py_NewRef(Py_None);
+    }
+
+    PyObject *py_use = a->use_raw
+        ? parse_use_raw(a->use_raw, a->use_raw_len)
+        : Py_NewRef(Py_None);
+
+    if (!py_operator || !py_blocker || !py_slot || !py_sub || !py_slot_op || !py_use)
+        goto cleanup;
+
+    PyObject *obj = atom_new(py_str, py_cp, py_cpv, py_ver, py_operator, py_blocker,
+                             py_slot, py_sub, py_slot_op, py_use);
+    if (obj)
+        return obj;
+
+cleanup:
+    Py_DECREF(py_str);
+    Py_DECREF(py_cp);
+    Py_DECREF(py_cpv);
+    Py_DECREF(py_ver);
+    Py_XDECREF(py_operator);
+    Py_XDECREF(py_blocker);
+    Py_XDECREF(py_slot);
+    Py_XDECREF(py_sub);
+    Py_XDECREF(py_slot_op);
+    Py_XDECREF(py_use);
+    return NULL;
+}
+
+typedef struct {
+    PyObject *list;
+    PyObject *op;
+} PyGroupFrame;
+
+/* Groups nest only a few levels deep in practice, so the first levels live in
+ * the context itself and deeper nesting spills to the heap.  There is no fixed
+ * ceiling: the pure-Python path has none either, and rejecting a dep string it
+ * accepts would be a divergence between the two. */
+#define PY_PARSE_INLINE_DEPTH 32
+
+typedef struct {
+    PyGroupFrame  inline_frames[PY_PARSE_INLINE_DEPTH];
+    PyGroupFrame *frames;
+    int         depth;
+    int         capacity;
+    PyObject   *useset;
+    int         matchall;
+} PyParseContext;
+
+static int py_ctx_grow(PyParseContext *ctx)
+{
+    int new_cap = ctx->capacity * 2;
+    PyGroupFrame *frames;
+
+    if (ctx->frames == ctx->inline_frames) {
+        frames = PyMem_New(PyGroupFrame, new_cap);
+        if (frames)
+            memcpy(frames, ctx->inline_frames, sizeof(ctx->inline_frames));
+    } else {
+        frames = PyMem_Realloc(ctx->frames, new_cap * sizeof(*frames));
+    }
+
+    if (!frames) {
+        PyErr_NoMemory();
+        return 0;
+    }
+
+    ctx->frames   = frames;
+    ctx->capacity = new_cap;
+    return 1;
+}
+
+static void py_ctx_free(PyParseContext *ctx)
+{
+    if (ctx->frames != ctx->inline_frames)
+        PyMem_Free(ctx->frames);
+}
+
+static int py_on_atom(void *vctx, const char *start, int len, const AtomInfo *info)
+{
+    PyParseContext *ctx = vctx;
+    PyObject *obj = build_atom_obj(info, start, len);
+    if (!obj)
+        return 0;
+
+    int rc = PyList_Append(ctx->frames[ctx->depth - 1].list, obj);
+    Py_DECREF(obj);
+    return rc >= 0;
+}
+
+static int py_on_group_start(void *vctx, const char *op, int op_len)
+{
+    PyParseContext *ctx = vctx;
+    if (ctx->depth >= ctx->capacity && !py_ctx_grow(ctx))
+        return 0;
+
+    PyObject *group_op = PyUnicode_FromStringAndSize(op, op_len);
+    if (!group_op)
+        return 0;
+
+    PyObject *sublist = PyList_New(0);
+    if (!sublist) {
+        Py_DECREF(group_op);
+        return 0;
+    }
+
+    ctx->frames[ctx->depth].op   = group_op;
+    ctx->frames[ctx->depth].list = sublist;
+    ctx->depth++;
+    return 1;
+}
+
+static int py_on_group_end(void *vctx)
+{
+    PyParseContext *ctx      = vctx;
+    ctx->depth--;
+    PyObject *group_op = ctx->frames[ctx->depth].op;
+    PyObject *sublist  = ctx->frames[ctx->depth].list;
+    PyObject *parent   = ctx->frames[ctx->depth - 1].list;
+
+    int rc = PyList_Append(parent, group_op);
+    Py_DECREF(group_op);
+    if (rc < 0) {
+        Py_DECREF(sublist);
+        return 0;
+    }
+
+    rc = PyList_Append(parent, sublist);
+    Py_DECREF(sublist);
+    return rc >= 0;
+}
+
+static int py_use_active(void *vctx, const char *flag, int len, int is_neg)
+{
+    PyParseContext *ctx = vctx;
+    if (ctx->matchall)
+        return 1;
+    int in_set = 0;
+    if (ctx->useset) {
+        PyObject *key = PyUnicode_FromStringAndSize(flag, len);
+        if (!key)
+            return -1;
+        in_set = PySet_Contains(ctx->useset, key);
+        Py_DECREF(key);
+        if (in_set < 0)
+            return -1;
+    }
+    return is_neg ? !in_set : in_set;
+}
+
+static int dep_parse(const char *s, Py_ssize_t n, const char **err,
+                     PyObject *result, UseContext *use)
+{
+    DepScanner p = { s, s + n, NULL };
+
+    PyParseContext ctx = {
+        .depth    = 1,
+        .capacity = PY_PARSE_INLINE_DEPTH,
+        .useset   = use->useset,
+        .matchall = use->matchall,
+    };
+
+    ctx.frames = ctx.inline_frames;
+    ctx.frames[0].list = result;
+    ctx.frames[0].op   = NULL;
+    DepVisitor v = {
+        .ctx            = &ctx,
+        .on_atom        = py_on_atom,
+        .on_group_start = py_on_group_start,
+        .on_group_end   = py_on_group_end,
+        .use_active     = py_use_active,
+    };
+
+    skip_whitespace(&p);
+
+    if (p.cur < p.end && !scan_dep_list(&p, &v)) {
+        for (int i = 1; i < ctx.depth; i++) {  /* frame 0's list is caller-owned */
+            Py_XDECREF(ctx.frames[i].op);
+            Py_XDECREF(ctx.frames[i].list);
+        }
+        py_ctx_free(&ctx);
+
+        if (PyErr_Occurred())
+            return 0;
+
+        if (err)
+            *err = p.err ? p.err : "parse error";
+        return 0;
+    }
+
+    py_ctx_free(&ctx);
+
+    skip_whitespace(&p);
+
+    if (p.cur < p.end) {
+        if (err)
+            *err = "unexpected token";
+        return 0;
+    }
+    return 1;
+}
+
+/*
+ * classify_use_deps(tokens) -> tuple or None
+ *
+ * Classify a sequence of use-dep token strings (already split at ',') into
+ * the sets that _use_dep.__init__ would produce, bypassing its per-token
+ * regex.  Returns a 6-tuple:
+ *   (enabled_fs, disabled_fs, missing_enabled_fs, missing_disabled_fs,
+ *    conditional_dict_or_None, required_fs)
+ * where the frozensets and dict match exactly what _use_dep expects in its
+ * shortcut constructor path (enabled_flags is not None).
+ * Raises ValueError if any token cannot be classified.
+ */
+static PyObject *
+py_classify_use_deps(UNUSED PyObject *self, PyObject *arg)
+{
+    AUTO_PY seq  = PySequence_Fast(arg, "expected sequence");
+    if (!seq)
+        return NULL;
+
+    Py_ssize_t ntok = PySequence_Fast_GET_SIZE(seq);
+
+    AUTO_PY en   = PySet_New(NULL);
+    AUTO_PY dis  = PySet_New(NULL);
+    AUTO_PY me   = PySet_New(NULL);
+    AUTO_PY md   = PySet_New(NULL);
+    AUTO_PY req  = PySet_New(NULL);
+    AUTO_PY cen  = NULL;
+    AUTO_PY cdis = NULL;
+    AUTO_PY ceq  = NULL;
+    AUTO_PY cneq = NULL;
+    if (!en || !dis || !me || !md || !req)
+        return NULL;
+
+#define SET_ADD(set, f)  do { if (PySet_Add((set), (f)) < 0) return NULL; } while (0)
+#define SET_LAZY(ptr)    do { if (!(ptr) && !((ptr) = PySet_New(NULL))) return NULL; } while (0)
+
+    for (Py_ssize_t i = 0; i < ntok; i++) {
+        PyObject *tok = PySequence_Fast_GET_ITEM(seq, i);  /* borrowed */
+        Py_ssize_t slen;
+
+        const char *s = PyUnicode_AsUTF8AndSize(tok, &slen);
+        if (!s)
+            return NULL;
+
+        const char *p = s, *end = s + slen;
+
+        int is_neg = 0, is_dis_pfx = 0;
+        if (p < end && *p == '!') {
+            is_neg = 1;
+            p++;
+        } else if (p < end && *p == '-') {
+            is_dis_pfx = 1;
+            p++;
+        }
+
+        if (p >= end || !is_nw_char(*p)) {
+            PyErr_Format(PyExc_ValueError, "invalid use dep token: %R", tok);
+            return NULL;
+        }
+
+        const char *flag_start = p++;
+        while (p < end && is_use_char(*p)) {
+            p++;
+        }
+        const char *flag_end = p;
+
+        /* optional default: (+) or (-) */
+        int def = 0;  /* 0=none, +1=(+), -1=(-) */
+        if (p + 3 <= end && p[0] == '(' && p[2] == ')') {
+            if (p[1] == '+') {
+                def = 1;
+                p += 3;
+            } else if (p[1] == '-') {
+                def = -1;
+                p += 3;
+            }
+        }
+
+        /* optional suffix */
+        char suf = 0;
+        if (p < end && (*p == '?' || *p == '=')) {
+            suf = *p++;
+        }
+
+        if (p != end || (is_neg && !suf) || (is_dis_pfx && suf)) {
+            PyErr_Format(PyExc_ValueError, "invalid use dep token: %R", tok);
+            return NULL;
+        }
+
+        AUTO_PY flag = PyUnicode_FromStringAndSize(flag_start, flag_end - flag_start);
+        if (!flag)
+            return NULL;
+
+        /* classify into enabled/disabled/conditional */
+        if (!is_neg && !is_dis_pfx && !suf) {
+            SET_ADD(en, flag);
+        } else if (is_dis_pfx) {
+            SET_ADD(dis, flag);
+        } else if (!is_neg && suf == '?') {
+            SET_LAZY(cen);  SET_ADD(cen, flag);
+        } else if (!is_neg && suf == '=') {
+            SET_LAZY(ceq);  SET_ADD(ceq, flag);
+        } else if (is_neg && suf == '?') {
+            SET_LAZY(cdis); SET_ADD(cdis, flag);
+        } else {  /* is_neg && suf == '=' */
+            SET_LAZY(cneq); SET_ADD(cneq, flag);
+        }
+
+        /* required = flags without a default */
+        if (!def)         SET_ADD(req, flag);
+        if (def > 0)      SET_ADD(me,  flag);
+        else if (def < 0) SET_ADD(md,  flag);
+    }
+
+#undef SET_ADD
+#undef SET_LAZY
+
+    AUTO_PY cond = NULL;
+    if (cen || cdis || ceq || cneq) {
+        cond = PyDict_New();
+        if (!cond)
+            return NULL;
+
+#define COND_SET(key, obj) \
+        if (obj) { \
+            AUTO_PY fs = PyFrozenSet_New(obj); \
+            if (!fs || PyDict_SetItemString(cond, key, fs) < 0) return NULL; \
+        }
+        COND_SET("enabled",   cen)
+        COND_SET("disabled",  cdis)
+        COND_SET("equal",     ceq)
+        COND_SET("not_equal", cneq)
+#undef COND_SET
+    } else {
+        cond = Py_NewRef(Py_None);
+    }
+
+    AUTO_PY fen  = PyFrozenSet_New(en);
+    AUTO_PY fdis = PyFrozenSet_New(dis);
+    AUTO_PY fme  = PyFrozenSet_New(me);
+    AUTO_PY fmd  = PyFrozenSet_New(md);
+    AUTO_PY freq = PyFrozenSet_New(req);
+    if (!fen || !fdis || !fme || !fmd || !freq)
+        return NULL;
+
+    return PyTuple_Pack(6, fen, fdis, fme, fmd, cond, freq);
+}
+
+static PyObject *
+py_parse(UNUSED PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    static const char * const kwlist[] = {"s", "uselist", "matchall", NULL};
+    PyObject *py_str;
+    PyObject *py_uselist = Py_None;
+    int matchall = 0;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Op", (char **)kwlist,
+                                      &py_str, &py_uselist, &matchall))
+        return NULL;
+
+    const char *s;
+    Py_ssize_t n;
+    s = PyUnicode_AsUTF8AndSize(py_str, &n);
+    if (!s)
+        return NULL;
+
+    AUTO_PY useset = NULL;
+    if (py_uselist != Py_None) {
+        useset = PyFrozenSet_New(py_uselist);
+        if (!useset) {
+            return NULL;
+        }
+    }
+
+    UseContext use = { useset, matchall };
+    AUTO_PY result = PyList_New(0);
+    if (!result) {
+        return NULL;
+    }
+
+    const char *err = NULL;
+    if (!dep_parse(s, n, &err, result, &use)) {
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_ValueError, err ? err : "parse error");
+        }
+        return NULL;
+    }
+    return Py_NewRef(result);
+}
+
+static PyMethodDef methods[] = {
+    {
+        .ml_name  = "parse",
+        .ml_meth  = (PyCFunction)py_parse,
+        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_doc   =
+            "parse(s, uselist=None, matchall=False) -> list\n"
+            "Parse a Gentoo dep spec. Returns a list of Atom objects, where\n"
+            "|| / ^^ / ?? groups appear as the operator string followed by a\n"
+            "sublist and a plain all-of group appears as a bare sublist.\n"
+            "Use conditionals are evaluated: an active one contributes a\n"
+            "sublist, an inactive one contributes nothing.",
+    },
+    {
+        .ml_name  = "classify_use_deps",
+        .ml_meth  = py_classify_use_deps,
+        .ml_flags = METH_O,
+        .ml_doc   =
+            "classify_use_deps(tokens) -> tuple\n"
+            "Classify pre-split use-dep tokens into (enabled_fs, disabled_fs,\n"
+            "missing_enabled_fs, missing_disabled_fs, conditional_dict_or_None,\n"
+            "required_fs). Raises ValueError if a token cannot be classified.",
+    },
+    { NULL, NULL, 0, NULL },
+};
+
+static struct PyModuleDef module = {
+    .m_base    = PyModuleDef_HEAD_INIT,
+    .m_name    = MODULE_NAME,
+    .m_doc     = NULL,
+    .m_size    = -1,
+    .m_methods = methods,
+};
+
+PyMODINIT_FUNC
+PyInit__parser(void)
+{
+    if (!init_globals())
+        return NULL;
+
+    PyObject *m = PyModule_Create(&module);
+    if (!m)
+        return NULL;
+
+    if (atom_add_to_module(m) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
+#ifdef Py_GIL_DISABLED
+    /* Safe to run without the GIL: the character-class table and the interned
+     * strings are written once here and only read afterwards, the scanner
+     * keeps all of its state on the stack or in a per-call context, and Atom
+     * is an ordinary refcounted object with no mutable fields. */
+    if (PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+#endif
+
+    return m;
+}
+
+/* vim: set ts=4 sw=4 et: */

--- a/src/dep_parser.c
+++ b/src/dep_parser.c
@@ -377,14 +377,19 @@ static int py_on_group_end(void *vctx)
     PyObject *sublist  = ctx->frames[ctx->depth].list;
     PyObject *parent   = ctx->frames[ctx->depth - 1].list;
 
-    int rc = PyList_Append(parent, group_op);
-    Py_DECREF(group_op);
-    if (rc < 0) {
-        Py_DECREF(sublist);
-        return 0;
+    /* Empty operator = naked all-of: append only the sublist. */
+    if (PyUnicode_GET_LENGTH(group_op) != 0) {
+        int rc = PyList_Append(parent, group_op);
+        Py_DECREF(group_op);
+        if (rc < 0) {
+            Py_DECREF(sublist);
+            return 0;
+        }
+    } else {
+        Py_DECREF(group_op);
     }
 
-    rc = PyList_Append(parent, sublist);
+    int rc = PyList_Append(parent, sublist);
     Py_DECREF(sublist);
     return rc >= 0;
 }

--- a/src/dep_parser.c
+++ b/src/dep_parser.c
@@ -96,46 +96,25 @@ static void parse_slot_raw(const char *raw, int rlen,
         return;
     }
 
-    const char *slash = memchr(raw, '/', rlen);
-    char slot_op = 0;
+    /* Past the bare ":=" / ":*" forms above, the only operator is a trailing
+     * '=', and it always comes last -- what precedes it is "slot" or
+     * "slot/sub_slot". */
+    int len = rlen;
+    int slot_op = len > 0 && raw[len - 1] == '=';
+    if (slot_op)
+        len--;
 
-    if (!slash) {
-        int slen = rlen;
-        if (slen > 0 && raw[slen - 1] == '=') {
-            slot_op = '=';
-            slen--;
-        }
-        *out_slot = PyUnicode_FromStringAndSize(raw, slen);
+    const char *slash = memchr(raw, '/', len);
+    if (slash) {
+        *out_slot = PyUnicode_FromStringAndSize(raw, (int)(slash - raw));
+        *out_sub  = PyUnicode_FromStringAndSize(slash + 1,
+                                                len - (int)(slash + 1 - raw));
+    } else {
+        *out_slot = PyUnicode_FromStringAndSize(raw, len);
         *out_sub  = Py_NewRef(Py_None);
-    } else {
-        int main_len = (int)(slash - raw);
-        if (main_len > 0 && raw[main_len - 1] == '=') {
-            slot_op = '=';
-            main_len--;
-        }
-        *out_slot = PyUnicode_FromStringAndSize(raw, main_len);
-
-        const char *sub = slash + 1;
-        int sub_len = rlen - (int)(sub - raw);
-        if (sub_len == 1 && (sub[0] == '*' || sub[0] == '=')) {
-            *out_sub = Py_NewRef(Py_None);
-            slot_op = sub[0];
-        } else {
-            if (sub_len > 0 && sub[sub_len - 1] == '=') {
-                slot_op = '=';
-                sub_len--;
-            }
-            *out_sub = PyUnicode_FromStringAndSize(sub, sub_len);
-        }
     }
 
-    if (slot_op == '=') {
-        *out_op = Py_NewRef(interned.slot_op_eq);
-    } else if (slot_op == '*') {
-        *out_op = Py_NewRef(interned.slot_op_star);
-    } else {
-        *out_op = Py_NewRef(Py_None);
-    }
+    *out_op = slot_op ? Py_NewRef(interned.slot_op_eq) : Py_NewRef(Py_None);
 }
 
 /* Split the raw text between '[' and ']' into one string per flag:
@@ -658,6 +637,32 @@ py_parse(UNUSED PyObject *self, PyObject *args, PyObject *kwargs)
     return Py_NewRef(result);
 }
 
+/*
+ * scan_atom(s) -> Atom
+ *
+ * Parse a single atom string; the whole string must be exactly one atom.
+ * Raises ValueError on anything the scanner does not fully consume -- in
+ * particular repository specs ("::repo") and build-ids, which it does not
+ * handle -- so the caller can fall back to the pure-Python regex path.
+ */
+static PyObject *
+py_scan_atom(UNUSED PyObject *self, PyObject *arg)
+{
+    Py_ssize_t  n;
+    const char *s = PyUnicode_AsUTF8AndSize(arg, &n);
+    if (!s)
+        return NULL;
+
+    DepScanner p = { s, s + n, NULL };
+    AtomInfo   info;
+    memset(&info, 0, sizeof(info));
+    if (!scan_atom(&p, &info) || p.cur != p.end) {
+        PyErr_SetString(PyExc_ValueError, p.err ? p.err : "invalid atom");
+        return NULL;
+    }
+    return build_atom_obj(&info, s, (int)n);
+}
+
 static PyMethodDef methods[] = {
     {
         .ml_name  = "parse",
@@ -672,6 +677,16 @@ static PyMethodDef methods[] = {
             "sublist, an inactive one contributes nothing.",
     },
     {
+        .ml_name  = "scan_atom",
+        .ml_meth  = py_scan_atom,
+        .ml_flags = METH_O,
+        .ml_doc   =
+            "scan_atom(s) -> Atom\n"
+            "Parse a string that must be exactly one atom. Raises ValueError\n"
+            "for anything the scanner does not fully consume, including repo\n"
+            "specs and build-ids, so the caller can fall back to the regex.",
+    },
+    {
         .ml_name  = "classify_use_deps",
         .ml_meth  = py_classify_use_deps,
         .ml_flags = METH_O,
@@ -679,7 +694,7 @@ static PyMethodDef methods[] = {
             "classify_use_deps(tokens) -> tuple\n"
             "Classify pre-split use-dep tokens into (enabled_fs, disabled_fs,\n"
             "missing_enabled_fs, missing_disabled_fs, conditional_dict_or_None,\n"
-            "required_fs). Raises ValueError if a token cannot be classified.",
+            "required_fs). Raises ValueError if a token cannot be classified."
     },
     { NULL, NULL, 0, NULL },
 };

--- a/src/dep_parser_core.c
+++ b/src/dep_parser_core.c
@@ -1,0 +1,635 @@
+/* Copyright 2026 Gentoo Authors
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+#include <string.h>
+#include "dep_parser_core.h"
+
+uint8_t CC[256];
+
+void init_cc_table(void)
+{
+    for (int c = 0; c < ARRAY_SIZE(CC); c++) {
+        unsigned char uc = (unsigned char)c;
+        uint8_t v = 0;
+
+        /* digits */
+        if (uc >= '0' && uc <= '9') {
+            v |= CC_DIGIT | CC_NW | CC_CAT | CC_USE;
+        }
+
+        /* letters */
+        if ((uc >= 'a' && uc <= 'z') || (uc >= 'A' && uc <= 'Z')) {
+            v |= CC_ALPHA | CC_NW | CC_CAT | CC_USE;
+
+            if (uc >= 'a' && uc <= 'z') {
+                v |= CC_LOWER;
+            }
+        }
+        /* extra name-word chars */
+        if (uc == '+' || uc == '_') v |= CC_NW | CC_CAT | CC_USE;
+        if (uc == '.') v |= CC_CAT;
+        if (uc == '-') v |= CC_CAT | CC_USE;
+        if (uc == '@') v |= CC_USE;
+        CC[c] = v;
+    }
+}
+
+void skip_whitespace(DepScanner *p)
+{
+    while (p->cur < p->end && is_whitespace(*p->cur)) {
+        p->cur++;
+    }
+}
+
+/* PMS 3.2: a version is digits, optionally dot-separated, an optional single
+ * letter, zero or more _alpha/_beta/_pre/_rc/_p suffixes with optional
+ * numbers, and an optional -rN revision.  A trailing '*' is accepted here and
+ * rejected later unless the operator is '='.
+ *
+ *   "1.2.3"        -> consumed
+ *   "1.0_alpha1"   -> consumed
+ *   "1.0-r1"       -> consumed
+ *   "1.2*"         -> consumed
+ *   "1.0 rest"     -> consumes "1.0", stops at the space
+ *   "alpha"        -> rejected, must start with a digit
+ *
+ * Advances cur past the version and returns 1, or leaves cur alone and
+ * returns 0.  A version must end at whitespace, ':', '[' or ')'. */
+int scan_version(DepScanner *p)
+{
+    static const struct {
+        const char *str;
+        int len;
+    } sfx[] = {
+#define SFX(s) { s, (int)(sizeof(s) - 1) }
+        SFX("_alpha"), SFX("_beta"), SFX("_pre"), SFX("_rc"), SFX("_p"),
+#undef SFX
+    };
+
+    const char *s = p->cur;
+
+    if (s >= p->end || !is_digit_c(*s))
+        return 0;
+
+    while (s < p->end && is_digit_c(*s)) {
+        s++;
+    }
+
+    while (s < p->end && *s == '.') {
+        s++;
+        if (s >= p->end || !is_digit_c(*s))
+            return 0;
+
+        while (s < p->end && is_digit_c(*s)) {
+            s++;
+        }
+    }
+
+    if (s < p->end && is_lower_c(*s))
+        s++;
+
+    for (;;) {
+        int hit = 0;
+        for (int i = 0; i < ARRAY_SIZE(sfx); i++) {
+            int l = sfx[i].len;
+            if (s + l <= p->end && memcmp(s, sfx[i].str, l) == 0 &&
+                (s + l >= p->end || !is_alpha_c(s[l]))) {
+                s += l;
+                while (s < p->end && is_digit_c(*s)) {
+                    s++;
+                }
+                hit = 1;
+                break;
+            }
+        }
+        if (!hit) {
+            break;
+        }
+    }
+
+    if (s + 2 < p->end && s[0] == '-' && s[1] == 'r' &&
+        is_digit_c(s[2])) {
+        s += 2;
+        while (s < p->end && is_digit_c(*s)) {
+            s++;
+        }
+    }
+
+    if (s < p->end && *s == '*') {
+        s++;  /* glob: =cat/pkg-1.2* */
+    }
+
+    if (s >= p->end || is_whitespace(*s) || *s == ':' || *s == '[' || *s == ')') {
+        p->cur = s;
+        return 1;
+    }
+    return 0;
+}
+
+/* The examples below spell out a "0/" slot followed by '*', which the
+ * compiler sees as a comment opener. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcomment"
+/* PMS 8.3.3: the text after ':' -- a slot, an optional /sub-slot, and an
+ * optional '=' operator, or a bare ':=' / ':*'.
+ *
+ *   "0"     "myslot"   "0/53"   "0="   "0/53="   "="   "*"   -> consumed
+ *   "/slot"  "-slot"                                        -> rejected
+ *
+ * Slot names share the category character set, except that the first
+ * character may not be '+'. */
+#pragma GCC diagnostic pop
+int scan_slot(DepScanner *p)
+{
+    const char *s = p->cur;
+    if (s >= p->end)
+        return 0;
+
+    if (*s == '*' || *s == '=') {
+        p->cur = s + 1;
+        return 1;
+    }
+
+    if (!is_nw_char(*s))
+        return 0;
+
+    s++;
+    while (s < p->end && is_slot_char(*s)) {
+        s++;
+    }
+    if (s < p->end && *s == '=') {
+        s++;
+    }
+
+    if (s < p->end && *s == '/') {
+        s++;
+        if (s < p->end && (*s == '*' || *s == '=')) {
+            s++;
+        } else if (s < p->end && is_nw_char(*s)) {
+            s++;
+            while (s < p->end && is_slot_char(*s)) {
+                s++;
+            }
+            if (s < p->end && *s == '=') {
+                s++;
+            }
+        } else {
+            return 0;
+        }
+    }
+
+    p->cur = s;
+    return 1;
+}
+
+/* PMS 8.3.4: one use dep, with its optional prefix, (+)/(-) default and
+ * suffix.  Flag names may contain '-', '+' and '@' (c++, LINGUAS_en@euro), so
+ * the name body is scanned with is_use_char rather than the name-word set.
+ *
+ *   "foo"  "-foo"  "foo?"  "foo="  "foo(+)"  "!foo?"  "!foo(-)="  -> consumed
+ *   "!foo"   -> rejected, '!' requires a '?' or '=' suffix
+ *   "-foo="  -> rejected, '-' and a suffix are mutually exclusive
+ *
+ * Advances cur past the flag and returns 1, or returns 0. */
+int scan_use_flag(DepScanner *p)
+{
+    const char *s = p->cur;
+    if (s >= p->end)
+        return 0;
+
+    int is_neg = 0, is_dis = 0;
+    if (*s == '!') {
+        is_neg = 1;
+        s++;
+    } else if (*s == '-') {
+        is_dis = 1;
+        s++;
+    }
+
+    if (s >= p->end || !is_nw_char(*s))
+        return 0;
+
+    s++;
+    while (s < p->end && is_use_char(*s)) {
+        s++;
+    }
+
+    if (s + 2 < p->end && *s == '(' && (s[1] == '+' || s[1] == '-') && s[2] == ')')
+        s += 3;
+
+    if (is_neg) {
+        if (s < p->end && (*s == '?' || *s == '=')) {
+            s++;
+        } else {
+            return 0;
+        }
+    } else if (!is_dis) {
+        if (s < p->end && (*s == '?' || *s == '=' || *s == '-')) {
+            s++;
+        }
+    }
+
+    p->cur = s;
+    return 1;
+}
+
+int scan_usedep(DepScanner *p)
+{
+    for (;;) {
+        if (!scan_use_flag(p))
+            return 0;
+
+        if (p->cur < p->end && *p->cur == ',') {
+            p->cur++;
+        } else {
+            break;
+        }
+    }
+    return 1;
+}
+
+/* One whole atom: [blocker][operator]category/package[-version][:slot][use].
+ *
+ *   "dev-libs/foo"                  -> cat "dev-libs", pkg "foo"
+ *   ">=dev-libs/foo-1.2:0=[a,-b]"   -> op ">=", ver "1.2", slot ":0=", use "a,-b"
+ *   "!!dev-libs/foo"                -> block "!!"
+ *
+ * Package names may contain hyphens, so the boundary between name and version
+ * is ambiguous ("log4j-12-api-2.0") and is resolved by trying to scan a
+ * version after each '-'.  On success the spans in *info point into the
+ * caller's string; on failure cur is restored and 0 is returned, which lets
+ * the caller try a different production. */
+int scan_atom(DepScanner *p, AtomInfo *info)
+{
+    const char *start = p->cur;
+    const char *s = start;
+
+    /* block */
+    SPAN(block, NULL);
+    if (s < p->end && *s == '!') {
+        block = s; s++;
+        if (s < p->end && *s == '!') {
+            s++;
+        }
+        block_len = (int)(s - block);
+    }
+
+    /* operator */
+    SPAN(op, NULL);
+    if (s < p->end) {
+        if ((s[0] == '<' || s[0] == '>') && s + 1 < p->end && s[1] == '=') {
+            op = s;
+            op_len = 2;
+            s += 2;
+        } else if (s[0] == '<' || s[0] == '>' || s[0] == '=' || s[0] == '~') {
+            op = s;
+            op_len = 1;
+            s++;
+        }
+    }
+
+    /* category */
+    const char *cat = s;
+    if (s >= p->end || !is_nw_char(*s))
+        goto fail;
+
+    s++;
+    while (s < p->end && is_cat_char(*s)) {
+        s++;
+    }
+    int cat_len = (int)(s - cat);
+
+    if (s >= p->end || *s != '/')
+        goto fail;
+    s++;
+
+    /* first name-word */
+    const char *pkg = s;
+    if (s >= p->end)
+        goto fail;
+
+    if (is_alpha_c(*s) || *s == '_') {
+        s++;
+        while (s < p->end && is_nw_char(*s)) {
+            s++;
+        }
+    } else if (is_digit_c(*s)) {
+        while (s < p->end && is_digit_c(*s)) {
+            s++;
+        }
+
+        if (s >= p->end || (!is_alpha_c(*s) && *s != '_'))
+            goto fail;
+
+        s++;
+        while (s < p->end && is_nw_char(*s)) {
+            s++;
+        }
+    } else {
+        goto fail;
+    }
+
+    {
+        int pkg_len = 0;
+        SPAN(ver, NULL);
+
+        const char *pkg_end = s;
+
+        /* additional '-' segments: name-word or version */
+        for (;;) {
+            if (s >= p->end || *s != '-' || s + 1 >= p->end)
+                break;
+
+            char nxt = s[1];
+            if (is_digit_c(nxt)) {
+                DepScanner tmp = { s + 1, p->end, NULL };
+                if (scan_version(&tmp)) {
+                    ver = s + 1;
+                    ver_len = (int)(tmp.cur - ver);
+                    pkg_end = s;
+                    s = tmp.cur;
+                    goto after_pkgver;
+                }
+
+                const char *t = s + 1;
+                while (t < p->end && is_digit_c(*t)) {
+                    t++;
+                }
+
+                if (t < p->end && (is_alpha_c(*t) || *t == '_')) {
+                    t++;
+                    while (t < p->end && is_nw_char(*t)) {
+                        t++;
+                    }
+                    s = t;
+                } else if (t < p->end && *t == '-') {
+                    s = t;
+                } else {
+                    break;
+                }
+            } else if (is_alpha_c(nxt) || nxt == '_') {
+                s += 2;
+                while (s < p->end && is_nw_char(*s)) {
+                    s++;
+                }
+            } else {
+                break;
+            }
+        }
+        pkg_end = s;
+
+after_pkgver:
+        pkg_len = (int)(pkg_end - pkg);
+        p->cur = s;
+
+        /* optional ':' slot */
+        SPAN(slot_raw, NULL);
+        if (p->cur < p->end && *p->cur == ':') {
+            p->cur++;
+            slot_raw = p->cur;
+            if (!scan_slot(p))
+                goto fail;
+            slot_raw_len = (int)(p->cur - slot_raw);
+        }
+
+        /* optional '[' usedep ']' */
+        SPAN(use_raw, NULL);
+        if (p->cur < p->end && *p->cur == '[') {
+            p->cur++;
+            use_raw = p->cur;
+
+            if (!scan_usedep(p))
+                goto fail;
+
+            use_raw_len = (int)(p->cur - use_raw);
+
+            if (p->cur >= p->end || *p->cur != ']')
+                goto fail;
+
+            p->cur++;
+        }
+
+        if (op && !ver)
+            goto fail;
+
+        if (info) {
+            SPAN_SET(info, block);
+            SPAN_SET(info, op);
+            SPAN_SET(info, cat);
+            SPAN_SET(info, pkg);
+            SPAN_SET(info, ver);
+            SPAN_SET(info, slot_raw);
+            SPAN_SET(info, use_raw);
+        }
+        return 1;
+    }
+
+fail:
+    p->cur = start;
+    return 0;
+}
+
+static int scan_item(DepScanner *p, DepVisitor *v);
+
+/* Read items until ')' (stopping before it). */
+static int scan_group_contents(DepScanner *p, DepVisitor *v);
+
+/* Skipping the body of an inactive USE-conditional group still has to
+ * validate its contents -- "x? ( bogus )" is a malformed dep string whether or
+ * not x is set -- so the body is scanned with the real grammar and this
+ * visitor, which builds nothing and reports every nested conditional inactive
+ * so its body is skipped in turn.  The alternative, a second copy of the
+ * grammar that only skips, is one more thing to keep in sync. */
+static int skip_on_atom(UNUSED void *ctx, UNUSED const char *start,
+                        UNUSED int len, UNUSED const AtomInfo *info)
+{
+    return 1;
+}
+
+static int skip_on_group_start(UNUSED void *ctx, UNUSED const char *op,
+                               UNUSED int op_len)
+{
+    return 1;
+}
+
+static int skip_on_group_end(UNUSED void *ctx)
+{
+    return 1;
+}
+
+static int skip_use_active(UNUSED void *ctx, UNUSED const char *flag,
+                           UNUSED int len, UNUSED int is_neg)
+{
+    return 0;
+}
+
+static DepVisitor skip_visitor = {
+    .ctx            = NULL,
+    .on_atom        = skip_on_atom,
+    .on_group_start = skip_on_group_start,
+    .on_group_end   = skip_on_group_end,
+    .use_active     = skip_use_active,
+};
+
+static int scan_group_contents(DepScanner *p, DepVisitor *v)
+{
+    for (;;) {
+        if (!scan_item(p, v))
+            return 0;
+
+        if (p->cur >= p->end || !is_whitespace(*p->cur)) {
+            p->err = "expected whitespace after item in group";
+            return 0;
+        }
+        skip_whitespace(p);
+
+        if (p->cur < p->end && *p->cur == ')')
+            return 1;
+
+        if (p->cur >= p->end) {
+            p->err = "unexpected end inside group";
+            return 0;
+        }
+    }
+}
+
+/* One element of a dep list: an atom, a plain "( ... )" group, an operator
+ * group "|| ( ... )", or a use conditional "flag? ( ... )".
+ *
+ *   "dev-libs/a"          -> on_atom
+ *   "( a b )"             -> on_group_start(""), items, on_group_end
+ *   "|| ( a b )"          -> on_group_start("||"), items, on_group_end
+ *   "foo? ( a )", active  -> on_group_start(""), items, on_group_end
+ *   "foo? ( a )", not     -> nothing reported; body still validated
+ *
+ * A conditional group is reported as a plain group rather than inlined so
+ * that a conjunction inside an any-of keeps its nesting. */
+static int scan_item(DepScanner *p, DepVisitor *v)
+{
+    const char *save      = p->cur;
+    const char *tok_start = p->cur;
+    AtomInfo    info;
+
+    if (scan_atom(p, &info))
+        return v->on_atom(v->ctx, tok_start, (int)(p->cur - tok_start), &info);
+    p->cur = save;
+
+    const char *s = p->cur;
+
+    /* naked group: ( items ) - all-of, inline */
+    if (s < p->end && *s == '(') {
+        p->cur = s + 1;
+        if (p->cur >= p->end || !is_whitespace(*p->cur)) {
+            p->err = "expected whitespace after '('";
+            return 0;
+        }
+        skip_whitespace(p);
+
+        if (!scan_group_contents(p, v))
+            return 0;
+
+        p->cur++;  /* consume ')' */
+        return 1;
+    }
+
+    int         is_group_op = 0;
+    int         is_neg      = 0;
+    SPAN(flag, NULL);
+    const char *op          = NULL;
+    int         op_len      = 0;
+
+    if (s + 2 <= p->end &&
+        (s[0] == s[1] && (s[0] == '|' || s[0] == '^' || s[0] == '?'))) {
+        op          = s;
+        op_len      = 2;
+        is_group_op = 1;
+        p->cur        = s + 2;
+    } else {
+        if (s < p->end && *s == '!') {
+            is_neg = 1;
+            s++;
+        }
+        if (s < p->end && is_nw_char(*s)) {
+            flag = s++;
+            while (s < p->end && is_use_char(*s)) {
+                s++;
+            }
+            flag_len = (int)(s - flag);
+
+            if (s < p->end && *s == '?') {
+                p->cur = s + 1;
+            } else {
+                p->err = "expected '?'";
+                return 0;
+            }
+        } else {
+            p->err = "expected atom or group";
+            return 0;
+        }
+    }
+
+    if (p->cur >= p->end || !is_whitespace(*p->cur)) {
+        p->err = "expected whitespace after prefix";
+        return 0;
+    }
+    skip_whitespace(p);
+
+    if (p->cur >= p->end || *p->cur != '(') {
+        p->err = "expected '('";
+        return 0;
+    }
+    p->cur++;
+
+    if (p->cur >= p->end || !is_whitespace(*p->cur)) {
+        p->err = "expected whitespace after '('";
+        return 0;
+    }
+    skip_whitespace(p);
+
+    if (is_group_op) {
+        if (!v->on_group_start(v->ctx, op, op_len))
+            return 0;
+
+        if (!scan_group_contents(p, v))
+            return 0;
+
+        p->cur++;  /* consume ')' */
+        return v->on_group_end(v->ctx);
+    } else {
+        int active = v->use_active(v->ctx, flag, flag_len, is_neg);
+        if (active < 0)
+            return 0;
+
+        if (active) {
+            if (!scan_group_contents(p, v)) {
+                return 0;
+            }
+        } else {
+            if (!scan_group_contents(p, &skip_visitor)) {
+                return 0;
+            }
+        }
+        p->cur++;  /* consume ')' */
+        return 1;
+    }
+}
+
+int scan_dep_list(DepScanner *p, DepVisitor *v)
+{
+    if (!scan_item(p, v))
+        return 0;
+
+    while (p->cur < p->end && is_whitespace(*p->cur)) {
+        skip_whitespace(p);
+
+        if (p->cur >= p->end)
+            return 1;
+
+        if (!scan_item(p, v))
+            return 0;
+    }
+    return 1;
+}
+
+/* vim: set ts=4 sw=4 et: */

--- a/src/dep_parser_core.c
+++ b/src/dep_parser_core.c
@@ -135,7 +135,10 @@ int scan_version(DepScanner *p)
  * optional '=' operator, or a bare ':=' / ':*'.
  *
  *   "0"     "myslot"   "0/53"   "0="   "0/53="   "="   "*"   -> consumed
- *   "/slot"  "-slot"                                        -> rejected
+ *   "/slot"  "-slot"   "0/="    "0/*"  "0=/53"              -> rejected
+ *
+ * ':=' and ':*' are only the whole slot dep; they are not a sub-slot, and the
+ * '=' operator only ever comes last.
  *
  * Slot names share the category character set, except that the first
  * character may not be '+'. */
@@ -151,32 +154,29 @@ int scan_slot(DepScanner *p)
         return 1;
     }
 
-    if (!is_nw_char(*s))
+    /* PMS: a slot name's first character must be [A-Za-z0-9_] ('+' is a slot
+     * char only after the first position). */
+    if (!is_nw_char(*s) || *s == '+')
         return 0;
 
     s++;
     while (s < p->end && is_slot_char(*s)) {
         s++;
     }
-    if (s < p->end && *s == '=') {
-        s++;
-    }
 
     if (s < p->end && *s == '/') {
         s++;
-        if (s < p->end && (*s == '*' || *s == '=')) {
-            s++;
-        } else if (s < p->end && is_nw_char(*s)) {
-            s++;
-            while (s < p->end && is_slot_char(*s)) {
-                s++;
-            }
-            if (s < p->end && *s == '=') {
-                s++;
-            }
-        } else {
+        if (s >= p->end || !is_nw_char(*s) || *s == '+')
             return 0;
+
+        s++;
+        while (s < p->end && is_slot_char(*s)) {
+            s++;
         }
+    }
+
+    if (s < p->end && *s == '=') {
+        s++;
     }
 
     p->cur = s;
@@ -291,7 +291,9 @@ int scan_atom(DepScanner *p, AtomInfo *info)
 
     /* category */
     const char *cat = s;
-    if (s >= p->end || !is_nw_char(*s))
+    /* PMS: the first character must be [A-Za-z0-9_]; '+' (a name-word char
+     * elsewhere) is not allowed to lead a category. */
+    if (s >= p->end || !is_nw_char(*s) || *s == '+')
         goto fail;
 
     s++;
@@ -410,8 +412,29 @@ after_pkgver:
             p->cur++;
         }
 
-        if (op && !ver)
+        /* An operator requires a version and a version requires an operator:
+         * ">=cat/pkg" and a bare "cat/pkg-1" are both invalid atoms. */
+        if ((op != NULL) != (ver != NULL))
             goto fail;
+
+        /* PMS: a package name must not end in a hyphen followed by a version.
+         * The trailing version may itself span a "-rN" revision, so check every
+         * '-' position: if the whole remainder after any '-' is a full version,
+         * the atom is invalid (e.g. "<cat/bar-2-0", "=cat/bar-1-r1-1-r1"). */
+        for (const char *t = pkg; t < pkg_end; t++) {
+            if (*t != '-')
+                continue;
+            DepScanner vt = { t + 1, pkg_end, NULL };
+            if (scan_version(&vt) && vt.cur == pkg_end)
+                goto fail;
+        }
+
+        /* A trailing '*' (the "=*" glob form) is only valid with the '='
+         * operator, e.g. "=cat/pkg-1.2*"; reject it with any other operator. */
+        if (ver && ver_len > 0 && ver[ver_len - 1] == '*' &&
+            !(op_len == 1 && op[0] == '=')) {
+            goto fail;
+        }
 
         if (info) {
             SPAN_SET(info, block);

--- a/src/dep_parser_core.c
+++ b/src/dep_parser_core.c
@@ -517,7 +517,8 @@ static int scan_item(DepScanner *p, DepVisitor *v)
 
     const char *s = p->cur;
 
-    /* naked group: ( items ) - all-of, inline */
+    /* Plain "( items )": reported as a group with an empty operator rather
+     * than inlined, so a conjunction inside an any-of keeps its nesting. */
     if (s < p->end && *s == '(') {
         p->cur = s + 1;
         if (p->cur >= p->end || !is_whitespace(*p->cur)) {
@@ -526,11 +527,14 @@ static int scan_item(DepScanner *p, DepVisitor *v)
         }
         skip_whitespace(p);
 
+        if (!v->on_group_start(v->ctx, "", 0))
+            return 0;
+
         if (!scan_group_contents(p, v))
             return 0;
 
         p->cur++;  /* consume ')' */
-        return 1;
+        return v->on_group_end(v->ctx);
     }
 
     int         is_group_op = 0;
@@ -602,16 +606,20 @@ static int scan_item(DepScanner *p, DepVisitor *v)
             return 0;
 
         if (active) {
-            if (!scan_group_contents(p, v)) {
+            /* active conditional: emit as naked all-of to preserve nesting */
+            if (!v->on_group_start(v->ctx, "", 0))
                 return 0;
-            }
+            if (!scan_group_contents(p, v))
+                return 0;
+            p->cur++;  /* consume ')' */
+            return v->on_group_end(v->ctx);
         } else {
             if (!scan_group_contents(p, &skip_visitor)) {
                 return 0;
             }
+            p->cur++;  /* consume ')' */
+            return 1;
         }
-        p->cur++;  /* consume ')' */
-        return 1;
     }
 }
 

--- a/src/dep_parser_core.h
+++ b/src/dep_parser_core.h
@@ -1,0 +1,85 @@
+/* Copyright 2026 Gentoo Authors
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+#pragma once
+#include <stdint.h>
+
+/* Cursor over the dep string being scanned.  Every scan_* function advances
+ * cur on success and leaves it untouched on failure, so a caller can try one
+ * production and fall back to another. */
+typedef struct {
+    const char *cur;   /* next unconsumed character */
+    const char *end;   /* one past the last character */
+    const char *err;   /* static message describing the first failure */
+} DepScanner;
+
+typedef enum {
+    CC_CAT   = 1 << 0,  /* category / slot:  alnum + _ + . - */
+    CC_NW    = 1 << 1,  /* name-word:        alnum + _        */
+    CC_USE   = 1 << 2,  /* use dep:          alnum + _ @ - +  */
+    CC_DIGIT = 1 << 3,
+    CC_LOWER = 1 << 4,
+    CC_ALPHA = 1 << 5,  /* any letter */
+} CC_flag;
+
+extern uint8_t CC[256];  /* filled by init_cc_table() */
+
+#define is_cat_char(c)  (CC[(unsigned char)(c)] & CC_CAT)
+#define is_nw_char(c)   (CC[(unsigned char)(c)] & CC_NW)
+/* PMS gives slot names and category names the same character set, so this is
+ * deliberately an alias; it is spelled out for readability at the use sites. */
+#define is_slot_char(c) is_cat_char(c)
+#define is_use_char(c)  (CC[(unsigned char)(c)] & CC_USE)
+#define is_digit_c(c)   (CC[(unsigned char)(c)] & CC_DIGIT)
+#define is_lower_c(c)   (CC[(unsigned char)(c)] & CC_LOWER)
+#define is_alpha_c(c)   (CC[(unsigned char)(c)] & CC_ALPHA)
+
+#define ARRAY_SIZE(a) ((int)(sizeof(a) / sizeof((a)[0])))
+
+/* For parameters a function must declare to match a signature but never
+ * reads, so that -Wunused-parameter stays usable. */
+#define UNUSED __attribute__((unused))
+
+/* Declare a pointer+length pair.  With an initializer: SPAN(name, NULL). */
+#define SPAN(name, ...)  const char *name __VA_OPT__(= __VA_ARGS__); int name##_len __VA_OPT__(= 0)
+/* Copy locals `name` / `name_len` into the matching SPAN fields of *s. */
+#define SPAN_SET(s, name)  do { (s)->name = name; (s)->name##_len = name##_len; } while (0)
+
+static inline int is_whitespace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+typedef struct {
+    SPAN(block);
+    SPAN(op);
+    SPAN(cat);
+    SPAN(pkg);
+    SPAN(ver);       /* NULL if absent */
+    SPAN(slot_raw);  /* NULL if absent */
+    SPAN(use_raw);   /* NULL if absent */
+} AtomInfo;
+
+void init_cc_table(void);
+void skip_whitespace(DepScanner *p);
+int  scan_version(DepScanner *p);
+int  scan_slot(DepScanner *p);
+int  scan_use_flag(DepScanner *p);
+int  scan_usedep(DepScanner *p);
+int  scan_atom(DepScanner *p, AtomInfo *info);
+
+typedef struct {
+    void *ctx;
+    /* Called for each atom token. Returns 1 on success, 0 on error. */
+    int (*on_atom)(void *ctx, const char *start, int len, const AtomInfo *info);
+    /* Called before/after || ^^ ?? group contents. */
+    int (*on_group_start)(void *ctx, const char *op, int op_len);
+    int (*on_group_end)(void *ctx);
+    /* Returns 1 if the use flag is active, 0 if not, -1 on error. */
+    int (*use_active)(void *ctx, const char *flag, int len, int is_neg);
+} DepVisitor;
+
+int scan_dep_list(DepScanner *p, DepVisitor *v);
+
+/* vim: set ts=4 sw=4 et: */

--- a/src/dep_parser_core.h
+++ b/src/dep_parser_core.h
@@ -73,7 +73,9 @@ typedef struct {
     void *ctx;
     /* Called for each atom token. Returns 1 on success, 0 on error. */
     int (*on_atom)(void *ctx, const char *start, int len, const AtomInfo *info);
-    /* Called before/after || ^^ ?? group contents. */
+    /* Called before/after group contents.  op is "||", "^^" or "??";
+     * an empty op means a plain all-of group, which nests but has no
+     * operator token of its own. */
     int (*on_group_start)(void *ctx, const char *op, int op_len);
     int (*on_group_end)(void *ctx);
     /* Returns 1 if the use flag is active, 0 if not, -1 on error. */

--- a/src/fuzz_parser.c
+++ b/src/fuzz_parser.c
@@ -1,0 +1,89 @@
+/* Copyright 2026 Gentoo Authors
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+/* libFuzzer entry point for the dep-string scanner.
+ *
+ * This drives the pure-C side only -- no Python objects are built -- so it can
+ * run without an interpreter.  Build it with:
+ *
+ *     meson setup build -Dfuzzing=true -Db_sanitize=address,undefined
+ *     ninja -C build src/fuzz_parser
+ *     ./build/src/fuzz_parser corpus/
+ *
+ * It is not part of `meson test`; the fixed cases live in test_parser.c.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dep_parser_core.h"
+
+/* Counting visitor: exercises the callback paths without allocating. */
+static int fuzz_on_atom(void *ctx, UNUSED const char *start, UNUSED int len,
+                        UNUSED const AtomInfo *info)
+{
+    ++*(unsigned long *)ctx;
+    return 1;
+}
+
+static int fuzz_on_group_start(UNUSED void *ctx, UNUSED const char *op,
+                               UNUSED int op_len)
+{
+    return 1;
+}
+
+static int fuzz_on_group_end(UNUSED void *ctx)
+{
+    return 1;
+}
+
+/* Derive activity from the flag text so both branches get explored without
+ * needing a USE list in the input. */
+static int fuzz_use_active(UNUSED void *ctx, const char *flag, int len,
+                           int is_neg)
+{
+    int active = len > 0 && (flag[0] & 1);
+    return is_neg ? !active : active;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    static int initialized;
+    if (!initialized) {
+        init_cc_table();
+        initialized = 1;
+    }
+
+    /* Copy so the scanner runs against an exactly-sized buffer and any read
+     * past the end is caught by the sanitizer rather than landing in slack. */
+    char *buf = malloc(size ? size : 1);
+    if (!buf)
+        return 0;
+    memcpy(buf, data, size);
+
+    unsigned long atoms = 0;
+    DepVisitor visitor = {
+        .ctx            = &atoms,
+        .on_atom        = fuzz_on_atom,
+        .on_group_start = fuzz_on_group_start,
+        .on_group_end   = fuzz_on_group_end,
+        .use_active     = fuzz_use_active,
+    };
+
+    DepScanner scanner = { buf, buf + size, NULL };
+    skip_whitespace(&scanner);
+    if (scanner.cur < scanner.end)
+        scan_dep_list(&scanner, &visitor);
+
+    /* Also drive the single-atom entry, which has its own validation. */
+    DepScanner atom_scanner = { buf, buf + size, NULL };
+    AtomInfo info;
+    scan_atom(&atom_scanner, &info);
+
+    free(buf);
+    return 0;
+}
+
+/* vim: set ts=4 sw=4 et: */

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,3 +19,44 @@ run_command(
     capture : false,
     check : true
 )
+
+dep_parser_ext = py.extension_module(
+    '_parser',
+    'dep_parser_core.c',
+    'dep_parser.c',
+    include_directories : include_directories('.'),
+    dependencies : py.dependency(),
+    subdir : 'portage' / 'dep',
+    install : true,
+)
+
+run_command(
+    [
+        'ln', '-srnf',
+        dep_parser_ext.full_path(),
+        meson.project_source_root() / 'lib' / 'portage' / 'dep/'
+    ],
+    capture : false,
+    check : true
+)
+
+test_parser = executable(
+    'test_parser',
+    'dep_parser_core.c',
+    'test_parser.c',
+    include_directories : include_directories('.'),
+)
+
+test('parser', test_parser)
+
+if get_option('fuzzing')
+    fuzz_parser = executable(
+        'fuzz_parser',
+        'dep_parser_core.c',
+        'fuzz_parser.c',
+        include_directories : include_directories('.'),
+        c_args : ['-fsanitize=fuzzer'],
+        link_args : ['-fsanitize=fuzzer'],
+        build_by_default : false,
+    )
+endif

--- a/src/test_parser.c
+++ b/src/test_parser.c
@@ -242,6 +242,15 @@ static void test_scan_slot(void)
         { "",        0, NULL     },
         { "/slot",   0, NULL     },
         { "-slot",   0, NULL     },
+        { "+slot",   0, NULL     },
+        /* ":=" and ":*" are the whole slot dep, never a sub-slot. */
+        { "0/*",     0, NULL     },
+        { "0/=",     0, NULL     },
+        { "0/",      0, NULL     },
+        { "0/+sub",  0, NULL     },
+        /* The '=' operator comes last, so "0=" is all that is consumed here
+         * and the caller rejects the atom on the leftover "/53". */
+        { "0=/53",   1, "0="     },
     };
 
     for (int i = 0; i < ARRAY_SIZE(cases); i++) {

--- a/src/test_parser.c
+++ b/src/test_parser.c
@@ -1,0 +1,339 @@
+/* Copyright 2026 Gentoo Authors
+ * SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ */
+
+#include "dep_parser_core.h"
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+static int passes = 0;
+
+#define FAIL(fmt, ...) \
+    do { fprintf(stderr, "FAIL %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); failures++; } while (0)
+#define PASS() \
+    do { passes++; } while (0)
+
+#define CHECK(expr) \
+    do { if (expr) { PASS(); } else { FAIL("%s", #expr); } } while (0)
+
+static int span_eq(const char *ptr, size_t len, const char *expected)
+{
+    if (!expected)
+        return ptr == NULL;
+
+    if (!ptr)
+        return 0;
+
+    size_t elen = strlen(expected);
+    return len == elen && memcmp(ptr, expected, elen) == 0;
+}
+
+/* Parse a complete atom string; return 1 on success and fill *info. */
+static int parse_atom_str(const char *s, AtomInfo *info)
+{
+    DepScanner p = { s, s + strlen(s), NULL };
+    if (!scan_atom(&p, info))
+        return 0;
+
+    return p.cur == p.end;  /* must consume all input */
+}
+
+static void test_scan_version(void)
+{
+    static const struct {
+        const char *input;
+        int ok;
+        const char *ver;
+    } cases[] = {
+        { "1",                 1, "1"                },
+        { "1.0",               1, "1.0"              },
+        { "1.2.3",             1, "1.2.3"            },
+        { "1.0a",              1, "1.0a"             },
+        { "1.0_alpha",         1, "1.0_alpha"        },
+        { "1.0_alpha1",        1, "1.0_alpha1"       },
+        { "1.0_beta2_rc3",     1, "1.0_beta2_rc3"    },
+        { "1.0_pre",           1, "1.0_pre"          },
+        { "1.0_pre1",          1, "1.0_pre1"         },
+        { "1.0_rc1",           1, "1.0_rc1"          },
+        { "1.0_p1",            1, "1.0_p1"           },
+        { "1.0_p",             1, "1.0_p"            },
+        { "1.0-r1",            1, "1.0-r1"           },
+        { "1.0-r12",           1, "1.0-r12"          },
+        { "99999999",          1, "99999999"         },
+        { "1.0*",              1, "1.0*"             },
+        /* must stop at terminating chars */
+        { "1.0 rest",          1, "1.0"              },
+        { "1.0:slot",          1, "1.0"              },
+        { "1.0[use]",          1, "1.0"              },
+        { "1.0)",              1, "1.0"              },
+        /* invalid */
+        { "alpha",             0, NULL               },
+        { ".1",                0, NULL               },
+        { "1.",                0, NULL               },
+    };
+
+    for (int i = 0; i < ARRAY_SIZE(cases); i++) {
+        const char *s = cases[i].input;
+        DepScanner p = { s, s + strlen(s), NULL };
+        int ok = scan_version(&p);
+        if (ok != cases[i].ok) {
+            FAIL("scan_version(%s): got %d, want %d", s, ok, cases[i].ok);
+            continue;
+        }
+        if (ok && cases[i].ver) {
+            size_t vlen = (size_t)(p.cur - s);
+            if (!span_eq(s, vlen, cases[i].ver)) {
+                FAIL("scan_version(%s): ver=%.*s, want %s", s, (int)vlen, s, cases[i].ver);
+                continue;
+            }
+        }
+        PASS();
+    }
+}
+
+static void test_scan_atom_basic(void)
+{
+    AtomInfo a;
+
+    /* simple unversioned */
+    CHECK(parse_atom_str("cat/pkg", &a));
+    CHECK(span_eq(a.cat, a.cat_len, "cat"));
+    CHECK(span_eq(a.pkg, a.pkg_len, "pkg"));
+    CHECK(a.ver == NULL);
+    CHECK(a.op  == NULL);
+    CHECK(a.block == NULL);
+
+    /* operator + version */
+    CHECK(parse_atom_str(">=cat/pkg-1.2.3", &a));
+    CHECK(span_eq(a.op,  a.op_len,  ">="));
+    CHECK(span_eq(a.cat, a.cat_len, "cat"));
+    CHECK(span_eq(a.pkg, a.pkg_len, "pkg"));
+    CHECK(span_eq(a.ver, a.ver_len, "1.2.3"));
+
+    /* single blocker */
+    CHECK(parse_atom_str("!cat/pkg", &a));
+    CHECK(span_eq(a.block, a.block_len, "!"));
+
+    /* double blocker */
+    CHECK(parse_atom_str("!!cat/pkg", &a));
+    CHECK(span_eq(a.block, a.block_len, "!!"));
+
+    /* tilde operator */
+    CHECK(parse_atom_str("~cat/pkg-1.0", &a));
+    CHECK(span_eq(a.op, a.op_len, "~"));
+    CHECK(span_eq(a.ver, a.ver_len, "1.0"));
+
+    /* glob */
+    CHECK(parse_atom_str("=cat/pkg-1.0*", &a));
+    CHECK(span_eq(a.ver, a.ver_len, "1.0*"));
+}
+
+static void test_scan_atom_hyphenated_name(void)
+{
+    AtomInfo a;
+
+    CHECK(parse_atom_str("sys-apps/portage", &a));
+    CHECK(span_eq(a.cat, a.cat_len, "sys-apps"));
+    CHECK(span_eq(a.pkg, a.pkg_len, "portage"));
+
+    /* digit segment in package name */
+    CHECK(parse_atom_str("=dev-java/log4j-12-api-2.0", &a));
+    CHECK(span_eq(a.cat, a.cat_len, "dev-java"));
+    CHECK(span_eq(a.pkg, a.pkg_len, "log4j-12-api"));
+    CHECK(span_eq(a.ver, a.ver_len, "2.0"));
+
+    /* multiple hyphen segments */
+    CHECK(parse_atom_str("=dev-libs/libfoo-bar-baz-1.0", &a));
+    CHECK(span_eq(a.pkg, a.pkg_len, "libfoo-bar-baz"));
+    CHECK(span_eq(a.ver, a.ver_len, "1.0"));
+}
+
+static void test_scan_atom_slot(void)
+{
+    AtomInfo a;
+
+    CHECK(parse_atom_str("cat/pkg:0", &a));
+    CHECK(span_eq(a.slot_raw, a.slot_raw_len, "0"));
+
+    CHECK(parse_atom_str("cat/pkg:0/53", &a));
+    CHECK(span_eq(a.slot_raw, a.slot_raw_len, "0/53"));
+
+    CHECK(parse_atom_str("cat/pkg:0=", &a));
+    CHECK(span_eq(a.slot_raw, a.slot_raw_len, "0="));
+
+    CHECK(parse_atom_str("cat/pkg:*", &a));
+    CHECK(span_eq(a.slot_raw, a.slot_raw_len, "*"));
+
+    CHECK(parse_atom_str("cat/pkg:=", &a));
+    CHECK(span_eq(a.slot_raw, a.slot_raw_len, "="));
+
+    /* no slot */
+    CHECK(parse_atom_str("cat/pkg", &a));
+    CHECK(a.slot_raw == NULL);
+}
+
+static void test_scan_atom_use(void)
+{
+    AtomInfo a;
+
+    CHECK(parse_atom_str("cat/pkg[foo]", &a));
+    CHECK(span_eq(a.use_raw, a.use_raw_len, "foo"));
+
+    CHECK(parse_atom_str("cat/pkg[-foo]", &a));
+    CHECK(span_eq(a.use_raw, a.use_raw_len, "-foo"));
+
+    CHECK(parse_atom_str("cat/pkg[foo,bar]", &a));
+    CHECK(span_eq(a.use_raw, a.use_raw_len, "foo,bar"));
+
+    CHECK(parse_atom_str("cat/pkg[!foo=]", &a));
+    CHECK(span_eq(a.use_raw, a.use_raw_len, "!foo="));
+
+    CHECK(parse_atom_str("cat/pkg[foo(+)]", &a));
+    CHECK(span_eq(a.use_raw, a.use_raw_len, "foo(+)"));
+
+    /* @ in use flag name (old LINGUAS_en@euro style) */
+    CHECK(parse_atom_str("cat/pkg[LINGUAS_en@euro]", &a));
+    CHECK(span_eq(a.use_raw, a.use_raw_len, "LINGUAS_en@euro"));
+}
+
+static void test_scan_atom_combined(void)
+{
+    AtomInfo a;
+
+    CHECK(parse_atom_str("=cat/pkg-1.0:2[foo,-bar]", &a));
+    CHECK(span_eq(a.op,       a.op_len,       "="));
+    CHECK(span_eq(a.cat,      a.cat_len,      "cat"));
+    CHECK(span_eq(a.pkg,      a.pkg_len,      "pkg"));
+    CHECK(span_eq(a.ver,      a.ver_len,      "1.0"));
+    CHECK(span_eq(a.slot_raw, a.slot_raw_len, "2"));
+    CHECK(span_eq(a.use_raw,  a.use_raw_len,  "foo,-bar"));
+}
+
+static void test_scan_atom_invalid(void)
+{
+    AtomInfo a;
+
+    CHECK(!parse_atom_str("pkg", &a));            /* missing category */
+    CHECK(!parse_atom_str("/pkg", &a));           /* empty category */
+    CHECK(!parse_atom_str("cat/", &a));           /* empty package */
+    CHECK(!parse_atom_str(".cat/pkg", &a));       /* leading dot in category */
+    CHECK(!parse_atom_str("cat/pkg:/slot", &a));  /* invalid slot */
+    CHECK(!parse_atom_str(">=cat/pkg", &a));       /* operator without version */
+    CHECK(!parse_atom_str("=cat/pkg", &a));        /* operator without version */
+    /* use before slot */
+    CHECK(!parse_atom_str("cat/pkg[doc]:0", &a));
+}
+
+static void test_scan_slot(void)
+{
+    static const struct {
+        const char *input;
+        int ok;
+        const char *slot;
+    } cases[] = {
+        { "0",       1, "0"      },
+        { "myslot",  1, "myslot" },
+        { "0/53",    1, "0/53"   },
+        { "0=",      1, "0="     },
+        { "0/53=",   1, "0/53="  },
+        { "*",       1, "*"      },
+        { "=",       1, "="      },
+        { "",        0, NULL     },
+        { "/slot",   0, NULL     },
+        { "-slot",   0, NULL     },
+    };
+
+    for (int i = 0; i < ARRAY_SIZE(cases); i++) {
+        const char *s = cases[i].input;
+        DepScanner p = { s, s + strlen(s), NULL };
+        int ok = scan_slot(&p);
+        if (ok != cases[i].ok) {
+            FAIL("scan_slot(%s): got %d, want %d", s, ok, cases[i].ok);
+            continue;
+        }
+        if (ok && cases[i].slot) {
+            int slen = (int)(p.cur - s);
+            if (!span_eq(s, slen, cases[i].slot)) {
+                FAIL("scan_slot(%s): slot=%.*s, want %s", s, slen, s, cases[i].slot);
+                continue;
+            }
+        }
+        PASS();
+    }
+}
+
+static void test_scan_use_flag(void)
+{
+    static const struct {
+        const char *input;
+        int ok;
+    } cases[] = {
+        { "foo",              1 },
+        { "-foo",             1 },
+        { "!foo=",            1 },
+        { "!foo?",            1 },
+        { "foo=",             1 },
+        { "foo?",             1 },
+        { "foo(+)",           1 },
+        { "foo(-)",           1 },
+        { "foo(+)=",          1 },
+        { "!foo(-)=",         1 },
+        /* flag names with - */
+        { "foo-bar",          1 },
+        { "-foo-bar",         1 },
+        { "foo-bar?",         1 },
+        { "!foo-bar?",        1 },
+        { "foo-bar=",         1 },
+        /* flag names with + (e.g. c++) */
+        { "c++",              1 },
+        { "-c++",             1 },
+        { "c++?",             1 },
+        { "!c++?",            1 },
+        /* flag names with @ (old LINGUAS syntax) */
+        { "LINGUAS_en@euro",  1 },
+        { "-LINGUAS_en@euro", 1 },
+        { "LINGUAS_en@euro?", 1 },
+        /* invalid */
+        { "!foo",             0 },  /* bare ! without ?/= */
+        { "-foo=",            0 },  /* -foo with suffix */
+        { "",                 0 },
+    };
+
+    for (int i = 0; i < ARRAY_SIZE(cases); i++) {
+        const char *s = cases[i].input;
+        DepScanner p = { s, s + strlen(s), NULL };
+        int ok = scan_use_flag(&p);
+        /* for valid flags, must also consume all input */
+        if (ok && p.cur != p.end) ok = 0;
+        if (ok != cases[i].ok) {
+            FAIL("scan_use_flag(%s): got %d, want %d", s, ok, cases[i].ok);
+        } else {
+            PASS();
+        }
+    }
+}
+
+int main(void)
+{
+    init_cc_table();
+
+    test_scan_version();
+    test_scan_atom_basic();
+    test_scan_atom_hyphenated_name();
+    test_scan_atom_slot();
+    test_scan_atom_use();
+    test_scan_atom_combined();
+    test_scan_atom_invalid();
+    test_scan_slot();
+    test_scan_use_flag();
+
+    if (failures) {
+        fprintf(stderr, "%d/%d tests failed\n", failures, failures + passes);
+        return 1;
+    }
+    printf("%d tests passed\n", passes);
+    return 0;
+}
+
+/* vim: set ts=4 sw=4 et: */


### PR DESCRIPTION
Dependency-string parsing is one of the largest single costs in a `@world` resolve. This adds a recursive-descent parser in C and routes `use_reduce()` and `Atom` construction through it, falling back to the existing pure-Python implementation whenever the fast path cannot serve a call.

The two paths are meant to be indistinguishable. `PORTAGE_NATIVE_DEP_PARSER=0` forces the pure-Python one, both so that can be verified and so a user who hits a defect in the C parser has a way to keep working while it is fixed. It is read once, when `portage.dep` is imported, long before make.conf is parsed, so it is an environment variable only, documented in `emerge(1)` alongside the other Portage development variables.

## Results

Over the 80065 DEPEND/RDEPEND/BDEPEND/PDEPEND/IDEPEND strings in the ::gentoo md5-cache (`token_class=Atom`, `matchall=True`, `eapi=8`), best of three, `-O2`. The pure-Python path is memoized, so its `lru_cache` is cleared between runs:

| | time | str/s | |
|---|---|---|---|
| `_parser.parse()` alone | 0.167 s | 479124 | |
| `use_reduce`, Python path | 2.908 s | 27536 | |
| `use_reduce`, C path | 1.178 s | 67990 | **2.5x** |

End to end, unprofiled, `emerge -uDNp @world` goes from **54.3s to 50.1s** (best of three, `PORTAGE_NATIVE_DEP_PARSER=0` as the baseline). Under cProfile, `Atom.__init__` drops from 14.65s to 6.98s cumulative and the Atom fast path serves 663538 of 779655 constructions (85%) — nearly every call not excluded by an injected `_use` or a virtual-expansion original. The `@world` merge list is unchanged.

### Why 2.5x and not 2.9x

The C path is fastest partway through the series — 78938 str/s after commit 2 — and settles at 67990 by the end. Two commits account for the difference, and both buy correctness:

- **Commit 5** (~14%, the bulk of it). The parser originally inlined naked all-of groups into their parent, which is right in an all-of context but silently drops the conjunction inside an any-of: `|| ( ( a b ) c )` came back as `["||", ["a", "b", "c"]]` instead of `["||", [["a", "b"], "c"]]`. Fixing it means emitting explicit group boundaries and then normalizing that tree back into `use_reduce`'s shape on the Python side. That normalization is the cost.
- **Commit 7** (~2%). Making `scan_atom` byte-exact with the regex atom grammar needs validations the low-level scanner did not have — a version requires an operator, `=*` is only valid with `=`, and a package name must not end in a hyphen followed by a version, which means checking every `-` position rather than just the last.

Both are the difference between a fast parser and a fast parser that returns a different answer. Since the entire design rests on the two paths being indistinguishable — that is what makes the kill switch meaningful and what the fuzzing checks — paying ~16% for it is the right trade. The end-to-end `@world` number above is measured on the as-merged series, so it already includes this cost.

## Commits

1. `dep: add native C dep-string parser` — the scanner, the Python extension, and C unit tests
2. `dep: wire C parser into use_reduce fast path` — gated to EAPI 5+, whose atom grammar the scanner implements
3. `dep: add a PORTAGE_NATIVE_DEP_PARSER kill switch`
4. `tests: add C parser parity and classify_use_deps tests`
5. `dep: preserve conjunctions inside any-of groups`
6. `dep: extend C parser fast path to flat=True`
7. `dep: add C fast path for Atom construction`
8. `dep: widen the Atom C fast path to wildcard-flag and is_valid_flag callers`
9. `NEWS: mention the native C dependency-string parser`

Every commit builds warning-free and passes the full test suite on its own.

## Testing

`_UseReduceTests` is a mixin run twice — `TestUseReducePythonPath` and `TestUseReduceCPath` — so every correctness assertion executes on both code paths. On top of that, `TestCFastVsPython` and `TestScanAtom` assert the two paths are byte-identical field by field and reject the same malformed input, `TestCParserEapiGuard` covers EAPI 0–8, and `TestDeepNesting` checks nesting parity across the point where the C parser's group stack spills to the heap.

Beyond the suite: a differential fuzz of 192000 combinations (nesting depths 0–5, varied USE lists, matchall on/off, EAPI 8/6/5/None, flat and non-flat) found no differences against the pure-Python path, and the same fuzz under ASan+UBSan is clean. The standalone `test_parser` binary runs 127 C-level cases and is wired into `meson test`.

## Notes for reviewers

- **License headers.** The new files use `SPDX-License-Identifier: GPL-2.0-or-later OR MIT` rather than the tree's usual GPL-2 boilerplate, since this is all new code. GPL-2.0-or-later is because there have been some discussions on trying to make this change more generally for portage. MIT is so the code could be included in pkgcraft or other tools if wanted.
- **Nonstandard C.** `__attribute__((cleanup))` for scope-bound `Py_DECREF`, and `__VA_OPT__` (C2x) in one helper macro. Both work with GCC and Clang, which is what Portage builds with in practice, but no `c_std` is set anywhere in the build so it is worth a conscious decision.
- **No hardcoded optimization flags.** The extension inherits the buildtype, so Gentoo's `--buildtype plain` plus user `CFLAGS` applies. Note this means a bare `meson setup build` (default `optimization=0`) produces an extension about 1.6x slower than `-O2`; `-O2` and `-O3` are within noise of each other. Same as `_whirlpool` today.
- **Nesting depth is unbounded** (heap-grown group stack) rather than capped, because the pure-Python path has no limit either and rejecting a dep string it accepts would be a divergence.
