### PR TITLE
util: accept Atom instances in stack_dictlist()

### DIFF
--- a/lib/portage/package/ebuild/_config/VirtualsManager.py
+++ b/lib/portage/package/ebuild/_config/VirtualsManager.py
@@ -232,7 +232,7 @@ class VirtualsManager:
         virts = self.getvirtuals()
         virts_p = {}
         for x in virts:
-            vkeysplit = x.split("/")
+            vkeysplit = str(x).split("/")
             if vkeysplit[1] not in virts_p:
                 virts_p[vkeysplit[1]] = virts[x]
         self._virts_p = virts_p

--- a/lib/portage/tests/util/test_stackDictList.py
+++ b/lib/portage/tests/util/test_stackDictList.py
@@ -23,3 +23,22 @@ class StackDictListTestCase(TestCase):
             self.assertEqual(
                 stack_dictlist([test[0], test[1]], incremental=test[2]), test[3]
             )
+
+    def testStackDictListAtomValues(self):
+        from portage.dep import Atom
+        from portage.util import stack_dictlist
+
+        virt = Atom("virtual/editor")
+        result = stack_dictlist(
+            [
+                {virt: [Atom("app-editors/vim"), Atom("app-editors/emacs")]},
+                {virt: ["-app-editors/vim", Atom("app-editors/nano")]},
+            ],
+            incremental=True,
+        )
+
+        self.assertEqual(
+            result, {virt: [Atom("app-editors/emacs"), Atom("app-editors/nano")]}
+        )
+        for provider in result[virt]:
+            self.assertIsInstance(provider, Atom)

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -242,9 +242,9 @@ def stack_dictlist(original_dicts, incremental=0, incrementals=[], ignore_none=0
                         if thing == "-*":
                             final_dict[y] = []
                             continue
-                        elif thing[:1] == "-":
+                        elif str(thing)[:1] == "-":
                             try:
-                                final_dict[y].remove(thing[1:])
+                                final_dict[y].remove(str(thing)[1:])
                             except ValueError:
                                 pass
                             continue


### PR DESCRIPTION
VirtualsManager._read_dirVirtuals() builds a dict whose keys and values are Atom instances and hands it to stack_dictlist(), which inspects each value with thing[:1] to implement the incremental "-" prefix. That worked only while Atom was a str subclass. Since commit 7e15fc7fa ("dep: Atom: remove str subtyping") every emerge invocation on a host whose profile ships a non-empty 'virtuals' file fails during config setup with:

    TypeError: 'Atom' object is not subscriptable

Wrap the value with str() for the two subscripts. The values themselves are stored unchanged, so providers remain Atom instances, and removing an entry by its "-cat/pkg" form still works because Atom compares equal to the matching str.

get_virts_p() has the same problem one call further on: it splits the keys of the compiled virtuals dict, which come from _dirVirtuals and are therefore Atom instances too. Wrap that in str() as well.

Bug: https://bugs.gentoo.org/981272
Fixes: 7e15fc7fa4c1 ("dep: Atom: remove str subtyping")