### PR TITLE
observability: republish snapshots on a timer

### DIFF
--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -245,6 +245,11 @@ class ObservabilityMonitor:
     # rate-limiting intent.
     _min_write_latency = 1.0
 
+    # Republish this often (seconds) even when no task event occurs, so that
+    # the live gauges (elapsed time, cgroup counters, task PIDs) keep moving
+    # through a phase that runs for hours.
+    _refresh_interval = 2.0
+
     def __init__(self, scheduler):
         self._scheduler = scheduler
         settings = scheduler.settings
@@ -264,6 +269,7 @@ class ObservabilityMonitor:
         self._server_started = False
         self._last_write = 0
         self._last_snapshot = None
+        self._refresh_handle = None
 
         if not self.enabled:
             return
@@ -314,7 +320,9 @@ class ObservabilityMonitor:
         if not force and (now - self._last_write) < self._min_write_latency:
             return
         self._last_write = now
+        self._publish()
 
+    def _publish(self):
         try:
             snapshot = build_snapshot(self)
         except Exception as e:
@@ -330,6 +338,29 @@ class ObservabilityMonitor:
         self._write_status_file(snapshot)
         self._ensure_server()
         self._broadcast(snapshot)
+        self._schedule_refresh()
+
+    def _schedule_refresh(self):
+        if not self.enabled or self._refresh_handle is not None:
+            return
+        try:
+            self._refresh_handle = self._scheduler._event_loop.call_later(
+                self._refresh_interval, self._refresh
+            )
+        except RuntimeError:
+            # The loop is closed (shutdown in progress), so there will be no
+            # further refreshes. Task events still publish.
+            self._refresh_handle = None
+
+    def _refresh(self):
+        self._refresh_handle = None
+        # A publish that fails disables the monitor, but the handle armed by
+        # the previous one is still pending at that point.
+        if not self.enabled:
+            return
+        # Publish without advancing _last_write: the rate limit is there for
+        # bursty task events, not for this timer.
+        self._publish()
 
     def _write_status_file(self, snapshot):
         try:
@@ -427,6 +458,12 @@ class ObservabilityMonitor:
             return False
 
     def close(self):
+        # Nothing may publish after this: a later update() would re-arm the
+        # timer and recreate the status file unlinked below.
+        self.enabled = False
+        if self._refresh_handle is not None:
+            self._refresh_handle.cancel()
+            self._refresh_handle = None
         for writer in self._writers:
             try:
                 writer.close()

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -51,7 +51,28 @@ class _Settings(dict):
         self.features = set(features)
 
 
-def _make_scheduler(features=("observability",), eprefix="", tasks=None):
+class _FakeLoop:
+    """Stand-in for the scheduler's event loop, with call_later run on demand."""
+
+    def __init__(self):
+        self.calls = []
+
+    def call_later(self, delay, callback):
+        entry = [delay, callback]
+        self.calls.append(entry)
+        return SimpleNamespace(cancel=lambda: self._cancel(entry))
+
+    def _cancel(self, entry):
+        if entry in self.calls:
+            self.calls.remove(entry)
+
+    def run_pending(self):
+        pending, self.calls = self.calls, []
+        for _delay, callback in pending:
+            callback()
+
+
+def _make_scheduler(features=("observability",), eprefix="", tasks=None, loop=None):
     tasks = tasks or []
     running = {id(t): t for t in tasks}
     return SimpleNamespace(
@@ -63,7 +84,7 @@ def _make_scheduler(features=("observability",), eprefix="", tasks=None):
         _merge_wait_queue=[],
         _task_queues=SimpleNamespace(merge=[]),
         _status_display=SimpleNamespace(curval=1, maxval=5),
-        _event_loop=None,
+        _event_loop=loop if loop is not None else _FakeLoop(),
         _cgroup=None,
     )
 
@@ -216,6 +237,122 @@ class ObservabilitySnapshotTestCase(TestCase):
                 global_event_loop().run_until_complete(exercise())
             finally:
                 monitor.close()
+
+    def test_snapshot_is_republished_without_task_events(self):
+        loop = _FakeLoop()
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build], loop=loop)
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+            monitor.update(force=True)
+
+            path = os.path.join(status_dir(tmp), f"emerge-{os.getpid()}.json")
+            with open(path, encoding="utf_8") as f:
+                first = json.load(f)
+
+            self.assertEqual(len(loop.calls), 1)
+            self.assertEqual(loop.calls[0][0], monitor._refresh_interval)
+            loop.run_pending()
+
+            with open(path, encoding="utf_8") as f:
+                second = json.load(f)
+            self.assertGreater(second["timestamp"], first["timestamp"])
+            self.assertGreater(
+                second["tasks"][0]["elapsed"], first["tasks"][0]["elapsed"]
+            )
+            # The republish rearms the timer for the one after it.
+            self.assertEqual(len(loop.calls), 1)
+
+            monitor.close()
+            self.assertEqual(loop.calls, [])
+
+    def test_timer_republish_does_not_suppress_the_next_task_event(self):
+        loop = _FakeLoop()
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build], loop=loop)
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+            monitor.update(force=True)
+
+            # Age the last event-driven publish past the rate limit, so that
+            # only the timer below can put the next event back under it.
+            monitor._last_write -= monitor._min_write_latency * 2
+            last_write = monitor._last_write
+            loop.run_pending()
+            self.assertEqual(monitor._last_write, last_write)
+
+            path = os.path.join(status_dir(tmp), f"emerge-{os.getpid()}.json")
+            with open(path, encoding="utf_8") as f:
+                after_timer = json.load(f)
+
+            monitor.update()
+            with open(path, encoding="utf_8") as f:
+                after_event = json.load(f)
+            self.assertGreater(after_event["timestamp"], after_timer["timestamp"])
+
+            monitor.close()
+
+    def test_pending_refresh_is_dropped_when_publishing_fails(self):
+        loop = _FakeLoop()
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build], loop=loop)
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+            monitor.update(force=True)
+            self.assertEqual(len(loop.calls), 1)
+
+            # What a failed status file write leaves behind.  The timer armed
+            # by the publish above is already pending at this point.
+            monitor._status_path = None
+            monitor.enabled = False
+
+            loop.run_pending()
+            self.assertEqual(loop.calls, [])
+
+            monitor.close()
+
+    def test_no_refresh_is_armed_once_the_loop_is_closed(self):
+        loop = _FakeLoop()
+
+        def call_later(delay, callback):
+            raise RuntimeError("Event loop is closed")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build], loop=loop)
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+            loop.call_later = call_later
+
+            # The publish itself still has to go through.
+            monitor.update(force=True)
+            path = os.path.join(status_dir(tmp), f"emerge-{os.getpid()}.json")
+            self.assertTrue(os.path.exists(path))
+            self.assertIsNone(monitor._refresh_handle)
+
+            monitor.close()
+
+    def test_close_stops_further_publishing(self):
+        loop = _FakeLoop()
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build], loop=loop)
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+            monitor.update(force=True)
+
+            path = os.path.join(status_dir(tmp), f"emerge-{os.getpid()}.json")
+            monitor.close()
+            self.assertFalse(os.path.exists(path))
+
+            # A task event arriving after close() must not recreate the file
+            # or re-arm the timer.
+            monitor.update(force=True)
+            self.assertFalse(os.path.exists(path))
+            self.assertEqual(loop.calls, [])
 
     def test_hint_when_nothing_read_and_feature_absent(self):
         self.assertIn("observability", missing_feature_hint([], features=set()))


### PR DESCRIPTION
The snapshot was only rebuilt on task events (start, finish, phase change),
but a single phase can run for hours: a gcc bootstrap leaves the status file
untouched for the entire compile. Consumers polling it then read stale
gauges, and since cgroup cpu.usage_usec is cumulative, a CPU% derived from
two reads of an unchanging counter comes out as zero for a fully busy build.
The PID recorded at a phase transition can likewise be null forever, because
the phase's process had not been spawned when that snapshot was built.

Have each publish arm a timer for the next one, so the snapshot keeps moving
between events. The timer runs at one interval throughout, rather than
backing off while no task is running: the windows with nothing to report are
the moment between one task exiting and the next starting, and the tail of
the run, both of them brief. A consumer can also read the steady interval as
a heartbeat, and age out an emerge that was killed without getting to unlink
its status file. The cost is a wakeup and a status file write every 2s for
the life of the emerge; say if that is too much and I will make the interval
a setting.

Complements #1650 and #1651:

#1650 consumes what this keeps fresh. Without a timer, the parallelism figure
it prints during a long compile is computed from a frozen cpu_usec.

#1651 fixes the same staleness from the reader side, and the two do not
overlap much. Its on-connect update() is a tighter bound than 2s while a
client is asking; it does not cover the JSON file it keeps as a fallback, or
clients that stay connected and stream. It also benefits from the split here:
_publish() does not advance _last_write, so the on-connect update() is less
likely to hit the rate limit and return without publishing.

All three touch disjoint functions and merge cleanly.