### PR TITLE
emerge --status: say when there is nothing to report

### DIFF
--- a/bin/portageq
+++ b/bin/portageq
@@ -221,20 +221,30 @@ try:
 
     def jobs(argv):
         import json as _json
-        from _emerge._observability import read_snapshots, format_snapshots
+        from _emerge._observability import (
+            format_snapshots,
+            missing_feature_hint,
+            read_snapshots,
+        )
         from portage.const import EPREFIX
 
         snapshots = read_snapshots(EPREFIX)
+        hint = missing_feature_hint(snapshots)
+        if hint is not None:
+            sys.stderr.write(hint)
+
         if "--json" in argv:
+            # Still valid JSON with nothing to report.
             print(_json.dumps(snapshots, sort_keys=True, indent=2))
-        else:
+        elif hint is None:
             sys.stdout.write(format_snapshots(snapshots))
         return 0
 
     docstrings["jobs"] = """[--json]
 		Show packages currently being built/merged by running emerge
-		processes (requires FEATURES="observability").  With --json, emit
-		the raw status snapshots.
+		processes (requires the observed emerge to have been started with
+		FEATURES="observability").  With --json, emit the raw status
+		snapshots.
 		"""
     jobs.__doc__ = docstrings["jobs"]
 

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -202,6 +202,31 @@ def format_snapshots(snapshots):
     return "\n".join(lines) + "\n"
 
 
+NOT_ENABLED_HINT = (
+    "Nothing to report. Note that emerge only publishes status when it is "
+    'started with FEATURES="observability"; see make.conf(5).\n'
+)
+
+
+def missing_feature_hint(snapshots, features=None):
+    """Return a hint about FEATURES="observability", or None.
+
+    There is only something to say when nothing was read, since the
+    feature applies to the emerge being observed rather than to the one
+    observing it.
+
+    `features` defaults to this configuration's FEATURES, looked up only
+    when it is needed, since loading the config is not cheap.
+    """
+    if snapshots:
+        return None
+    if features is None:
+        features = portage.settings.features
+    if "observability" in features:
+        return None
+    return NOT_ENABLED_HINT
+
+
 class ObservabilityMonitor:
     """Owns the status file and streaming socket for one Scheduler.
 

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -1263,9 +1263,19 @@ def emerge_main(args: Optional[list[str]] = None):
         # (For machine-readable output, use `portageq jobs --json`.)
         from portage.const import EPREFIX
 
-        from _emerge._observability import format_snapshots, read_snapshots
+        from _emerge._observability import (
+            format_snapshots,
+            missing_feature_hint,
+            read_snapshots,
+        )
 
-        sys.stdout.write(format_snapshots(read_snapshots(EPREFIX)))
+        snapshots = read_snapshots(EPREFIX)
+        hint = missing_feature_hint(snapshots)
+        if hint is not None:
+            sys.stderr.write(hint)
+            return 1
+
+        sys.stdout.write(format_snapshots(snapshots))
         return os.EX_OK
     if myaction == "sync":
         # need to set this to True now in order for the repository config

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -10,6 +10,7 @@ from _emerge._observability import (
     ObservabilityMonitor,
     build_snapshot,
     format_snapshots,
+    missing_feature_hint,
     read_snapshots,
     status_dir,
 )
@@ -158,6 +159,17 @@ class ObservabilitySnapshotTestCase(TestCase):
 
             monitor.close()
             self.assertFalse(os.path.exists(path))
+
+    def test_hint_when_nothing_read_and_feature_absent(self):
+        self.assertIn("observability", missing_feature_hint([], features=set()))
+
+    def test_no_hint_when_nothing_read_but_feature_present(self):
+        self.assertIsNone(missing_feature_hint([], features={"observability"}))
+
+    def test_no_hint_when_something_was_read(self):
+        # The feature is enabled for the emerge being observed, not for the
+        # process observing it, so a readable snapshot is never held back.
+        self.assertIsNone(missing_feature_hint([{"emerge_pid": 1}], features=set()))
 
     def test_stale_file_skipped(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
`emerge --status` prints "No emerge processes are currently running." whether or not anything could have been reported. Nothing publishes a status file unless FEATURES="observability" is enabled, so a user who never enabled it gets an answer that reads like a result but is not one.

Print a hint in that case instead, and exit non-zero:

    $ emerge --status
    Nothing to report. Note that emerge only publishes status when it is
    started with FEATURES="observability"; see make.conf(5).

The check only applies when there is nothing at all to report. The feature has to be enabled for the emerge process being observed, not for the one doing the observing. The Scheduler consults its own settings before publishing, and emerge.1 documents it that way, so an emerge started with FEATURES="observability" in the environment, or from a different --config-root, is still reported normally even if this configuration does not enable the feature. Checking FEATURES only in the empty case also keeps it out of the pre-config fast path that the "status" action deliberately lives in, next to --help and moo.

`portageq jobs` reads the same status files and now says the same thing. Its hint goes to stderr and its exit status is unchanged. `--json` still emits an empty list, so stdout stays machine-readable either way.

Based on #1642 by Florian Schmaus, which had `emerge --status` refuse outright based on the invoking process' FEATURES.
