### PR TITLE
tests: shut down gpg-agent before removing the temporary GNUPGHOME

### DIFF
--- a/lib/portage/tests/conftest.py
+++ b/lib/portage/tests/conftest.py
@@ -9,6 +9,7 @@ import os.path as osp
 import pwd
 import shutil
 import signal
+import subprocess
 import sys
 import tempfile
 
@@ -66,10 +67,10 @@ def prepare_environment():
         path.insert(0, PORTAGE_BIN_PATH)
         os.environ["PATH"] = ":".join(path)
 
-    try:
-        # Copy GnuPG test keys to temporary directory
-        gpg_path = tempfile.mkdtemp(prefix="gpg_")
+    # Copy GnuPG test keys to temporary directory
+    gpg_path = tempfile.mkdtemp(prefix="gpg_")
 
+    try:
         shutil.copytree(
             os.path.join(os.path.dirname(os.path.realpath(__file__)), ".gnupg"),
             gpg_path,
@@ -83,6 +84,17 @@ def prepare_environment():
 
     finally:
         global_event_loop().close()
+        # Signing spawns a gpg-agent and scdaemon which daemonize, so they
+        # outlive the test session unless they are shut down here.
+        try:
+            subprocess.run(
+                ["gpgconf", "--homedir", gpg_path, "--kill", "all"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError:
+            # No gpgconf, so no agent can have been started either.
+            pass
         shutil.rmtree(gpg_path, ignore_errors=True)
 
 


### PR DESCRIPTION
Signing spawns a gpg-agent and scdaemon for the temporary home directory that the session fixture creates. They daemonize, so removing the directory leaves them running with a home directory that no longer exists, and a test run aborted before the fixture teardown leaks the directory too. Kill them with "gpgconf --kill all" before removing it.

Also move the mkdtemp() call out of the try block, since the finally block already assumes gpg_path is bound.