### PR TITLE
tests/resolver: give binhost packages a fixed mtime

### DIFF
--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -43,6 +43,11 @@ from portage.tests import cnf_path
 from portage.util import ensure_dirs, normalize_path
 from portage.versions import catsplit
 
+# Fixed mtime for binary packages created in a remote binhost, so that
+# they never collide with the local PKGDIR copies of the same packages
+# (see _create_binpkgs).
+_BINREPO_MTIME = 1000000000
+
 
 def _combine_repo_config(conf, lines):
     merged = lines.copy()
@@ -276,7 +281,7 @@ class ResolverPlayground:
 
         for binrepo, binpkgs in binrepos.items():
             binrepo_dir = self._get_binrepo_dir(binrepo)
-            self._create_binpkgs(binrepo_dir, binpkgs)
+            self._create_binpkgs(binrepo_dir, binpkgs, mtime=_BINREPO_MTIME)
 
         portage.util.noiselimit = 0
 
@@ -398,10 +403,18 @@ class ResolverPlayground:
                     f"command failed with returncode {result.returncode}: {egencache_cmd}"
                 )
 
-    def _create_binpkgs(self, repo_dir, binpkgs):
+    def _create_binpkgs(self, repo_dir, binpkgs, mtime=None):
         # When using BUILD_ID, there can be multiple instances for the
         # same cpv. Therefore, binpkgs may be an iterable instead of
         # a dict.
+        #
+        # A binary package instance is identified by
+        # (cpv, build_id, file_size, build_time, mtime), so a package created
+        # here in two different repositories differs only by file mtime.
+        # Callers creating a remote binhost pass an explicit mtime to keep
+        # those instances distinct from the local PKGDIR copies regardless of
+        # how the two creation times happen to fall relative to a one-second
+        # boundary.
         items = getattr(binpkgs, "items", None)
         items = items() if items is not None else binpkgs
         binpkg_format = self.settings.get(
@@ -459,6 +472,9 @@ class ResolverPlayground:
                 t.compress(os.path.dirname(binpkg_path), metadata)
             else:
                 raise InvalidBinaryPackageFormat(binpkg_format)
+
+            if mtime is not None:
+                os.utime(binpkg_path, (mtime, mtime))
 
         bintree = binarytree(pkgdir=repo_dir, settings=self.settings)
         bintree.populate(force_reindex=True)


### PR DESCRIPTION
ResolverPlayground creates the same binary packages twice when a test uses binrepos: once in PKGDIR and once in the remote binhost directory. A binary package instance is keyed on (cpv, build_id, file_size, build_time, mtime), and the playground sets BUILD_TIME to 0 with no BUILD_ID, so two copies of one package differ only by file mtime.

bintree._populate_remote_repo() drops a remote package whose instance key already exists locally. Whether that happened depended on whether the PKGDIR copy and the binhost copy of a given package were written in the same wall-clock second: usually they were not and both instances survived, but under load the two writes could land in the same second, the remote instance was discarded as a duplicate, and the affected package resolved to [binary] where the test expected [binary,remote].

This showed up as intermittent failures in test_binpackage_selection, one package at a time and a different package each occurrence -- about 2 in 8 runs of that file on a loaded machine, rarer in a full suite run. It reproduces deterministically by forcing the two mtimes to match with os.utime.

Give the binhost copies a fixed mtime well in the past instead. PKGDIR copies always carry the current time, so the two instance keys can never collide, whatever the timing.

10 consecutive runs of test_binpackage_selection pass; full resolver suite: 230 passed, 7 xfailed, 222 subtests.