### PR TITLE
observability: cgroup resources in emerge --status, plus follow-ups

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,15 +25,17 @@ Features:
 
 * Add FEATURES="cgroup" to account each source build's CPU time, peak memory,
   and I/O in a per-build cgroup v2. No limits are imposed. Totals are written
-  to the build log and, with FEATURES="observability", included in the live
-  status snapshot. Configurable via PORTAGE_CGROUP_ROOT (default
+  to the build log, along with the average number of CPUs the build kept
+  busy, and, with FEATURES="observability", included in the live status
+  snapshot. Configurable via PORTAGE_CGROUP_ROOT (default
   /sys/fs/cgroup/portage); requires root and cgroup v2.
 
 * Add FEATURES="observability" to publish a machine-readable snapshot of the
   running emerge process (which packages are building/merging, their current
-  ebuild phase, and elapsed time) to /run/portage/emerge-<pid>.json. Query it
-  with the new "portageq jobs" command or "emerge --status". A Unix socket
-  streams the same snapshots live to connected clients.
+  ebuild phase, elapsed time, and cgroup resource usage where available) to
+  /run/portage/emerge-<pid>.json. Query it with the new "portageq jobs"
+  command or "emerge --status". A Unix socket streams the same snapshots
+  live to connected clients.
 
 * vartree: Avoid pruning preserved-libs database or syncing to disk if we
   installed no files.

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -39,7 +39,7 @@ from portage.util.SlotObject import SlotObject
 import _emerge
 from _emerge._find_deep_system_runtime_deps import _find_deep_system_runtime_deps
 from _emerge._flush_elog_mod_echo import _flush_elog_mod_echo
-from _emerge._observability import ObservabilityMonitor
+from _emerge._observability import ObservabilityMonitor, average_parallelism
 from _emerge.BinpkgFetcher import BinpkgFetcher
 from _emerge.BinpkgPrefetcher import BinpkgPrefetcher
 from _emerge.BinpkgVerifier import BinpkgVerifier
@@ -416,16 +416,16 @@ class Scheduler(PollScheduler):
         # the monitor keeps what it is given for the merge to report.
         self._observability.note_build_resources(cpv, stats)
         if stats:
-            elapsed = self._observability.build_elapsed(cpv)
-
             parts = []
             if "cpu_usec" in stats:
                 cpu_s = stats["cpu_usec"] / 1e6
-                if elapsed is not None and elapsed > 0:
-                    parallelism = cpu_s / elapsed
-                    parts.append(f"cpu {cpu_s:.1f}s ({parallelism:.2f}x)")
-                else:
+                parallelism = average_parallelism(
+                    stats["cpu_usec"], self._observability.build_elapsed(cpv)
+                )
+                if parallelism is None:
                     parts.append(f"cpu {cpu_s:.1f}s")
+                else:
+                    parts.append(f"cpu {cpu_s:.1f}s ({parallelism:.2f}x)")
             if "mem_peak" in stats:
                 parts.append(f"peak-mem {bytes_to_human(stats['mem_peak'])}")
             if stats.get("mem_swap_peak"):

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -413,10 +413,7 @@ class Scheduler(PollScheduler):
         cpv = build.pkg.cpv
         stats = self._cgroup.read_stats(cpv)
         if stats:
-            elapsed = None
-            times = self._observability._build_times.get(str(cpv))
-            if times is not None and times[0] is not None and times[1] is not None:
-                elapsed = times[1] - times[0]
+            elapsed = self._observability.build_elapsed(cpv)
 
             parts = []
             if "cpu_usec" in stats:

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -412,6 +412,9 @@ class Scheduler(PollScheduler):
             return
         cpv = build.pkg.cpv
         stats = self._cgroup.read_stats(cpv)
+        # The only read of these counters: the cgroup goes away below, and
+        # the monitor keeps what it is given for the merge to report.
+        self._observability.note_build_resources(cpv, stats)
         if stats:
             elapsed = self._observability.build_elapsed(cpv)
 

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -39,7 +39,7 @@ from portage.util.SlotObject import SlotObject
 import _emerge
 from _emerge._find_deep_system_runtime_deps import _find_deep_system_runtime_deps
 from _emerge._flush_elog_mod_echo import _flush_elog_mod_echo
-from _emerge._observability import ObservabilityMonitor, average_parallelism
+from _emerge._observability import ObservabilityMonitor, format_resources
 from _emerge.BinpkgFetcher import BinpkgFetcher
 from _emerge.BinpkgPrefetcher import BinpkgPrefetcher
 from _emerge.BinpkgVerifier import BinpkgVerifier
@@ -411,39 +411,18 @@ class Scheduler(PollScheduler):
         if self._cgroup is None:
             return
         cpv = build.pkg.cpv
-        stats = self._cgroup.read_stats(cpv)
         # The only read of these counters: the cgroup goes away below, and
-        # the monitor keeps what it is given for the merge to report.
-        self._observability.note_build_resources(cpv, stats)
-        if stats:
-            parts = []
-            if "cpu_usec" in stats:
-                cpu_s = stats["cpu_usec"] / 1e6
-                parallelism = average_parallelism(
-                    stats["cpu_usec"], self._observability.build_elapsed(cpv)
-                )
-                if parallelism is None:
-                    parts.append(f"cpu {cpu_s:.1f}s")
-                else:
-                    parts.append(f"cpu {cpu_s:.1f}s ({parallelism:.2f}x)")
-            if "mem_peak" in stats:
-                parts.append(f"peak-mem {bytes_to_human(stats['mem_peak'])}")
-            if stats.get("mem_swap_peak"):
-                parts.append(f"peak-swap {bytes_to_human(stats['mem_swap_peak'])}")
-            if stats.get("mem_zswap_current"):
-                parts.append(f"zswap {bytes_to_human(stats['mem_zswap_current'])}")
-            if "io_read_bytes" in stats:
-                parts.append(
-                    "io {} / {} r/w".format(
-                        bytes_to_human(stats["io_read_bytes"]),
-                        bytes_to_human(stats.get("io_write_bytes", 0)),
-                    )
-                )
-            if parts:
-                msg = f"=== Resource usage for {cpv}: {', '.join(parts)}"
-                log_path = build.settings.get("PORTAGE_LOG_FILE")
-                self._sched_iface.output(f"{msg}\n", log_path=log_path)
-                self._logger.log(f" {msg}")
+        # what the monitor keeps is what the merge goes on reporting. Log
+        # exactly that, rendered the way "emerge --status" renders it.
+        resources = self._observability.note_build_resources(
+            cpv, self._cgroup.read_stats(cpv)
+        )
+        rendered = format_resources(resources, self._observability.build_elapsed(cpv))
+        if rendered:
+            msg = f"=== Resource usage for {cpv} [{rendered}]"
+            log_path = build.settings.get("PORTAGE_LOG_FILE")
+            self._sched_iface.output(f"{msg}\n", log_path=log_path)
+            self._logger.log(f" {msg}")
         self._cgroup.destroy(cpv)
 
     def _init_graph(self, graph_config):

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -413,9 +413,19 @@ class Scheduler(PollScheduler):
         cpv = build.pkg.cpv
         stats = self._cgroup.read_stats(cpv)
         if stats:
+            elapsed = None
+            times = self._observability._build_times.get(str(cpv))
+            if times is not None and times[0] is not None and times[1] is not None:
+                elapsed = times[1] - times[0]
+
             parts = []
             if "cpu_usec" in stats:
-                parts.append(f"cpu {stats['cpu_usec'] / 1e6:.1f}s")
+                cpu_s = stats["cpu_usec"] / 1e6
+                if elapsed is not None and elapsed > 0:
+                    parallelism = cpu_s / elapsed
+                    parts.append(f"cpu {cpu_s:.1f}s ({parallelism:.2f}x)")
+                else:
+                    parts.append(f"cpu {cpu_s:.1f}s")
             if "mem_peak" in stats:
                 parts.append(f"peak-mem {bytes_to_human(stats['mem_peak'])}")
             if stats.get("mem_swap_peak"):

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -1622,6 +1622,7 @@ class Scheduler(PollScheduler):
         if build.returncode == os.EX_OK and self._terminated_tasks:
             # We've been interrupted, so we won't
             # add this to the merge queue.
+            self._observability.forget_build(build)
             self.curval += 1
             self._deallocate_config(build.settings)
         elif build.returncode == os.EX_OK:
@@ -1648,6 +1649,7 @@ class Scheduler(PollScheduler):
                 merge.addExitListener(self._merge_exit)
                 self._status_display.merges = len(self._task_queues.merge)
         else:
+            self._observability.forget_build(build)
             settings = build.settings
             build_dir = settings.get("PORTAGE_BUILDDIR")
             build_log = settings.get("PORTAGE_LOG_FILE")

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -33,6 +33,7 @@ from portage import os
 from portage.const import PORTAGE_RUN_PATH
 from portage.util import atomic_ofstream, ensure_dirs, writemsg_level
 from portage.util.futures import asyncio
+from portage.util.human_readable import bytes_to_human
 
 from _emerge.PackageMerge import PackageMerge as _PackageMerge
 
@@ -181,6 +182,27 @@ def _pid_alive(pid):
     return True
 
 
+def _format_cpu(val, task):
+    cpu_s = val / 1e6
+    elapsed = task.get("elapsed")
+    if elapsed is not None and elapsed > 0:
+        parallelism = cpu_s / elapsed
+        return f"{cpu_s:.2f}s ({parallelism:.2f}x)"
+    return f"{cpu_s:.2f}s"
+
+
+_RESOURCE_FIELDS = (
+    ("cpu_usec", "CPU", _format_cpu),
+    ("mem_current", "Mem", lambda v, t: bytes_to_human(v)),
+    ("mem_peak", "MaxMem", lambda v, t: bytes_to_human(v)),
+    ("mem_swap_current", "Swap", lambda v, t: bytes_to_human(v)),
+    ("mem_swap_peak", "MaxSwap", lambda v, t: bytes_to_human(v)),
+    ("mem_zswap_current", "ZSwap", lambda v, t: bytes_to_human(v)),
+    ("io_read_bytes", "I/O R", lambda v, t: bytes_to_human(v)),
+    ("io_write_bytes", "I/O W", lambda v, t: bytes_to_human(v)),
+)
+
+
 def format_snapshots(snapshots):
     """Render snapshots as a human-readable table."""
     if not snapshots:
@@ -203,7 +225,20 @@ def format_snapshots(snapshots):
             elapsed = task.get("elapsed")
             elapsed_str = f"{max(0, int(elapsed))}s" if elapsed is not None else "-"
             phase = task.get("phase") or task.get("kind") or "-"
-            lines.append(f"  {task.get('cpv', '?'):<45} {phase:<10} {elapsed_str:>7}")
+            line = f"  {task.get('cpv', '?'):<45} {phase:<10} {elapsed_str:>7}"
+
+            resources = task.get("resources")
+            if resources:
+                res_strs = []
+                for field, label, formatter in _RESOURCE_FIELDS:
+                    val = resources.get(field)
+                    if val is not None:
+                        res_strs.append(f"{label}: {formatter(val, task)}")
+
+                if res_strs:
+                    line += f"  [{', '.join(res_strs)}]"
+
+            lines.append(line)
     return "\n".join(lines) + "\n"
 
 

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -66,6 +66,34 @@ def _task_pid(task):
     return None
 
 
+class _BuildTimes:
+    """Timing and final resource usage for one package's build.
+
+    Created when the build task starts and kept until the package's merge
+    finishes, so that consumers see one continuous record across the
+    build -> merge hand-off.
+    """
+
+    __slots__ = ("start", "finished", "resources")
+
+    def __init__(self, start):
+        self.start = start
+        self.finished = None
+        # Final cgroup counters, captured when the build finishes and
+        # before the cgroup is destroyed.
+        self.resources = None
+
+    def elapsed(self, now):
+        """Wall-clock duration of the build itself.
+
+        Frozen once the build finishes, so that time spent waiting to merge
+        does not inflate it.
+        """
+        if self.finished is not None:
+            return self.finished - self.start
+        return now - self.start
+
+
 def build_snapshot(monitor):
     """Serialize the scheduler's current state into a plain dict."""
     scheduler = monitor._scheduler
@@ -88,12 +116,12 @@ def build_snapshot(monitor):
         # Prefer the build's own start/finish times (continuous across the
         # build -> merge hand-off) over the per-task start time.
         times = monitor._build_times.get(cpv)
-        frozen_res = None
         if times is not None:
-            start, build_finished = times[0], times[1]
-            frozen_res = times[2] if len(times) > 2 else None
+            start, build_finished = times.start, times.finished
+            frozen_res = times.resources
         else:
             start, build_finished = monitor._task_start.get(id(task)), None
+            frozen_res = None
 
         # A package waiting to merge is done building: freeze its elapsed time at
         # build completion rather than letting the wait inflate it.
@@ -324,7 +352,7 @@ class ObservabilityMonitor:
         # id(task) -> epoch start time; str(cpv) -> current phase name.
         self._task_start = {}
         self._phases = {}
-        # str(cpv) -> [build_start, build_finished or None]
+        # str(cpv) -> _BuildTimes
         self._build_times = {}
 
         self._status_path = None
@@ -353,7 +381,7 @@ class ObservabilityMonitor:
         if not isinstance(task, _PackageMerge):
             pkg = _task_pkg(task)
             if pkg is not None:
-                self._build_times[str(pkg.cpv)] = [now, None, None]
+                self._build_times[str(pkg.cpv)] = _BuildTimes(now)
 
     def note_task_finished(self, task):
         if not self.enabled:
@@ -369,12 +397,21 @@ class ObservabilityMonitor:
         else:
             times = self._build_times.get(cpv)
             if times is not None:
-                times[1] = time.time()
+                times.finished = time.time()
                 cgroup = getattr(self._scheduler, "_cgroup", None)
                 if cgroup is not None:
-                    res = cgroup.read_stats(cpv)
-                    if res:
-                        times[2] = res
+                    times.resources = cgroup.read_stats(cpv) or None
+
+    def build_elapsed(self, cpv):
+        """Wall-clock duration of the build of cpv, or None if unknown.
+
+        Frozen once the build finishes, so callers reporting on a package
+        that has moved on to merging still see the build's own duration.
+        """
+        times = self._build_times.get(str(cpv))
+        if times is None:
+            return None
+        return times.elapsed(time.time())
 
     def note_phase(self, cpv, phase):
         if not self.enabled:

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -577,7 +577,9 @@ class ObservabilityMonitor:
             )
 
     async def _client_connected(self, reader, writer):
-        self.update()
+        # Unconditional: under the rate limit a task event that published
+        # moments ago would leave the client with the older state.
+        self.update(force=True)
         if self._last_snapshot is not None:
             data = (json.dumps(self._last_snapshot, sort_keys=True) + "\n").encode(
                 "utf_8"

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -23,8 +23,10 @@ writable (e.g. unprivileged, no /run) emerge proceeds unaffected.
 """
 
 import asyncio as _asyncio
+import glob
 import json
 import os as _os
+import socket
 import time
 
 import portage
@@ -206,48 +208,84 @@ def status_dir(eprefix=""):
     return PORTAGE_RUN_PATH
 
 
+# How long to wait for one emerge to answer on its socket. The waits are
+# serial, so this is the per-emerge cost of falling back to the status file
+# when an emerge's main loop is too busy to serve the connection.
+_SOCKET_TIMEOUT = 0.5
+
+
+def _status_path_pid(path):
+    """The pid encoded in an emerge-<pid>.{json,sock} path, or None."""
+    stem, _, _suffix = os.path.basename(path).rpartition(".")
+    name, _, pid = stem.partition("-")
+    if name != "emerge" or not pid.isdigit():
+        return None
+    return int(pid)
+
+
+def _snapshot_is_live(snapshot, path):
+    """True if snapshot came from a live emerge that still owns path.
+
+    A status file or socket left behind by an emerge that died without
+    cleaning up is claimed by an unrelated process as soon as its pid is
+    recycled, so the pid has to agree with the name it was published under.
+    """
+    if not isinstance(snapshot, dict):
+        return False
+    pid = snapshot.get("emerge_pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    if pid != _status_path_pid(path):
+        return False
+    return _pid_alive(pid)
+
+
+def _read_socket_snapshot(path, timeout):
+    """Read one snapshot from an emerge status socket, or None."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(path)
+            with sock.makefile("r", encoding="utf_8") as f:
+                line = f.readline()
+        # socket.timeout is an OSError and JSONDecodeError is a ValueError,
+        # so this covers a refused connection, an emerge that never answers
+        # and a truncated line alike.
+        return json.loads(line) if line else None
+    except (OSError, ValueError):
+        return None
+
+
 def read_snapshots(eprefix=""):
-    """Read all live emerge status files; return a list of snapshot dicts."""
-    import glob
-    import socket
+    """Read all live emerge status snapshots; return a list of snapshot dicts.
 
-    snapshots = []
+    Each emerge's socket is tried first: connecting makes it publish a
+    snapshot built at that moment, whereas its status file is only as fresh
+    as the last publish. The status file is the fallback for an emerge
+    whose socket does not answer within _SOCKET_TIMEOUT, which happens when
+    its main loop is busy.
+    """
+    by_pid = {}
 
-    # Try reading from sockets first to trigger a fresh snapshot
-    for path in sorted(glob.glob(os.path.join(status_dir(eprefix), "emerge-*.sock"))):
-        try:
-            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
-                s.settimeout(0.5)
-                s.connect(path)
-                with s.makefile("r", encoding="utf_8") as f:
-                    line = f.readline()
-                    if line:
-                        snapshot = json.loads(line)
-                        pid = snapshot.get("emerge_pid")
-                        if isinstance(pid, int) and pid > 0 and _pid_alive(pid):
-                            snapshots.append(snapshot)
-        except (OSError, ValueError, socket.timeout, json.JSONDecodeError):
-            pass
+    for path in glob.glob(os.path.join(status_dir(eprefix), "emerge-*.sock")):
+        snapshot = _read_socket_snapshot(path, _SOCKET_TIMEOUT)
+        if snapshot is not None and _snapshot_is_live(snapshot, path):
+            by_pid[snapshot["emerge_pid"]] = snapshot
 
-    # Fall back to json files, e.g., in case we run into the socket timeout above.
-    for path in sorted(glob.glob(os.path.join(status_dir(eprefix), "emerge-*.json"))):
+    for path in glob.glob(os.path.join(status_dir(eprefix), "emerge-*.json")):
+        if _status_path_pid(path) in by_pid:
+            continue
         try:
             with open(path, encoding="utf_8") as f:
                 snapshot = json.load(f)
         except (OSError, ValueError):
             continue
-        pid = snapshot.get("emerge_pid")
-        if not isinstance(pid, int) or pid <= 0 or not _pid_alive(pid):
-            continue
-        # If we successfully read a live snapshot for this PID via the socket,
-        # skip the JSON fallback to avoid duplicating the same process in the output.
-        # Note: the socket connect above triggers an update() server-side which rewrites
-        # the JSON status file. So by the time this loop runs, the JSON is fresh too
-        # and either would do, but the socket snapshot is the one we know is current.
-        if not any(s.get("emerge_pid") == pid for s in snapshots):
-            snapshots.append(snapshot)
+        if _snapshot_is_live(snapshot, path):
+            by_pid[snapshot["emerge_pid"]] = snapshot
 
-    return snapshots
+    # Order by pid rather than by path, so that the result does not depend
+    # on which transport answered for which emerge.
+    return [by_pid[pid] for pid in sorted(by_pid)]
 
 
 def _pid_alive(pid):

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -123,6 +123,12 @@ def build_snapshot(monitor):
             start, build_finished = monitor._task_start.get(id(task)), None
             frozen_res = None
 
+        # Duration of the build itself, which stops advancing once the build
+        # is done. "elapsed" below keeps running through the merge, so it is
+        # the wrong denominator for anything derived from the build's own
+        # cgroup counters.
+        build_elapsed = times.elapsed(now) if times is not None else None
+
         # A package waiting to merge is done building: freeze its elapsed time at
         # build completion rather than letting the wait inflate it.
         if waiting and build_finished is not None and start is not None:
@@ -145,6 +151,7 @@ def build_snapshot(monitor):
             "pid": _task_pid(task),
             "start_time": start,
             "elapsed": elapsed,
+            "build_elapsed": build_elapsed,
         }
         if frozen_res is not None:
             entry["resources"] = frozen_res
@@ -253,7 +260,7 @@ def average_parallelism(cpu_usec, elapsed):
 
 def _format_cpu(val, task):
     cpu_s = val / 1e6
-    parallelism = average_parallelism(val, task.get("elapsed"))
+    parallelism = average_parallelism(val, task.get("build_elapsed"))
     if parallelism is None:
         return f"{cpu_s:.2f}s"
     return f"{cpu_s:.2f}s ({parallelism:.2f}x)"

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -329,8 +329,10 @@ def missing_feature_hint(snapshots, features=None):
 class ObservabilityMonitor:
     """Owns the status file and streaming socket for one Scheduler.
 
-    All public methods are no-ops when the feature is disabled, so the
-    Scheduler can call them unconditionally.
+    The Scheduler calls the public methods unconditionally. Everything
+    that publishes is a no-op when the feature is disabled; build timing is
+    still recorded, since FEATURES="cgroup" reports build parallelism from
+    it and is independent of this feature.
     """
 
     # Don't rewrite the status file more often than this (seconds), to
@@ -374,18 +376,17 @@ class ObservabilityMonitor:
         self._socket_path = os.path.join(run_dir, f"emerge-{pid}.sock")
 
     def note_task_started(self, task):
-        if not self.enabled:
-            return
         now = time.time()
-        self._task_start[id(task)] = now
+        if self.enabled:
+            self._task_start[id(task)] = now
+        # Build timing is recorded either way: FEATURES="cgroup" reports a
+        # build's average parallelism from it.
         if not isinstance(task, _PackageMerge):
             pkg = _task_pkg(task)
             if pkg is not None:
                 self._build_times[str(pkg.cpv)] = _BuildTimes(now)
 
     def note_task_finished(self, task):
-        if not self.enabled:
-            return
         self._task_start.pop(id(task), None)
         pkg = _task_pkg(task)
         if pkg is None:

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -157,8 +157,27 @@ def status_dir(eprefix=""):
 def read_snapshots(eprefix=""):
     """Read all live emerge status files; return a list of snapshot dicts."""
     import glob
+    import socket
 
     snapshots = []
+
+    # Try reading from sockets first to trigger a fresh snapshot
+    for path in sorted(glob.glob(os.path.join(status_dir(eprefix), "emerge-*.sock"))):
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                s.connect(path)
+                with s.makefile("r", encoding="utf_8") as f:
+                    line = f.readline()
+                    if line:
+                        snapshot = json.loads(line)
+                        pid = snapshot.get("emerge_pid")
+                        if isinstance(pid, int) and pid > 0 and _pid_alive(pid):
+                            snapshots.append(snapshot)
+        except (OSError, ValueError, socket.timeout, json.JSONDecodeError):
+            pass
+
+    # Fall back to json files, e.g., in case we run into the socket timeout above.
     for path in sorted(glob.glob(os.path.join(status_dir(eprefix), "emerge-*.json"))):
         try:
             with open(path, encoding="utf_8") as f:
@@ -168,7 +187,14 @@ def read_snapshots(eprefix=""):
         pid = snapshot.get("emerge_pid")
         if not isinstance(pid, int) or pid <= 0 or not _pid_alive(pid):
             continue
-        snapshots.append(snapshot)
+        # If we successfully read a live snapshot for this PID via the socket,
+        # skip the JSON fallback to avoid duplicating the same process in the output.
+        # Note: the socket connect above triggers an update() server-side which rewrites
+        # the JSON status file. So by the time this loop runs, the JSON is fresh too
+        # and either would do, but the socket snapshot is the one we know is current.
+        if not any(s.get("emerge_pid") == pid for s in snapshots):
+            snapshots.append(snapshot)
+
     return snapshots
 
 

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -182,6 +182,23 @@ def build_snapshot(monitor):
     }
 
 
+# Counters that describe the cgroup as it is right now. They stop meaning
+# anything once the build is over and its cgroup has been destroyed, so they
+# are dropped rather than frozen; the peaks and the monotonic totals stay.
+_TRANSIENT_RESOURCE_FIELDS = frozenset(
+    ("mem_current", "mem_swap_current", "mem_zswap_current")
+)
+
+
+def freeze_resources(stats):
+    """Keep the counters from stats that outlive the cgroup, or None."""
+    if not stats:
+        return None
+    return {
+        k: v for k, v in stats.items() if k not in _TRANSIENT_RESOURCE_FIELDS
+    } or None
+
+
 def status_dir(eprefix=""):
     """Directory where running emerge processes publish status files."""
     if eprefix:
@@ -425,7 +442,7 @@ class ObservabilityMonitor:
         """
         times = self._build_times.get(str(cpv))
         if times is not None:
-            times.resources = stats or None
+            times.resources = freeze_resources(stats)
 
     def build_elapsed(self, cpv):
         """Wall-clock duration of the build of cpv, or None if unknown.

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -458,6 +458,7 @@ class ObservabilityMonitor:
             )
 
     async def _client_connected(self, reader, writer):
+        self.update()
         if self._last_snapshot is not None:
             data = (json.dumps(self._last_snapshot, sort_keys=True) + "\n").encode(
                 "utf_8"

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -313,24 +313,46 @@ def average_parallelism(cpu_usec, elapsed):
     return (cpu_usec / 1e6) / elapsed
 
 
-def _format_cpu(val, task):
-    cpu_s = val / 1e6
-    parallelism = average_parallelism(val, task.get("build_elapsed"))
+def _format_cpu(cpu_usec, build_elapsed):
+    cpu_s = cpu_usec / 1e6
+    parallelism = average_parallelism(cpu_usec, build_elapsed)
     if parallelism is None:
         return f"{cpu_s:.2f}s"
     return f"{cpu_s:.2f}s ({parallelism:.2f}x)"
 
 
+def _format_bytes(value, _build_elapsed):
+    # Same signature as _format_cpu(), which is the one that needs the
+    # duration, so that _RESOURCE_FIELDS can call either the same way.
+    return bytes_to_human(value)
+
+
 _RESOURCE_FIELDS = (
     ("cpu_usec", "CPU", _format_cpu),
-    ("mem_current", "Mem", lambda v, t: bytes_to_human(v)),
-    ("mem_peak", "MaxMem", lambda v, t: bytes_to_human(v)),
-    ("mem_swap_current", "Swap", lambda v, t: bytes_to_human(v)),
-    ("mem_swap_peak", "MaxSwap", lambda v, t: bytes_to_human(v)),
-    ("mem_zswap_current", "ZSwap", lambda v, t: bytes_to_human(v)),
-    ("io_read_bytes", "I/O R", lambda v, t: bytes_to_human(v)),
-    ("io_write_bytes", "I/O W", lambda v, t: bytes_to_human(v)),
+    ("mem_current", "Mem", _format_bytes),
+    ("mem_peak", "MaxMem", _format_bytes),
+    ("mem_swap_current", "Swap", _format_bytes),
+    ("mem_swap_peak", "MaxSwap", _format_bytes),
+    ("mem_zswap_current", "ZSwap", _format_bytes),
+    ("io_read_bytes", "I/O R", _format_bytes),
+    ("io_write_bytes", "I/O W", _format_bytes),
 )
+
+
+def format_resources(resources, build_elapsed=None):
+    """Render cgroup counters as "Label: value" pairs, or "" if there are none.
+
+    A counter the kernel did report is rendered even when it is zero: no
+    I/O at all is a fact about the build, not a missing measurement.
+    """
+    if not resources:
+        return ""
+    parts = []
+    for key, label, formatter in _RESOURCE_FIELDS:
+        value = resources.get(key)
+        if value is not None:
+            parts.append(f"{label}: {formatter(value, build_elapsed)}")
+    return ", ".join(parts)
 
 
 def format_snapshots(snapshots):
@@ -357,16 +379,11 @@ def format_snapshots(snapshots):
             phase = task.get("phase") or task.get("kind") or "-"
             line = f"  {task.get('cpv', '?'):<45} {phase:<10} {elapsed_str:>7}"
 
-            resources = task.get("resources")
-            if resources:
-                res_strs = []
-                for field, label, formatter in _RESOURCE_FIELDS:
-                    val = resources.get(field)
-                    if val is not None:
-                        res_strs.append(f"{label}: {formatter(val, task)}")
-
-                if res_strs:
-                    line += f"  [{', '.join(res_strs)}]"
+            rendered = format_resources(
+                task.get("resources"), task.get("build_elapsed")
+            )
+            if rendered:
+                line += f"  [{rendered}]"
 
             lines.append(line)
     return "\n".join(lines) + "\n"
@@ -473,14 +490,18 @@ class ObservabilityMonitor:
                 times.finished = time.time()
 
     def note_build_resources(self, cpv, stats):
-        """Keep the final cgroup counters for the build of cpv.
+        """Keep the final cgroup counters for the build of cpv, and return them.
 
         Called just before the cgroup is destroyed, so that a package that
-        has moved on to merging goes on reporting what its build used.
+        has moved on to merging goes on reporting what its build used. The
+        counters that only describe a live cgroup are dropped, so the caller
+        gets back what it is worth reporting from here on.
         """
+        resources = freeze_resources(stats)
         times = self._build_times.get(str(cpv))
         if times is not None:
-            times.resources = freeze_resources(stats)
+            times.resources = resources
+        return resources
 
     def build_elapsed(self, cpv):
         """Wall-clock duration of the build of cpv, or None if unknown.

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -88,8 +88,10 @@ def build_snapshot(monitor):
         # Prefer the build's own start/finish times (continuous across the
         # build -> merge hand-off) over the per-task start time.
         times = monitor._build_times.get(cpv)
+        frozen_res = None
         if times is not None:
             start, build_finished = times[0], times[1]
+            frozen_res = times[2] if len(times) > 2 else None
         else:
             start, build_finished = monitor._task_start.get(id(task)), None
 
@@ -116,7 +118,9 @@ def build_snapshot(monitor):
             "start_time": start,
             "elapsed": elapsed,
         }
-        if cgroup is not None:
+        if frozen_res is not None:
+            entry["resources"] = frozen_res
+        elif cgroup is not None:
             res = cgroup.read_stats(str(pkg.cpv))
             if res:
                 entry["resources"] = res
@@ -323,7 +327,7 @@ class ObservabilityMonitor:
         if not isinstance(task, _PackageMerge):
             pkg = _task_pkg(task)
             if pkg is not None:
-                self._build_times[str(pkg.cpv)] = [now, None]
+                self._build_times[str(pkg.cpv)] = [now, None, None]
 
     def note_task_finished(self, task):
         if not self.enabled:
@@ -340,6 +344,11 @@ class ObservabilityMonitor:
             times = self._build_times.get(cpv)
             if times is not None:
                 times[1] = time.time()
+                cgroup = getattr(self._scheduler, "_cgroup", None)
+                if cgroup is not None:
+                    res = cgroup.read_stats(cpv)
+                    if res:
+                        times[2] = res
 
     def note_phase(self, cpv, phase):
         if not self.enabled:

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -240,13 +240,23 @@ def _pid_alive(pid):
     return True
 
 
+def average_parallelism(cpu_usec, elapsed):
+    """Mean number of CPUs kept busy over elapsed seconds, or None.
+
+    None when elapsed is unknown or non-positive, i.e. whenever the
+    quotient would not mean anything.
+    """
+    if not elapsed or elapsed <= 0:
+        return None
+    return (cpu_usec / 1e6) / elapsed
+
+
 def _format_cpu(val, task):
     cpu_s = val / 1e6
-    elapsed = task.get("elapsed")
-    if elapsed is not None and elapsed > 0:
-        parallelism = cpu_s / elapsed
-        return f"{cpu_s:.2f}s ({parallelism:.2f}x)"
-    return f"{cpu_s:.2f}s"
+    parallelism = average_parallelism(val, task.get("elapsed"))
+    if parallelism is None:
+        return f"{cpu_s:.2f}s"
+    return f"{cpu_s:.2f}s ({parallelism:.2f}x)"
 
 
 _RESOURCE_FIELDS = (

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -421,6 +421,20 @@ class ObservabilityMonitor:
             return None
         return times.elapsed(time.time())
 
+    def forget_build(self, task):
+        """Drop what is kept for a build that will not be merged.
+
+        note_task_finished() leaves the record in place so that the merge
+        can go on reporting the build's duration and resource usage. A
+        build that produces no merge task has to say so, or nothing ever
+        drops it.
+        """
+        pkg = _task_pkg(task)
+        if pkg is not None:
+            cpv = str(pkg.cpv)
+            self._build_times.pop(cpv, None)
+            self._phases.pop(cpv, None)
+
     def note_phase(self, cpv, phase):
         if not self.enabled:
             return

--- a/lib/_emerge/_observability.py
+++ b/lib/_emerge/_observability.py
@@ -398,9 +398,16 @@ class ObservabilityMonitor:
             times = self._build_times.get(cpv)
             if times is not None:
                 times.finished = time.time()
-                cgroup = getattr(self._scheduler, "_cgroup", None)
-                if cgroup is not None:
-                    times.resources = cgroup.read_stats(cpv) or None
+
+    def note_build_resources(self, cpv, stats):
+        """Keep the final cgroup counters for the build of cpv.
+
+        Called just before the cgroup is destroyed, so that a package that
+        has moved on to merging goes on reporting what its build used.
+        """
+        times = self._build_times.get(str(cpv))
+        if times is not None:
+            times.resources = stats or None
 
     def build_elapsed(self, cpv):
         """Wall-clock duration of the build of cpv, or None if unknown.

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -514,6 +514,53 @@ class ObservabilitySnapshotTestCase(TestCase):
         self.assertEqual(monitor._phases, {})
         self.assertIsNone(monitor.build_elapsed("dev-libs/foo-1.2"))
 
+    def test_connect_publishes_a_current_snapshot(self):
+        # Rate limiting bounds IO from bursty task events; it must not hand
+        # a connecting client the state as it was up to a second ago.
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build])
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+
+            async def exercise():
+                monitor.update(force=True)
+                for _ in range(100):
+                    if monitor._server is not None:
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertIsNotNone(monitor._server)
+
+                # A second task appears, with no event to publish it, and
+                # the rate limit would suppress an unforced update.
+                later = EbuildBuild(_Pkg("sys-apps/bar-3"), pid=100)
+                sched._running_tasks[id(later)] = later
+                monitor.note_task_started(later)
+                monitor._last_write = time.time()
+
+                reader, writer = await asyncio.open_unix_connection(
+                    monitor._socket_path
+                )
+                try:
+                    snap = json.loads(await reader.readline())
+                finally:
+                    writer.close()
+                    await writer.wait_closed()
+
+                self.assertEqual(
+                    sorted(t["cpv"] for t in snap["tasks"]),
+                    ["dev-libs/foo-1.2", "sys-apps/bar-3"],
+                )
+                # The status file is rewritten too, which is what makes it
+                # safe for read_snapshots() to fall back to it.
+                with open(monitor._status_path, encoding="utf_8") as f:
+                    self.assertEqual(len(json.load(f)["tasks"]), 2)
+
+            try:
+                global_event_loop().run_until_complete(exercise())
+            finally:
+                monitor.close()
+
     def test_hint_when_nothing_read_and_feature_absent(self):
         self.assertIn("observability", missing_feature_hint([], features=set()))
 

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -201,6 +201,39 @@ class ObservabilitySnapshotTestCase(TestCase):
         entry = build_snapshot(monitor)["tasks"][0]
         self.assertEqual(entry["resources"]["cpu_usec"], 4_000_000)
 
+    def test_transient_counters_are_not_frozen(self):
+        # memory.current and friends describe a cgroup that no longer
+        # exists once the build is done; the peaks and totals do not.
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        monitor = ObservabilityMonitor(_make_scheduler(tasks=[build]))
+        monitor.note_task_started(build)
+        monitor.note_task_finished(build)
+        monitor.note_build_resources(
+            "dev-libs/foo-1.2",
+            {
+                "cpu_usec": 1_000_000,
+                "mem_current": 111,
+                "mem_peak": 222,
+                "mem_swap_current": 333,
+                "mem_swap_peak": 444,
+                "mem_zswap_current": 555,
+                "io_read_bytes": 0,
+                "io_write_bytes": 666,
+            },
+        )
+
+        frozen = monitor._build_times["dev-libs/foo-1.2"].resources
+        self.assertEqual(
+            sorted(frozen),
+            [
+                "cpu_usec",
+                "io_read_bytes",
+                "io_write_bytes",
+                "mem_peak",
+                "mem_swap_peak",
+            ],
+        )
+
     def test_disabled_when_feature_absent(self):
         sched = _make_scheduler(features=(), tasks=[])
         monitor = ObservabilityMonitor(sched)

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from _emerge._observability import (
     ObservabilityMonitor,
     _BuildTimes,
+    average_parallelism,
     build_snapshot,
     format_snapshots,
     missing_feature_hint,
@@ -385,6 +386,11 @@ class ObservabilitySnapshotTestCase(TestCase):
             monitor.update(force=True)
             self.assertFalse(os.path.exists(path))
             self.assertEqual(loop.calls, [])
+
+    def test_average_parallelism_without_a_usable_duration(self):
+        for elapsed in (None, 0, -1):
+            with self.subTest(elapsed=elapsed):
+                self.assertIsNone(average_parallelism(1_000_000, elapsed))
 
     def test_build_timing_is_recorded_while_disabled(self):
         # FEATURES="cgroup" reports build parallelism from this timing and

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -188,6 +188,8 @@ class ObservabilitySnapshotTestCase(TestCase):
         monitor = ObservabilityMonitor(sched)
         monitor.note_task_started(build)
         monitor.note_task_finished(build)
+        cpv = "dev-libs/foo-1.2"
+        monitor.note_build_resources(cpv, sched._cgroup.read_stats(cpv))
 
         # A later read of the cgroup must not leak into the snapshot.
         live["cpu_usec"] = 9_000_000
@@ -428,6 +430,30 @@ class SchedulerCgroupLogTestCase(TestCase):
         sched._logger = SimpleNamespace(log=lambda msg: None)
         sched._cgroup_finish(build)
         return "".join(messages)
+
+    def test_final_counters_reach_the_monitor(self):
+        # _cgroup_finish() is the last reader before the cgroup is
+        # destroyed, so what it read is what the merge has to report.
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        build.settings = _Settings()
+        monitor = ObservabilityMonitor(_make_scheduler())
+        monitor.note_task_started(build)
+        monitor.note_task_finished(build)
+
+        sched = Scheduler.__new__(Scheduler)
+        sched._observability = monitor
+        sched._cgroup = SimpleNamespace(
+            read_stats=lambda cpv: {"cpu_usec": 5_000_000},
+            destroy=lambda cpv: None,
+        )
+        sched._sched_iface = SimpleNamespace(output=lambda msg, log_path=None: None)
+        sched._logger = SimpleNamespace(log=lambda msg: None)
+        sched._cgroup_finish(build)
+
+        self.assertEqual(
+            monitor._build_times["dev-libs/foo-1.2"].resources,
+            {"cpu_usec": 5_000_000},
+        )
 
     def test_build_duration_comes_from_the_monitor(self):
         # The log line divides CPU time by the build's wall clock, which

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -405,6 +405,23 @@ class ObservabilitySnapshotTestCase(TestCase):
         # Nothing that only the published snapshot needs is kept.
         self.assertEqual(monitor._task_start, {})
 
+    def test_forget_build_drops_the_record(self):
+        # A build that produces no merge task -- it failed, or emerge was
+        # interrupted -- would otherwise keep its record for the rest of
+        # the run, since only the merge drops it.
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        monitor = ObservabilityMonitor(_make_scheduler(tasks=[build]))
+        monitor.note_task_started(build)
+        monitor.note_phase("dev-libs/foo-1.2", "compile")
+        monitor.note_task_finished(build)
+        # Still there: a merge would go on reporting the build's duration.
+        self.assertIn("dev-libs/foo-1.2", monitor._build_times)
+
+        monitor.forget_build(build)
+        self.assertEqual(monitor._build_times, {})
+        self.assertEqual(monitor._phases, {})
+        self.assertIsNone(monitor.build_elapsed("dev-libs/foo-1.2"))
+
     def test_hint_when_nothing_read_and_feature_absent(self):
         self.assertIn("observability", missing_feature_hint([], features=set()))
 

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -387,6 +387,59 @@ class ObservabilitySnapshotTestCase(TestCase):
             self.assertFalse(os.path.exists(path))
             self.assertEqual(loop.calls, [])
 
+    def test_parallelism_is_frozen_through_merge_wait_and_merge(self):
+        # cpu_usec stops advancing when the build ends, so the parallelism
+        # derived from it must be divided by the build's own duration and
+        # not by a wall clock that keeps running through the merge.
+        for merge_wait in (True, False):
+            with self.subTest(merge_wait=merge_wait):
+                merge = PackageMerge(EbuildBuild(_Pkg("dev-libs/foo-1.2")))
+                sched = _make_scheduler(tasks=[merge])
+                if merge_wait:
+                    sched._merge_wait_queue = [merge]
+                monitor = ObservabilityMonitor(sched)
+                monitor.note_task_started(merge)
+                # 40s of building earning 800s of CPU, finished 60s ago.
+                now = time.time()
+                _set_build_times(
+                    monitor,
+                    "dev-libs/foo-1.2",
+                    now - 100,
+                    now - 60,
+                    {"cpu_usec": 800_000_000},
+                )
+
+                entry = build_snapshot(monitor)["tasks"][0]
+                self.assertAlmostEqual(entry["build_elapsed"], 40, delta=1)
+                self.assertIn("(20.0", format_snapshots([build_snapshot(monitor)]))
+
+    def test_format_snapshots_renders_resources(self):
+        snap = {
+            "emerge_pid": 4242,
+            "jobs": {"running": 1, "completed": 0, "total": 1, "failed": 0},
+            "tasks": [
+                {
+                    "cpv": "dev-libs/foo-1.2",
+                    "phase": "compile",
+                    "elapsed": 30.0,
+                    "build_elapsed": 30.0,
+                    "resources": {
+                        "cpu_usec": 60_000_000,
+                        "mem_current": 1024,
+                        "mem_peak": 2048,
+                        "io_read_bytes": 0,
+                        "io_write_bytes": 4096,
+                    },
+                }
+            ],
+        }
+        line = format_snapshots([snap]).splitlines()[1]
+        self.assertIn(
+            "[CPU: 60.00s (2.00x), Mem: 1.00 KiB, MaxMem: 2.00 KiB, "
+            "I/O R: 0.00 B, I/O W: 4.00 KiB]",
+            line,
+        )
+
     def test_average_parallelism_without_a_usable_duration(self):
         for elapsed in (None, 0, -1):
             with self.subTest(elapsed=elapsed):

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -386,6 +386,25 @@ class ObservabilitySnapshotTestCase(TestCase):
             self.assertFalse(os.path.exists(path))
             self.assertEqual(loop.calls, [])
 
+    def test_build_timing_is_recorded_while_disabled(self):
+        # FEATURES="cgroup" reports build parallelism from this timing and
+        # does not imply FEATURES="observability".
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        sched = _make_scheduler(features=(), tasks=[build])
+        monitor = ObservabilityMonitor(sched)
+        self.assertFalse(monitor.enabled)
+
+        monitor.note_task_started(build)
+        monitor._build_times["dev-libs/foo-1.2"].start = time.time() - 40
+        self.assertAlmostEqual(monitor.build_elapsed("dev-libs/foo-1.2"), 40, delta=1)
+
+        monitor.note_task_finished(build)
+        frozen = monitor.build_elapsed("dev-libs/foo-1.2")
+        self.assertAlmostEqual(frozen, 40, delta=1)
+        self.assertIsNone(monitor.build_elapsed("no-such/pkg-1"))
+        # Nothing that only the published snapshot needs is kept.
+        self.assertEqual(monitor._task_start, {})
+
     def test_hint_when_nothing_read_and_feature_absent(self):
         self.assertIn("observability", missing_feature_hint([], features=set()))
 
@@ -460,3 +479,28 @@ class SchedulerCgroupLogTestCase(TestCase):
         # only the monitor knows.
         msg = self._cgroup_finish(("observability",), {"cpu_usec": 800_000_000})
         self.assertIn("cpu 800.0s (20.00x)", msg)
+
+    def test_parallelism_without_the_observability_feature(self):
+        # FEATURES="cgroup" does not imply FEATURES="observability", and
+        # used to lose the parallelism suffix with no hint as to why.
+        msg = self._cgroup_finish((), {"cpu_usec": 800_000_000})
+        self.assertIn("cpu 800.0s (20.00x)", msg)
+
+    def test_no_parallelism_without_a_build_duration(self):
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        build.settings = _Settings()
+        messages = []
+        sched = Scheduler.__new__(Scheduler)
+        sched._observability = ObservabilityMonitor(_make_scheduler(features=()))
+        sched._cgroup = SimpleNamespace(
+            read_stats=lambda cpv: {"cpu_usec": 800_000_000},
+            destroy=lambda cpv: None,
+        )
+        sched._sched_iface = SimpleNamespace(
+            output=lambda msg, log_path=None: messages.append(msg)
+        )
+        sched._logger = SimpleNamespace(log=lambda msg: None)
+        sched._cgroup_finish(build)
+
+        self.assertIn("cpu 800.0s", "".join(messages))
+        self.assertNotIn("x)", "".join(messages))

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -4,10 +4,13 @@
 import asyncio
 import json
 import os
+import socket
 import tempfile
+import threading
 import time
 from types import SimpleNamespace
 
+from _emerge import _observability
 from _emerge._observability import (
     ObservabilityMonitor,
     _BuildTimes,
@@ -74,6 +77,57 @@ class _FakeLoop:
         pending, self.calls = self.calls, []
         for _delay, callback in pending:
             callback()
+
+
+class _FakeStatusSocket:
+    """Stand-in for a running emerge's status socket.
+
+    Serves one canned line per connection, optionally after a delay, so
+    that both the happy path and the timeout fallback can be exercised.
+    """
+
+    def __init__(self, path, payload, delay=0.0):
+        self._payload = payload
+        self._delay = delay
+        self._stop = False
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.settimeout(0.1)
+        self._sock.bind(path)
+        self._sock.listen(4)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while not self._stop:
+            try:
+                conn, _addr = self._sock.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+            with conn:
+                if self._delay:
+                    time.sleep(self._delay)
+                try:
+                    conn.sendall(json.dumps(self._payload).encode("utf_8") + b"\n")
+                except OSError:
+                    pass
+
+    def close(self):
+        self._stop = True
+        self._thread.join(timeout=10)
+        self._sock.close()
+
+
+def _write_status_file(directory, pid, payload):
+    with open(
+        os.path.join(directory, f"emerge-{pid}.json"), "w", encoding="utf_8"
+    ) as f:
+        json.dump(payload, f)
+
+
+def _snapshot(pid, cpv):
+    return {"type": "snapshot", "schema": 1, "emerge_pid": pid, "tasks": [{"cpv": cpv}]}
 
 
 def _set_build_times(monitor, cpv, start, finished=None, resources=None):
@@ -513,6 +567,157 @@ class ObservabilitySnapshotTestCase(TestCase):
         self.assertEqual(monitor._build_times, {})
         self.assertEqual(monitor._phases, {})
         self.assertIsNone(monitor.build_elapsed("dev-libs/foo-1.2"))
+
+    def test_socket_wins_over_the_status_file(self):
+        # The socket answer is built when we ask; the file is only as fresh
+        # as the last publish. The same emerge must appear once, not twice.
+        pid = os.getpid()
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            _write_status_file(d, pid, _snapshot(pid, "stale/pkg-1"))
+            server = _FakeStatusSocket(
+                os.path.join(d, f"emerge-{pid}.sock"), _snapshot(pid, "fresh/pkg-1")
+            )
+            try:
+                found = read_snapshots(tmp)
+            finally:
+                server.close()
+
+            self.assertEqual(len(found), 1)
+            self.assertEqual(found[0]["tasks"][0]["cpv"], "fresh/pkg-1")
+
+    def test_status_file_used_when_the_socket_times_out(self):
+        # An emerge whose main loop is busy never answers; its status file
+        # is still readable and is what we fall back to.
+        pid = os.getpid()
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            _write_status_file(d, pid, _snapshot(pid, "from/file-1"))
+            server = _FakeStatusSocket(
+                os.path.join(d, f"emerge-{pid}.sock"),
+                _snapshot(pid, "from/socket-1"),
+                delay=0.5,
+            )
+            timeout = _observability._SOCKET_TIMEOUT
+            _observability._SOCKET_TIMEOUT = 0.05
+            try:
+                found = read_snapshots(tmp)
+            finally:
+                _observability._SOCKET_TIMEOUT = timeout
+                server.close()
+
+            self.assertEqual(len(found), 1)
+            self.assertEqual(found[0]["tasks"][0]["cpv"], "from/file-1")
+
+    def test_socket_pid_must_match_the_name_it_is_published_under(self):
+        # A socket left behind by an emerge that was killed is answered by
+        # whatever inherits its pid. _pid_alive() cannot tell the
+        # difference, but the pid in the name can.
+        pid = os.getpid()
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            server = _FakeStatusSocket(
+                os.path.join(d, f"emerge-{pid}.sock"),
+                _snapshot(os.getppid(), "impostor/pkg-1"),
+            )
+            try:
+                self.assertEqual(read_snapshots(tmp), [])
+            finally:
+                server.close()
+
+    def test_status_file_pid_must_match_the_name_it_is_published_under(self):
+        pid = os.getpid()
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            _write_status_file(d, pid, _snapshot(os.getppid(), "impostor/pkg-1"))
+            self.assertEqual(read_snapshots(tmp), [])
+
+    def test_snapshots_are_ordered_by_pid(self):
+        # Which transport answered for which emerge must not reorder the
+        # result: one comes from a socket here and the other from a file.
+        pids = sorted({os.getpid(), os.getppid()})
+        if len(pids) < 2:
+            self.skipTest("need two distinct live pids")
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            _write_status_file(d, pids[1], _snapshot(pids[1], "second/pkg-1"))
+            server = _FakeStatusSocket(
+                os.path.join(d, f"emerge-{pids[0]}.sock"),
+                _snapshot(pids[0], "first/pkg-1"),
+            )
+            try:
+                found = read_snapshots(tmp)
+            finally:
+                server.close()
+
+            self.assertEqual([s["emerge_pid"] for s in found], pids)
+
+    def test_unreadable_socket_does_not_hide_the_status_file(self):
+        # No listener on the socket path at all: connect fails immediately.
+        pid = os.getpid()
+        with tempfile.TemporaryDirectory() as tmp:
+            d = status_dir(tmp)
+            os.makedirs(d)
+            _write_status_file(d, pid, _snapshot(pid, "from/file-1"))
+            with open(os.path.join(d, f"emerge-{pid}.sock"), "w"):
+                pass
+            found = read_snapshots(tmp)
+
+            self.assertEqual(len(found), 1)
+            self.assertEqual(found[0]["tasks"][0]["cpv"], "from/file-1")
+
+    def test_read_snapshots_over_a_real_server_socket(self):
+        # End to end over the wire the monitor actually serves: the
+        # snapshot read is the one the connect itself caused to be
+        # published, not the one in the status file.
+        with tempfile.TemporaryDirectory() as tmp:
+            build = EbuildBuild(_Pkg("dev-libs/foo-1.2"), pid=99)
+            sched = _make_scheduler(eprefix=tmp, tasks=[build])
+            sched._cgroup = SimpleNamespace(
+                read_stats=lambda cpv: {"cpu_usec": 2_000_000, "mem_peak": 4096}
+            )
+            monitor = ObservabilityMonitor(sched)
+            monitor.note_task_started(build)
+
+            async def exercise():
+                monitor.update(force=True)
+                for _ in range(100):
+                    if monitor._server is not None:
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertIsNotNone(monitor._server)
+
+                # Only in the status file at this point, and the rate limit
+                # would keep an unforced publish from picking it up.
+                later = EbuildBuild(_Pkg("sys-apps/bar-3"), pid=100)
+                sched._running_tasks[id(later)] = later
+                monitor.note_task_started(later)
+                monitor._last_write = time.time()
+
+                # read_snapshots() blocks, so it cannot run on this loop.
+                return await asyncio.get_event_loop().run_in_executor(
+                    None, read_snapshots, tmp
+                )
+
+            try:
+                found = global_event_loop().run_until_complete(exercise())
+            finally:
+                monitor.close()
+
+            self.assertEqual(len(found), 1)
+            self.assertEqual(found[0]["emerge_pid"], os.getpid())
+            self.assertEqual(
+                sorted(t["cpv"] for t in found[0]["tasks"]),
+                ["dev-libs/foo-1.2", "sys-apps/bar-3"],
+            )
+            rendered = format_snapshots(found)
+            self.assertIn("CPU: 2.00s", rendered)
+            self.assertIn("MaxMem: 4.00 KiB", rendered)
 
     def test_connect_publishes_a_current_snapshot(self):
         # Rate limiting bounds IO from bursty task events; it must not hand

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -5,10 +5,12 @@ import asyncio
 import json
 import os
 import tempfile
+import time
 from types import SimpleNamespace
 
 from _emerge._observability import (
     ObservabilityMonitor,
+    _BuildTimes,
     build_snapshot,
     format_snapshots,
     missing_feature_hint,
@@ -16,6 +18,7 @@ from _emerge._observability import (
     status_dir,
 )
 from _emerge.PackageMerge import PackageMerge as _RealPackageMerge
+from _emerge.Scheduler import Scheduler
 
 from portage.tests import TestCase
 from portage.util._eventloop.global_event_loop import global_event_loop
@@ -70,6 +73,15 @@ class _FakeLoop:
         pending, self.calls = self.calls, []
         for _delay, callback in pending:
             callback()
+
+
+def _set_build_times(monitor, cpv, start, finished=None, resources=None):
+    """Install a synthetic build timing record for cpv on monitor."""
+    times = _BuildTimes(start)
+    times.finished = finished
+    times.resources = resources
+    monitor._build_times[cpv] = times
+    return times
 
 
 def _make_scheduler(features=("observability",), eprefix="", tasks=None, loop=None):
@@ -159,14 +171,32 @@ class ObservabilitySnapshotTestCase(TestCase):
         monitor.note_task_started(waiting)
         # Build started 100s ago and finished building 40s ago: elapsed should
         # freeze at the 60s build duration, not the ~100s since it started.
-        import time as _t
-
-        now = _t.time()
-        monitor._build_times["dev-libs/foo-1.2"] = [now - 100, now - 40]
+        now = time.time()
+        _set_build_times(monitor, "dev-libs/foo-1.2", now - 100, now - 40)
 
         entry = build_snapshot(monitor)["tasks"][0]
         self.assertEqual(entry["start_time"], now - 100)
         self.assertAlmostEqual(entry["elapsed"], 60, delta=1)
+
+    def test_resources_frozen_at_build_completion(self):
+        # The cgroup is destroyed once the build is over, so the counters
+        # captured at completion are the only ones left to report.
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        sched = _make_scheduler(tasks=[build])
+        live = {"cpu_usec": 4_000_000, "mem_peak": 4096}
+        sched._cgroup = SimpleNamespace(read_stats=lambda cpv: dict(live))
+        monitor = ObservabilityMonitor(sched)
+        monitor.note_task_started(build)
+        monitor.note_task_finished(build)
+
+        # A later read of the cgroup must not leak into the snapshot.
+        live["cpu_usec"] = 9_000_000
+        merge = PackageMerge(build)
+        sched._running_tasks = {id(merge): merge}
+        monitor.note_task_started(merge)
+
+        entry = build_snapshot(monitor)["tasks"][0]
+        self.assertEqual(entry["resources"]["cpu_usec"], 4_000_000)
 
     def test_disabled_when_feature_absent(self):
         sched = _make_scheduler(features=(), tasks=[])
@@ -373,3 +403,34 @@ class ObservabilitySnapshotTestCase(TestCase):
             with open(os.path.join(d, "emerge-2147480000.json"), "w") as f:
                 json.dump({"emerge_pid": 2147480000, "tasks": []}, f)
             self.assertEqual(read_snapshots(tmp), [])
+
+
+class SchedulerCgroupLogTestCase(TestCase):
+    def _cgroup_finish(self, features, stats):
+        """Run Scheduler._cgroup_finish() and return what it logged."""
+        build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
+        build.settings = _Settings()
+        monitor = ObservabilityMonitor(_make_scheduler(features=features))
+        monitor.note_task_started(build)
+        # 40s of wall clock for the build.
+        monitor._build_times["dev-libs/foo-1.2"].start = time.time() - 40
+        monitor.note_task_finished(build)
+
+        messages = []
+        sched = Scheduler.__new__(Scheduler)
+        sched._observability = monitor
+        sched._cgroup = SimpleNamespace(
+            read_stats=lambda cpv: stats, destroy=lambda cpv: None
+        )
+        sched._sched_iface = SimpleNamespace(
+            output=lambda msg, log_path=None: messages.append(msg)
+        )
+        sched._logger = SimpleNamespace(log=lambda msg: None)
+        sched._cgroup_finish(build)
+        return "".join(messages)
+
+    def test_build_duration_comes_from_the_monitor(self):
+        # The log line divides CPU time by the build's wall clock, which
+        # only the monitor knows.
+        msg = self._cgroup_finish(("observability",), {"cpu_usec": 800_000_000})
+        self.assertIn("cpu 800.0s (20.00x)", msg)

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -527,6 +527,22 @@ class ObservabilitySnapshotTestCase(TestCase):
             line,
         )
 
+    def test_zero_valued_resources_are_still_reported(self):
+        # Zero bytes of I/O is a fact about the build, not a missing value.
+        snap = {
+            "emerge_pid": 1,
+            "jobs": {"running": 1, "completed": 0, "total": 1, "failed": 0},
+            "tasks": [
+                {
+                    "cpv": "dev-libs/foo-1.2",
+                    "phase": "compile",
+                    "elapsed": 1.0,
+                    "resources": {"io_read_bytes": 0, "io_write_bytes": 0},
+                }
+            ],
+        }
+        self.assertIn("I/O R: 0.00 B, I/O W: 0.00 B", format_snapshots([snap]))
+
     def test_average_parallelism_without_a_usable_duration(self):
         for elapsed in (None, 0, -1):
             with self.subTest(elapsed=elapsed):
@@ -839,13 +855,40 @@ class SchedulerCgroupLogTestCase(TestCase):
         # The log line divides CPU time by the build's wall clock, which
         # only the monitor knows.
         msg = self._cgroup_finish(("observability",), {"cpu_usec": 800_000_000})
-        self.assertIn("cpu 800.0s (20.00x)", msg)
+        self.assertIn("CPU: 800.00s (20.00x)", msg)
 
     def test_parallelism_without_the_observability_feature(self):
         # FEATURES="cgroup" does not imply FEATURES="observability", and
         # used to lose the parallelism suffix with no hint as to why.
         msg = self._cgroup_finish((), {"cpu_usec": 800_000_000})
-        self.assertIn("cpu 800.0s (20.00x)", msg)
+        self.assertIn("CPU: 800.00s (20.00x)", msg)
+
+    def test_summary_matches_the_status_rendering(self):
+        # One renderer drives both, so the log line and the "emerge
+        # --status" bracket cannot drift apart.
+        stats = {
+            "cpu_usec": 800_000_000,
+            "mem_peak": 4096,
+            "io_read_bytes": 0,
+            "io_write_bytes": 8192,
+        }
+        msg = self._cgroup_finish((), stats)
+        self.assertIn(
+            "=== Resource usage for dev-libs/foo-1.2 "
+            "[CPU: 800.00s (20.00x), MaxMem: 4.00 KiB, "
+            "I/O R: 0.00 B, I/O W: 8.00 KiB]",
+            msg,
+        )
+
+    def test_transient_counters_are_left_out_of_the_summary(self):
+        # The build is over and its cgroup is about to be destroyed, so
+        # what it happens to be using right now is not worth logging.
+        msg = self._cgroup_finish(
+            (),
+            {"cpu_usec": 800_000_000, "mem_current": 1024, "mem_peak": 4096},
+        )
+        self.assertIn("MaxMem: 4.00 KiB", msg)
+        self.assertNotIn("Mem: 1.00 KiB", msg)
 
     def test_no_parallelism_without_a_build_duration(self):
         build = EbuildBuild(_Pkg("dev-libs/foo-1.2"))
@@ -863,5 +906,5 @@ class SchedulerCgroupLogTestCase(TestCase):
         sched._logger = SimpleNamespace(log=lambda msg: None)
         sched._cgroup_finish(build)
 
-        self.assertIn("cpu 800.0s", "".join(messages))
+        self.assertIn("CPU: 800.00s", "".join(messages))
         self.assertNotIn("x)", "".join(messages))

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -254,6 +254,12 @@ matched as regular expressions.
 .BR \-\-status
 Displays the packages that running \fBemerge\fR processes are currently
 building or merging, including the current ebuild phase and elapsed time.
+When the observed \fBemerge\fR also has FEATURES="cgroup" enabled, each
+package's CPU time, average parallelism, peak memory and I/O totals are
+shown alongside. The figures for a package that has finished building are
+those from the end of its build, so they do not drift while it waits to
+merge.
+.br
 This requires the target \fBemerge\fR to have been started with
 FEATURES="observability" (see \fBmake.conf\fR(5)). For machine\-readable
 output, use \fBportageq jobs \-\-json\fR instead.

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -452,7 +452,8 @@ work, do not enable ccache.
 Place each source build's process tree in its own cgroup v2 under
 \fIPORTAGE_CGROUP_ROOT\fR (default \fI/sys/fs/cgroup/portage\fR), so the kernel
 accounts the build's CPU time, peak memory, and I/O. The totals are reported in
-the build log and, with FEATURES="observability", in the live status snapshot.
+the build log, together with the average number of CPUs the build kept busy,
+and, with FEATURES="observability", in the live status snapshot.
 No limits are imposed. Requires root and a cgroup v2 unified hierarchy;
 degrades silently otherwise.
 .TP
@@ -694,8 +695,10 @@ Disables xterm titlebar updates (which contains status info).
 Publish a machine\-readable snapshot of the running \fBemerge\fR(1)
 process to \fI/run/portage/emerge\-<pid>.json\fR, listing the packages
 currently being built or merged, their current ebuild phase, and elapsed
-time. The file is updated on every job state change and removed when
-emerge exits. Query it with \fBportageq jobs\fR or \fBemerge \-\-status\fR.
+time. The file is refreshed on every job state change, periodically while
+a phase runs, and whenever a client connects to the socket described
+below; it is removed when emerge exits. Query it with \fBportageq jobs\fR
+or \fBemerge \-\-status\fR.
 A \fI/run/portage/emerge\-<pid>.sock\fR Unix socket additionally streams
 newline\-delimited JSON snapshots to connected clients. This feature
 degrades silently when the runtime directory is not writable (for


### PR DESCRIPTION
Includes @Flowdalic's #1650, #1651 and #1652, carried unmodified and with authorship intact:

* #1650: human-readable cgroup resources in `emerge --status`, frozen at build completion
* #1651: read status over the socket first, refreshing on client connect
* #1652: average parallelism in the cgroup summary logged to emerge.log

The rest is on top of those, kept as separate commits so @Flowdalic's patches stay as authored.

### Fixes

* Parallelism was wrong once a package started merging: `elapsed` keeps running through the merge while the counters are frozen, so 20x decayed to 8x. The build's own duration is published as `build_elapsed` and used as the denominator (additive key, schema unchanged).
* `FEATURES="cgroup"` never showed the `(N.NNx)` suffix without `FEATURES="observability"`, since only the latter recorded the build timing it divides by. Timing is now recorded either way.
* Freezing kept `memory.current` and friends, which describe a cgroup that is destroyed moments later, so `--status` rendered them as live usage for the whole merge window. Dropped when freezing; peaks and totals kept.
* A snapshot read from `emerge-<pid>.sock` was never checked against the pid in its name, so a socket left by a killed emerge is answered by whatever inherits the pid. The pid now has to match, for status files too, and results are ordered by pid rather than by transport.
* Refresh on connect was rate-limited, leaving the client with the older snapshot and the status file unrewritten. Forced now.
* `_build_times`/`_phases` leaked for a build that produces no merge task (it failed, or emerge was interrupted).
* The cgroup was read twice per build, to freeze and to log. Its owner reads it once and hands the result to the monitor.

### Cleanups

* `_build_times` is a `_BuildTimes` object instead of a positional list that grew from two elements to three.
* emerge.log and `--status` disagreed on labels, CPU precision and whether to print zeros. Both call `format_resources()`:

  === Resource usage for dev-libs/foo-1.2 [CPU: 800.00s (20.00x), MaxMem: 4.00 KiB, I/O R: 0.00 B, I/O W: 8.00 KiB]

Zeros are logged, and `memory.zswap.current` is no longer summarized (no peak to report instead, and it says as little as `memory.current` by then). `FEATURES="cgroup"` has not been released, so nothing parses the old format.
