### PR TITLE
man/ebuild: document 'fetchall' command

### DIFF
--- a/man/ebuild.1
+++ b/man/ebuild.1
@@ -66,6 +66,9 @@ just\-downloaded sources' checksums don't match those recorded
 in files/digest\-[package]\-[version\-rev], a warning is printed
 and ebuild exits with an error code of 1.
 .TP
+.BR fetchall
+Like \fBfetch\fR, but fetches all URIs (even ones invalid due to USE conditionals).
+.TP
 .BR digest
 This is now equivalent to the \fImanifest\fR command.
 .TP


### PR DESCRIPTION
The 'fetchall' command was previously not mentioned in the ebuild(1) man page. Fix this by documenting it.