### PR TITLE
man/emerge: document implicit quiet-build behavior

### DIFF
--- a/man/emerge.1
+++ b/man/emerge.1
@@ -712,7 +712,8 @@ run simultaneously.  If 0 is given as argument, emerge will limit the jobs to
 the number of processors.  Using 'n' as argument can be used to disable this
 setting.  Also see the related \fB\-\-load\-average\fR option.
 Similarly to the \-\-quiet\-build option, the \-\-jobs option causes all
-build output to be redirected to logs.
+build output to be redirected to logs, unless there is only one package
+to emerge.
 Note that interactive packages currently force a setting
 of \fI\-\-jobs=1\fR. This issue can be temporarily avoided
 by specifying \fI\-\-accept\-properties=\-interactive\fR.
@@ -933,7 +934,10 @@ Note that interactive packages currently force all build output to
 be displayed on stdout. This issue can be temporarily avoided
 by specifying \fI\-\-accept\-properties=\-interactive\fR.
 Further, note that disabling \fI\-\-quiet\-build\fR has no effect if
-\fI\-\-jobs\fR is set to anything higher than 1.
+\fI\-\-jobs\fR is set to anything higher than one and there is more than
+one package to emerge.  If there is only one package to emerge, build
+output will be displayed on stdout unless \fI\-\-quiet\fR or
+\fI\-\-quiet\-build\fR is enabled.
 .TP
 .BR "\-\-quiet\-fail [ y | n ]"
 Suppresses display of the build log on stdout when build output is hidden


### PR DESCRIPTION
Starting with portage 3.0.78 portage would show the build log even with parallel jobs are enabled, if there is only one package to emerge. Document this behavior in the emerge man page.

Bug: https://bugs.gentoo.org/976455