### PR TITLE
news: some small improvements

### DIFF
--- a/lib/portage/__init__.py
+++ b/lib/portage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 1998-2025 Gentoo Authors
+# Copyright 1998-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # pylint: disable=ungrouped-imports
 
@@ -275,6 +275,8 @@ _ForkWatcher.hook(_ForkWatcher)
 
 os.register_at_fork(after_in_child=functools.partial(_ForkWatcher.hook, _ForkWatcher))
 
+portage._uname = None
+
 
 def getpid():
     """
@@ -295,6 +297,15 @@ def _get_stdin():
     if not sys.__stdin__.closed:
         return sys.__stdin__
     return sys.stdin
+
+
+def uname():
+    """
+    Cached version of os.uname().
+    """
+    if portage._uname is None:
+        portage._uname = os.uname()
+    return portage._uname
 
 
 bsd_chflags = None

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -1,4 +1,4 @@
-# Copyright 2004-2023 Gentoo Authors
+# Copyright 2004-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 """
@@ -577,9 +577,10 @@ def unlockfile(mytuple):
 
 def hardlock_name(path):
     base, tail = os.path.split(path)
+    myhost = os.uname()[1]
     return os.path.join(
         base,
-        f".{tail}.hardlock-{os.uname()[1]}-{portage.getpid()}",
+        f".{tail}.hardlock-{myhost}-{portage.getpid()}",
     )
 
 

--- a/lib/portage/locks.py
+++ b/lib/portage/locks.py
@@ -577,7 +577,7 @@ def unlockfile(mytuple):
 
 def hardlock_name(path):
     base, tail = os.path.split(path)
-    myhost = os.uname()[1]
+    myhost = portage.uname()[1]
     return os.path.join(
         base,
         f".{tail}.hardlock-{myhost}-{portage.getpid()}",
@@ -750,7 +750,7 @@ def unhardlink_lockfile(lockfilename, unlinkfile=True):
 
 
 def hardlock_cleanup(path, remove_all_locks=False):
-    myhost = os.uname()[1]
+    myhost = portage.uname()[1]
 
     results = []
     mycount = 0

--- a/lib/portage/news.py
+++ b/lib/portage/news.py
@@ -133,9 +133,9 @@ class NewsManager:
             return
 
         news_dir: str = self._news_dir(repoid)
-        try:
-            news: list[str] = os.listdir(news_dir)
-        except OSError:
+        news: list[str] = os.listdir(news_dir)
+
+        if not news:
             return
 
         skip_filename: str = self._skip_filename(repoid)
@@ -212,7 +212,11 @@ class NewsManager:
         """
 
         if update:
-            self.updateItems(repoid)
+            try:
+                self.updateItems(repoid)
+            except OSError:
+                # Repository doesn't have any news items
+                return 0
 
         unread_filename = self._unread_filename(repoid)
         unread_lock: Optional[bool] = None

--- a/lib/portage/news.py
+++ b/lib/portage/news.py
@@ -1,5 +1,5 @@
 # portage: news management code
-# Copyright 2006-2025 Gentoo Authors
+# Copyright 2006-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 __all__ = [
@@ -430,10 +430,10 @@ class DisplayInstalledRestriction(DisplayRestriction):
         self.format = news_format
 
     def isValid(self) -> bool:
-        if fnmatch.fnmatch(self.format, "1.*"):
-            return isvalidatom(self.atom, eapi="0")
         if fnmatch.fnmatch(self.format, "2.*"):
             return isvalidatom(self.atom, eapi="5")
+        elif fnmatch.fnmatch(self.format, "1.*"):
+            return isvalidatom(self.atom, eapi="0")
         return isvalidatom(self.atom)
 
     def checkRestriction(self, **kwargs) -> Optional[Match[str]]:


### PR DESCRIPTION
The 2.0 format was added in 2017. I've cleaned up the remaining handful
of pre-2020 news items which used 1.0 in 8e623892138d252cdbf5a652c7cf825e84a8094d
(gento-news.git).

Check for the newer format first as it's the common case.

Signed-off-by: Sam James <sam@gentoo.org>