### PR TITLE
emaint: drop the blank lines around results output

### DIFF
--- a/lib/portage/emaint/main.py
+++ b/lib/portage/emaint/main.py
@@ -153,9 +153,7 @@ class TaskHandler:
 
 def print_results(results):
     if results:
-        print()
         print("\n".join(results))
-        print("\n")
 
 
 def emaint_main(myargv):


### PR DESCRIPTION
print_results() padded every module's output with one blank line before and two after, so a one-line result printed as five lines. Print just the result.

This is shared by every emaint module and by the 'emerge --sync' message path in _emerge/actions.py, so their output loses the padding too.