### PR TITLE
dep, Package: intern the values that packages have in common

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,10 @@ Features:
   VDB (var database) to skip writing files that are already identical on
   disk, which saves I/O and reduces filesystem cache pressure.
 
+* emerge: Reduce the memory used by a dependency calculation. Interning the
+  atoms, USE dependencies, USE flag names and flag sets that packages have in
+  common cuts the peak of "emerge -puDN @world" by about 46% (bug #240320).
+
 portage-3.0.82 (2026-08-22)
 --------------
 

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -23,6 +23,24 @@ from portage.versions import _pkg_str, _unknown_repo
 
 from _emerge.Task import Task
 
+# Packages hold several frozensets which are derived from metadata that
+# thousands of them have in common, and CPython shares none of them, not even
+# the empty one. The number of distinct values is bounded by the number of
+# distinct IUSE and USE values in the repositories, which is a few thousand.
+#
+# Unlike the caches in portage.dep this one holds strong references, since
+# frozenset does not support weak references.
+_frozensets = {}
+
+
+def _intern_frozenset(value):
+    """
+    Return a canonical frozenset which is equal to the given value.
+    """
+    if type(value) is not frozenset:
+        value = frozenset(value)
+    return _frozensets.setdefault(value, value)
+
 
 class Package(Task):
     __hash__ = Task.__hash__
@@ -631,16 +649,13 @@ class Package(Task):
     class _use_class:
         __slots__ = ("_expand", "_expand_hidden", "_force", "_mask", "_pkg", "enabled")
 
-        # Share identical frozenset instances when available.
-        _frozensets = {}
-
         def __init__(self, pkg, enabled_flags):
             self._pkg = pkg
             self._expand = None
             self._expand_hidden = None
             self._force = None
             self._mask = None
-            self.enabled = frozenset(enabled_flags)
+            self.enabled = _intern_frozenset(enabled_flags)
             if pkg.built:
                 # Use IUSE to validate USE settings for built packages,
                 # in case the package manager that built this package
@@ -648,19 +663,20 @@ class Package(Task):
                 # data corruption).
                 missing_iuse = pkg.iuse.get_missing_iuse(self.enabled)
                 if missing_iuse:
-                    self.enabled = self.enabled.difference(missing_iuse)
+                    self.enabled = _intern_frozenset(
+                        self.enabled.difference(missing_iuse)
+                    )
 
         def _init_force_mask(self):
             pkgsettings = self._pkg._get_pkgsettings()
-            frozensets = self._frozensets
-            s = frozenset(pkgsettings.get("USE_EXPAND", "").lower().split())
-            self._expand = frozensets.setdefault(s, s)
-            s = frozenset(pkgsettings.get("USE_EXPAND_HIDDEN", "").lower().split())
-            self._expand_hidden = frozensets.setdefault(s, s)
-            s = pkgsettings.useforce
-            self._force = frozensets.setdefault(s, s)
-            s = pkgsettings.usemask
-            self._mask = frozensets.setdefault(s, s)
+            self._expand = _intern_frozenset(
+                pkgsettings.get("USE_EXPAND", "").lower().split()
+            )
+            self._expand_hidden = _intern_frozenset(
+                pkgsettings.get("USE_EXPAND_HIDDEN", "").lower().split()
+            )
+            self._force = _intern_frozenset(pkgsettings.useforce)
+            self._mask = _intern_frozenset(pkgsettings.usemask)
 
         @property
         def expand(self):
@@ -770,9 +786,9 @@ class Package(Task):
                     disabled.append(sys.intern(x[1:]))
                 else:
                     other.append(x)
-            self.enabled = frozenset(enabled)
-            self.disabled = frozenset(disabled)
-            self.all = frozenset(chain(enabled, disabled, other))
+            self.enabled = _intern_frozenset(enabled)
+            self.disabled = _intern_frozenset(disabled)
+            self.all = _intern_frozenset(chain(enabled, disabled, other))
 
         def is_valid_flag(self, flags):
             """

--- a/lib/_emerge/Package.py
+++ b/lib/_emerge/Package.py
@@ -1,6 +1,7 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import sys
 from itertools import chain
 
 import portage
@@ -17,6 +18,7 @@ from portage.dep import (
 from portage.dep.soname.parse import parse_soname_deps
 from portage.eapi import _get_eapi_attrs
 from portage.exception import InvalidData, InvalidDependString
+from portage.util import split_interned
 from portage.versions import _pkg_str, _unknown_repo
 
 from _emerge.Task import Task
@@ -141,7 +143,7 @@ class Package(Task):
 
         implicit_match = db._iuse_implicit_cnstr(self.cpv, self._metadata)
         self.iuse = self._iuse(
-            self, self._metadata["IUSE"].split(), implicit_match, self.eapi
+            self, split_interned(self._metadata["IUSE"]), implicit_match, self.eapi
         )
 
         if (self.iuse.enabled or self.iuse.disabled) and not eapi_attrs.iuse_defaults:
@@ -716,7 +718,7 @@ class Package(Task):
             # inconsistencies in USE dep matching (see bug #453400).
             use_str = self._metadata["USE"]
             is_valid_flag = self.iuse.is_valid_flag
-            enabled_flags = [x for x in use_str.split() if is_valid_flag(x)]
+            enabled_flags = [x for x in split_interned(use_str) if is_valid_flag(x)]
             use_str = " ".join(enabled_flags)
             self._use = self._use_class(self, enabled_flags)
         else:
@@ -728,7 +730,7 @@ class Package(Task):
             if not use_str:
                 use_str = self._get_pkgsettings()["PORTAGE_USE"]
                 calculated_use = True
-            self._use = self._use_class(self, use_str.split())
+            self._use = self._use_class(self, split_interned(use_str))
             # Initialize these now, since USE access has just triggered
             # setcpv, and we want to cache the result of the force/mask
             # calculations that were done.
@@ -759,10 +761,13 @@ class Package(Task):
             other = []
             for x in tokens:
                 prefix = x[:1]
+                # Stripping the IUSE default creates a new string, so intern
+                # the result as well. These are the names that USE matching
+                # compares against, so they are worth sharing.
                 if prefix == "+":
-                    enabled.append(x[1:])
+                    enabled.append(sys.intern(x[1:]))
                 elif prefix == "-":
-                    disabled.append(x[1:])
+                    disabled.append(sys.intern(x[1:]))
                 else:
                     other.append(x)
             self.enabled = frozenset(enabled)
@@ -936,7 +941,7 @@ class _PackageMetadataWrapper(_PackageMetadataWrapperBase):
 
     def _set_inherited(self, k, v):
         if isinstance(v, str):
-            v = frozenset(v.split())
+            v = frozenset(split_interned(v))
         self._pkg.inherited = v
 
     def _set_counter(self, k, v):

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -126,7 +126,7 @@ def _c_atom_from_c(catom, eapi, eapi_attrs, uselist, matchall):
             a = a.evaluate_conditionals(uselist)
     else:
         a._use = None
-    return a
+    return _intern_atom(a)
 
 
 def _c_convert_result(items, eapi, eapi_attrs, uselist, matchall):
@@ -981,6 +981,13 @@ def _use_reduce_cached(
                     if not matchall and hasattr(token, "evaluate_conditionals"):
                         token = token.evaluate_conditionals(uselist)
 
+                    if type(token) is Atom:
+                        # The is_valid_flag check above is the only part of
+                        # construction which is not a pure function of the
+                        # constructor arguments, so interning has to happen
+                        # here rather than in Atom.__new__.
+                        token = _intern_atom(token)
+
             stack[level].append(token)
 
     if level != 0:
@@ -1555,14 +1562,90 @@ def _intern_use_dep(use_dep):
     return use_dep
 
 
+# Atom instances are immutable, apart from the lazily computed without_use
+# cache. There are two caches because there are two ways to reach a canonical
+# instance: by the parsed state of an instance which already exists, and by
+# the arguments which would construct one. Their keys are not interchangeable,
+# so they must not share a dict.
+_atom_intern_cache = weakref.WeakValueDictionary()
+_atom_ctor_cache = weakref.WeakValueDictionary()
+
+
+def _atom_intern_key(atom):
+    unevaluated_atom = atom._unevaluated_atom
+    orig_atom = atom._orig_atom
+    blocker = atom._blocker_obj
+    return (
+        atom._string,
+        atom._eapi,
+        atom._extended_syntax,
+        atom._repo,
+        atom._build_id,
+        atom._use,
+        (
+            None
+            if unevaluated_atom is atom
+            else (unevaluated_atom._string, unevaluated_atom._eapi)
+        ),
+        None if orig_atom is None else (orig_atom._string, orig_atom._eapi),
+        None if blocker is None else blocker.overlap.forbid,
+    )
+
+
+def _intern_atom(atom):
+    """
+    Return a canonical instance which is equal by value to the given Atom
+    instance (possibly the given instance itself).
+    """
+    key = _atom_intern_key(atom)
+    cached = _atom_intern_cache.get(key)
+    if cached is not None:
+        return cached
+    _atom_intern_cache[key] = atom
+    return atom
+
+
+def _atom_ctor_key(
+    s, unevaluated_atom, allow_wildcard, allow_repo, _use, eapi, allow_build_id
+):
+    """
+    Cache key for Atom instances created via the Atom constructor. The
+    parsed state of an Atom is fully determined by these arguments, so
+    instances that share a key are interchangeable. Atom instances hash by
+    string alone, so they are reduced to (string, eapi) pairs here in order
+    to avoid conflating atoms which differ in EAPI.
+
+    Return None for an argument which the constructor accepts but which
+    cannot be part of a key. Everything else it accepts is a string, a flag
+    or a _use_dep, all of which are hashable.
+    """
+    if type(s) is not str:
+        return None
+    if unevaluated_atom is not None:
+        if not isinstance(unevaluated_atom, Atom):
+            return None
+        unevaluated_atom = (unevaluated_atom._string, unevaluated_atom._eapi)
+    return (
+        s,
+        unevaluated_atom,
+        allow_wildcard,
+        allow_repo,
+        _use,
+        eapi,
+        allow_build_id,
+    )
+
+
 class Atom:
     __slots__ = (
+        "__weakref__",
         "_blocker_obj",
         "_build_id",
         "_cp",
         "_cpv",
         "_eapi",
         "_extended_syntax",
+        "_intern_key",
         "_operator",
         "_orig_atom",
         "_repo",
@@ -1803,6 +1886,53 @@ class Atom:
                 category="EAPI.incompatible",
             )
 
+    def __new__(
+        cls,
+        s=None,
+        unevaluated_atom=None,
+        allow_wildcard=False,
+        allow_repo=None,
+        _use=None,
+        eapi=None,
+        is_valid_flag=None,
+        allow_build_id=None,
+        orig_atom=None,
+    ):
+        # An is_valid_flag callable makes the constructor raise for USE
+        # conditionals which are not in IUSE, so those instances are not
+        # interchangeable with the ones that skip the check.
+        if s is None or is_valid_flag is not None or orig_atom is not None:
+            return object.__new__(cls)
+
+        key = _atom_ctor_key(
+            s, unevaluated_atom, allow_wildcard, allow_repo, _use, eapi, allow_build_id
+        )
+        if key is None:
+            return object.__new__(cls)
+
+        cached = _atom_ctor_cache.get(key)
+        if cached is not None:
+            return cached
+
+        instance = object.__new__(cls)
+        # Remember the key, so that __init__ can add the fully initialized
+        # instance to the cache.
+        instance._intern_key = key
+        return instance
+
+    def _finish_intern(self):
+        """
+        Add a newly initialized instance to the intern cache, if __new__
+        found it eligible.
+        """
+        try:
+            key = self._intern_key
+        except AttributeError:
+            return
+        # The cache holds the only reference to the key from here on.
+        del self._intern_key
+        _atom_ctor_cache[key] = self
+
     def __init__(
         self,
         s,
@@ -1815,6 +1945,13 @@ class Atom:
         allow_build_id=None,
         orig_atom=None,
     ):
+        if getattr(self, "_string", None) is not None:
+            # __new__ returned an instance from the intern cache, which is
+            # already initialized with an identical set of arguments. Only
+            # an initialized instance has _string, and only a fully
+            # initialized one reaches the cache.
+            return
+
         if isinstance(s, Atom):
             # This is an efficiency assertion, to ensure that the Atom
             # constructor is not called redundantly.
@@ -1860,6 +1997,7 @@ class Atom:
                 self._c_fast_init(
                     catom, eapi, eapi_attrs, is_valid_flag, unevaluated_atom
                 )
+                self._finish_intern()
                 return
 
         if s[:1] == "!":
@@ -2057,6 +2195,8 @@ class Atom:
                     _("Strong blocks are not allowed in EAPI %s: '%s'") % (eapi, self),
                     category="EAPI.incompatible",
                 )
+
+        self._finish_intern()
 
     @property
     def slot_operator_built(self) -> bool:

--- a/lib/portage/dep/__init__.py
+++ b/lib/portage/dep/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
 import os
 import re
 import warnings
+import weakref
 from functools import lru_cache
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -109,15 +110,17 @@ def _c_atom_from_c(catom, eapi, eapi_attrs, uselist, matchall):
         en, dis, miss_en, miss_dis, cond, req = _c_dep_parser.classify_use_deps(
             use_tokens
         )
-        a._use = _use_dep(
-            use_tokens,
-            eapi_attrs,
-            enabled_flags=en,
-            disabled_flags=dis,
-            missing_enabled=miss_en,
-            missing_disabled=miss_dis,
-            conditional=cond,
-            required=req,
+        a._use = _intern_use_dep(
+            _use_dep(
+                use_tokens,
+                eapi_attrs,
+                enabled_flags=en,
+                disabled_flags=dis,
+                missing_enabled=miss_en,
+                missing_disabled=miss_dis,
+                conditional=cond,
+                required=req,
+            )
         )
         if not matchall and a._use.conditional:
             a = a.evaluate_conditionals(uselist)
@@ -1104,6 +1107,7 @@ def use_reduce(
 
 class _use_dep:
     __slots__ = (
+        "__weakref__",
         "_eapi_attrs",
         "conditional",
         "disabled",
@@ -1313,14 +1317,16 @@ class _use_dep:
             else:
                 tokens.append(x)
 
-        return _use_dep(
-            tokens,
-            self._eapi_attrs,
-            enabled_flags=enabled_flags,
-            disabled_flags=disabled_flags,
-            missing_enabled=self.missing_enabled,
-            missing_disabled=self.missing_disabled,
-            required=self.required,
+        return _intern_use_dep(
+            _use_dep(
+                tokens,
+                self._eapi_attrs,
+                enabled_flags=enabled_flags,
+                disabled_flags=disabled_flags,
+                missing_enabled=self.missing_enabled,
+                missing_disabled=self.missing_disabled,
+                required=self.required,
+            )
         )
 
     def violated_conditionals(self, other_use, is_valid_flag, parent_use=None):
@@ -1436,15 +1442,17 @@ class _use_dep:
                         tokens.append(x)
                         conditional.setdefault("disabled", set()).add(flag)
 
-        return _use_dep(
-            tokens,
-            self._eapi_attrs,
-            enabled_flags=enabled_flags,
-            disabled_flags=disabled_flags,
-            missing_enabled=self.missing_enabled,
-            missing_disabled=self.missing_disabled,
-            conditional=conditional,
-            required=self.required,
+        return _intern_use_dep(
+            _use_dep(
+                tokens,
+                self._eapi_attrs,
+                enabled_flags=enabled_flags,
+                disabled_flags=disabled_flags,
+                missing_enabled=self.missing_enabled,
+                missing_disabled=self.missing_disabled,
+                conditional=conditional,
+                required=self.required,
+            )
         )
 
     def _eval_qa_conditionals(self, use_mask, use_force):
@@ -1499,15 +1507,52 @@ class _use_dep:
             else:
                 tokens.append(x)
 
-        return _use_dep(
-            tokens,
-            self._eapi_attrs,
-            enabled_flags=enabled_flags,
-            disabled_flags=disabled_flags,
-            missing_enabled=missing_enabled,
-            missing_disabled=missing_disabled,
-            required=self.required,
+        return _intern_use_dep(
+            _use_dep(
+                tokens,
+                self._eapi_attrs,
+                enabled_flags=enabled_flags,
+                disabled_flags=disabled_flags,
+                missing_enabled=missing_enabled,
+                missing_disabled=missing_disabled,
+                required=self.required,
+            )
         )
+
+
+# Weak references, so that an entry is released together with the last user
+# of the value that it holds.
+_use_dep_intern_cache = weakref.WeakValueDictionary()
+
+
+def _intern_use_dep(use_dep):
+    """
+    Return a canonical instance which is equal by value to the given
+    _use_dep instance (possibly the given instance itself).
+    """
+    conditional = use_dep.conditional
+    key = (
+        use_dep.tokens,
+        use_dep._eapi_attrs,
+        use_dep.required,
+        use_dep.enabled,
+        use_dep.disabled,
+        use_dep.missing_enabled,
+        use_dep.missing_disabled,
+        (
+            None
+            if conditional is None
+            else tuple(
+                getattr(conditional, k, None)
+                for k in _use_dep._conditionals_class.__slots__
+            )
+        ),
+    )
+    cached = _use_dep_intern_cache.get(key)
+    if cached is not None:
+        return cached
+    _use_dep_intern_cache[key] = use_dep
+    return use_dep
 
 
 class Atom:
@@ -1711,7 +1756,7 @@ class Atom:
         use_tokens = catom.use
         if use_tokens is not None:
             # _use_dep validates conflicting flags, same as the regex path.
-            self._use = _use_dep(list(use_tokens), eapi_attrs)
+            self._use = _intern_use_dep(_use_dep(list(use_tokens), eapi_attrs))
         else:
             self._use = None
 
@@ -1946,7 +1991,7 @@ class Atom:
             if _use is not None:
                 use = _use
             else:
-                use = _use_dep(use_str[1:-1].split(","), eapi_attrs)
+                use = _intern_use_dep(_use_dep(use_str[1:-1].split(","), eapi_attrs))
         else:
             use = None
 

--- a/lib/portage/util/__init__.py
+++ b/lib/portage/util/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     "new_protect_filename",
     "no_color",
     "normalize_path",
+    "split_interned",
     "stack_dictlist",
     "stack_dicts",
     "stack_lists",
@@ -67,12 +68,26 @@ import tempfile
 import traceback
 from contextlib import AbstractContextManager
 from copy import deepcopy
+from functools import lru_cache
 from itertools import chain, filterfalse
 from typing import Optional, TextIO
 
 import portage
 
 noiselimit = 0
+
+
+@lru_cache(maxsize=4096)
+def split_interned(value: str) -> tuple:
+    """
+    Split a whitespace separated metadata value, interning the tokens.
+
+    Metadata like IUSE and USE repeats the same flag names in thousands of
+    packages, and str.split() creates a new string object for every one of
+    them. Interning the tokens makes all of those packages share a single
+    instance of each flag name.
+    """
+    return tuple(sys.intern(token) for token in value.split())
 
 
 def initialize_logger(level=logging.WARNING) -> None:


### PR DESCRIPTION
A dependency calculation keeps far more memory alive than it needs to, because it builds a fresh object for every occurrence of a value that thousands of packages share: the same atom, the same USE dependency, the same USE flag name, the same set of flags. CPython shares none of them on its own, not even the empty frozenset.

These four commits intern each of those by value. For `emerge -puDN @world` here:

    dep: intern _use_dep instances             292.3MB -> 206.9MB
    dep: intern Atom instances                 206.9MB -> 172.5MB
    Package: intern IUSE and USE flag names    172.5MB -> 165.4MB
    Package: intern the frozensets ...         165.4MB -> 158.1MB

That is 46% off the peak. Interning Atom also takes the run time from 29.2s to 27.0s, because a cache hit skips the regex parse as well; the other three leave it alone.

The two caches in portage.dep hold weak references, so an entry goes away with the last user of its value. The one in Package holds strong references, because frozenset does not support weak references; it is bounded by the number of distinct IUSE and USE values in the repositories, which came to about 2200 entries here.

Every peak RSS figure above is the median of five runs of the same `emerge -puDN @world`, all measured in one session, so they chain. The five runs of a revision spanned at most 2.8MB. Every revision printed the same merge list, and the full test suite passes at each one.
