### PR TITLE
Warn about deprecated 'virtuals' files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,12 @@ Release notes take the form of the following optional categories:
 portage-3.0.83 (UNRELEASED)
 --------------
 
+Breaking changes:
+
+* Output a deprecation warning when a profile 'virtuals' file is used.
+  Support for PROVIDE virtuals was removed in portage-2.3.25, so these
+  files are obsolete; use GLEP 37 virtual packages instead (bug #981272).
+
 Features:
 
 * Add FEATURES="merge-use-vdb" to bypass identical file rewrites during

--- a/lib/portage/package/ebuild/_config/VirtualsManager.py
+++ b/lib/portage/package/ebuild/_config/VirtualsManager.py
@@ -4,8 +4,10 @@
 __all__ = ("VirtualsManager",)
 
 import os
+import warnings
 from copy import deepcopy
 
+import portage
 from portage.dep import Atom
 from portage.exception import InvalidAtom
 from portage.localization import _
@@ -48,6 +50,16 @@ class VirtualsManager:
         for x in profiles:
             virtuals_file = os.path.join(x, "virtuals")
             virtuals_dict = grabdict(virtuals_file)
+            if virtuals_dict and portage._internal_caller:
+                warnings.warn(
+                    _(
+                        "%s is deprecated, support for PROVIDE virtuals "
+                        "was removed in portage-2.3.25, use GLEP 37 virtual "
+                        "packages instead"
+                    )
+                    % virtuals_file,
+                    UserWarning,
+                )
             atoms_dict = {}
             for k, v in virtuals_dict.items():
                 try:

--- a/lib/portage/package/ebuild/config.py
+++ b/lib/portage/package/ebuild/config.py
@@ -1452,9 +1452,10 @@ class config:
 
         abs_user_virtuals = os.path.join(self["PORTAGE_CONFIGROOT"], USER_VIRTUALS_FILE)
         if os.path.exists(abs_user_virtuals):
-            writemsg("\n!!! /etc/portage/virtuals is deprecated in favor of\n")
-            writemsg("!!! /etc/portage/profile/virtuals. Please move it to\n")
-            writemsg("!!! this new location.\n\n")
+            writemsg("\n!!! /etc/portage/virtuals is deprecated and ignored.\n")
+            writemsg("!!! Support for PROVIDE virtuals was removed in\n")
+            writemsg("!!! portage-2.3.25; use GLEP 37 virtual packages\n")
+            writemsg("!!! instead. Please remove this file.\n\n")
 
         if not sandbox_capable and (
             "sandbox" in self.features or "usersandbox" in self.features

--- a/lib/portage/tests/ebuild/meson.build
+++ b/lib/portage/tests/ebuild/meson.build
@@ -9,6 +9,7 @@ py.install_sources(
         'test_prepare_self_update.py',
         'test_spawn.py',
         'test_use_expand_incremental.py',
+        'test_virtuals_manager.py',
         '__init__.py',
         '__test__.py',
     ],

--- a/lib/portage/tests/ebuild/test_virtuals_manager.py
+++ b/lib/portage/tests/ebuild/test_virtuals_manager.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+import os
+import shutil
+import tempfile
+
+import portage
+from portage.dep import Atom
+from portage.package.ebuild._config.VirtualsManager import VirtualsManager
+from portage.tests import TestCase
+
+
+class _FakeVartree:
+    def __init__(self, provides=None):
+        self._provides = provides or {}
+
+    def get_all_provides(self):
+        return self._provides
+
+
+class VirtualsManagerTestCase(TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._internal_caller = portage._internal_caller
+        portage._internal_caller = True
+
+    def tearDown(self):
+        portage._internal_caller = self._internal_caller
+        shutil.rmtree(self._tmpdir)
+
+    def _profile(self, name, virtuals=None):
+        """
+        Create a profile directory, optionally containing a virtuals file
+        with the given lines, and return its path.
+        """
+        profile_path = os.path.join(self._tmpdir, name)
+        os.mkdir(profile_path)
+        if virtuals is not None:
+            with open(os.path.join(profile_path, "virtuals"), "w") as f:
+                f.write("".join(f"{line}\n" for line in virtuals))
+        return profile_path
+
+    def _manager(self, profiles, provides=None):
+        """
+        Return a VirtualsManager for the given profiles, with _treeVirtuals
+        populated from a fake vartree so that getvirtuals() can be called.
+        """
+        virtuals_manager = VirtualsManager(profiles)
+        virtuals_manager._populate_treeVirtuals(_FakeVartree(provides))
+        return virtuals_manager
+
+    def testDirVirtuals(self):
+        profile = self._profile(
+            "profile", ["virtual/editor app-editors/vim app-editors/emacs"]
+        )
+        virtuals_manager = VirtualsManager([profile])
+        # The provider list is reversed, so that providers from the profile
+        # read last come first.
+        self.assertEqual(
+            virtuals_manager._dirVirtuals,
+            {
+                Atom("virtual/editor"): [
+                    Atom("app-editors/emacs"),
+                    Atom("app-editors/vim"),
+                ]
+            },
+        )
+
+    def testDirVirtualsIncremental(self):
+        parent = self._profile(
+            "parent", ["virtual/editor app-editors/vim app-editors/emacs"]
+        )
+        child = self._profile("child", ["virtual/editor -app-editors/vim"])
+        virtuals_manager = VirtualsManager([parent, child])
+        self.assertEqual(
+            virtuals_manager._dirVirtuals,
+            {Atom("virtual/editor"): [Atom("app-editors/emacs")]},
+        )
+
+    def testDirVirtualsInvalidAtom(self):
+        profile = self._profile("profile", ["virtual/editor !app-editors/vim"])
+        virtuals_manager = VirtualsManager([profile])
+        self.assertEqual(virtuals_manager._dirVirtuals, {})
+
+    def testGetVirtuals(self):
+        profile = self._profile("profile", ["virtual/editor app-editors/vim"])
+        virtuals_manager = self._manager([profile])
+        self.assertEqual(
+            virtuals_manager.getvirtuals(),
+            {Atom("virtual/editor"): [Atom("app-editors/vim")]},
+        )
+
+    def testGetVirtualsInstalled(self):
+        profile = self._profile(
+            "profile", ["virtual/editor app-editors/vim app-editors/emacs"]
+        )
+        # An installed provider is preferred over one that is not installed.
+        virtuals_manager = self._manager(
+            [profile], {"virtual/editor": ["app-editors/vim-9"]}
+        )
+        self.assertEqual(
+            virtuals_manager.getvirtuals()[Atom("virtual/editor")],
+            [Atom("app-editors/vim"), Atom("app-editors/emacs")],
+        )
+
+    def testGetVirtsP(self):
+        profile = self._profile("profile", ["virtual/editor app-editors/vim"])
+        virtuals_manager = self._manager([profile])
+        self.assertEqual(
+            virtuals_manager.get_virts_p(),
+            {"editor": [Atom("app-editors/vim")]},
+        )

--- a/lib/portage/tests/ebuild/test_virtuals_manager.py
+++ b/lib/portage/tests/ebuild/test_virtuals_manager.py
@@ -4,6 +4,7 @@
 import os
 import shutil
 import tempfile
+import warnings
 
 import portage
 from portage.dep import Atom
@@ -111,3 +112,15 @@ class VirtualsManagerTestCase(TestCase):
             virtuals_manager.get_virts_p(),
             {"editor": [Atom("app-editors/vim")]},
         )
+
+    def testDeprecationWarning(self):
+        profile = self._profile("profile", ["virtual/editor app-editors/vim"])
+        self.assertWarnsRegex(UserWarning, "is deprecated", VirtualsManager, [profile])
+
+    def testNoDeprecationWarning(self):
+        empty = self._profile("empty", [])
+        missing = self._profile("missing")
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            VirtualsManager([empty, missing])
+        self.assertEqual([str(x.message) for x in recorded], [])

--- a/man/portage.5
+++ b/man/portage.5
@@ -584,11 +584,9 @@ doc
 .BR virtuals
 The virtuals file controls default preferences for virtuals that
 are defined via the \fBPROVIDE\fR ebuild variable (see
-\fBebuild\fR(5)). Since Gentoo now uses \fBGLEP 37\fR virtuals
-instead of \fBPROVIDE\fR virtuals, the virtuals file is
-irrelevant for all Gentoo ebuilds. However, it is still possible
-for third\-parties to distribute ebuilds that make use of
-\fBPROVIDE\fR.
+\fBebuild\fR(5)). Support for \fBPROVIDE\fR was removed in
+portage\-2.3.25, so this file is deprecated and its use generates
+a warning. Use \fBGLEP 37\fR virtual packages instead.
 
 .I Format:
 .nf


### PR DESCRIPTION
Follow-up to the review of #1667.

Support for PROVIDE virtuals was removed in portage-2.3.25 (7ddb34f2d772,
"Remove support for PROVIDE virtuals"), so nothing can define such virtuals
any more, but portage still reads a profile 'virtuals' file silently.
Warn when a non-empty one is found, in the same way KeywordsManager warns
about package.keywords.

portage(5) claimed the file was only irrelevant to Gentoo ebuilds and that
third parties could still ship PROVIDE ebuilds, which has not been true
since 2.3.25. The /etc/portage/virtuals notice in config.py told users to
move the file to /etc/portage/profile/virtuals, which is now deprecated
too. Both are updated.

VirtualsManager had no test coverage, which is how the "'Atom' object is
not subscriptable" regression fixed in #1667 went unnoticed. The first
commit adds tests for the parsing path and for getvirtuals() and
get_virts_p(), both of which that bug touched.

Bug: https://bugs.gentoo.org/981272