### PR TITLE
vartree: fix the match cache and the vdb syscalls it hides

### DIFF
--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -689,16 +689,24 @@ class vardbapi(dbapi):
 
         return moves
 
-    def cp_list(self, mycp, use_cache=1):
+    def cp_list(self, mycp, use_cache=1, _cat_mtime=None):
+        """
+        @param _cat_mtime: st_mtime_ns of the category directory, for internal
+                callers that have already stat()ed it. Saves a redundant stat()
+                of the same directory.
+        """
         from portage.versions import _pkg_str, catsplit, pkgsplit
 
         mysplit = catsplit(mycp)
         if mysplit[0] == "*":
             mysplit[0] = mysplit[0][1:]
-        try:
-            mystat = os.stat(self.getpath(mysplit[0])).st_mtime_ns
-        except OSError:
-            mystat = 0
+        if _cat_mtime is not None:
+            mystat = _cat_mtime
+        else:
+            try:
+                mystat = os.stat(self.getpath(mysplit[0])).st_mtime_ns
+            except OSError:
+                mystat = 0
         if use_cache and mycp in self.cpcache:
             cpc = self.cpcache[mycp]
             if cpc[0] == mystat:
@@ -858,7 +866,10 @@ class vardbapi(dbapi):
             self.matchcache[mycat] = {}
         if cache_key not in self.matchcache[mycat]:
             mymatch = list(
-                self._iter_match(mydep, self.cp_list(mydep.cp, use_cache=use_cache))
+                self._iter_match(
+                    mydep,
+                    self.cp_list(mydep.cp, use_cache=use_cache, _cat_mtime=curmtime),
+                )
             )
             self.matchcache[mycat][cache_key] = mymatch
         return self.matchcache[mycat][cache_key][:]

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -856,7 +856,7 @@ class vardbapi(dbapi):
             # clear cache entry
             self.mtdircache[mycat] = curmtime
             self.matchcache[mycat] = {}
-        if mydep not in self.matchcache[mycat]:
+        if cache_key not in self.matchcache[mycat]:
             mymatch = list(
                 self._iter_match(mydep, self.cp_list(mydep.cp, use_cache=use_cache))
             )

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -700,25 +700,33 @@ class vardbapi(dbapi):
         mysplit = catsplit(mycp)
         if mysplit[0] == "*":
             mysplit[0] = mysplit[0][1:]
+        cat_dir = self.getpath(mysplit[0])
+        cat_missing = False
         if _cat_mtime is not None:
             mystat = _cat_mtime
         else:
             try:
-                mystat = os.stat(self.getpath(mysplit[0])).st_mtime_ns
-            except OSError:
+                mystat = os.stat(cat_dir).st_mtime_ns
+            except OSError as e:
                 mystat = 0
+                cat_missing = e.errno == errno.ENOENT
         if use_cache and mycp in self.cpcache:
             cpc = self.cpcache[mycp]
             if cpc[0] == mystat:
                 return cpc[1][:]
-        cat_dir = self.getpath(mysplit[0])
-        try:
-            dir_list = os.listdir(cat_dir)
-        except OSError as e:
-            if e.errno == PermissionDenied.errno:
-                raise PermissionDenied(cat_dir)
-            del e
+        if cat_missing:
+            # The stat() above already reported ENOENT, so listdir() can only
+            # report it again. Any other stat() failure falls through, since
+            # listdir() is what turns EACCES into PermissionDenied.
             dir_list = []
+        else:
+            try:
+                dir_list = os.listdir(cat_dir)
+            except OSError as e:
+                if e.errno == PermissionDenied.errno:
+                    raise PermissionDenied(cat_dir)
+                del e
+                dir_list = []
 
         returnme = []
         for x in dir_list:
@@ -855,22 +863,31 @@ class vardbapi(dbapi):
             return list(
                 self._iter_match(mydep, self.cp_list(mydep.cp, use_cache=use_cache))
             )
+        cat_missing = False
         try:
             curmtime = os.stat(os.path.join(self._eroot, VDB_PATH, mycat)).st_mtime_ns
-        except OSError:
+        except OSError as e:
             curmtime = 0
+            cat_missing = e.errno == errno.ENOENT
 
         if mycat not in self.matchcache or self.mtdircache[mycat] != curmtime:
             # clear cache entry
             self.mtdircache[mycat] = curmtime
             self.matchcache[mycat] = {}
         if cache_key not in self.matchcache[mycat]:
-            mymatch = list(
-                self._iter_match(
-                    mydep,
-                    self.cp_list(mydep.cp, use_cache=use_cache, _cat_mtime=curmtime),
+            if cat_missing:
+                # Nothing is installed in a category that has no directory,
+                # so there is nothing for cp_list() to list.
+                mymatch = []
+            else:
+                mymatch = list(
+                    self._iter_match(
+                        mydep,
+                        self.cp_list(
+                            mydep.cp, use_cache=use_cache, _cat_mtime=curmtime
+                        ),
+                    )
                 )
-            )
             self.matchcache[mycat][cache_key] = mymatch
         return self.matchcache[mycat][cache_key][:]
 


### PR DESCRIPTION
`vardbapi.match()` stores and returns its cached result under
`cache_key = (mydep, mydep.unevaluated_atom)`, but tests membership with the
bare atom, which is never a key in that dict. The test always succeeds, so
every call recomputes and the cache has done nothing since commit
d603f1440c81 introduced the key in 2012.

Recomputing means calling `cp_list()`, which stat()s the category directory
`match()` has just stat()ed itself: the doubled stat in bug 980860. The third
commit stops both of them reading a category directory that does not exist,
which a news item's Display-If-Installed lines hit repeatedly (bug 980777).
That skip is gated on ENOENT alone, since any other stat() failure has to
reach listdir(), which is the call that turns EACCES into PermissionDenied.

Syscalls under /var/db/pkg, per commit:

| | `emerge --info` | match loop | news-style |
|---|---|---|---|
| before | 251 stat | 12245 stat | 240 stat, 60 opendir |
| cache key | 251 stat | 8829 stat | 120 stat, 60 opendir |
| single stat | 215 stat | 7121 stat | 120 stat, 60 opendir |
| listdir skip | 215 stat | 7121 stat | 120 stat, 0 opendir |

The match loop calls `vdb.match(cp)` three times for each of the 1708
installed cps, which is where a working match cache shows up and an
`emerge --info` that matches each atom once does not. News-style is 60 atoms
across three categories that have no directory, matched twice.

Wall clock barely moves: 0.247s to 0.230s for that match loop on a warm page
cache, and `emerge -p -uDN @world` is unchanged at about 29s. The cost was
always syscalls and strace noise, which is what the bugs are about.

match() and cp_list() results for 8550 atoms are identical before and after
(every installed cp as bare, `>=`, `:0` and `=cpv`, plus missing-category and
`*/*` cases), and PermissionDenied is still raised both for an unreadable
category directory and for an unsearchable /var/db/pkg. Test suite passes.

Bug: https://bugs.gentoo.org/980777
Bug: https://bugs.gentoo.org/980860