### PR TITLE
unmerge: stringify Atom before str operations

### DIFF
--- a/lib/_emerge/unmerge.py
+++ b/lib/_emerge/unmerge.py
@@ -208,12 +208,13 @@ def _unmerge_display(
         for x in candidate_catpkgs:
             # cycle through all our candidate deps and determine
             # what will and will not get unmerged
+            x_str = str(x)  # this could be an Atom, stringify
             try:
                 mymatch = vartree.dbapi.match(x)
             except portage.exception.AmbiguousPackageName as errpkgs:
                 print(
                     '\n\n!!! The short ebuild name "'
-                    + x
+                    + x_str
                     + '" is ambiguous.  Please specify'
                 )
                 print(
@@ -225,11 +226,11 @@ def _unmerge_display(
                 print()
                 sys.exit(1)
 
-            if not mymatch and x[0] not in "<>=~":
+            if not mymatch and x_str[0] not in "<>=~":
                 mymatch = vartree.dep_match(x)
             if not mymatch:
                 portage.writemsg(
-                    f"\n--- Couldn't find '{str(x).replace('null/', '')}' to {unmerge_action}.\n",
+                    f"\n--- Couldn't find '{x_str.replace('null/', '')}' to {unmerge_action}.\n",
                     noiselevel=-1,
                 )
                 continue

--- a/lib/portage/dep/dep_check.py
+++ b/lib/portage/dep/dep_check.py
@@ -151,7 +151,7 @@ def _expand_new_virtuals(
                     mysettings._populate_treeVirtuals_if_needed(myvartree)
                 mychoices = mysettings.getvirtuals().get(mykey, [])
                 for y in mychoices:
-                    a.append(Atom(x.replace(x.cp, y.cp, 1)))
+                    a.append(x.with_cp(y.cp))
                 if not a:
                     newsplit.append(x)
                 elif is_disjunction:
@@ -272,7 +272,7 @@ def _expand_new_virtuals(
         if not a and mychoices:
             # Check for a virtual package.provided match.
             for y in mychoices:
-                new_atom = Atom(x.replace(x.cp, y.cp, 1))
+                new_atom = x.with_cp(y.cp)
                 if match_from_list(new_atom, pprovideddict.get(new_atom.cp, [])):
                     a.append(new_atom)
                     if atom_graph is not None:


### PR DESCRIPTION
Atom is no longer a str subclass, but _unmerge_display() still indexed and concatenated candidate_catpkgs entries directly, which crashed with
```
    TypeError: 'Atom' object is not subscriptable
```
when the operator-prefix check ran (i.e. whenever the initial match failed). Take str() up front like the loop above does, and use it for the operator check, the ambiguous-name message, and the "Couldn't find" message.

Bug: https://bugs.gentoo.org/980394
Fixes: 7e15fc7fa ("dep: Atom: remove str subtyping")