### PR TITLE
doebuild: rebind loaded module paths for self update

### DIFF
--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -3352,6 +3352,34 @@ def _merge_unicode_error(errors):
     return lines
 
 
+def _rebind_loaded_modules(orig_pym_path, new_pym_path):
+    """
+    Rewrite the __path__ of loaded portage packages to point at a
+    temporary backup copy of the running version of portage. Submodule
+    imports are resolved via the __path__ of the parent package rather
+    than via sys.path, so this is what allows a process which has
+    already imported portage to import anything else after the
+    installed copy is replaced or removed (bug 976616).
+    """
+
+    orig_prefix = orig_pym_path.rstrip(os.sep) + os.sep
+
+    def _remap(path):
+        # The __path__ entries are not necessarily resolved, unlike
+        # orig_pym_path.
+        resolved = os.path.realpath(path)
+        if resolved.startswith(orig_prefix):
+            return os.path.join(new_pym_path, resolved[len(orig_prefix) :])
+        return path
+
+    for name, module in list(sys.modules.items()):
+        if name.partition(".")[0] not in PORTAGE_PYM_PACKAGES:
+            continue
+        path = getattr(module, "__path__", None)
+        if path is not None:
+            module.__path__ = [_remap(x) for x in path]
+
+
 def _prepare_self_update(settings):
     """
     Call this when portage is updating itself, in order to create
@@ -3392,6 +3420,11 @@ def _prepare_self_update(settings):
     # Update sys.path used to unpickle child process arguments for
     # multiprocessing forkserver and spawn start methods (bug 965976).
     sys.path.insert(0, portage._pym_path)
+
+    # The sys.path update above does nothing for this process, which
+    # has already imported portage, or for anything forked from it
+    # (bug 976616).
+    _rebind_loaded_modules(orig_pym_path, portage._pym_path)
 
     if multiprocessing.get_start_method() == "forkserver":
 

--- a/lib/portage/tests/ebuild/meson.build
+++ b/lib/portage/tests/ebuild/meson.build
@@ -6,6 +6,7 @@ py.install_sources(
         'test_doebuild_spawn.py',
         'test_fetch.py',
         'test_ipc_daemon.py',
+        'test_prepare_self_update.py',
         'test_spawn.py',
         'test_use_expand_incremental.py',
         '__init__.py',

--- a/lib/portage/tests/ebuild/test_prepare_self_update.py
+++ b/lib/portage/tests/ebuild/test_prepare_self_update.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import portage
+from portage.const import PORTAGE_BIN_PATH, PORTAGE_PYM_PATH
+from portage.tests import TestCase
+
+# Runs in a subprocess with an installed copy of portage which is
+# deleted after _prepare_self_update() has run, in order to emulate a
+# self update which installs to a different location, as happens when
+# PYTHON_TARGETS changes (bug 976616).
+_SCRIPT = """
+import multiprocessing
+import os
+import shutil
+import sys
+
+def child():
+    import portage.dbapi.vartree
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, sys.argv[1])
+
+    import portage
+    from portage.package.ebuild.doebuild import _prepare_self_update
+
+    # The modules imported below must not be imported before the update.
+    assert "portage.util.env_update" not in sys.modules
+    assert "portage.dbapi.vartree" not in sys.modules
+
+    _prepare_self_update({"PORTAGE_TMPDIR": sys.argv[2]})
+
+    shutil.rmtree(os.path.dirname(sys.argv[1]))
+
+    import portage.util.env_update
+
+    ctx = multiprocessing.get_context(sys.argv[3])
+    proc = ctx.Process(target=child)
+    proc.start()
+    proc.join()
+    sys.exit(proc.exitcode)
+"""
+
+
+class PrepareSelfUpdateTestCase(TestCase):
+    def testPrepareSelfUpdate(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            script = os.path.join(tmpdir, "self_update.py")
+            with open(script, "w") as f:
+                f.write(_SCRIPT)
+
+            # PYTHONPATH would provide a second copy of the modules
+            # which are expected to become unimportable.
+            env = os.environ.copy()
+            env.pop("PYTHONPATH", None)
+
+            for start_method in ("fork", "forkserver"):
+                # The installed copy is deleted by the subprocess, so
+                # create a fresh one for each start method.
+                base_path = os.path.join(tmpdir, f"base-{start_method}")
+                pym_path = os.path.join(base_path, os.path.basename(PORTAGE_PYM_PATH))
+                os.mkdir(base_path)
+                shutil.copytree(PORTAGE_PYM_PATH, pym_path, symlinks=True)
+                shutil.copytree(
+                    PORTAGE_BIN_PATH,
+                    os.path.join(base_path, os.path.basename(PORTAGE_BIN_PATH)),
+                    symlinks=True,
+                )
+
+                proc = subprocess.run(
+                    [
+                        portage._python_interpreter,
+                        script,
+                        pym_path,
+                        tmpdir,
+                        start_method,
+                    ],
+                    env=env,
+                    stderr=subprocess.PIPE,
+                )
+                self.assertEqual(
+                    proc.returncode,
+                    os.EX_OK,
+                    msg=proc.stderr.decode(errors="replace"),
+                )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
_prepare_self_update() copies the running version of portage to a
temporary directory and prepends it to sys.path, so that a portage
update cannot pull modules out from under the running process.

sys.path only governs top-level imports. By the time the update runs,
the portage package is already imported, so an import of a submodule
such as portage.util.env_update is resolved via portage.util.__path__,
which still points at the installed copy. That copy disappears when the
new version installs somewhere else, as happens when PYTHON_TARGETS
changes, and the import then fails with:

    ModuleNotFoundError: No module named 'portage.util.env_update'

Only the multiprocessing forkserver and spawn start methods escaped
this, since their children import portage from scratch and pick up the
sys.path entry. The parent process, and anything forked from it, kept
the stale paths.

Rewrite `__path__` of the already imported portage and _emerge packages
to point at the backup copy, so that lazily imported submodules come
from the same snapshot as the rest of the running process.

Bug: https://bugs.gentoo.org/976616