### PR TITLE
Run pkg_pretend phases in parallel (bug 579526)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,11 @@ Features:
   atoms, USE dependencies, USE flag names and flag sets that packages have in
   common cuts the peak of "emerge -puDN @world" by about 46% (bug #240320).
 
+* emerge: Run pkg_pretend phases concurrently, subject to --jobs and
+  --load-average. Output from each package is still shown one package at a
+  time, in merge order (bug #579526).
+
+
 portage-3.0.82 (2026-08-22)
 --------------
 

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -876,263 +876,275 @@ class Scheduler(PollScheduler):
 
         return prefetcher
 
+    def _pkg_needs_pretend(self, pkg):
+        return (
+            isinstance(pkg, Package)
+            and pkg.operation != "uninstall"
+            and pkg.eapi not in ("0", "1", "2", "3")
+            and "pretend" in pkg.defined_phases
+        )
+
     async def _run_pkg_pretend(self, loop=None):
         """
         Since pkg_pretend output may be important, this method sends all
         output directly to stdout (regardless of options like --quiet or
         --jobs).
         """
+        loop = asyncio._wrap_loop(loop or self._sched_iface)
 
         failures = 0
-        sched_iface = loop = asyncio._wrap_loop(loop or self._sched_iface)
 
         for x in self._mergelist:
-            if not isinstance(x, Package):
+            if not self._pkg_needs_pretend(x):
                 continue
 
-            if x.operation == "uninstall":
-                continue
+            failures += await self._run_pkg_pretend_one(x, loop)
 
-            if x.eapi in ("0", "1", "2", "3"):
-                continue
+        if failures:
+            return FAILURE
+        return os.EX_OK
 
-            if "pretend" not in x.defined_phases:
-                continue
+    async def _run_pkg_pretend_one(self, x, loop):
+        """
+        Run the pkg_pretend phase for a single package.
 
-            self._termination_check()
-            if self._terminated_tasks:
-                raise asyncio.CancelledError
+        @rtype: int
+        @return: the number of failures (0 or 1)
+        """
+        sched_iface = loop
 
-            root_config = x.root_config
-            settings = self._allocate_config(root_config.root)
-            settings.setcpv(x)
+        self._termination_check()
+        if self._terminated_tasks:
+            raise asyncio.CancelledError
 
-            color = "PKG_BINARY_MERGE" if x.built else "INFORM"
-            self._status_msg(f"Running pre-merge checks for {colorize(color, x.cpv)}")
+        failures = 0
 
-            if not x.built:
-                # Get required SRC_URI metadata (it's not cached in x.metadata
-                # because some packages have an extremely large SRC_URI value).
-                portdb = root_config.trees["porttree"].dbapi
-                (settings.configdict["pkg"]["SRC_URI"],) = await portdb.async_aux_get(
-                    x.cpv, ["SRC_URI"], myrepo=x.repo, loop=loop
-                )
+        root_config = x.root_config
+        settings = self._allocate_config(root_config.root)
+        settings.setcpv(x)
 
-            # setcpv/package.env allows for per-package PORTAGE_TMPDIR so we
-            # have to validate it for each package
-            rval = _check_temp_dir(settings)
-            if rval != os.EX_OK:
-                failures += 1
-                self._record_pkg_failure(x, settings, FAILURE)
-                self._deallocate_config(settings)
-                continue
+        color = "PKG_BINARY_MERGE" if x.built else "INFORM"
+        self._status_msg(f"Running pre-merge checks for {colorize(color, x.cpv)}")
 
-            build_dir_path = os.path.join(
-                os.path.realpath(settings["PORTAGE_TMPDIR"]),
-                "portage",
-                x.category,
-                x.pf,
+        if not x.built:
+            # Get required SRC_URI metadata (it's not cached in x.metadata
+            # because some packages have an extremely large SRC_URI value).
+            portdb = root_config.trees["porttree"].dbapi
+            (settings.configdict["pkg"]["SRC_URI"],) = await portdb.async_aux_get(
+                x.cpv, ["SRC_URI"], myrepo=x.repo, loop=loop
             )
-            existing_builddir = os.path.isdir(build_dir_path)
-            settings["PORTAGE_BUILDDIR"] = build_dir_path
-            build_dir = EbuildBuildDir(scheduler=sched_iface, settings=settings)
-            await build_dir.async_lock()
-            current_task = None
 
-            try:
-                # Clean up the existing build dir, in case pkg_pretend
-                # checks for available space (bug #390711).
-                if existing_builddir:
-                    if x.built:
-                        tree = "bintree"
-                        infloc = os.path.join(build_dir_path, "build-info")
-                        ebuild_path = os.path.join(infloc, x.pf + ".ebuild")
-                    else:
-                        tree = "porttree"
-                        portdb = root_config.trees["porttree"].dbapi
-                        ebuild_path = portdb.findname(x.cpv, myrepo=x.repo)
-                        if ebuild_path is None:
-                            raise AssertionError(f"ebuild not found for '{x.cpv}'")
-                    portage.package.ebuild.doebuild.doebuild_environment(
-                        ebuild_path,
-                        "clean",
-                        settings=settings,
-                        db=self.trees[settings["EROOT"]][tree].dbapi,
-                    )
-                    clean_phase = EbuildPhase(
-                        background=False,
-                        phase="clean",
-                        scheduler=sched_iface,
-                        settings=settings,
-                    )
-                    current_task = clean_phase
-                    clean_phase.start()
-                    await clean_phase.async_wait()
-                    current_task = None
+        # setcpv/package.env allows for per-package PORTAGE_TMPDIR so we
+        # have to validate it for each package
+        rval = _check_temp_dir(settings)
+        if rval != os.EX_OK:
+            self._record_pkg_failure(x, settings, FAILURE)
+            self._deallocate_config(settings)
+            return 1
 
+        build_dir_path = os.path.join(
+            os.path.realpath(settings["PORTAGE_TMPDIR"]),
+            "portage",
+            x.category,
+            x.pf,
+        )
+        existing_builddir = os.path.isdir(build_dir_path)
+        settings["PORTAGE_BUILDDIR"] = build_dir_path
+        build_dir = EbuildBuildDir(scheduler=sched_iface, settings=settings)
+        await build_dir.async_lock()
+        current_task = None
+
+        try:
+            # Clean up the existing build dir, in case pkg_pretend
+            # checks for available space (bug #390711).
+            if existing_builddir:
                 if x.built:
                     tree = "bintree"
-                    bintree = root_config.trees["bintree"].dbapi.bintree
-                    fetched = False
-
-                    # Display fetch on stdout, so that it's always clear what
-                    # is consuming time here.
-                    if bintree.download_required(x.cpv):
-                        fetcher = self._get_prefetcher(x)
-                        if fetcher is not None and not fetcher.isAlive():
-                            # Cancel it because it hasn't started yet.
-                            fetcher.cancel()
-                            fetcher = None
-                        if fetcher is None:
-                            fetcher = BinpkgFetcher(pkg=x, scheduler=loop)
-                            fetcher.start()
-                            # We only set the fetched value when fetcher
-                            # is a BinpkgFetcher, since BinpkgPrefetcher
-                            # handles fetch, verification, and the
-                            # bintree.inject call which moves the file.
-                            fetched = fetcher.pkg_path
-                        else:
-                            msg = (
-                                "Fetching in the background:",
-                                fetcher.pkg_path,
-                                "To view fetch progress, run in another terminal:",
-                                f"tail -f {self._fetch_log}",
-                            )
-                            out = portage.output.EOutput()
-                            for l in msg:
-                                out.einfo(l)
-                        if await fetcher.async_wait() != os.EX_OK:
-                            failures += 1
-                            self._record_pkg_failure(x, settings, fetcher.returncode)
-                            continue
-
-                    if fetched is False:
-                        filename = bintree.getname(x.cpv)
-                    else:
-                        filename = fetched
-                    verifier = BinpkgVerifier(
-                        pkg=x, scheduler=sched_iface, _pkg_path=filename
-                    )
-                    current_task = verifier
-                    verifier.start()
-                    if await verifier.async_wait() != os.EX_OK:
-                        failures += 1
-                        self._record_pkg_failure(x, settings, verifier.returncode)
-                        continue
-
-                    current_task = None
-                    if fetched and bintree.get_local_repo_location(x.cpv):
-                        os.rename(fetched, fetcher.pkg_allocated_path)
-                    elif fetched:
-                        injected_pkg = None
-                        stdout_orig = sys.stdout
-                        stderr_orig = sys.stderr
-                        out = io.StringIO()
-                        try:
-                            sys.stdout = out
-                            sys.stderr = out
-
-                            injected_pkg = bintree.inject(
-                                x.cpv,
-                                current_pkg_path=fetched,
-                                allocated_pkg_path=fetcher.pkg_allocated_path,
-                            )
-                        finally:
-                            sys.stdout = stdout_orig
-                            sys.stderr = stderr_orig
-
-                        output_value = out.getvalue()
-                        if injected_pkg is None:
-                            msg = ["Binary package is not usable:"]
-                            if output_value:
-                                msg.extend(
-                                    "\t" + line for line in output_value.splitlines()
-                                )
-                            self._elog("eerror", msg)
-
-                            failures += 1
-                            self._record_pkg_failure(x, settings, 1)
-                            continue
-
                     infloc = os.path.join(build_dir_path, "build-info")
-                    ensure_dirs(infloc)
-                    try:
-                        await bintree.dbapi.unpack_metadata(settings, infloc, loop=loop)
-                    except portage.exception.SignatureException as e:
-                        writemsg(
-                            f"!!! Invalid binary package: '{bintree.getname(x.cpv)}', {e}\n",
-                            noiselevel=-1,
-                        )
-                        failures += 1
-                        self._record_pkg_failure(x, settings, 1)
-                        continue
                     ebuild_path = os.path.join(infloc, x.pf + ".ebuild")
-                    settings.configdict["pkg"]["EMERGE_FROM"] = "binary"
-                    settings.configdict["pkg"]["MERGE_TYPE"] = "binary"
-
                 else:
                     tree = "porttree"
                     portdb = root_config.trees["porttree"].dbapi
                     ebuild_path = portdb.findname(x.cpv, myrepo=x.repo)
                     if ebuild_path is None:
                         raise AssertionError(f"ebuild not found for '{x.cpv}'")
-                    settings.configdict["pkg"]["EMERGE_FROM"] = "ebuild"
-                    if self._build_opts.buildpkgonly:
-                        settings.configdict["pkg"]["MERGE_TYPE"] = "buildonly"
-                    else:
-                        settings.configdict["pkg"]["MERGE_TYPE"] = "source"
-
                 portage.package.ebuild.doebuild.doebuild_environment(
                     ebuild_path,
-                    "pretend",
+                    "clean",
                     settings=settings,
                     db=self.trees[settings["EROOT"]][tree].dbapi,
                 )
-
-                prepare_build_dirs(root_config.root, settings, cleanup=0)
-
-                vardb = root_config.trees["vartree"].dbapi
-                settings["REPLACING_VERSIONS"] = " ".join(
-                    {
-                        portage.versions.cpv_getversion(match)
-                        for match in vardb.match(x.slot_atom) + vardb.match("=" + x.cpv)
-                    }
+                clean_phase = EbuildPhase(
+                    background=False,
+                    phase="clean",
+                    scheduler=sched_iface,
+                    settings=settings,
                 )
-                pretend_phase = EbuildPhase(
-                    phase="pretend", scheduler=sched_iface, settings=settings
+                current_task = clean_phase
+                clean_phase.start()
+                await clean_phase.async_wait()
+                current_task = None
+
+            if x.built:
+                tree = "bintree"
+                bintree = root_config.trees["bintree"].dbapi.bintree
+                fetched = False
+
+                # Display fetch on stdout, so that it's always clear what
+                # is consuming time here.
+                if bintree.download_required(x.cpv):
+                    fetcher = self._get_prefetcher(x)
+                    if fetcher is not None and not fetcher.isAlive():
+                        # Cancel it because it hasn't started yet.
+                        fetcher.cancel()
+                        fetcher = None
+                    if fetcher is None:
+                        fetcher = BinpkgFetcher(pkg=x, scheduler=loop)
+                        fetcher.start()
+                        # We only set the fetched value when fetcher
+                        # is a BinpkgFetcher, since BinpkgPrefetcher
+                        # handles fetch, verification, and the
+                        # bintree.inject call which moves the file.
+                        fetched = fetcher.pkg_path
+                    else:
+                        msg = (
+                            "Fetching in the background:",
+                            fetcher.pkg_path,
+                            "To view fetch progress, run in another terminal:",
+                            f"tail -f {self._fetch_log}",
+                        )
+                        out = portage.output.EOutput()
+                        for l in msg:
+                            out.einfo(l)
+                    if await fetcher.async_wait() != os.EX_OK:
+                        self._record_pkg_failure(x, settings, fetcher.returncode)
+                        return 1
+
+                if fetched is False:
+                    filename = bintree.getname(x.cpv)
+                else:
+                    filename = fetched
+                verifier = BinpkgVerifier(
+                    pkg=x, scheduler=sched_iface, _pkg_path=filename
                 )
+                current_task = verifier
+                verifier.start()
+                if await verifier.async_wait() != os.EX_OK:
+                    self._record_pkg_failure(x, settings, verifier.returncode)
+                    return 1
 
-                current_task = pretend_phase
-                pretend_phase.start()
-                ret = await pretend_phase.async_wait()
-                # Leave current_task assigned in order to trigger clean
-                # on success in the below finally block.
-                if ret != os.EX_OK:
-                    failures += 1
-                    self._record_pkg_failure(x, settings, ret)
-            finally:
-                if current_task is not None:
-                    if current_task.isAlive():
-                        current_task.cancel()
+                current_task = None
+                if fetched and bintree.get_local_repo_location(x.cpv):
+                    os.rename(fetched, fetcher.pkg_allocated_path)
+                elif fetched:
+                    injected_pkg = None
+                    stdout_orig = sys.stdout
+                    stderr_orig = sys.stderr
+                    out = io.StringIO()
+                    try:
+                        sys.stdout = out
+                        sys.stderr = out
 
-                portage.elog.elog_process(x.cpv, settings)
+                        injected_pkg = bintree.inject(
+                            x.cpv,
+                            current_pkg_path=fetched,
+                            allocated_pkg_path=fetcher.pkg_allocated_path,
+                        )
+                    finally:
+                        sys.stdout = stdout_orig
+                        sys.stderr = stderr_orig
 
-                if current_task is not None and current_task.returncode == os.EX_OK:
-                    clean_phase = EbuildPhase(
-                        background=False,
-                        phase="clean",
-                        scheduler=sched_iface,
-                        settings=settings,
+                    output_value = out.getvalue()
+                    if injected_pkg is None:
+                        msg = ["Binary package is not usable:"]
+                        if output_value:
+                            msg.extend(
+                                "\t" + line for line in output_value.splitlines()
+                            )
+                        self._elog("eerror", msg)
+
+                        self._record_pkg_failure(x, settings, 1)
+                        return 1
+
+                infloc = os.path.join(build_dir_path, "build-info")
+                ensure_dirs(infloc)
+                try:
+                    await bintree.dbapi.unpack_metadata(settings, infloc, loop=loop)
+                except portage.exception.SignatureException as e:
+                    writemsg(
+                        f"!!! Invalid binary package: '{bintree.getname(x.cpv)}', {e}\n",
+                        noiselevel=-1,
                     )
-                    clean_phase.start()
-                    await clean_phase.async_wait()
+                    self._record_pkg_failure(x, settings, 1)
+                    return 1
+                ebuild_path = os.path.join(infloc, x.pf + ".ebuild")
+                settings.configdict["pkg"]["EMERGE_FROM"] = "binary"
+                settings.configdict["pkg"]["MERGE_TYPE"] = "binary"
 
-                await build_dir.async_unlock()
-                self._deallocate_config(settings)
+            else:
+                tree = "porttree"
+                portdb = root_config.trees["porttree"].dbapi
+                ebuild_path = portdb.findname(x.cpv, myrepo=x.repo)
+                if ebuild_path is None:
+                    raise AssertionError(f"ebuild not found for '{x.cpv}'")
+                settings.configdict["pkg"]["EMERGE_FROM"] = "ebuild"
+                if self._build_opts.buildpkgonly:
+                    settings.configdict["pkg"]["MERGE_TYPE"] = "buildonly"
+                else:
+                    settings.configdict["pkg"]["MERGE_TYPE"] = "source"
 
-        if failures:
-            return FAILURE
-        return os.EX_OK
+            portage.package.ebuild.doebuild.doebuild_environment(
+                ebuild_path,
+                "pretend",
+                settings=settings,
+                db=self.trees[settings["EROOT"]][tree].dbapi,
+            )
+
+            prepare_build_dirs(root_config.root, settings, cleanup=0)
+
+            vardb = root_config.trees["vartree"].dbapi
+            settings["REPLACING_VERSIONS"] = " ".join(
+                {
+                    portage.versions.cpv_getversion(match)
+                    for match in vardb.match(x.slot_atom) + vardb.match("=" + x.cpv)
+                }
+            )
+            pretend_phase = EbuildPhase(
+                background=False,
+                phase="pretend",
+                scheduler=sched_iface,
+                settings=settings,
+            )
+
+            current_task = pretend_phase
+            pretend_phase.start()
+            ret = await pretend_phase.async_wait()
+            # Leave current_task assigned in order to trigger clean
+            # on success in the below finally block.
+            if ret != os.EX_OK:
+                self._record_pkg_failure(x, settings, ret)
+                failures = 1
+        finally:
+            if current_task is not None:
+                if current_task.isAlive():
+                    current_task.cancel()
+
+            portage.elog.elog_process(x.cpv, settings)
+
+            if current_task is not None and current_task.returncode == os.EX_OK:
+                clean_phase = EbuildPhase(
+                    background=False,
+                    phase="clean",
+                    scheduler=sched_iface,
+                    settings=settings,
+                )
+                clean_phase.start()
+                await clean_phase.async_wait()
+
+            await build_dir.async_unlock()
+            self._deallocate_config(settings)
+
+        return failures
 
     def _record_pkg_failure(self, pkg, settings, ret):
         """Record a package failure. This eliminates the package

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -1,6 +1,7 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import functools
 import gc
 import gzip
 import io
@@ -8,6 +9,7 @@ import logging
 import os
 import signal
 import sys
+import tempfile
 import textwrap
 import time
 import weakref
@@ -31,6 +33,7 @@ from portage.util import ensure_dirs, writemsg, writemsg_level
 from portage.util._async.SchedulerInterface import SchedulerInterface
 from portage.util.cgroup import DEFAULT_CGROUP_ROOT, CgroupManager
 from portage.util.futures import asyncio
+from portage.util.futures.iter_completed import async_iter_completed
 from portage.util.human_readable import bytes_to_human
 from portage.util.path import first_existing
 from portage.util.SlotObject import SlotObject
@@ -120,6 +123,17 @@ class Scheduler(PollScheduler):
 
     class _failed_pkg(SlotObject):
         __slots__ = ("build_dir", "build_log", "pkg", "postinst_failure", "returncode")
+
+    class _pretend_result(SlotObject):
+        __slots__ = (
+            "build_dir",
+            "build_log",
+            "index",
+            "msgs",
+            "output",
+            "pkg",
+            "returncode",
+        )
 
     class _ConfigPool:
         """Interface for a task to temporarily allocate a config
@@ -889,27 +903,108 @@ class Scheduler(PollScheduler):
         Since pkg_pretend output may be important, this method sends all
         output directly to stdout (regardless of options like --quiet or
         --jobs).
+
+        When more than one job is allowed, the phases run concurrently and
+        their output is buffered, then replayed in mergelist order.
         """
         loop = asyncio._wrap_loop(loop or self._sched_iface)
 
+        pretend_pkgs = [x for x in self._mergelist if self._pkg_needs_pretend(x)]
+        if not pretend_pkgs:
+            return os.EX_OK
+
+        max_jobs = self._max_jobs
+        if max_jobs is True:
+            max_jobs = len(pretend_pkgs)
+        max_jobs = max(1, min(max_jobs, len(pretend_pkgs)))
+
+        # A max_load of True disables load average throttling, which is
+        # what we want when the user has not requested --load-average.
+        max_load = True if self._max_load is None else self._max_load
+
+        # With a single job there is nothing to interleave. A
+        # PROPERTIES=interactive package needs the terminal to itself, and
+        # _background_mode() has already forced --jobs=1 for those, so they
+        # take the unbuffered path here.
+        buffered = max_jobs > 1
+
+        def future_generator():
+            for index, pkg in enumerate(pretend_pkgs):
+                yield asyncio.ensure_future(
+                    self._run_pkg_pretend_one(index, pkg, buffered, loop), loop=loop
+                )
+
         failures = 0
+        results = {}
+        next_index = 0
 
-        for x in self._mergelist:
-            if not self._pkg_needs_pretend(x):
-                continue
+        for done_set_future in async_iter_completed(
+            future_generator(),
+            max_jobs=max_jobs,
+            max_load=max_load,
+            loop=loop,
+        ):
+            for future in await done_set_future:
+                result = future.result()
+                results[result.index] = result
 
-            failures += await self._run_pkg_pretend_one(x, loop)
+            while next_index in results:
+                failures += self._emit_pkg_pretend_result(results.pop(next_index))
+                next_index += 1
+
+            self._termination_check()
+            if self._terminated_tasks:
+                raise asyncio.CancelledError
 
         if failures:
             return FAILURE
         return os.EX_OK
 
-    async def _run_pkg_pretend_one(self, x, loop):
+    def _emit_pkg_pretend_result(self, result):
         """
-        Run the pkg_pretend phase for a single package.
+        Send buffered pkg_pretend output to stdout and record a failure if
+        the job failed.
 
         @rtype: int
         @return: the number of failures (0 or 1)
+        """
+        for msg in result.msgs:
+            msg()
+
+        if result.output:
+            # Use the file descriptor that unbuffered phase output would
+            # have gone to, and flush first so that pending output does not
+            # appear afterwards.
+            sys.stdout.flush()
+            sys.stderr.flush()
+            sys.__stdout__.buffer.write(result.output)
+            sys.__stdout__.buffer.flush()
+
+        if result.returncode == os.EX_OK:
+            return 0
+
+        self._record_pkg_failure(
+            result.pkg, result.build_dir, result.build_log, result.returncode
+        )
+        return 1
+
+    def _read_pretend_log(self, capture_path):
+        """
+        Return the contents of a buffered pkg_pretend log, and remove it.
+        """
+        try:
+            with open(capture_path, "rb") as f:
+                return f.read()
+        finally:
+            os.unlink(capture_path)
+
+    async def _run_pkg_pretend_one(self, index, x, buffered, loop):
+        """
+        Run the pkg_pretend phase for a single package. If buffered is True
+        then all output is captured in the returned result, so that the
+        caller can replay it in mergelist order.
+
+        @rtype: Scheduler._pretend_result
         """
         sched_iface = loop
 
@@ -917,14 +1012,33 @@ class Scheduler(PollScheduler):
         if self._terminated_tasks:
             raise asyncio.CancelledError
 
-        failures = 0
+        msgs = []
+        capture_path = None
+        real_log_path = None
+        result = self._pretend_result(index=index, msgs=msgs, output=b"", pkg=x)
+
+        def add_msg(func, *args, **kwargs):
+            if buffered:
+                msgs.append(functools.partial(func, *args, **kwargs))
+            else:
+                func(*args, **kwargs)
+
+        def finish(returncode, settings):
+            result.build_dir = settings.get("PORTAGE_BUILDDIR")
+            result.build_log = (
+                real_log_path if buffered else settings.get("PORTAGE_LOG_FILE")
+            )
+            result.returncode = returncode
+            return result
 
         root_config = x.root_config
         settings = self._allocate_config(root_config.root)
         settings.setcpv(x)
 
         color = "PKG_BINARY_MERGE" if x.built else "INFORM"
-        self._status_msg(f"Running pre-merge checks for {colorize(color, x.cpv)}")
+        add_msg(
+            self._status_msg, f"Running pre-merge checks for {colorize(color, x.cpv)}"
+        )
 
         if not x.built:
             # Get required SRC_URI metadata (it's not cached in x.metadata
@@ -938,9 +1052,9 @@ class Scheduler(PollScheduler):
         # have to validate it for each package
         rval = _check_temp_dir(settings)
         if rval != os.EX_OK:
-            self._record_pkg_failure(x, settings, FAILURE)
+            finish(FAILURE, settings)
             self._deallocate_config(settings)
-            return 1
+            return result
 
         build_dir_path = os.path.join(
             os.path.realpath(settings["PORTAGE_TMPDIR"]),
@@ -975,7 +1089,7 @@ class Scheduler(PollScheduler):
                     db=self.trees[settings["EROOT"]][tree].dbapi,
                 )
                 clean_phase = EbuildPhase(
-                    background=False,
+                    background=buffered,
                     phase="clean",
                     scheduler=sched_iface,
                     settings=settings,
@@ -1015,10 +1129,9 @@ class Scheduler(PollScheduler):
                         )
                         out = portage.output.EOutput()
                         for l in msg:
-                            out.einfo(l)
+                            add_msg(out.einfo, l)
                     if await fetcher.async_wait() != os.EX_OK:
-                        self._record_pkg_failure(x, settings, fetcher.returncode)
-                        return 1
+                        return finish(fetcher.returncode, settings)
 
                 if fetched is False:
                     filename = bintree.getname(x.cpv)
@@ -1030,8 +1143,7 @@ class Scheduler(PollScheduler):
                 current_task = verifier
                 verifier.start()
                 if await verifier.async_wait() != os.EX_OK:
-                    self._record_pkg_failure(x, settings, verifier.returncode)
-                    return 1
+                    return finish(verifier.returncode, settings)
 
                 current_task = None
                 if fetched and bintree.get_local_repo_location(x.cpv):
@@ -1061,22 +1173,25 @@ class Scheduler(PollScheduler):
                             msg.extend(
                                 "\t" + line for line in output_value.splitlines()
                             )
-                        self._elog("eerror", msg)
+                        add_msg(
+                            writemsg,
+                            "".join(f"!!! {line}\n" for line in msg),
+                            noiselevel=-1,
+                        )
 
-                        self._record_pkg_failure(x, settings, 1)
-                        return 1
+                        return finish(1, settings)
 
                 infloc = os.path.join(build_dir_path, "build-info")
                 ensure_dirs(infloc)
                 try:
                     await bintree.dbapi.unpack_metadata(settings, infloc, loop=loop)
                 except portage.exception.SignatureException as e:
-                    writemsg(
+                    add_msg(
+                        writemsg,
                         f"!!! Invalid binary package: '{bintree.getname(x.cpv)}', {e}\n",
                         noiselevel=-1,
                     )
-                    self._record_pkg_failure(x, settings, 1)
-                    return 1
+                    return finish(1, settings)
                 ebuild_path = os.path.join(infloc, x.pf + ".ebuild")
                 settings.configdict["pkg"]["EMERGE_FROM"] = "binary"
                 settings.configdict["pkg"]["MERGE_TYPE"] = "binary"
@@ -1102,6 +1217,16 @@ class Scheduler(PollScheduler):
 
             prepare_build_dirs(root_config.root, settings, cleanup=0)
 
+            if buffered:
+                # Redirect phase output to a temporary file, so that it can
+                # be replayed in mergelist order once this job completes.
+                real_log_path = settings.get("PORTAGE_LOG_FILE")
+                fd, capture_path = tempfile.mkstemp(
+                    dir=settings["T"], suffix=".pretend.log"
+                )
+                os.close(fd)
+                settings["PORTAGE_LOG_FILE"] = capture_path
+
             vardb = root_config.trees["vartree"].dbapi
             settings["REPLACING_VERSIONS"] = " ".join(
                 {
@@ -1110,7 +1235,7 @@ class Scheduler(PollScheduler):
                 }
             )
             pretend_phase = EbuildPhase(
-                background=False,
+                background=buffered,
                 phase="pretend",
                 scheduler=sched_iface,
                 settings=settings,
@@ -1121,19 +1246,33 @@ class Scheduler(PollScheduler):
             ret = await pretend_phase.async_wait()
             # Leave current_task assigned in order to trigger clean
             # on success in the below finally block.
-            if ret != os.EX_OK:
-                self._record_pkg_failure(x, settings, ret)
-                failures = 1
+            return finish(ret, settings)
         finally:
             if current_task is not None:
                 if current_task.isAlive():
                     current_task.cancel()
 
+            if capture_path is not None:
+                # Collect the phase output before the clean phase below
+                # removes it, and restore the real log file before settings
+                # is returned to the config pool.
+                result.output = self._read_pretend_log(capture_path)
+                if real_log_path is None:
+                    settings.pop("PORTAGE_LOG_FILE", None)
+                else:
+                    settings["PORTAGE_LOG_FILE"] = real_log_path
+                    if result.output:
+                        self._sched_iface.output(
+                            result.output.decode("utf-8", "replace"),
+                            log_path=real_log_path,
+                            background=True,
+                        )
+
             portage.elog.elog_process(x.cpv, settings)
 
             if current_task is not None and current_task.returncode == os.EX_OK:
                 clean_phase = EbuildPhase(
-                    background=False,
+                    background=buffered,
                     phase="clean",
                     scheduler=sched_iface,
                     settings=settings,
@@ -1144,16 +1283,14 @@ class Scheduler(PollScheduler):
             await build_dir.async_unlock()
             self._deallocate_config(settings)
 
-        return failures
-
-    def _record_pkg_failure(self, pkg, settings, ret):
+    def _record_pkg_failure(self, pkg, build_dir, build_log, ret):
         """Record a package failure. This eliminates the package
         from the --keep-going merge list, and immediately calls
         _failed_pkg_msg if we have not been terminated."""
         self._failed_pkgs.append(
             self._failed_pkg(
-                build_dir=settings.get("PORTAGE_BUILDDIR"),
-                build_log=settings.get("PORTAGE_LOG_FILE"),
+                build_dir=build_dir,
+                build_log=build_log,
                 pkg=pkg,
                 returncode=ret,
             )

--- a/lib/portage/tests/emerge/meson.build
+++ b/lib/portage/tests/emerge/meson.build
@@ -13,6 +13,7 @@ py.install_sources(
         'test_libc_dep_inject.py',
         'test_noreplace.py',
         'test_observability.py',
+        'test_pkg_pretend.py',
         '__init__.py',
         '__test__.py',
     ],

--- a/lib/portage/tests/emerge/test_pkg_pretend.py
+++ b/lib/portage/tests/emerge/test_pkg_pretend.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import re
+import subprocess
+import sys
+import textwrap
+
+import portage
+from portage.const import (
+    PORTAGE_PYM_PATH,
+    USER_CONFIG_PATH,
+)
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import ResolverPlayground
+from portage.util import ensure_dirs
+
+# Each pkg_pretend records the time it started and finished, so that the
+# test can tell whether the phases overlapped. The sleep has to be long
+# enough that all of the jobs are guaranteed to overlap on a slow machine.
+PRETEND_SLEEP = 5
+
+MISC_CONTENT = textwrap.dedent(f"""
+    S="${{WORKDIR}}"
+
+    pkg_pretend() {{
+        einfo "PRETEND-BEGIN ${{PN}} $(date +%s.%N)"
+        einfo "PRETEND-BODY ${{PN}}"
+        sleep {PRETEND_SLEEP}
+        einfo "PRETEND-END ${{PN}} $(date +%s.%N)"
+    }}
+    """)
+
+FAILING_MISC_CONTENT = textwrap.dedent("""
+    S="${WORKDIR}"
+
+    pkg_pretend() {
+        eerror "PRETEND-FAIL ${PN}"
+        die "pkg_pretend failed on purpose"
+    }
+    """)
+
+MARKER_RE = re.compile(r"PRETEND-(BEGIN|BODY|END) (\w+)(?: (\d+\.\d+))?")
+
+
+class PkgPretendTestCase(TestCase):
+    def _playground_env(self, playground):
+        settings = playground.settings
+        eprefix = settings["EPREFIX"]
+
+        portage_python = portage._python_interpreter
+        emerge_cmd = (
+            portage_python,
+            "-b",
+            "-Wd",
+            os.path.join(str(self.bindir), "emerge"),
+            "--oneshot",
+        )
+
+        pythonpath = os.environ.get("PYTHONPATH")
+        if pythonpath is not None and not pythonpath.strip():
+            pythonpath = None
+        if pythonpath is not None and pythonpath.split(":")[0] == PORTAGE_PYM_PATH:
+            pass
+        else:
+            if pythonpath is None:
+                pythonpath = ""
+            else:
+                pythonpath = ":" + pythonpath
+            pythonpath = PORTAGE_PYM_PATH + pythonpath
+
+        env = {
+            "PORTAGE_OVERRIDE_EPREFIX": eprefix,
+            "PATH": settings.get("PATH"),
+            "PORTAGE_PYTHON": portage_python,
+            "PORTAGE_REPOSITORIES": settings.repositories.config_string(),
+            "PYTHONDONTWRITEBYTECODE": os.environ.get("PYTHONDONTWRITEBYTECODE", ""),
+            "PYTHONPATH": pythonpath,
+            "PORTAGE_INST_GID": str(os.getgid()),
+            "PORTAGE_INST_UID": str(os.getuid()),
+        }
+
+        dirs = [
+            playground.distdir,
+            os.path.join(eprefix, "var", "tmp", "portage"),
+            os.path.join(eprefix, USER_CONFIG_PATH),
+            os.path.join(eprefix, "var", "cache", "edb"),
+        ]
+        for d in dirs:
+            ensure_dirs(d)
+
+        with open(os.path.join(eprefix, "var", "cache", "edb", "counter"), "wb") as f:
+            f.write(b"100")
+
+        return emerge_cmd, env
+
+    def _run_emerge(self, emerge_cmd, env, args):
+        proc = subprocess.Popen(
+            emerge_cmd + args,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        output = proc.communicate()[0].decode("utf-8", "replace")
+        return proc.returncode, output
+
+    def _parse_markers(self, output):
+        """
+        Return the ordered list of (kind, pn, timestamp) markers found in
+        the given emerge output.
+        """
+        markers = []
+        for line in output.splitlines():
+            match = MARKER_RE.search(line)
+            if match is not None:
+                kind, pn, timestamp = match.groups()
+                markers.append(
+                    (kind, pn, None if timestamp is None else float(timestamp))
+                )
+        return markers
+
+    def _assert_not_interleaved(self, markers, pns):
+        """
+        Assert that each package emitted BEGIN, BODY and END consecutively,
+        with no output from another package in between.
+        """
+        self.assertEqual(len(markers), 3 * len(pns), f"unexpected markers: {markers}")
+        seen = []
+        for i in range(0, len(markers), 3):
+            block = markers[i : i + 3]
+            self.assertEqual(
+                [kind for kind, _, _ in block],
+                ["BEGIN", "BODY", "END"],
+                f"markers out of order: {block}",
+            )
+            block_pns = {pn for _, pn, _ in block}
+            self.assertEqual(
+                len(block_pns), 1, f"output of concurrent jobs is interleaved: {block}"
+            )
+            seen.append(block[0][1])
+
+        self.assertEqual(sorted(seen), sorted(pns))
+        return seen
+
+    def testParallelPkgPretend(self):
+        """
+        With --jobs greater than 1, pkg_pretend phases run concurrently, but
+        their output is still emitted one package at a time (bug 579526).
+        """
+        pns = ("A", "B", "C", "D")
+        ebuilds = {
+            f"dev-libs/{pn}-1": {"EAPI": "8", "MISC_CONTENT": MISC_CONTENT}
+            for pn in pns
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds, debug=False)
+        try:
+            emerge_cmd, env = self._playground_env(playground)
+            returncode, output = self._run_emerge(
+                emerge_cmd,
+                env,
+                ("--jobs=4",) + tuple(f"dev-libs/{pn}" for pn in pns),
+            )
+            if returncode != os.EX_OK:
+                sys.stderr.write(output)
+            self.assertEqual(os.EX_OK, returncode)
+
+            markers = self._parse_markers(output)
+            self._assert_not_interleaved(markers, pns)
+
+            begins = [ts for kind, _, ts in markers if kind == "BEGIN"]
+            ends = [ts for kind, _, ts in markers if kind == "END"]
+            # If the phases ran concurrently then there is an instant at
+            # which all of them were running.
+            self.assertTrue(
+                max(begins) < min(ends),
+                f"pkg_pretend phases did not overlap: begins={begins} ends={ends}",
+            )
+        finally:
+            playground.cleanup()
+
+    def testSerialPkgPretend(self):
+        """
+        With a single job, pkg_pretend output is still complete and ordered.
+        """
+        pns = ("A", "B")
+        ebuilds = {
+            f"dev-libs/{pn}-1": {"EAPI": "8", "MISC_CONTENT": MISC_CONTENT}
+            for pn in pns
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds, debug=False)
+        try:
+            emerge_cmd, env = self._playground_env(playground)
+            returncode, output = self._run_emerge(
+                emerge_cmd, env, tuple(f"dev-libs/{pn}" for pn in pns)
+            )
+            if returncode != os.EX_OK:
+                sys.stderr.write(output)
+            self.assertEqual(os.EX_OK, returncode)
+
+            markers = self._parse_markers(output)
+            self._assert_not_interleaved(markers, pns)
+
+            # Serial phases cannot share their sleeps, so the whole run
+            # takes at least one sleep per package.
+            begins = [ts for kind, _, ts in markers if kind == "BEGIN"]
+            ends = [ts for kind, _, ts in markers if kind == "END"]
+            elapsed = max(ends) - min(begins)
+            self.assertTrue(
+                elapsed >= len(pns) * PRETEND_SLEEP,
+                f"pkg_pretend phases were expected to be serial: "
+                f"elapsed={elapsed} begins={begins} ends={ends}",
+            )
+        finally:
+            playground.cleanup()
+
+    def testInteractivePkgPretend(self):
+        """
+        A PROPERTIES=interactive package needs the terminal to itself, so
+        the phases run serially and unbuffered even with --jobs greater
+        than 1.
+        """
+        pns = ("A", "B")
+        ebuilds = {
+            f"dev-libs/{pn}-1": {"EAPI": "8", "MISC_CONTENT": MISC_CONTENT}
+            for pn in pns
+        }
+        ebuilds["dev-libs/A-1"]["PROPERTIES"] = "interactive"
+
+        playground = ResolverPlayground(ebuilds=ebuilds, debug=False)
+        try:
+            emerge_cmd, env = self._playground_env(playground)
+            returncode, output = self._run_emerge(
+                emerge_cmd,
+                env,
+                ("--jobs=2",) + tuple(f"dev-libs/{pn}" for pn in pns),
+            )
+            if returncode != os.EX_OK:
+                sys.stderr.write(output)
+            self.assertEqual(os.EX_OK, returncode)
+
+            markers = self._parse_markers(output)
+            self._assert_not_interleaved(markers, pns)
+
+            begins = [ts for kind, _, ts in markers if kind == "BEGIN"]
+            ends = [ts for kind, _, ts in markers if kind == "END"]
+            elapsed = max(ends) - min(begins)
+            self.assertTrue(
+                elapsed >= len(pns) * PRETEND_SLEEP,
+                f"pkg_pretend phases were expected to be serial: "
+                f"elapsed={elapsed} begins={begins} ends={ends}",
+            )
+        finally:
+            playground.cleanup()
+
+    def testParallelPkgPretendFailure(self):
+        """
+        A pkg_pretend failure aborts the merge, and its output is not lost
+        when other jobs run concurrently.
+        """
+        ebuilds = {
+            "dev-libs/A-1": {"EAPI": "8", "MISC_CONTENT": MISC_CONTENT},
+            "dev-libs/B-1": {"EAPI": "8", "MISC_CONTENT": FAILING_MISC_CONTENT},
+            "dev-libs/C-1": {"EAPI": "8", "MISC_CONTENT": MISC_CONTENT},
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds, debug=False)
+        try:
+            emerge_cmd, env = self._playground_env(playground)
+            returncode, output = self._run_emerge(
+                emerge_cmd,
+                env,
+                ("--jobs=3", "dev-libs/A", "dev-libs/B", "dev-libs/C"),
+            )
+            self.assertNotEqual(os.EX_OK, returncode)
+            self.assertIn("PRETEND-FAIL B", output)
+            # The packages which passed still ran, and nothing was merged.
+            self.assertIn("PRETEND-END A", output)
+            self.assertIn("PRETEND-END C", output)
+            vardb = playground.trees[playground.eroot]["vartree"].dbapi
+            self.assertEqual([], vardb.cpv_all())
+        finally:
+            playground.cleanup()


### PR DESCRIPTION
pkg_pretend runs one package at a time. Ebuilds doing real work there mean minutes of waiting before the first package is built.

The phases have run in a coroutine since c7fa3f1eb, so this drives them with async_iter_completed(), which already implements `--jobs` and `--load-average` throttling. Output needs more care: _run_pkg_pretend() sends everything to stdout regardless of `--quiet` or `--jobs`, and concurrent phases sharing a terminal interleave. So with more than one job, each phase runs in background mode with PORTAGE_LOG_FILE pointed at a capture file in its own build dir, and results are replayed to stdout in mergelist order as they become available. Failures are recorded in that same ordered pass, so _failed_pkgs and `--keep-going` are unchanged. With `--jobs=1` the original direct-to-stdout path is kept.

The first commit is a pure extraction of the loop body into _run_pkg_pretend_one(). It carries the reindentation, so `git show -w` on the second commit is identical to `git show`.

Over 91 installed acct-user/acct-group packages on a 20-core machine, with `--jobs=8 --load-average=16`, the pkg_pretend phase drops from 51.8s to 5.9s and the whole run from 391.2s to 353.8s.

I checked every pkg_pretend in ::gentoo for anything that breaks under concurrency. Nothing reads stdin, writes outside ${T}, takes a lock, or mounts anything. Two things worth knowing:

dev-lang/perl warns and sleeps two seconds to let you abort. Buffered, the warning is replayed after the sleep has elapsed, so it no longer does its job.

linux-info.eclass's getfilevar() runs emake in ${KERNEL_DIR}, reached from 24 pkg_pretend functions. This concurrency is new, since _schedule_setup() puts setup phases on the merge queue to serialize them. I ran it 16-wide against a 6.18 tree: identical output, empty stderr, nothing written to the kernel tree or M=${T}.

Bug: https://bugs.gentoo.org/579526
