### PR TITLE
Scheduler: tear down observability once, not once per keep-going pass

### DIFF
--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -1221,97 +1221,105 @@ class Scheduler(PollScheduler):
         if rval != os.EX_OK and not keep_going:
             return rval
 
-        while True:
-            received_signal = []
+        try:
+            while True:
+                received_signal = []
 
-            def sighandler(signum, frame):
-                signal.signal(signal.SIGINT, signal.SIG_IGN)
-                signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                portage.util.writemsg(f"\n\nExiting on signal {signum}\n")
-                self.terminate()
-                received_signal.append(128 + signum)
+                def sighandler(signum, frame):
+                    signal.signal(signal.SIGINT, signal.SIG_IGN)
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                    portage.util.writemsg(f"\n\nExiting on signal {signum}\n")
+                    self.terminate()
+                    received_signal.append(128 + signum)
 
-            def sigusr2handler(signum, frame):
-                self._flush_merge_wait_queue = True
+                def sigusr2handler(signum, frame):
+                    self._flush_merge_wait_queue = True
 
-            earlier_sigint_handler = signal.signal(signal.SIGINT, sighandler)
-            earlier_sigterm_handler = signal.signal(signal.SIGTERM, sighandler)
-            earlier_sigcont_handler = signal.signal(
-                signal.SIGCONT, self._sigcont_handler
-            )
-            signal.siginterrupt(signal.SIGCONT, False)
-            earlier_sigusr2_handler = signal.signal(signal.SIGUSR2, sigusr2handler)
+                earlier_sigint_handler = signal.signal(signal.SIGINT, sighandler)
+                earlier_sigterm_handler = signal.signal(signal.SIGTERM, sighandler)
+                earlier_sigcont_handler = signal.signal(
+                    signal.SIGCONT, self._sigcont_handler
+                )
+                signal.siginterrupt(signal.SIGCONT, False)
+                earlier_sigusr2_handler = signal.signal(signal.SIGUSR2, sigusr2handler)
 
-            earlier_sigwinch_handler = signal.signal(
-                signal.SIGWINCH, self._sigwinch_handler
-            )
-            try:
-                rval = self._merge()
-            finally:
-                # Restore previous handlers
-                if earlier_sigint_handler is not None:
-                    signal.signal(signal.SIGINT, earlier_sigint_handler)
-                else:
-                    signal.signal(signal.SIGINT, signal.SIG_DFL)
-                if earlier_sigterm_handler is not None:
-                    signal.signal(signal.SIGTERM, earlier_sigterm_handler)
-                else:
-                    signal.signal(signal.SIGTERM, signal.SIG_DFL)
-                if earlier_sigcont_handler is not None:
-                    signal.signal(signal.SIGCONT, earlier_sigcont_handler)
-                else:
-                    signal.signal(signal.SIGCONT, signal.SIG_DFL)
-                if earlier_sigusr2_handler is not None:
-                    signal.signal(signal.SIGUSR2, earlier_sigusr2_handler)
-                else:
-                    signal.signal(signal.SIGUSR2, signal.SIG_DFL)
+                earlier_sigwinch_handler = signal.signal(
+                    signal.SIGWINCH, self._sigwinch_handler
+                )
+                try:
+                    rval = self._merge()
+                finally:
+                    # Restore previous handlers
+                    if earlier_sigint_handler is not None:
+                        signal.signal(signal.SIGINT, earlier_sigint_handler)
+                    else:
+                        signal.signal(signal.SIGINT, signal.SIG_DFL)
+                    if earlier_sigterm_handler is not None:
+                        signal.signal(signal.SIGTERM, earlier_sigterm_handler)
+                    else:
+                        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+                    if earlier_sigcont_handler is not None:
+                        signal.signal(signal.SIGCONT, earlier_sigcont_handler)
+                    else:
+                        signal.signal(signal.SIGCONT, signal.SIG_DFL)
+                    if earlier_sigusr2_handler is not None:
+                        signal.signal(signal.SIGUSR2, earlier_sigusr2_handler)
+                    else:
+                        signal.signal(signal.SIGUSR2, signal.SIG_DFL)
 
-                if earlier_sigwinch_handler is not None:
-                    signal.signal(signal.SIGWINCH, earlier_sigwinch_handler)
-                else:
-                    signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+                    if earlier_sigwinch_handler is not None:
+                        signal.signal(signal.SIGWINCH, earlier_sigwinch_handler)
+                    else:
+                        signal.signal(signal.SIGWINCH, signal.SIG_DFL)
 
-            self._termination_check()
-            if received_signal:
-                sys.exit(received_signal[0])
+                self._termination_check()
+                if received_signal:
+                    sys.exit(received_signal[0])
 
-            if rval == os.EX_OK or fetchonly or not keep_going:
-                break
-            if "resume" not in mtimedb:
-                break
-            mergelist = self._mtimedb["resume"].get("mergelist")
-            if not mergelist:
-                break
+                if rval == os.EX_OK or fetchonly or not keep_going:
+                    break
+                if "resume" not in mtimedb:
+                    break
+                mergelist = self._mtimedb["resume"].get("mergelist")
+                if not mergelist:
+                    break
 
-            if not failed_pkgs:
-                break
+                if not failed_pkgs:
+                    break
 
-            for failed_pkg in failed_pkgs:
-                mergelist.remove(list(failed_pkg.pkg))
+                for failed_pkg in failed_pkgs:
+                    mergelist.remove(list(failed_pkg.pkg))
 
-            self._failed_pkgs_all.extend(failed_pkgs)
-            del failed_pkgs[:]
+                self._failed_pkgs_all.extend(failed_pkgs)
+                del failed_pkgs[:]
 
-            if not mergelist:
-                break
+                if not mergelist:
+                    break
 
-            if not self._calc_resume_list():
-                break
+                if not self._calc_resume_list():
+                    break
 
-            clear_caches(self.trees)
-            if not self._mergelist:
-                break
+                clear_caches(self.trees)
+                if not self._mergelist:
+                    break
 
-            self._save_resume_list()
-            self._pkg_count.curval = 0
-            self._pkg_count.maxval = len(
-                [
-                    x
-                    for x in self._mergelist
-                    if isinstance(x, Package) and x.operation == "merge"
-                ]
-            )
-            self._status_display.maxval = self._pkg_count.maxval
+                self._save_resume_list()
+                self._pkg_count.curval = 0
+                self._pkg_count.maxval = len(
+                    [
+                        x
+                        for x in self._mergelist
+                        if isinstance(x, Package) and x.operation == "merge"
+                    ]
+                )
+                self._status_display.maxval = self._pkg_count.maxval
+        finally:
+            # _merge() runs once per --keep-going pass, but the monitor and
+            # the cgroup manager are created once per Scheduler and nothing
+            # recreates them, so they can only be torn down out here.
+            self._observability.close()
+            if self._cgroup is not None:
+                self._cgroup.close()
 
         # Cleanup any callbacks that have been registered with the global
         # event loop by calls to the terminate method.
@@ -1759,9 +1767,6 @@ class Scheduler(PollScheduler):
             self._main_loop()
         finally:
             self._main_loop_cleanup()
-            self._observability.close()
-            if self._cgroup is not None:
-                self._cgroup.close()
             portage.locks._quiet = False
             portage.elog.remove_listener(self._elog_listener)
             if display_callback.handle is not None:

--- a/lib/portage/tests/emerge/test_observability.py
+++ b/lib/portage/tests/emerge/test_observability.py
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 import asyncio
+import contextlib
+import io
 import json
 import os
 import socket
@@ -908,3 +910,93 @@ class SchedulerCgroupLogTestCase(TestCase):
 
         self.assertIn("CPU: 800.00s", "".join(messages))
         self.assertNotIn("x)", "".join(messages))
+
+
+class KeepGoingTeardownTestCase(TestCase):
+    def _run_keep_going_merge(self, tmpdir):
+        monitor = ObservabilityMonitor(_make_scheduler(eprefix=tmpdir))
+        monitor._last_snapshot = {"type": "snapshot", "schema": 1}
+        monitor._write_status_file(monitor._last_snapshot)
+
+        cgroup = SimpleNamespace(enabled=True, closed=0)
+
+        def cgroup_close():
+            cgroup.enabled = False
+            cgroup.closed += 1
+
+        cgroup.close = cgroup_close
+
+        # What a client polling at the start of each pass would have seen.
+        seen = []
+        failed_pkg = SimpleNamespace(
+            pkg=["dev-libs", "foo-1"],
+            returncode=1,
+            postinst_failure=False,
+            build_log=None,
+        )
+
+        sched = Scheduler.__new__(Scheduler)
+
+        def fake_merge():
+            seen.append(
+                (
+                    monitor.enabled,
+                    cgroup.enabled,
+                    os.path.exists(monitor._status_path),
+                )
+            )
+            if len(seen) == 1:
+                sched._failed_pkgs.append(failed_pkg)
+                return 1
+            return os.EX_OK
+
+        sched.myopts = {"--keep-going": True}
+        sched.trees = {}
+        sched._observability = monitor
+        sched._cgroup = cgroup
+        sched._merge = fake_merge
+        sched._background = False
+        sched._build_opts = SimpleNamespace(fetchonly=False)
+        sched._failed_pkgs = []
+        sched._failed_pkgs_all = []
+        sched._failed_pkgs_die_msgs = []
+        sched._post_mod_echo_msgs = []
+        sched._mergelist = ["dev-libs/bar-1"]
+        sched._mtimedb = {
+            "resume": {"mergelist": [["dev-libs", "foo-1"], ["dev-libs", "bar-1"]]}
+        }
+        sched._pkg_count = SimpleNamespace(curval=0, maxval=1)
+        sched._status_display = SimpleNamespace(maxval=1, quiet=False)
+        sched._logger = SimpleNamespace(log=lambda msg: None)
+        sched._save_resume_list = lambda: None
+        sched._background_mode = lambda: False
+        sched._handle_self_update = lambda: os.EX_OK
+        sched._generate_digests = lambda: os.EX_OK
+        sched._check_manifests = lambda: os.EX_OK
+        sched._termination_check = lambda: None
+        sched._calc_resume_list = lambda: True
+        sched._cleanup = lambda: None
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rval = sched.merge()
+
+        return monitor, cgroup, seen
+
+    def test_publishing_survives_a_keep_going_restart(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _monitor, cgroup, seen = self._run_keep_going_merge(tmpdir)
+
+            self.assertEqual(len(seen), 2)
+            # The second pass is the one that used to run blind: no
+            # monitor, no cgroup accounting and no status file to read.
+            self.assertEqual(seen[1], (True, True, True))
+            self.assertEqual(cgroup.closed, 1)
+
+    def test_teardown_still_happens_once_the_loop_is_done(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monitor, cgroup, _seen = self._run_keep_going_merge(tmpdir)
+
+            self.assertFalse(monitor.enabled)
+            self.assertEqual(cgroup.closed, 1)
+            self.assertFalse(os.path.exists(monitor._status_path))

--- a/lib/portage/util/cgroup.py
+++ b/lib/portage/util/cgroup.py
@@ -468,8 +468,9 @@ class CgroupManager:
             return False
         _enable_subtree_control(self.emerge_root)
         self.enabled = True
-        # close() is called from Scheduler.merge(), but that is skipped if
-        # we exit via an unhandled exception or a signal handler.
+        # close() is called from Scheduler.merge(), once the --keep-going
+        # loop is done, but that is skipped if we die before the loop or
+        # take a signal we do not handle.
         atexit.register(self.close)
         return True
 


### PR DESCRIPTION
"emerge --status" reported nothing at all for the rest of an emerge that had restarted after a failure with --keep-going.

merge() runs _merge() once per pass of its --keep-going loop, but the ObservabilityMonitor and the CgroupManager are built once, in the Scheduler's constructor, and nothing recreates them. Tearing them down in _merge()'s finally block therefore disabled them permanently at the end of the first pass, taking emerge-<pid>.json and emerge-<pid>.sock with it. Everything merged after the first failure was published nowhere, so a status client found no file to read and printed "Nothing to report...".

The cgroup manager was lost the same way, along with the per-emerge cgroup tree: builds in later passes were accounted for nowhere and their resource lines disappeared from both "emerge --status" and the build log.

Move both calls out to merge(), around the loop rather than inside it, so that they run once the last pass is done. _main_loop_cleanup() stays in _merge(), since that one is per-pass. A comment in CgroupManager.setup() already claimed close() was called from merge(); now it is.