### PR TITLE
Improve the circular dependency report

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,14 @@ Features:
   --load-average. Output from each package is still shown one package at a
   time, in merge order (bug #579526).
 
+* emerge: Improve the circular dependency report. It now names the USE flags
+  responsible for each edge (bug #310613), points at FEATURES=test for test
+  dependency cycles (bug #416871, bug #604566, bug #703348), lists masked
+  packages that could be used instead (bug #971256), says when the search for
+  a USE change was given up on (configurable with
+  PORTAGE_CIRCULAR_MAX_USE_FLAGS), and is never empty (bug #929010, bug
+  #877549). Add --circular-deps-report=json for automated consumers.
+
 portage-3.0.82.2 (2026-08-28)
 ----------------
 

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -4,6 +4,7 @@
 import collections
 import errno
 import functools
+import json
 import logging
 import os
 import stat
@@ -10415,6 +10416,10 @@ class depgraph:
         )
         handler = self._dynamic_config._circular_dependency_handler
 
+        if self._frozen_config.myopts.get("--circular-deps-report") == "json":
+            self._show_circular_deps_json(handler)
+            return
+
         self._frozen_config.myopts.pop("--quiet", None)
         self._frozen_config.myopts["--verbose"] = True
         self._frozen_config.myopts["--tree"] = True
@@ -10527,6 +10532,72 @@ class depgraph:
                 + "optional dependencies.\n",
                 noiselevel=-1,
             )
+
+    def _show_circular_deps_json(self, handler):
+        """
+        Report the cycle in a machine readable form, for use by
+        tinderboxes and other automated consumers.
+        """
+        report = {
+            # A cycle can pass through a node that is not a package, so
+            # fall back to its string form rather than dropping it and
+            # reporting something that is not a cycle.
+            "cycles": [
+                [node.cpv if isinstance(node, Package) else str(node) for node in cycle]
+                for cycle in handler.cycles
+            ],
+            "shortest_cycle": [],
+            "solutions": [],
+            "test_dep_parents": sorted(pkg.cpv for pkg in handler.test_dep_parents),
+            "masked_alternatives": [],
+            # Without these, an empty "solutions" cannot be told apart
+            # from a search that was never run.
+            "search_truncated": sorted(pkg.cpv for pkg in handler.search_truncated),
+            "max_affecting_use": handler.max_affecting_use,
+        }
+
+        for pos, pkg in enumerate(handler.shortest_cycle or []):
+            parent = handler.shortest_cycle[pos - 1]
+            if not isinstance(pkg, Package) or not isinstance(parent, Package):
+                # Only packages have a cpv to report.
+                continue
+            priorities = handler.graph.nodes[parent][0][pkg]
+            report["shortest_cycle"].append(
+                {
+                    "parent": parent.cpv,
+                    "child": pkg.cpv,
+                    "priority": str(priorities[-1]),
+                    "affecting_use": sorted(
+                        handler._affecting_use(parent, pkg, priorities[-1])
+                    ),
+                }
+            )
+
+        # These are lists rather than objects keyed by cpv, since two
+        # packages in the graph can share a cpv.
+        for pkg, solutions in sorted(
+            handler.parent_solutions.items(), key=lambda x: x[0].cpv
+        ):
+            report["solutions"].append(
+                {
+                    "package": pkg.cpv,
+                    "use_changes": [dict(solution) for solution in solutions],
+                }
+            )
+
+        for pkg, alternatives in sorted(
+            handler.masked_alternatives.items(), key=lambda x: x[0].cpv
+        ):
+            report["masked_alternatives"].append(
+                {
+                    "package": pkg.cpv,
+                    "alternatives": sorted(
+                        alternative.cpv for alternative in alternatives
+                    ),
+                }
+            )
+
+        portage.writemsg_stdout(json.dumps(report, indent=2) + "\n", noiselevel=-1)
 
     def _show_merge_list(self):
         if self._dynamic_config._serialized_tasks_cache is not None and not (

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -10432,6 +10432,26 @@ class depgraph:
         if handler.circular_dep_message is not None:
             portage.writemsg(handler.circular_dep_message, noiselevel=-1)
 
+        if handler.test_dep_parents:
+            writemsg(
+                "\n\n"
+                + prefix
+                + "This cycle involves test dependencies. If you do not\n"
+                + prefix
+                + "need to run the test suites of the packages listed below,\n"
+                + prefix
+                + 'disable FEATURES=test for them. Put FEATURES="-test" in\n'
+                + prefix
+                + "/etc/portage/env/no-test.conf, then add the following to\n"
+                + prefix
+                + '/etc/portage/package.env (see "package.env" in the\n'
+                + prefix
+                + "portage(5) man page for more details):\n\n",
+                noiselevel=-1,
+            )
+            for pkg in sorted(handler.test_dep_parents, key=lambda x: x.cpv):
+                writemsg(f"={pkg.cpv} no-test.conf\n", noiselevel=-1)
+
         suggestions = handler.suggestions
         if suggestions:
             writemsg("\n\nIt might be possible to break this cycle\n", noiselevel=-1)

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -10432,6 +10432,25 @@ class depgraph:
         if handler.circular_dep_message is not None:
             portage.writemsg(handler.circular_dep_message, noiselevel=-1)
 
+        if handler.masked_alternatives:
+            writemsg(
+                "\n\n"
+                + prefix
+                + "The following masked packages could be used instead of a\n"
+                + prefix
+                + "package in the cycle. Unmasking them, for example via\n"
+                + prefix
+                + "/etc/portage/package.accept_keywords, might solve it:\n",
+                noiselevel=-1,
+            )
+            for pkg, alternatives in sorted(
+                handler.masked_alternatives.items(), key=lambda x: x[0].cpv
+            ):
+                for alternative in sorted(alternatives, key=lambda x: x.cpv):
+                    writemsg(
+                        f"- {alternative.cpv} (instead of {pkg.cpv})\n", noiselevel=-1
+                    )
+
         if handler.test_dep_parents:
             writemsg(
                 "\n\n"

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -10432,6 +10432,23 @@ class depgraph:
         if handler.circular_dep_message is not None:
             portage.writemsg(handler.circular_dep_message, noiselevel=-1)
 
+        if handler.search_truncated:
+            writemsg(
+                "\n\n"
+                + prefix
+                + "The search for USE changes was given up on for the following\n"
+                + prefix
+                + "packages, because they have too many USE flags that affect the\n"
+                + prefix
+                + "dependency. Raise PORTAGE_CIRCULAR_MAX_USE_FLAGS (currently "
+                + f"{handler.max_affecting_use})\n"
+                + prefix
+                + "to search harder:\n",
+                noiselevel=-1,
+            )
+            for pkg in sorted(handler.search_truncated, key=lambda x: x.cpv):
+                writemsg(f"- {pkg.cpv}\n", noiselevel=-1)
+
         if handler.masked_alternatives:
             writemsg(
                 "\n\n"

--- a/lib/_emerge/main.py
+++ b/lib/_emerge/main.py
@@ -152,6 +152,7 @@ def insert_optional_args(args):
         "--changed-deps": y_or_n,
         "--changed-slot": y_or_n,
         "--changed-deps-report": y_or_n,
+        "--circular-deps-report": ("text", "json"),
         "--complete-graph": y_or_n,
         "--deep": valid_integers,
         "--depclean-lib-check": y_or_n,
@@ -413,6 +414,12 @@ def parse_opts(tmpcmdline, silent=False):
         "--changed-slot": {
             "help": ("replace installed packages with " "outdated SLOT metadata"),
             "choices": true_y_or_n,
+        },
+        "--circular-deps-report": {
+            "help": "format of the circular dependency report",
+            # "True" is what insert_optional_args() substitutes when no
+            # format follows the option, and means the default format.
+            "choices": ("True", "text", "json"),
         },
         "--config-root": {
             "help": "specify the location for portage configuration files",

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -47,6 +47,8 @@ class circular_dependency_handler:
         self.solutions, self.suggestions = self._find_suggestions()
         # Packages in the cycle whose test dependencies are involved
         self.test_dep_parents = self._find_test_dep_parents()
+        # Masked packages that could be used instead of a cycle member
+        self.masked_alternatives = self._find_masked_alternatives()
 
     def _find_cycles(self):
         # Ignoring soft dependencies usually gives the most relevant
@@ -204,6 +206,105 @@ class circular_dependency_handler:
                 parents.add(parent)
 
         return frozenset(parents)
+
+    def _iter_any_of_alternatives(self, dep, parent_atom):
+        """
+        Yield the atoms of every || ( ) group of dep that contains
+        parent_atom, except those of the choice that contains it.
+        """
+        # Compare unevaluated atoms, since parent_atom and the atoms of
+        # dep are not necessarily evaluated with the same USE flags.
+        unevaluated_atom = parent_atom.unevaluated_atom
+
+        def _is_parent_atom(node):
+            return isinstance(node, Atom) and node.unevaluated_atom == unevaluated_atom
+
+        def _flatten(node):
+            if isinstance(node, list):
+                for child in node:
+                    yield from _flatten(child)
+            else:
+                yield node
+
+        def _walk(node):
+            if not isinstance(node, list):
+                return
+            if node and node[0] == "||":
+                choices = [list(_flatten(choice)) for choice in node[1:]]
+                matched = [any(_is_parent_atom(x) for x in c) for c in choices]
+                if any(matched):
+                    for choice, choice_matched in zip(choices, matched):
+                        if choice_matched:
+                            continue
+                        yield from choice
+            for child in node:
+                yield from _walk(child)
+
+        yield from _walk(dep)
+
+    def _find_masked_alternatives(self):
+        """
+        Return a mapping of cycle member to masked packages that could
+        satisfy a || ( ) choice instead of it. Cycles that involve a
+        bootstrap package which is not keyworded are common, and the
+        masked candidate is never considered because || ( ) preferences
+        are evaluated with autounmask disabled (bug 971256).
+        """
+        alternatives = {}
+        if not self.shortest_cycle:
+            return alternatives
+
+        for pos, pkg in enumerate(self.shortest_cycle):
+            parent = self.shortest_cycle[pos - 1]
+            priorities = self.graph.nodes[parent][0][pkg]
+            dep = self._dep_string(parent, priorities[-1])
+            parent_atom = self._parent_atom(parent, pkg)
+            if not dep or parent_atom is None or not parent_atom.package:
+                continue
+
+            try:
+                dep = use_reduce(
+                    dep,
+                    uselist=self.depgraph._pkg_use_enabled(parent),
+                    is_valid_flag=parent.iuse.is_valid_flag,
+                    opconvert=True,
+                    token_class=Atom,
+                    eapi=parent.eapi,
+                )
+            except InvalidDependString:
+                continue
+
+            for atom in self._iter_any_of_alternatives(dep, parent_atom):
+                if not isinstance(atom, Atom) or not atom.package or atom.blocker:
+                    continue
+                candidates = list(
+                    self.depgraph._iter_match_pkgs_any(parent.root_config, atom)
+                )
+                if any(x.installed or x.visible for x in candidates):
+                    # An acceptable package exists, so it was rejected
+                    # for some other reason and unmasking would not help.
+                    continue
+
+                maskable = [x for x in candidates if self._maskable_by_config(x)]
+                if maskable:
+                    alternatives.setdefault(pkg, set()).add(max(maskable))
+
+        return alternatives
+
+    def _maskable_by_config(self, pkg):
+        """
+        Return True if every mask on pkg can be lifted with a
+        configuration change (keywords, package.mask, license).
+        """
+        # Imported here because _emerge.depgraph imports this module.
+        from _emerge.depgraph import _get_masking_status
+
+        pkgsettings = self.depgraph._frozen_config.pkgsettings[pkg.root]
+        root_config = self.depgraph._frozen_config.roots[pkg.root]
+        mreasons = _get_masking_status(pkg, pkgsettings, root_config)
+        if not mreasons:
+            return False
+        return all(reason.unmask_hint is not None for reason in mreasons)
 
     def _prepare_circular_dep_message(self):
         """

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -5,6 +5,7 @@ import logging
 from itertools import chain, product
 
 from portage.dep import (
+    Atom,
     check_required_use,
     extract_affecting_use,
     get_required_use_flags,
@@ -106,6 +107,83 @@ class circular_dependency_handler:
                 return atom
         return None
 
+    def _affecting_use(self, parent, pkg, priority):
+        """
+        Return the USE flags of parent that are responsible for the
+        dependency on pkg (bug 310613).
+        """
+        dep = self._dep_string(parent, priority)
+        parent_atom = self._parent_atom(parent, pkg)
+        if not dep or parent_atom is None or not parent_atom.package:
+            return frozenset()
+
+        try:
+            affecting_use = extract_affecting_use(
+                dep, parent_atom.unevaluated_atom, eapi=parent.eapi
+            )
+        except InvalidDependString:
+            return frozenset()
+
+        # extract_affecting_use() returns every flag that the dependency
+        # is nested under, including flags whose current setting is not
+        # what pulls it in. Blame the flags that the dependency goes away
+        # without, so that a flag under "!flag? ( )" is named while it is
+        # disabled, and an unconditional dependency that also appears
+        # under "flag? ( )" is blamed on nothing.
+        unevaluated_atom = parent_atom.unevaluated_atom
+        use = frozenset(self.depgraph._pkg_use_enabled(parent))
+        flipped = use ^ frozenset(affecting_use)
+
+        responsible = {
+            flag
+            for flag in affecting_use
+            if not self._depends_on(parent, dep, use ^ {flag}, unevaluated_atom)
+        }
+
+        if not self._depends_on(parent, dep, flipped, unevaluated_atom):
+            # No flag is enough on its own, but together they do control
+            # the dependency, as in "a? ( x ) b? ( x )" with both
+            # enabled. Blame each flag that keeps it alive by itself.
+            responsible.update(
+                flag
+                for flag in affecting_use
+                if self._depends_on(parent, dep, flipped ^ {flag}, unevaluated_atom)
+            )
+
+        return frozenset(responsible)
+
+    def _depends_on(self, parent, dep, use, unevaluated_atom):
+        """
+        Return True if dep still pulls in unevaluated_atom when the USE
+        flags of parent are set to use.
+        """
+        try:
+            atoms = use_reduce(
+                dep,
+                uselist=use,
+                is_valid_flag=parent.iuse.is_valid_flag,
+                flat=True,
+                token_class=Atom,
+                eapi=parent.eapi,
+            )
+        except InvalidDependString:
+            # Assume the worst, so that a flag is not blamed for a
+            # dependency that we cannot evaluate.
+            return True
+
+        return any(
+            isinstance(atom, Atom) and atom.unevaluated_atom == unevaluated_atom
+            for atom in atoms
+        )
+
+    def _edge_description(self, parent, pkg):
+        priorities = self.graph.nodes[parent][0][pkg]
+        description = str(priorities[-1])
+        affecting_use = self._affecting_use(parent, pkg, priorities[-1])
+        if affecting_use:
+            description += f", USE={' '.join(sorted(affecting_use))}"
+        return description
+
     def _prepare_circular_dep_message(self):
         """
         Like digraph.debug_print(), but prints only the shortest cycle.
@@ -117,17 +195,15 @@ class circular_dependency_handler:
         indent = ""
         for pos, pkg in enumerate(self.shortest_cycle):
             parent = self.shortest_cycle[pos - 1]
-            priorities = self.graph.nodes[parent][0][pkg]
             if pos > 0:
-                msg.append(indent + f"{pkg} ({priorities[-1]})")
+                msg.append(indent + f"{pkg} ({self._edge_description(parent, pkg)})")
             else:
                 msg.append(indent + f"{pkg} depends on")
             indent += " "
 
         pkg = self.shortest_cycle[0]
         parent = self.shortest_cycle[-1]
-        priorities = self.graph.nodes[parent][0][pkg]
-        msg.append(indent + f"{pkg} ({priorities[-1]})")
+        msg.append(indent + f"{pkg} ({self._edge_description(parent, pkg)})")
 
         return "\n".join(msg)
 

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -33,6 +33,10 @@ class circular_dependency_handler:
         # Packages for which the search for a USE change was given up
         # on, so that the user is not told that no solution exists.
         self.search_truncated = set()
+        # Solutions, keyed by the package whose USE flags have to
+        # change. Unlike self.solutions, this identifies the package
+        # that the change applies to.
+        self.parent_solutions = {}
 
         if "--debug" in depgraph._frozen_config.myopts:
             # Show this debug output before doing the calculations
@@ -556,6 +560,7 @@ class circular_dependency_handler:
                     )
                 suggestions.append(msg)
                 final_solutions.setdefault(pkg, set()).add(solution)
+                self.parent_solutions.setdefault(changed_parent, set()).add(solution)
 
         return final_solutions, suggestions
 

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -20,12 +20,19 @@ from _emerge.Package import Package
 
 
 class circular_dependency_handler:
+    # Default number of USE flags that are explored per cycle edge. The
+    # number of combinations is exponential in this, so raising it can be
+    # slow (bug 555698, bug 374397).
     MAX_AFFECTING_USE = 10
 
     def __init__(self, depgraph, graph):
         self.depgraph = depgraph
         self.graph = graph
         self.all_parent_atoms = depgraph._dynamic_config._parent_atoms
+        self.max_affecting_use = self._get_max_affecting_use()
+        # Packages for which the search for a USE change was given up
+        # on, so that the user is not told that no solution exists.
+        self.search_truncated = set()
 
         if "--debug" in depgraph._frozen_config.myopts:
             # Show this debug output before doing the calculations
@@ -342,6 +349,30 @@ class circular_dependency_handler:
         use, changes = needed_use_config_change
         return frozenset(changes.keys())
 
+    def _get_max_affecting_use(self):
+        """
+        Return the number of USE flags to explore per cycle edge, which
+        PORTAGE_CIRCULAR_MAX_USE_FLAGS can raise when the extra search
+        time is acceptable.
+        """
+        settings = self.depgraph._frozen_config.settings
+        value = settings.get("PORTAGE_CIRCULAR_MAX_USE_FLAGS")
+        if value:
+            try:
+                limit = int(value)
+            except ValueError:
+                limit = 0
+            if limit >= 1:
+                return limit
+            writemsg_level(
+                f"!!! Invalid PORTAGE_CIRCULAR_MAX_USE_FLAGS: {value}\n"
+                f"!!! Expected an integer greater than zero, using "
+                f"{self.MAX_AFFECTING_USE} instead.\n",
+                level=logging.ERROR,
+                noiselevel=-1,
+            )
+        return self.MAX_AFFECTING_USE
+
     def _find_suggestions(self):
         if not self.shortest_cycle:
             return None, None
@@ -409,7 +440,7 @@ class circular_dependency_handler:
                 total_flags = set()
                 total_flags.update(affecting_use, required_use_flags)
                 total_flags.difference_update(untouchable_flags)
-                if len(total_flags) <= self.MAX_AFFECTING_USE:
+                if len(total_flags) <= self.max_affecting_use:
                     affecting_use = total_flags
 
             affecting_use = tuple(affecting_use)
@@ -417,7 +448,7 @@ class circular_dependency_handler:
             if not affecting_use:
                 continue
 
-            if len(affecting_use) > self.MAX_AFFECTING_USE:
+            if len(affecting_use) > self.max_affecting_use:
                 # Limit the number of combinations explored (bug #555698).
                 # First, discard irrelevant flags that are not enabled.
                 # Since extract_affecting_use doesn't distinguish between
@@ -428,9 +459,10 @@ class circular_dependency_handler:
                     flag for flag in affecting_use if flag in current_use
                 )
 
-                if len(affecting_use) > self.MAX_AFFECTING_USE:
+                if len(affecting_use) > self.max_affecting_use:
                     # There are too many USE combinations to explore in
                     # a reasonable amount of time.
+                    self.search_truncated.add(parent)
                     continue
 
             # We iterate over all possible settings of these use flags and gather

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -46,13 +46,21 @@ class circular_dependency_handler:
         self.solutions, self.suggestions = self._find_suggestions()
 
     def _find_cycles(self):
-        shortest_cycle = None
-        cycles = self.graph.get_cycles(
-            ignore_priority=DepPrioritySatisfiedRange.ignore_medium_soft
-        )
-        for cycle in cycles:
-            if not shortest_cycle or len(cycle) < len(shortest_cycle):
-                shortest_cycle = cycle
+        # Ignoring soft dependencies usually gives the most relevant
+        # cycles, but a cycle can consist entirely of dependencies that
+        # would be ignored at that level. Lower the threshold until a
+        # cycle is found, so that we never report a cycle without being
+        # able to show it (bug 929010).
+        ignore_priorities = DepPrioritySatisfiedRange.ignore_priority
+        highest = ignore_priorities.index(DepPrioritySatisfiedRange.ignore_medium_soft)
+        for ignore_priority in reversed(ignore_priorities[: highest + 1]):
+            shortest_cycle = None
+            cycles = self.graph.get_cycles(ignore_priority=ignore_priority)
+            for cycle in cycles:
+                if not shortest_cycle or len(cycle) < len(shortest_cycle):
+                    shortest_cycle = cycle
+            if shortest_cycle is not None:
+                break
         return cycles, shortest_cycle
 
     def _prepare_reduced_merge_list(self):
@@ -332,6 +340,11 @@ class circular_dependency_handler:
                 ignore_priority=DepPrioritySatisfiedRange.ignore_medium_soft
             )
             if not root_nodes:
+                break
+            if len(root_nodes) == len(graph.order):
+                # Pruning would leave nothing to display, so show the
+                # last non-empty state instead of nothing at all
+                # (bug 929010).
                 break
             graph.difference_update(root_nodes)
 

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -73,6 +73,31 @@ class circular_dependency_handler:
             tempgraph.remove(node)
         return tuple(display_order)
 
+    def _dep_string(self, parent, priority):
+        """
+        Return the dependency string of parent that the given priority
+        was derived from, or None if the priority does not correspond to
+        a dependency string that USE flags can influence.
+        """
+        if not isinstance(parent, Package):
+            return None
+        if priority.buildtime:
+            return " ".join(parent._metadata[k] for k in Package._buildtime_keys)
+        if priority.runtime:
+            return parent._metadata["RDEPEND"]
+        if priority.runtime_post:
+            return parent._metadata["PDEPEND"]
+        return None
+
+    def _parent_atom(self, parent, pkg):
+        """
+        Return the atom of parent that pulls in pkg, or None.
+        """
+        for ppkg, atom in self.all_parent_atoms.get(pkg, ()):
+            if ppkg == parent:
+                return atom
+        return None
+
     def _prepare_circular_dep_message(self):
         """
         Like digraph.debug_print(), but prints only the shortest cycle.
@@ -121,18 +146,18 @@ class circular_dependency_handler:
         for pos, pkg in enumerate(self.shortest_cycle):
             parent = self.shortest_cycle[pos - 1]
             priorities = self.graph.nodes[parent][0][pkg]
-            parent_atoms = self.all_parent_atoms.get(pkg)
 
-            if priorities[-1].buildtime:
-                dep = " ".join(parent._metadata[k] for k in Package._buildtime_keys)
-            elif priorities[-1].runtime:
-                dep = parent._metadata["RDEPEND"]
+            if priorities[-1].buildtime or priorities[-1].runtime:
+                dep = self._dep_string(parent, priorities[-1])
+            else:
+                # The edge does not come from a dependency string that
+                # we can manipulate with USE flags.
+                continue
 
-            for ppkg, atom in parent_atoms:
-                if ppkg == parent:
-                    changed_parent = ppkg
-                    parent_atom = atom
-                    break
+            parent_atom = self._parent_atom(parent, pkg)
+            if dep is None or parent_atom is None:
+                continue
+            changed_parent = parent
 
             if parent_atom.package:
                 parent_atom = parent_atom.unevaluated_atom

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -45,6 +45,8 @@ class circular_dependency_handler:
         self.circular_dep_message = self._prepare_circular_dep_message()
         # Suggestions, in machine and human readable form
         self.solutions, self.suggestions = self._find_suggestions()
+        # Packages in the cycle whose test dependencies are involved
+        self.test_dep_parents = self._find_test_dep_parents()
 
     def _find_cycles(self):
         # Ignoring soft dependencies usually gives the most relevant
@@ -183,6 +185,25 @@ class circular_dependency_handler:
         if affecting_use:
             description += f", USE={' '.join(sorted(affecting_use))}"
         return description
+
+    def _find_test_dep_parents(self):
+        """
+        Return the packages in the cycle that pull in a cycle member via
+        their test dependencies (bug 416871, bug 703348). These cycles
+        can be avoided without changing the installed USE configuration,
+        by disabling FEATURES=test for the affected packages.
+        """
+        parents = set()
+        if not self.shortest_cycle:
+            return frozenset(parents)
+
+        for pos, pkg in enumerate(self.shortest_cycle):
+            parent = self.shortest_cycle[pos - 1]
+            priorities = self.graph.nodes[parent][0][pkg]
+            if "test" in self._affecting_use(parent, pkg, priorities[-1]):
+                parents.add(parent)
+
+        return frozenset(parents)
 
     def _prepare_circular_dep_message(self):
         """

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1076,6 +1076,23 @@ class ResolverPlaygroundTestCase:
             elif key == "forced_rebuilds" and expected is not None:
                 expected = {k: set(v) for k, v in expected.items()}
 
+            elif key == "circular_dependency_message" and expected is not None:
+                # The expected value is a list of substrings that the
+                # rendered message has to contain.
+                missing = [x for x in expected if got is None or x not in got]
+                if missing:
+                    fail_msgs.append(
+                        "atoms: ("
+                        + ", ".join(str(a) for a in result.atoms)
+                        + "), key: "
+                        + key
+                        + ", missing: "
+                        + str(missing)
+                        + ", got: "
+                        + str(got)
+                    )
+                continue
+
             if got != expected:
                 fail_msgs.append(
                     "atoms: ("
@@ -1130,6 +1147,7 @@ class ResolverPlaygroundResult:
         "unstable_keywords",
         "slot_collision_solutions",
         "circular_dependency_solutions",
+        "circular_dependency_message",
         "needed_p_mask_changes",
         "unsatisfied_deps",
         "forced_rebuilds",
@@ -1138,6 +1156,7 @@ class ResolverPlaygroundResult:
         "virtual_cycle",
     )
     optional_checks = (
+        "circular_dependency_message",
         "forced_rebuilds",
         "required_use_unsatisfied",
         "unsatisfied_deps",
@@ -1156,6 +1175,7 @@ class ResolverPlaygroundResult:
         self.needed_p_mask_changes = None
         self.slot_collision_solutions = None
         self.circular_dependency_solutions = None
+        self.circular_dependency_message = None
         self.unsatisfied_deps = frozenset()
         self.forced_rebuilds = None
         self.required_use_unsatisfied = None
@@ -1214,6 +1234,7 @@ class ResolverPlaygroundResult:
             self.circular_dependency_solutions = dict(
                 zip([x.cpv for x in sol.keys()], sol.values())
             )
+            self.circular_dependency_message = handler.circular_dep_message
 
         if self.depgraph._dynamic_config._unsatisfied_deps_for_display:
             self.unsatisfied_deps = {

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1076,6 +1076,9 @@ class ResolverPlaygroundTestCase:
             elif key == "forced_rebuilds" and expected is not None:
                 expected = {k: set(v) for k, v in expected.items()}
 
+            elif key == "circular_dependency_test_parents" and expected is not None:
+                expected = set(expected)
+
             elif key == "circular_dependency_message" and expected is not None:
                 # The expected value is a list of substrings that the
                 # rendered message has to contain.
@@ -1148,6 +1151,7 @@ class ResolverPlaygroundResult:
         "slot_collision_solutions",
         "circular_dependency_solutions",
         "circular_dependency_message",
+        "circular_dependency_test_parents",
         "needed_p_mask_changes",
         "unsatisfied_deps",
         "forced_rebuilds",
@@ -1157,6 +1161,7 @@ class ResolverPlaygroundResult:
     )
     optional_checks = (
         "circular_dependency_message",
+        "circular_dependency_test_parents",
         "forced_rebuilds",
         "required_use_unsatisfied",
         "unsatisfied_deps",
@@ -1176,6 +1181,7 @@ class ResolverPlaygroundResult:
         self.slot_collision_solutions = None
         self.circular_dependency_solutions = None
         self.circular_dependency_message = None
+        self.circular_dependency_test_parents = None
         self.unsatisfied_deps = frozenset()
         self.forced_rebuilds = None
         self.required_use_unsatisfied = None
@@ -1235,6 +1241,9 @@ class ResolverPlaygroundResult:
                 zip([x.cpv for x in sol.keys()], sol.values())
             )
             self.circular_dependency_message = handler.circular_dep_message
+            self.circular_dependency_test_parents = {
+                pkg.cpv for pkg in handler.test_dep_parents
+            }
 
         if self.depgraph._dynamic_config._unsatisfied_deps_for_display:
             self.unsatisfied_deps = {

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1081,6 +1081,7 @@ class ResolverPlaygroundTestCase:
                 in (
                     "circular_dependency_test_parents",
                     "circular_dependency_masked_alternatives",
+                    "circular_dependency_search_truncated",
                 )
                 and expected is not None
             ):
@@ -1160,6 +1161,7 @@ class ResolverPlaygroundResult:
         "circular_dependency_message",
         "circular_dependency_test_parents",
         "circular_dependency_masked_alternatives",
+        "circular_dependency_search_truncated",
         "needed_p_mask_changes",
         "unsatisfied_deps",
         "forced_rebuilds",
@@ -1171,6 +1173,7 @@ class ResolverPlaygroundResult:
         "circular_dependency_message",
         "circular_dependency_test_parents",
         "circular_dependency_masked_alternatives",
+        "circular_dependency_search_truncated",
         "forced_rebuilds",
         "required_use_unsatisfied",
         "unsatisfied_deps",
@@ -1192,6 +1195,7 @@ class ResolverPlaygroundResult:
         self.circular_dependency_message = None
         self.circular_dependency_test_parents = None
         self.circular_dependency_masked_alternatives = None
+        self.circular_dependency_search_truncated = None
         self.unsatisfied_deps = frozenset()
         self.forced_rebuilds = None
         self.required_use_unsatisfied = None
@@ -1253,6 +1257,9 @@ class ResolverPlaygroundResult:
             self.circular_dependency_message = handler.circular_dep_message
             self.circular_dependency_test_parents = {
                 pkg.cpv for pkg in handler.test_dep_parents
+            }
+            self.circular_dependency_search_truncated = {
+                pkg.cpv for pkg in handler.search_truncated
             }
             self.circular_dependency_masked_alternatives = {
                 alternative.cpv

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1076,7 +1076,14 @@ class ResolverPlaygroundTestCase:
             elif key == "forced_rebuilds" and expected is not None:
                 expected = {k: set(v) for k, v in expected.items()}
 
-            elif key == "circular_dependency_test_parents" and expected is not None:
+            elif (
+                key
+                in (
+                    "circular_dependency_test_parents",
+                    "circular_dependency_masked_alternatives",
+                )
+                and expected is not None
+            ):
                 expected = set(expected)
 
             elif key == "circular_dependency_message" and expected is not None:
@@ -1152,6 +1159,7 @@ class ResolverPlaygroundResult:
         "circular_dependency_solutions",
         "circular_dependency_message",
         "circular_dependency_test_parents",
+        "circular_dependency_masked_alternatives",
         "needed_p_mask_changes",
         "unsatisfied_deps",
         "forced_rebuilds",
@@ -1162,6 +1170,7 @@ class ResolverPlaygroundResult:
     optional_checks = (
         "circular_dependency_message",
         "circular_dependency_test_parents",
+        "circular_dependency_masked_alternatives",
         "forced_rebuilds",
         "required_use_unsatisfied",
         "unsatisfied_deps",
@@ -1182,6 +1191,7 @@ class ResolverPlaygroundResult:
         self.circular_dependency_solutions = None
         self.circular_dependency_message = None
         self.circular_dependency_test_parents = None
+        self.circular_dependency_masked_alternatives = None
         self.unsatisfied_deps = frozenset()
         self.forced_rebuilds = None
         self.required_use_unsatisfied = None
@@ -1243,6 +1253,11 @@ class ResolverPlaygroundResult:
             self.circular_dependency_message = handler.circular_dep_message
             self.circular_dependency_test_parents = {
                 pkg.cpv for pkg in handler.test_dep_parents
+            }
+            self.circular_dependency_masked_alternatives = {
+                alternative.cpv
+                for alternatives in handler.masked_alternatives.values()
+                for alternative in alternatives
             }
 
         if self.depgraph._dynamic_config._unsatisfied_deps_for_display:

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -24,6 +24,7 @@ py.install_sources(
         'test_circular_choices.py',
         'test_circular_choices_rust.py',
         'test_circular_dependencies.py',
+        'test_circular_dependency_display.py',
         'test_complete_graph.py',
         'test_complete_if_new_subslot_without_revbump.py',
         'test_cross_dep_priority.py',

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -196,3 +196,91 @@ class CircularDependencyUseDisplayTestCase(TestCase):
             )
         finally:
             playground.cleanup()
+
+
+class CircularTestDependencyTestCase(TestCase):
+    """
+    Cycles caused by test dependencies are identified as such, so that
+    the user can be pointed at FEATURES=test instead of a USE change
+    that FEATURES=test would have to be disabled for anyway
+    (bug 416871, bug 703348).
+    """
+
+    def testTestDepCycle(self):
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": "test? ( dev-libs/B )",
+                "IUSE": "test",
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        user_config = {
+            "make.conf": ('USE="test"',),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                success=False,
+                circular_dependency_test_parents=["dev-libs/A-1"],
+                circular_dependency_solutions={
+                    "dev-libs/B-1": frozenset([frozenset([("test", False)])])
+                },
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds, user_config=user_config)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testTestDepCycleWithAnotherFlag(self):
+        # A second flag pulls in the same dependency, so disabling
+        # FEATURES=test alone does not break the cycle. The package is
+        # still worth naming, since the test suite is the part the user
+        # can most easily do without.
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": "test? ( dev-libs/B ) doc? ( dev-libs/B )",
+                "IUSE": "test doc",
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        user_config = {
+            "make.conf": ('USE="test doc"',),
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                options={"--autounmask-use": "n"},
+                success=False,
+                circular_dependency_test_parents=["dev-libs/A-1"],
+                circular_dependency_solutions={
+                    "dev-libs/B-1": frozenset(
+                        [frozenset([("doc", False), ("test", False)])]
+                    )
+                },
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds, user_config=user_config)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.util.digraph import digraph
+
+from _emerge.DepPriority import DepPriority
+from _emerge.resolver.circular_dependency import circular_dependency_handler
+
+
+class CircularDependencyDisplayTestCase(TestCase):
+    """
+    Verify that the circular dependency handler is always able to
+    describe the cycle it was created for, even when the cycle consists
+    entirely of dependencies that are ignored by the default
+    ignore_priority (bug 929010).
+    """
+
+    def _handler(self, graph):
+        # The message preparation code does not need a depgraph, so
+        # avoid the cost of constructing one here.
+        handler = circular_dependency_handler.__new__(circular_dependency_handler)
+        handler.graph = graph
+        handler.cycles, handler.shortest_cycle = handler._find_cycles()
+        return handler
+
+    def testRuntimePostCycle(self):
+        # PDEPEND edges are ignored by ignore_medium_soft.
+        graph = digraph()
+        priority = DepPriority(runtime_post=True)
+        graph.add("B", "A", priority=priority)
+        graph.add("A", "B", priority=priority)
+
+        handler = self._handler(graph)
+        self.assertNotEqual(handler.shortest_cycle, None)
+        self.assertEqual(set(handler.shortest_cycle), {"A", "B"})
+
+        message = handler._prepare_circular_dep_message()
+        self.assertNotEqual(message, None)
+        self.assertTrue("A" in message)
+        self.assertTrue("B" in message)
+
+    def testOptionalCycle(self):
+        # Optional edges are ignored by every ignore_priority.
+        graph = digraph()
+        priority = DepPriority(optional=True)
+        graph.add("B", "A", priority=priority)
+        graph.add("A", "B", priority=priority)
+
+        handler = self._handler(graph)
+        self.assertNotEqual(handler.shortest_cycle, None)
+        self.assertNotEqual(handler._prepare_circular_dep_message(), None)
+
+    def testBuildtimeCycle(self):
+        # The common case still uses the default ignore_priority.
+        graph = digraph()
+        priority = DepPriority(buildtime=True)
+        graph.add("B", "A", priority=priority)
+        graph.add("A", "B", priority=priority)
+
+        handler = self._handler(graph)
+        self.assertEqual(set(handler.shortest_cycle), {"A", "B"})

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -2,6 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
 from portage.util.digraph import digraph
 
 from _emerge.DepPriority import DepPriority
@@ -21,6 +25,8 @@ class CircularDependencyDisplayTestCase(TestCase):
         # avoid the cost of constructing one here.
         handler = circular_dependency_handler.__new__(circular_dependency_handler)
         handler.graph = graph
+        handler.depgraph = None
+        handler.all_parent_atoms = {}
         handler.cycles, handler.shortest_cycle = handler._find_cycles()
         return handler
 
@@ -60,3 +66,133 @@ class CircularDependencyDisplayTestCase(TestCase):
 
         handler = self._handler(graph)
         self.assertEqual(set(handler.shortest_cycle), {"A", "B"})
+
+
+class CircularDependencyUseDisplayTestCase(TestCase):
+    """
+    The reported cycle names the USE flags that pull in each dependency
+    (bug 310613).
+    """
+
+    def testUseFlagInCycleMessage(self):
+        ebuilds = {
+            "media-libs/freetype-1": {
+                "DEPEND": "harfbuzz? ( media-libs/harfbuzz )",
+                "IUSE": "+harfbuzz",
+                "EAPI": "8",
+            },
+            "media-libs/harfbuzz-1": {
+                "DEPEND": "media-libs/freetype",
+                "EAPI": "8",
+            },
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["media-libs/freetype"],
+                success=False,
+                circular_dependency_message=["USE=harfbuzz"],
+                circular_dependency_solutions={
+                    "media-libs/harfbuzz-1": frozenset(
+                        [frozenset([("harfbuzz", False)])]
+                    )
+                },
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testNegatedUseFlagInCycleMessage(self):
+        # The flag is disabled, and disabling it is what pulls the
+        # dependency in, so enabling it is the way out of the cycle.
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": "!system-b? ( dev-libs/B )",
+                "IUSE": "system-b",
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                # Without this, a resolver that is able to apply the USE
+                # change itself would never report the cycle.
+                options={"--autounmask-use": "n"},
+                success=False,
+                circular_dependency_message=["USE=system-b"],
+                circular_dependency_solutions={
+                    "dev-libs/B-1": frozenset([frozenset([("system-b", True)])])
+                },
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testUnrelatedUseFlagNotReported(self):
+        # unrelated? ( ) encloses the dependency, but the dependency is
+        # pulled in unconditionally as well, so the flag is not to blame.
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": "unrelated? ( dev-libs/B ) dev-libs/B",
+                "IUSE": "+unrelated",
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            result = playground.run(["dev-libs/A"])
+            self.assertEqual(result.success, False)
+            self.assertTrue(
+                "USE=" not in result.circular_dependency_message,
+                result.circular_dependency_message,
+            )
+        finally:
+            playground.cleanup()
+
+    def testSeveralUseFlagsInCycleMessage(self):
+        # No single flag removes the dependency, but the two of them
+        # together do, so both are to blame.
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": "doc? ( dev-libs/B ) nls? ( dev-libs/B )",
+                "IUSE": "+doc +nls",
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            result = playground.run(["dev-libs/A"], options={"--autounmask-use": "n"})
+            self.assertEqual(result.success, False)
+            self.assertTrue(
+                "USE=doc nls" in result.circular_dependency_message,
+                result.circular_dependency_message,
+            )
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -1,6 +1,10 @@
 # Copyright 2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+import io
+import json
+from contextlib import redirect_stdout
+
 from portage.tests import TestCase
 from portage.tests.resolver.ResolverPlayground import (
     ResolverPlayground,
@@ -9,6 +13,7 @@ from portage.tests.resolver.ResolverPlayground import (
 from portage.util.digraph import digraph
 
 from _emerge.DepPriority import DepPriority
+from _emerge.main import parse_opts
 from _emerge.resolver.circular_dependency import circular_dependency_handler
 
 
@@ -425,5 +430,104 @@ class CircularSearchTruncatedTestCase(TestCase):
             self.assertEqual(result.success, False)
             self.assertEqual(result.circular_dependency_search_truncated, set())
             self.assertNotEqual(result.circular_dependency_solutions, {})
+        finally:
+            playground.cleanup()
+
+
+class CircularDependencyJsonReportTestCase(TestCase):
+    """
+    --circular-deps-report=json describes the cycle in a form that
+    automated consumers can parse.
+    """
+
+    def testJsonReport(self):
+        ebuilds = {
+            "media-libs/freetype-1": {
+                "DEPEND": "harfbuzz? ( media-libs/harfbuzz )",
+                "IUSE": "+harfbuzz",
+                "EAPI": "8",
+            },
+            "media-libs/harfbuzz-1": {
+                "DEPEND": "media-libs/freetype",
+                "EAPI": "8",
+            },
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            result = playground.run(
+                ["media-libs/freetype"], options={"--circular-deps-report": "json"}
+            )
+            self.assertEqual(result.success, False)
+
+            output = io.StringIO()
+            with redirect_stdout(output):
+                result.depgraph.display_problems()
+            report = json.loads(output.getvalue())
+
+            self.assertEqual(
+                {edge["parent"] for edge in report["shortest_cycle"]},
+                {"media-libs/freetype-1", "media-libs/harfbuzz-1"},
+            )
+            self.assertTrue(
+                any(
+                    edge["affecting_use"] == ["harfbuzz"]
+                    for edge in report["shortest_cycle"]
+                )
+            )
+            # The flag belongs to freetype, which is the package the
+            # change has to be applied to, not to harfbuzz, which is the
+            # package the change gets rid of the dependency on.
+            self.assertEqual(
+                report["solutions"],
+                [
+                    {
+                        "package": "media-libs/freetype-1",
+                        "use_changes": [{"harfbuzz": False}],
+                    }
+                ],
+            )
+            self.assertEqual(report["search_truncated"], [])
+            self.assertEqual(report["max_affecting_use"], 10)
+        finally:
+            playground.cleanup()
+
+    def testDefaultFormat(self):
+        # Without a format, the option selects the text report rather
+        # than failing to parse.
+        opts = parse_opts(["--circular-deps-report", "dev-libs/A"], silent=True)[1]
+        self.assertNotEqual(opts.get("--circular-deps-report"), "json")
+
+    def testJsonReportSearchTruncated(self):
+        flags = [f"flag{i}" for i in range(12)]
+        dep = " ".join(f"{flag}? ( dev-libs/B )" for flag in flags)
+
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": dep,
+                "IUSE": " ".join(f"+{flag}" for flag in flags),
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            result = playground.run(
+                ["dev-libs/A"],
+                options={"--circular-deps-report": "json", "--autounmask-use": "n"},
+            )
+            self.assertEqual(result.success, False)
+
+            output = io.StringIO()
+            with redirect_stdout(output):
+                result.depgraph.display_problems()
+            report = json.loads(output.getvalue())
+
+            self.assertEqual(report["solutions"], [])
+            self.assertEqual(report["search_truncated"], ["dev-libs/A-1"])
         finally:
             playground.cleanup()

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -354,3 +354,76 @@ class CircularMaskedAlternativeTestCase(TestCase):
                 self.assertEqual(test_case.test_success, True, test_case.fail_msg)
         finally:
             playground.cleanup()
+
+
+class CircularSearchTruncatedTestCase(TestCase):
+    """
+    The search for USE changes is limited, because the number of
+    combinations is exponential in the number of flags. Say so instead
+    of reporting that no solution exists.
+    """
+
+    def testSearchTruncated(self):
+        flags = [f"flag{i}" for i in range(12)]
+        dep = " ".join(f"{flag}? ( dev-libs/B )" for flag in flags)
+
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": dep,
+                "IUSE": " ".join(f"+{flag}" for flag in flags),
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                options={"--autounmask-use": "n"},
+                success=False,
+                circular_dependency_solutions={},
+                circular_dependency_search_truncated=["dev-libs/A-1"],
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testMaxUseFlagsRaised(self):
+        # PORTAGE_CIRCULAR_MAX_USE_FLAGS is high enough to cover the 12
+        # flags, so the search runs and finds a solution.
+        flags = [f"flag{i}" for i in range(12)]
+        dep = " ".join(f"{flag}? ( dev-libs/B )" for flag in flags)
+
+        ebuilds = {
+            "dev-libs/A-1": {
+                "DEPEND": dep,
+                "IUSE": " ".join(f"+{flag}" for flag in flags),
+                "EAPI": "8",
+            },
+            "dev-libs/B-1": {
+                "DEPEND": "dev-libs/A",
+                "EAPI": "8",
+            },
+        }
+
+        user_config = {
+            "make.conf": ('PORTAGE_CIRCULAR_MAX_USE_FLAGS="16"',),
+        }
+
+        playground = ResolverPlayground(ebuilds=ebuilds, user_config=user_config)
+        try:
+            result = playground.run(["dev-libs/A"], options={"--autounmask-use": "n"})
+            self.assertEqual(result.success, False)
+            self.assertEqual(result.circular_dependency_search_truncated, set())
+            self.assertNotEqual(result.circular_dependency_solutions, {})
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -284,3 +284,73 @@ class CircularTestDependencyTestCase(TestCase):
                 self.assertEqual(test_case.test_success, True, test_case.fail_msg)
         finally:
             playground.cleanup()
+
+
+class CircularMaskedAlternativeTestCase(TestCase):
+    """
+    A bootstrap package that is not keyworded is never considered for a
+    || ( ) choice, because those are evaluated with autounmask disabled.
+    Report it as a way out of the resulting cycle (bug 971256).
+    """
+
+    def testMaskedBootstrapAlternative(self):
+        ebuilds = {
+            "dev-lang/go-2": {
+                "BDEPEND": "|| ( dev-lang/go dev-lang/go-bootstrap )",
+                "EAPI": "8",
+            },
+            "dev-lang/go-bootstrap-1": {
+                "EAPI": "8",
+                "KEYWORDS": "",
+            },
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-lang/go"],
+                success=False,
+                circular_dependency_masked_alternatives=["dev-lang/go-bootstrap-1"],
+                circular_dependency_solutions={},
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()
+
+    def testUseDependencyAlternative(self):
+        # The cycle member is pulled in by an atom with a conditional
+        # USE dependency, which the || ( ) group has to be matched
+        # against in its unevaluated form.
+        ebuilds = {
+            "dev-lang/go-2": {
+                "BDEPEND": "|| ( dev-lang/go[cgo?] dev-lang/go-bootstrap )",
+                "IUSE": "+cgo",
+                "EAPI": "8",
+            },
+            "dev-lang/go-bootstrap-1": {
+                "EAPI": "8",
+                "KEYWORDS": "",
+            },
+        }
+
+        test_cases = (
+            ResolverPlaygroundTestCase(
+                ["dev-lang/go"],
+                success=False,
+                circular_dependency_masked_alternatives=["dev-lang/go-bootstrap-1"],
+                circular_dependency_solutions={},
+            ),
+        )
+
+        playground = ResolverPlayground(ebuilds=ebuilds)
+        try:
+            for test_case in test_cases:
+                playground.run_TestCase(test_case)
+                self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -522,6 +522,15 @@ changed since installation. This option also implies the
 \fB\-\-changed\-use\fR option does not trigger reinstallation when
 flags that the user has not enabled are added or removed.
 .TP
+.BR "\-\-circular\-deps\-report [ text | json ]"
+Selects the format of the circular dependency report. The default,
+\fItext\fR, is the human readable report. With \fIjson\fR, the cycles,
+the USE flags responsible for each edge, the suggested USE changes, the
+packages whose test dependencies are involved, any masked packages that
+could be used instead and the packages whose search for a USE change was
+given up on are written to stdout as a JSON object, for consumption by
+automated tools.
+.TP
 .BR "\-\-color < y | n >"
 Enable or disable color output.  This option will override \fINO_COLOR\fR
 and \fINOCOLOR\fR (see \fBmake.conf\fR(5)) and may also be used to force

--- a/man/emerge.1
+++ b/man/emerge.1
@@ -1522,6 +1522,15 @@ dependency resolution and fall back to the previous implementation.
 This variable is internal and experimental; it may be removed or changed
 in a future release.
 .TP
+.BR PORTAGE_CIRCULAR_MAX_USE_FLAGS
+The number of USE flags that Portage explores per dependency when it
+looks for a USE change that breaks a circular dependency (default:
+\fI10\fR).  The number of combinations grows exponentially with this
+value, so raising it can make the search much slower.  When the search
+is given up on because a dependency is affected by more flags than this,
+the affected packages are named in the circular dependency report.  It
+may also be set in \fBmake.conf\fR(5).
+.TP
 .BR PORTAGE_NATIVE_DEP_PARSER
 If this environment variable is set to \fI0\fR, then Portage will not use
 the native C dependency\-string parser and will fall back to the

--- a/man/make.conf.5
+++ b/man/make.conf.5
@@ -1184,6 +1184,14 @@ PORTAGE_CHECKSUM_FILTER="* \-whirlpool"
 PORTAGE_CHECKSUM_FILTER="\-* sha256"
 .fi
 .TP
+\fBPORTAGE_CIRCULAR_MAX_USE_FLAGS\fR = \fI[integer]\fR
+The number of USE flags that Portage explores per dependency when it looks
+for a USE change that breaks a circular dependency. The number of
+combinations grows exponentially with this value, so raising it can make
+the search much slower.
+.br
+Defaults to 10.
+.TP
 \fBPORTAGE_COMPRESS\fR = \fI"bzip2"\fR
 This variable contains the name of the command used to compress documentation
 during the install phase. If set as an empty string, the documentation shall


### PR DESCRIPTION
The circular dependency error tells the user that a cycle exists, but little about why it exists or what to do about it. This series adds that information.

The before/after output below is real: a stage3-amd64-systemd container on the stock default/linux/amd64/23.0/desktop/systemd profile, resolving against a current ::gentoo checkout, running emerge from this branch and from master. Where a case needed extra configuration to reproduce, that is stated.

### Name the USE flags responsible for each edge

Bug [310613](https://bugs.gentoo.org/310613). The report showed only the priority of each edge, so the user had to read the ebuilds to work out which flag pulled the dependency in, and had no way to match a suggested USE change to the edge it applies to.

Bug [222601](https://bugs.gentoo.org/222601), open since 2008, is still reproducible: on the desktop profile, avahi[gtk] needs gtk+, gtk+[cups] needs cups, and cups[zeroconf] needs avahi. Only zeroconf is off by default, so the whole config is the stock profile plus one line:

```
net-print/cups zeroconf
```

Before, `emerge -p net-dns/avahi`:

```
 * Error: circular dependencies:

(x11-libs/gtk+-3.24.52:3/3::gentoo, ebuild scheduled for merge) depends on
 (net-print/cups-2.4.19:0/0::gentoo, ebuild scheduled for merge) (buildtime)
  (net-dns/avahi-0.9_rc3:0/0::gentoo, ebuild scheduled for merge) (buildtime)
   (x11-libs/gtk+-3.24.52:3/3::gentoo, ebuild scheduled for merge) (buildtime)

It might be possible to break this cycle
by applying any of the following changes:
- net-dns/avahi-0.9_rc3 (Change USE: -gtk)
- x11-libs/gtk+-3.24.52 (Change USE: -cups)
- net-print/cups-2.4.19 (Change USE: -zeroconf)
```

After:

```
 * Error: circular dependencies:

(x11-libs/gtk+-3.24.52:3/3::gentoo, ebuild scheduled for merge) depends on
 (net-print/cups-2.4.19:0/0::gentoo, ebuild scheduled for merge) (buildtime, USE=cups)
  (net-dns/avahi-0.9_rc3:0/0::gentoo, ebuild scheduled for merge) (buildtime, USE=zeroconf)
   (x11-libs/gtk+-3.24.52:3/3::gentoo, ebuild scheduled for merge) (buildtime, USE=gtk)

It might be possible to break this cycle
by applying any of the following changes:
- net-dns/avahi-0.9_rc3 (Change USE: -gtk)
- x11-libs/gtk+-3.24.52 (Change USE: -cups)
- net-print/cups-2.4.19 (Change USE: -zeroconf)
```

Three edges, three flags, and the suggestions now line up with the edges they came from.

A flag is named when the dependency goes away without it, so a flag under "!flag? ( )" is named while it is disabled, and a dependency that is also pulled in unconditionally is blamed on nothing. When several flags pull in the same dependency and no single one of them is enough, all of them are named.

### Report masked packages that could be used instead

Bug [971256](https://bugs.gentoo.org/971256). || ( ) preferences are evaluated with autounmask disabled, so a bootstrap package that is not keyworded is never chosen and the resolver picks the branch that closes the cycle. Nothing told the user that keywording the bootstrap package would help.

Reproduced by masking the binary bootstrap package, which is the situation on an arch where it is not keyworded. `emerge -p dev-java/openjdk` with dev-java/openjdk-bin masked, before:

```
 * Error: circular dependencies:

(dev-java/openjdk-25.0.3_p9-r1:25/25::gentoo, ebuild scheduled for merge) depends on
 (dev-java/openjdk-25.0.3_p9-r1:25/25::gentoo, ebuild scheduled for merge) (buildtime)

 * Note that circular dependencies can often be avoided by temporarily
 * disabling USE flags that trigger optional dependencies.
```

There is no USE flag to disable here, so the advice is a dead end.

After:

```
 * Error: circular dependencies:

(dev-java/openjdk-25.0.3_p9-r1:25/25::gentoo, ebuild scheduled for merge) depends on
 (dev-java/openjdk-25.0.3_p9-r1:25/25::gentoo, ebuild scheduled for merge) (buildtime, USE=system-bootstrap)

 * The following masked packages could be used instead of a
 * package in the cycle. Unmasking them, for example via
 * /etc/portage/package.accept_keywords, might solve it:
- dev-java/openjdk-bin-25.0.4_p7 (instead of dev-java/openjdk-25.0.3_p9-r1)

 * Note that circular dependencies can often be avoided by temporarily
 * disabling USE flags that trigger optional dependencies.
```

dev-lang/go with go-bootstrap masked, which is the case in the bug, names dev-lang/go-bootstrap-1.24.6. dev-lang/rust with rust-bin masked lists both rust-bin-1.77.1-r102 and rust-bin-1.78.0-r102.

### Point at FEATURES=test for test dependency cycles

Bugs [416871](https://bugs.gentoo.org/416871), [604566](https://bugs.gentoo.org/604566), [703348](https://bugs.gentoo.org/703348). A cycle that only exists because USE=test pulls in a test dependency cannot be solved by the printed "Change USE: -test" suggestion alone, since FEATURES=test is what enables the flag in the first place. The report now names the packages whose test dependencies are in the cycle and prints the config lines that turn their test suites off:

```
 * This cycle involves test dependencies. If you do not
 * need to run the test suites of the packages listed below,
 * disable FEATURES=test for them. Put FEATURES="-test" in
 * /etc/portage/env/no-test.conf, then add the following to
 * /etc/portage/package.env (see "package.env" in the
 * portage(5) man page for more details):

=dev-python/py-1.11 no-test.conf
```

I did not find a package in the current tree that reproduces this from a stage3, so this one is covered by resolver tests.

### Say when the search for a USE change was given up on

The number of USE combinations explored per dependency is capped, because the search is exponential in the number of flags. Past the cap the dependency was skipped silently and the user was told there was no solution, when in fact none was looked for. Now:

```
 * The search for USE changes was given up on for the following
 * packages, because they have too many USE flags that affect the
 * dependency. Raise PORTAGE_CIRCULAR_MAX_USE_FLAGS (currently 10)
 * to search harder:
- x11-libs/gtk+-3.24
```

`PORTAGE_CIRCULAR_MAX_USE_FLAGS` is new and documented in `make.conf(5)`. Also covered by tests.

### Always show a cycle

Bugs [877549](https://bugs.gentoo.org/877549), [929010](https://bugs.gentoo.org/929010). circular_dependency_handler looked for cycles only at ignore_medium_soft, so a cycle made up entirely of dependencies that are ignored at that level (PDEPEND edges, satisfied deps, optional deps) left shortest_cycle unset. That produced an error with the "circular dependencies:" header and nothing after it, and debug_print() could prune the graph down to nothing as well. The handler now walks DepPrioritySatisfiedRange.ignore_priority down from ignore_medium_soft until it finds a cycle, and debug_print() stops pruning before it empties the graph.

### --circular-deps-report=json

Circular dependency failures are common enough in tinderboxes and CI that a machine readable form is worth having. The cycles, the USE flags responsible for each edge, the suggested USE changes, the test dependency parents, the masked alternatives and the truncated searches are written to stdout as a JSON object. For the avahi cycle above:

```json
{
  "shortest_cycle": [
    {
      "parent": "net-dns/avahi-0.9_rc3",
      "child": "x11-libs/gtk+-3.24.52",
      "priority": "buildtime",
      "affecting_use": ["gtk"]
    },
    {
      "parent": "x11-libs/gtk+-3.24.52",
      "child": "net-print/cups-2.4.19",
      "priority": "buildtime",
      "affecting_use": ["cups"]
    },
    {
      "parent": "net-print/cups-2.4.19",
      "child": "net-dns/avahi-0.9_rc3",
      "priority": "buildtime",
      "affecting_use": ["zeroconf"]
    }
  ],
  "solutions": [
    {"package": "net-dns/avahi-0.9_rc3", "use_changes": [{"gtk": false}]},
    {"package": "net-print/cups-2.4.19", "use_changes": [{"zeroconf": false}]},
    {"package": "x11-libs/gtk+-3.24.52", "use_changes": [{"cups": false}]}
  ],
  "test_dep_parents": [],
  "masked_alternatives": [],
  "search_truncated": [],
  "max_affecting_use": 10
}
```

"cycles" holds every cycle found, not just the shortest one. In this run there were 15.

`emerge(1)`, `make.conf(5)` and `NEWS` are updated to match.
