### PR TITLE
cgroup: drop the "using <root>" message

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -233,10 +233,7 @@ class Scheduler(PollScheduler):
         self._observability = ObservabilityMonitor(self)
         self._cgroup = None
         if "cgroup" in settings.features:
-            cg = CgroupManager(
-                settings.get("PORTAGE_CGROUP_ROOT", DEFAULT_CGROUP_ROOT),
-                verbose="--verbose" in myopts,
-            )
+            cg = CgroupManager(settings.get("PORTAGE_CGROUP_ROOT", DEFAULT_CGROUP_ROOT))
             if cg.setup():
                 self._cgroup = cg
                 settings.unlock()

--- a/lib/portage/util/cgroup.py
+++ b/lib/portage/util/cgroup.py
@@ -59,10 +59,6 @@ def _warn(msg: str) -> None:
     writemsg_level(f"!!! cgroup: {msg}\n", level=logging.WARNING, noiselevel=-1)
 
 
-def _info(msg: str) -> None:
-    writemsg_level(f"cgroup: {msg}\n", level=logging.INFO)
-
-
 def _debug(msg: str) -> None:
     writemsg_level(f"cgroup: {msg}\n", level=logging.DEBUG, noiselevel=2)
 
@@ -453,19 +449,17 @@ class CgroupManager:
     via settings.
     """
 
-    def __init__(self, root: str = DEFAULT_CGROUP_ROOT, verbose: bool = False) -> None:
+    def __init__(self, root: str = DEFAULT_CGROUP_ROOT) -> None:
         self.root = root
         self.emerge_root = os.path.join(root, f"emerge-{os.getpid()}")
         self.enabled = False
-        self.verbose = verbose
         self._seen: set[str] = set()
 
     def setup(self) -> bool:
         """Initialize the base and per-emerge cgroups. Sets self.enabled."""
         if not ensure_base(self.root):
             return False
-        if self.verbose:
-            _info(f"using {self.root}")
+        _debug(f"using {self.root}")
         cleanup_stale(self.root)
         try:
             os.makedirs(self.emerge_root, exist_ok=True)


### PR DESCRIPTION
It reads like leftover debugging output and tells the user nothing that PORTAGE_CGROUP_ROOT does not already say.

It was emitted only under --verbose, and was the only use of both CgroupManager's verbose parameter and the _info() helper, so drop those as well.