### PR TITLE
emerge: accept Atom instances in is_valid_package_atom()

### DIFF
--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -2511,7 +2511,7 @@ def action_uninstall(settings, trees, ldpath_mtimes, opts, action, files, spinne
     # For backward compat, leading '=' is not required.
     for x in files:
         if is_valid_package_atom(x, allow_repo=True) or (
-            ignore_missing_eq and is_valid_package_atom("=" + x)
+            ignore_missing_eq and is_valid_package_atom("=" + str(x))
         ):
             try:
                 atom = dep_expand(x, mydb=vardb, settings=settings)

--- a/lib/_emerge/is_valid_package_atom.py
+++ b/lib/_emerge/is_valid_package_atom.py
@@ -1,9 +1,9 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 import re
 
-from portage.dep import isvalidatom
+from portage.dep import Atom, isvalidatom
 
 
 def insert_category_into_atom(atom, category):
@@ -17,7 +17,8 @@ def insert_category_into_atom(atom, category):
 
 
 def is_valid_package_atom(x, allow_repo=False, allow_build_id=True):
-    if "/" not in x.split(":")[0]:
+    # An Atom always carries a category, so only strings need the placeholder.
+    if not isinstance(x, Atom) and "/" not in x.split(":")[0]:
         x2 = insert_category_into_atom(x, "cat")
         if x2 is not None:
             x = x2

--- a/lib/portage/tests/emerge/meson.build
+++ b/lib/portage/tests/emerge/meson.build
@@ -7,6 +7,7 @@ py.install_sources(
         'test_emerge_blocker_file_collision.py',
         'test_emerge_slot_abi.py',
         'test_global_updates.py',
+        'test_is_valid_package_atom.py',
         'test_baseline.py',
         'test_libc_dep_inject.py',
         'test_noreplace.py',

--- a/lib/portage/tests/emerge/test_is_valid_package_atom.py
+++ b/lib/portage/tests/emerge/test_is_valid_package_atom.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from _emerge.is_valid_package_atom import is_valid_package_atom
+
+from portage.dep import Atom
+from portage.tests import TestCase
+
+
+class IsValidPackageAtomTestCase(TestCase):
+    def testStringAtoms(self):
+        for atom, expected in (
+            ("dev-libs/A", True),
+            (">=dev-libs/A-1", True),
+            ("A", True),
+            ("!dev-libs/A", False),
+            ("dev-libs/A[", False),
+        ):
+            self.assertEqual(is_valid_package_atom(atom), expected, atom)
+
+    def testAtomInstances(self):
+        for atom, expected in (
+            (Atom("dev-libs/A"), True),
+            (Atom(">=dev-libs/A-1"), True),
+            (Atom("dev-libs/A:0/1"), True),
+            (Atom("dev-libs/A::gentoo", allow_repo=True), True),
+            (Atom("dev-libs/*", allow_wildcard=True), True),
+            (Atom("!dev-libs/A"), False),
+        ):
+            self.assertEqual(
+                is_valid_package_atom(atom, allow_repo=True), expected, atom
+            )
+
+    def testMissingEqConcatenation(self):
+        # A blocker Atom is rejected above, so action_uninstall() retries it
+        # as "=" + str(x), which must not raise.
+        atom = Atom("!dev-libs/A")
+        self.assertFalse(is_valid_package_atom("=" + str(atom)))


### PR DESCRIPTION
expand_set_arguments() expands package set arguments into Atom instances and puts them back into emerge's argument list. is_valid_package_atom() then called str.split() on them, which worked only while Atom was a str subclass. Since commit 7e15fc7fa ("dep: Atom: remove str subtyping") every action that expands sets before use (clean, depclean, deselect, info, prune, rage-clean, unmerge) fails with:

    AttributeError: 'Atom' object has no attribute 'split'

The str.split() call exists only to decide whether a placeholder category has to be inserted so that isvalidatom() will accept a bare package name. An Atom always carries a category, so skip that for Atom instances. isvalidatom() already documents that it takes a string or an Atom and passes Atom instances through without rechecking construction flags, so this restores the previous behavior exactly, including for the extended syntax atoms produced by WildcardPackageSet.

Also wrap the concatenation in action_uninstall() with str(), which is reachable when a set yields a blocker atom.

Bug: https://bugs.gentoo.org/981147
Fixes: 7e15fc7fa4c1 ("dep: Atom: remove str subtyping")