### PR TITLE
man/ebuild: s/invalid/irrelevant/ in fetchall description

### DIFF
--- a/man/ebuild.1
+++ b/man/ebuild.1
@@ -67,7 +67,8 @@ in files/digest\-[package]\-[version\-rev], a warning is printed
 and ebuild exits with an error code of 1.
 .TP
 .BR fetchall
-Like \fBfetch\fR, but fetches all URIs (even ones invalid due to USE conditionals).
+Like \fBfetch\fR, but fetches all URIs (even ones irrelevant due to USE
+conditionals).
 .TP
 .BR digest
 This is now equivalent to the \fImanifest\fR command.


### PR DESCRIPTION
Link: https://github.com/gentoo/portage/pull/1641#discussion_r3738461923
Reported-by: Eli Schwartz <eschwartz@gentoo.org>
Suggested-by: Sam James <sam@gentoo.org>