### PR TITLE
vartree: remove preserved libs that only consume each other

### DIFF
--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -1728,6 +1728,38 @@ class vartree:
         self.populated = 1
 
 
+def _find_unneeded_preserved_nodes(lib_graph, preserved_nodes):
+    """
+    Given a graph of libraries in which the parents of a node are its
+    consumers, find the preserved libraries which are not needed by
+    anything.
+
+    Repeatedly take the preserved libraries which have no consumers left
+    and drop them from the graph, which may in turn leave other preserved
+    libraries without consumers.
+
+    @param lib_graph: graph in which an edge from a consumer (parent) to a
+            library (child) means that the consumer links against the library.
+            It is modified in place.
+    @type lib_graph: digraph
+    @param preserved_nodes: the subset of nodes in lib_graph which are
+            preserved libraries
+    @type preserved_nodes: set
+    @rtype: set
+    @return: the subset of preserved_nodes which is not needed
+    """
+    unneeded_nodes = set()
+
+    while lib_graph:
+        root_nodes = preserved_nodes.intersection(lib_graph.root_nodes())
+        if not root_nodes:
+            break
+        lib_graph.difference_update(root_nodes)
+        unneeded_nodes.update(root_nodes)
+
+    return unneeded_nodes
+
+
 class dblink:
     """
     This class provides an interface to the installed package database
@@ -3718,35 +3750,30 @@ class dblink:
                     break
 
         cpv_lib_map = {}
-        while lib_graph:
-            root_nodes = preserved_nodes.intersection(lib_graph.root_nodes())
-            if not root_nodes:
-                break
-            lib_graph.difference_update(root_nodes)
-            unlink_list = set()
-            for node in root_nodes:
-                unlink_list.update(node.alt_paths)
-            unlink_list = sorted(unlink_list)
-            for obj in unlink_list:
-                cpv = path_cpv_map.get(obj)
-                if cpv is None:
-                    # This means that a symlink is in the preserved libs
-                    # registry, but the actual lib it points to is not.
-                    self._display_merge(
-                        _(
-                            "!!! symlink to lib is preserved, "
-                            "but not the lib itself:\n!!! '%s'\n"
-                        )
-                        % (obj,),
-                        level=logging.ERROR,
-                        noiselevel=-1,
+        unlink_list = set()
+        for node in _find_unneeded_preserved_nodes(lib_graph, preserved_nodes):
+            unlink_list.update(node.alt_paths)
+
+        for obj in sorted(unlink_list):
+            cpv = path_cpv_map.get(obj)
+            if cpv is None:
+                # This means that a symlink is in the preserved libs
+                # registry, but the actual lib it points to is not.
+                self._display_merge(
+                    _(
+                        "!!! symlink to lib is preserved, "
+                        "but not the lib itself:\n!!! '%s'\n"
                     )
-                    continue
-                removed = cpv_lib_map.get(cpv)
-                if removed is None:
-                    removed = set()
-                    cpv_lib_map[cpv] = removed
-                removed.add(obj)
+                    % (obj,),
+                    level=logging.ERROR,
+                    noiselevel=-1,
+                )
+                continue
+            removed = cpv_lib_map.get(cpv)
+            if removed is None:
+                removed = set()
+                cpv_lib_map[cpv] = removed
+            removed.add(obj)
 
         return cpv_lib_map
 

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -1734,13 +1734,14 @@ def _find_unneeded_preserved_nodes(lib_graph, preserved_nodes):
     consumers, find the preserved libraries which are not needed by
     anything.
 
-    Repeatedly take the preserved libraries which have no consumers left
-    and drop them from the graph, which may in turn leave other preserved
-    libraries without consumers.
+    A preserved library is needed if it has a consumer which is not itself
+    a preserved library, or if it has a consumer which is a preserved
+    library that is needed. Anything else is unneeded, including a group of
+    preserved libraries which consume each other in a cycle but which
+    nothing outside of the group consumes (bug 652382).
 
     @param lib_graph: graph in which an edge from a consumer (parent) to a
-            library (child) means that the consumer links against the library.
-            It is modified in place.
+            library (child) means that the consumer links against the library
     @type lib_graph: digraph
     @param preserved_nodes: the subset of nodes in lib_graph which are
             preserved libraries
@@ -1748,16 +1749,27 @@ def _find_unneeded_preserved_nodes(lib_graph, preserved_nodes):
     @rtype: set
     @return: the subset of preserved_nodes which is not needed
     """
-    unneeded_nodes = set()
+    needed_nodes = set()
+    stack = []
 
-    while lib_graph:
-        root_nodes = preserved_nodes.intersection(lib_graph.root_nodes())
-        if not root_nodes:
-            break
-        lib_graph.difference_update(root_nodes)
-        unneeded_nodes.update(root_nodes)
+    for preserved_node in preserved_nodes:
+        for consumer_node in lib_graph.parent_nodes(preserved_node):
+            if consumer_node not in preserved_nodes:
+                needed_nodes.add(preserved_node)
+                stack.append(preserved_node)
+                break
 
-    return unneeded_nodes
+    # Anything consumed by a needed preserved library is needed as well.
+    # This is what keeps a cycle alive when something outside of it still
+    # consumes part of it.
+    while stack:
+        node = stack.pop()
+        for child_node in lib_graph.child_nodes(node):
+            if child_node in preserved_nodes and child_node not in needed_nodes:
+                needed_nodes.add(child_node)
+                stack.append(child_node)
+
+    return preserved_nodes.difference(needed_nodes)
 
 
 class dblink:

--- a/lib/portage/tests/dbapi/meson.build
+++ b/lib/portage/tests/dbapi/meson.build
@@ -5,6 +5,7 @@ py.install_sources(
         'test_bintree_build_id.py',
         'test_fakedbapi.py',
         'test_portdb_cache.py',
+        'test_preserved_libs.py',
         '__init__.py',
         '__test__.py',
     ],

--- a/lib/portage/tests/dbapi/test_preserved_libs.py
+++ b/lib/portage/tests/dbapi/test_preserved_libs.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.dbapi.vartree import _find_unneeded_preserved_nodes
+from portage.tests import TestCase
+from portage.util.digraph import digraph
+
+
+class FindUnneededPreservedNodesTestCase(TestCase):
+    """
+    Tests for the graph analysis which decides that a preserved library
+    has no consumers left. In the graph, the parents of a node are its
+    consumers.
+    """
+
+    def _build(self, edges, preserved):
+        # Each edge is a (consumer, library) pair.
+        graph = digraph()
+        for node in preserved:
+            graph.add(node, None)
+        for consumer, lib in edges:
+            graph.add(lib, consumer)
+        return graph, set(preserved)
+
+    def testNoConsumers(self):
+        graph, preserved = self._build([], ["libfoo"])
+        self.assertEqual(_find_unneeded_preserved_nodes(graph, preserved), {"libfoo"})
+
+    def testInstalledConsumer(self):
+        graph, preserved = self._build([("bar", "libfoo")], ["libfoo"])
+        self.assertEqual(_find_unneeded_preserved_nodes(graph, preserved), set())
+
+    def testChainOfPreservedLibs(self):
+        # libbar is preserved and consumes libfoo, and nothing consumes
+        # libbar, so both are unneeded.
+        graph, preserved = self._build([("libbar", "libfoo")], ["libfoo", "libbar"])
+        self.assertEqual(
+            _find_unneeded_preserved_nodes(graph, preserved),
+            {"libfoo", "libbar"},
+        )
+
+    def testChainWithInstalledConsumer(self):
+        # An installed consumer at the head of the chain keeps everything
+        # in the chain alive.
+        graph, preserved = self._build(
+            [("baz", "libbar"), ("libbar", "libfoo")], ["libfoo", "libbar"]
+        )
+        self.assertEqual(_find_unneeded_preserved_nodes(graph, preserved), set())

--- a/lib/portage/tests/dbapi/test_preserved_libs.py
+++ b/lib/portage/tests/dbapi/test_preserved_libs.py
@@ -46,3 +46,63 @@ class FindUnneededPreservedNodesTestCase(TestCase):
             [("baz", "libbar"), ("libbar", "libfoo")], ["libfoo", "libbar"]
         )
         self.assertEqual(_find_unneeded_preserved_nodes(graph, preserved), set())
+
+    def testCycle(self):
+        # bug 652382: preserved libs which only consume each other must
+        # not keep each other alive. Cycles are not limited to two libs.
+        graph, preserved = self._build(
+            [("libfoo", "libbar"), ("libbar", "libbaz"), ("libbaz", "libfoo")],
+            ["libfoo", "libbar", "libbaz"],
+        )
+        self.assertEqual(
+            _find_unneeded_preserved_nodes(graph, preserved),
+            {"libfoo", "libbar", "libbaz"},
+        )
+
+    def testCycleWithInstalledConsumer(self):
+        # A cycle is needed if anything outside of it still consumes part
+        # of it.
+        graph, preserved = self._build(
+            [
+                ("libfoo", "libbar"),
+                ("libbar", "libbaz"),
+                ("libbaz", "libfoo"),
+                ("app", "libbar"),
+            ],
+            ["libfoo", "libbar", "libbaz"],
+        )
+        self.assertEqual(_find_unneeded_preserved_nodes(graph, preserved), set())
+
+    def testCycleFromBugReport(self):
+        # The graphite2 / freetype / harfbuzz / libpng case, in which
+        # freetype and harfbuzz consume each other, and graphite2 and
+        # libpng are consumed by harfbuzz and freetype respectively.
+        graph, preserved = self._build(
+            [
+                ("libharfbuzz", "libgraphite2"),
+                ("libharfbuzz", "libfreetype"),
+                ("libfreetype", "libharfbuzz"),
+                ("libfreetype", "libpng16"),
+            ],
+            ["libgraphite2", "libfreetype", "libharfbuzz", "libpng16"],
+        )
+        self.assertEqual(
+            _find_unneeded_preserved_nodes(graph, preserved),
+            {"libgraphite2", "libfreetype", "libharfbuzz", "libpng16"},
+        )
+
+    def testUnneededCycleAndNeededLib(self):
+        # An unneeded cycle is removed even though an unrelated preserved
+        # lib is still needed.
+        graph, preserved = self._build(
+            [
+                ("libfoo", "libbar"),
+                ("libbar", "libfoo"),
+                ("baz", "libqux"),
+            ],
+            ["libfoo", "libbar", "libqux"],
+        )
+        self.assertEqual(
+            _find_unneeded_preserved_nodes(graph, preserved),
+            {"libfoo", "libbar"},
+        )


### PR DESCRIPTION
_find_unneeded_preserved_nodes() peels the consumer graph from its roots, removing preserved libraries that have no consumers left and repeating until no root node is a preserved library. A group of preserved libraries which consume each other in a cycle has no root node, so the peel stops on the first iteration and nothing in the cycle is ever removed, even though nothing outside of the cycle consumes it. The libraries stay in the preserved libs registry forever, along with any libraries consumed only by the cycle.

Replace the peel with a least fixed point over the same graph: a preserved library is needed if it has a consumer which is not itself a preserved library, or if it has a consumer which is a preserved library that is needed. Everything else is unneeded. For an acyclic graph this is equivalent to the peel, and a cycle which nothing outside of it consumes is never seeded, so it is correctly reported as unneeded.

Bug: https://bugs.gentoo.org/652382
