### PR TITLE
vartree, movefile: survive a portage self update

### DIFF
--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -62,6 +62,7 @@ from portage.exception import (
 from portage.localization import _
 from portage.util.futures import asyncio
 from portage.util.futures.executor.fork import ForkExecutor
+from portage.util.movefile import _cmpxattr, movefile
 
 from ._ContentsCaseSensitivityManager import ContentsCaseSensitivityManager
 
@@ -5457,7 +5458,6 @@ class dblink:
         from portage.checksum import _perform_md5_merge as perform_md5
         from portage.eapi import eapi_rewrites_symlinks
         from portage.util import normalize_path
-        from portage.util.movefile import movefile
         from portage.versions import pkgsplit
 
         showMessage = self._display_merge
@@ -6325,7 +6325,6 @@ class dblink:
         Should only be used for regular files.
         """
         from portage.util import writemsg
-        from portage.util.movefile import _cmpxattr
 
         if mydmode is None or not stat.S_ISREG(mydmode):
             return MoveReason.FILE_MISSING_OR_NOT_REGULAR

--- a/lib/portage/tests/ebuild/test_prepare_self_update.py
+++ b/lib/portage/tests/ebuild/test_prepare_self_update.py
@@ -48,13 +48,70 @@ if __name__ == "__main__":
 """
 
 
+# Runs in a subprocess with an installed copy of portage which is
+# overwritten with incompatible modules after _prepare_self_update() has
+# run, in order to emulate a self update which installs to the same
+# location. Modules imported after the update must come from the backup
+# copy of the running version, since mixing them with the modules which
+# are already imported can call a function with a signature it no longer
+# has.
+_SKEW_SCRIPT = """
+import multiprocessing
+import os
+import sys
+
+POISON = "_SELF_UPDATE_POISON = True"
+
+
+def check():
+    import portage.util.movefile
+    import portage.dbapi.vartree
+
+    for mod in (portage.util.movefile, portage.dbapi.vartree):
+        assert not hasattr(mod, "_SELF_UPDATE_POISON"), mod.__file__
+        assert mod.__file__.startswith(portage._pym_path + os.sep), mod.__file__
+
+    # vartree calls into movefile, so the two must agree.
+    assert portage.dbapi.vartree.movefile is portage.util.movefile.movefile
+
+
+def child():
+    check()
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, sys.argv[1])
+
+    import portage
+    from portage.package.ebuild.doebuild import _prepare_self_update
+
+    # The modules imported by check() must not be imported before the update.
+    assert "portage.util.movefile" not in sys.modules
+    assert "portage.dbapi.vartree" not in sys.modules
+
+    _prepare_self_update({"PORTAGE_TMPDIR": sys.argv[2]})
+
+    for relative_path in ("portage/util/movefile.py", "portage/dbapi/vartree.py"):
+        with open(os.path.join(sys.argv[1], relative_path), "w") as f:
+            f.write(POISON)
+
+    check()
+
+    ctx = multiprocessing.get_context(sys.argv[3])
+    proc = ctx.Process(target=child)
+    proc.start()
+    proc.join()
+    sys.exit(proc.exitcode)
+"""
+
+
 class PrepareSelfUpdateTestCase(TestCase):
-    def testPrepareSelfUpdate(self):
+    def _run(self, script_text):
         tmpdir = tempfile.mkdtemp()
         try:
             script = os.path.join(tmpdir, "self_update.py")
             with open(script, "w") as f:
-                f.write(_SCRIPT)
+                f.write(script_text)
 
             # PYTHONPATH would provide a second copy of the modules
             # which are expected to become unimportable.
@@ -62,7 +119,7 @@ class PrepareSelfUpdateTestCase(TestCase):
             env.pop("PYTHONPATH", None)
 
             for start_method in ("fork", "forkserver"):
-                # The installed copy is deleted by the subprocess, so
+                # The installed copy is modified by the subprocess, so
                 # create a fresh one for each start method.
                 base_path = os.path.join(tmpdir, f"base-{start_method}")
                 pym_path = os.path.join(base_path, os.path.basename(PORTAGE_PYM_PATH))
@@ -92,3 +149,9 @@ class PrepareSelfUpdateTestCase(TestCase):
                 )
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def testPrepareSelfUpdate(self):
+        self._run(_SCRIPT)
+
+    def testPrepareSelfUpdateVersionSkew(self):
+        self._run(_SKEW_SCRIPT)

--- a/lib/portage/util/movefile.py
+++ b/lib/portage/util/movefile.py
@@ -144,11 +144,18 @@ def movefile(
     sstat=None,
     mysettings=None,
     hardlink_candidates=None,
+    encoding=None,
 ):
     """moves a file from src to dest, preserving all permissions and attributes; mtime will
     be preserved even when moving across filesystems.  Returns mtime as integer on success
     and None on failure.  mtime is expressed in seconds in Python <3.3 and nanoseconds in
-    Python >=3.3.  Move is atomic."""
+    Python >=3.3.  Move is atomic.
+
+    The encoding parameter is unused and accepted only for compatibility with
+    older callers. During a portage self update, a vartree module already
+    loaded from the previous version may call into this newly installed
+    module, so removing the parameter outright breaks the merge in progress.
+    """
 
     if mysettings is None:
         mysettings = portage.settings


### PR DESCRIPTION
A merge aborted mid-install with:

    TypeError: movefile() got an unexpected keyword argument 'encoding'

vartree imported portage.util.movefile from inside the merge loop, late enough that a portage self update had already installed the new movefile.py. The vartree in memory then called it with a signature 8d416df5 removed.

1b188f43 mostly handles this by rebinding `__path__` of the imported portage packages to a backup of the running version. The report predates it. This closes the rest:

- Import movefile and _cmpxattr in vartree at module scope, so the import cannot happen late. No cycle: movefile imports portage and leaf modules only.
- Accept an unused encoding parameter in movefile() again, so a vartree loaded from an older installed version can finish its merge.
- Test the same-location update. The existing case deletes the installed tree, catching a module that fails to import, not one that imports and is the wrong version. The new case overwrites the installed modules after _prepare_self_update() and checks that a later import comes from the backup, in the process and in a child, for fork and forkserver. It fails with the __path__ rebinding disabled.

Bug: https://bugs.gentoo.org/976616
