### PR TITLE
dep: fix three C dep-string parser divergences from the regex path

### DIFF
--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -1181,6 +1181,22 @@ class TestScanAtomNameGrammar(_AtomParityMixin, TestCase):
             with self.subTest(s=s):
                 self._assert_same(s, eapi="8")
 
+    def test_hyphens_that_do_not_start_a_version(self):
+        # A '-' that is not followed by a complete version is an ordinary
+        # name character, wherever it appears, so these names run to the end
+        # of the token rather than ending at the '-'.
+        for s in (
+            "dev-util/diff-mode-",
+            "dev-util/timidity--",
+            "dev-util/frob---",
+            "dev-util/diffball-9-",
+            "dev-util/foo-2048+",
+            "dev-util/foo-9-bar",
+        ):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+                self._assert_use_reduce_same(s)
+
     def test_all_digit_name_word(self):
         # bug 981298: a name word made only of digits is a name, not a
         # version, so "games-emulation/81-libretro" is an ordinary

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -974,6 +974,12 @@ class _AtomParityMixin:
             self.assertEqual(str(py._use or ""), str(c._use or ""), f"{s!r}: use")
             self.assertEqual(str(py), str(c))
 
+        # Atom() accepting through the regex fallback proves nothing about
+        # the scanner, so check the no-fallback path too.  Only Atom()
+        # takes allow_wildcard and friends, so those cases opt out.
+        if not set(kw) - {"eapi"}:
+            self._assert_use_reduce_same(s, **kw)
+
 
 class TestScanAtom(_AtomParityMixin, TestCase):
     """Test that _parser.scan_atom + Atom._c_fast_init matches the pure-Python

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -938,6 +938,22 @@ class _AtomParityMixin:
             c, c_exc = None, type(e)
         return (py, py_exc), (c, c_exc)
 
+    def _assert_use_reduce_same(self, s, eapi="8"):
+        """Assert that both paths accept or reject s identically.
+
+        Atom() falls back to the regex path when scan_atom rejects a string,
+        so _assert_same passes even for a scanner that rejects too much.
+        use_reduce has no such fallback: a token the C parser will not scan
+        as an atom is a hard error there."""
+        results = []
+        for use_c in (False, True):
+            with _use_c_parser(use_c):
+                try:
+                    results.append(str(use_reduce(s, token_class=Atom, eapi=eapi)))
+                except InvalidDependString:
+                    results.append(None)
+        self.assertEqual(results[0], results[1], f"{s!r}: use_reduce mismatch")
+
     def _assert_same(self, s, **kw):
         (py, pe), (c, ce) = self._both(s, **kw)
         self.assertEqual(pe, ce, f"{s!r}: exception {pe} vs {ce}")
@@ -1077,6 +1093,10 @@ class TestScanAtomNameGrammar(_AtomParityMixin, TestCase):
         "frob---",
         "diffball-9-",
         "7z",
+        "81",
+        "2048",
+        "81-libretro",
+        "12+",
         "xf86-video-r128",
         "emacs-cvs",
     )
@@ -1160,6 +1180,27 @@ class TestScanAtomNameGrammar(_AtomParityMixin, TestCase):
         ):
             with self.subTest(s=s):
                 self._assert_same(s, eapi="8")
+
+    def test_all_digit_name_word(self):
+        # bug 981298: a name word made only of digits is a name, not a
+        # version, so "games-emulation/81-libretro" is an ordinary
+        # unversioned atom.
+        for s in (
+            "games-emulation/81-libretro",
+            "games-emulation/2048-libretro",
+            "games-arcade/2048",
+            "cat/81",
+            "cat/81:0",
+            "cat/81[foo]",
+            "!cat/81",
+            "cat/81-r1",
+            "=cat/81-1.0",
+            "=games-emulation/81-libretro-1.2-r3",
+            "cat/81-1.0",
+        ):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+                self._assert_use_reduce_same(s)
 
     def test_slot_grammar(self):
         # ":=" and ":*" are whole slot deps, not sub-slots, and the "="

--- a/lib/portage/tests/dep/test_c_parser.py
+++ b/lib/portage/tests/dep/test_c_parser.py
@@ -1013,7 +1013,20 @@ class TestScanAtom(_AtomParityMixin, TestCase):
                 self._assert_same(s, eapi="8")
 
     def test_conflicting_use_rejected(self):
-        self._assert_same("cat/pkg[a(+),-a]", eapi="8")
+        # A flag's missing-USE default must be spelled the same way at every
+        # occurrence.  Repeating a flag is otherwise fine.
+        for s in (
+            "cat/pkg[a(+),-a]",
+            "cat/pkg[a(+),a(-)]",
+            "cat/pkg[a(-),a]",
+            "cat/pkg[a,a(+)]",
+            "cat/pkg[a(+),b,-a(+)]",
+            "cat/pkg[a,-a]",
+            "cat/pkg[a(+),-a(+)]",
+        ):
+            with self.subTest(s=s):
+                self._assert_same(s, eapi="8")
+                self._assert_use_reduce_same(s)
         self._assert_same("cat/pkg[a,a]", eapi="8")
 
     def test_repo_and_build_id_fall_back(self):

--- a/src/dep_parser.c
+++ b/src/dep_parser.c
@@ -551,6 +551,33 @@ py_classify_use_deps(UNUSED PyObject *self, PyObject *arg)
             SET_LAZY(cneq); SET_ADD(cneq, flag);
         }
 
+        /* A flag's missing-USE default has to be spelled the same way at
+         * every occurrence, so "[a(+),a(-)]" and "[a(+),-a]" are invalid.
+         * _use_dep rejects them when it tokenizes the use deps itself, and
+         * this shortcut has to reject them too. */
+        PyObject *conflicts[2];
+        if (def > 0) {
+            conflicts[0] = md;
+            conflicts[1] = req;
+        } else if (def < 0) {
+            conflicts[0] = me;
+            conflicts[1] = req;
+        } else {
+            conflicts[0] = me;
+            conflicts[1] = md;
+        }
+
+        for (int j = 0; j < ARRAY_SIZE(conflicts); j++) {
+            int dup = PySet_Contains(conflicts[j], flag);
+            if (dup < 0)
+                return NULL;
+
+            if (dup) {
+                PyErr_Format(PyExc_ValueError, "invalid use dep token: %R", tok);
+                return NULL;
+            }
+        }
+
         /* required = flags without a default */
         if (!def)         SET_ADD(req, flag);
         if (def > 0)      SET_ADD(me,  flag);

--- a/src/dep_parser_core.c
+++ b/src/dep_parser_core.c
@@ -328,11 +328,10 @@ int scan_atom(DepScanner *p, AtomInfo *info)
 
         /* additional '-' segments: name-word or version */
         for (;;) {
-            if (s >= p->end || *s != '-' || s + 1 >= p->end)
+            if (s >= p->end || *s != '-')
                 break;
 
-            char nxt = s[1];
-            if (is_digit_c(nxt)) {
+            if (s + 1 < p->end && is_digit_c(s[1])) {
                 DepScanner tmp = { s + 1, p->end, NULL };
                 if (scan_version(&tmp)) {
                     ver = s + 1;
@@ -341,30 +340,15 @@ int scan_atom(DepScanner *p, AtomInfo *info)
                     s = tmp.cur;
                     goto after_pkgver;
                 }
+            }
 
-                const char *t = s + 1;
-                while (t < p->end && is_digit_c(*t)) {
-                    t++;
-                }
-
-                if (t < p->end && (is_alpha_c(*t) || *t == '_')) {
-                    t++;
-                    while (t < p->end && is_nw_char(*t)) {
-                        t++;
-                    }
-                    s = t;
-                } else if (t < p->end && *t == '-') {
-                    s = t;
-                } else {
-                    break;
-                }
-            } else if (is_alpha_c(nxt) || nxt == '_') {
-                s += 2;
-                while (s < p->end && is_nw_char(*s)) {
-                    s++;
-                }
-            } else {
-                break;
+            /* Not a version, so this '-' is an ordinary name character, and
+             * it needs no successor: PMS forbids a name from starting with
+             * '-', not from ending with one.  "dev-util/timidity--" and
+             * "dev-util/diffball-9-" are names. */
+            s++;
+            while (s < p->end && is_nw_char(*s)) {
+                s++;
             }
         }
         pkg_end = s;

--- a/src/dep_parser_core.c
+++ b/src/dep_parser_core.c
@@ -308,28 +308,16 @@ int scan_atom(DepScanner *p, AtomInfo *info)
 
     /* first name-word */
     const char *pkg = s;
-    if (s >= p->end)
+    /* PMS: as for a category, only the first character is restricted, and
+     * '+' may not lead.  A word of nothing but digits is a name like any
+     * other ("games-emulation/81-libretro"); it cannot be mistaken for a
+     * version, which is only reached through the '-' segment loop below. */
+    if (s >= p->end || !is_nw_char(*s) || *s == '+')
         goto fail;
 
-    if (is_alpha_c(*s) || *s == '_') {
+    s++;
+    while (s < p->end && is_nw_char(*s)) {
         s++;
-        while (s < p->end && is_nw_char(*s)) {
-            s++;
-        }
-    } else if (is_digit_c(*s)) {
-        while (s < p->end && is_digit_c(*s)) {
-            s++;
-        }
-
-        if (s >= p->end || (!is_alpha_c(*s) && *s != '_'))
-            goto fail;
-
-        s++;
-        while (s < p->end && is_nw_char(*s)) {
-            s++;
-        }
-    } else {
-        goto fail;
     }
 
     {


### PR DESCRIPTION
The C dep-string parser accepted or rejected a few atoms differently from the regex path. Because `Atom()` falls back to the regex path whenever `scan_atom` rejects a string, the existing parity tests could not see a scanner that rejects too much, and three divergences reached a release with a name-grammar corpus that already listed the affected names.

`use_reduce` has no such fallback, so the rejections were user-visible: installing a package with a dependency on `games-arcade/2048` aborted in `_post_src_install_write_metadata` with `expected '?'` (bug 981298), the misleading message coming from `scan_item` falling through to the use-conditional production after `scan_atom` bailed.

Fixed here:

- An all-digit first word of a package name (`games-arcade/2048`, `games-emulation/81-libretro`) is accepted. PMS constrains only the first character, and a digit is allowed there.
- A hyphen that does not begin a version is treated as an ordinary name character, so names ending in a hyphen or containing a hyphen run (`dev-util/timidity--`, `dev-util/diff-mode-`, `dev-util/diffball-9-`) scan. PMS only forbids a name from *starting* with `-`.
- A use dep that spells one flag's missing-USE default two different ways (`cat/pkg[a(+),-a]`) is rejected, matching `_use_dep`. `classify_use_deps` built the sets in C and handed them to `_use_dep`'s shortcut constructor, which trusts them. Repeating a flag with a consistent default (`cat/pkg[a,-a]`) stays valid.

The last commit closes the hole that hid all three: `_assert_same` now also compares acceptance through `use_reduce` for every case that passes nothing but an EAPI. Cases using `allow_wildcard` or `allow_repo` opt out, since those are `Atom()`-only options.

Bug: https://bugs.gentoo.org/981298
