### PR TITLE
portage_lru_cache: report split_interned stats

### DIFF
--- a/lib/portage/util/portage_lru_cache.py
+++ b/lib/portage/util/portage_lru_cache.py
@@ -14,6 +14,7 @@ def show_lru_cache_info():
         portage.dep._use_reduce_cached: "use_reduce_cached",
         portage.eapi._get_eapi_attrs: "get_eapi_attrs",
         portage.process._encoded_length: "encoded_length",
+        portage.util.split_interned: "split_interned",
         portage.versions.catpkgsplit: "catpkgsplit",
         portage.versions.vercmp: "vercmp",
     }


### PR DESCRIPTION
split_interned() is an @lru_cache, so include it in the report that PORTAGE_SHOW_LRU_CACHE_INFO prints.