### PR TITLE
Make the scheduler and depclean cycle-aware

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,11 @@ Features:
   PORTAGE_CIRCULAR_MAX_USE_FLAGS), and is never empty (bug #929010, bug
   #877549). Add --circular-deps-report=json for automated consumers.
 
+* emerge: Packages in a dependency cycle no longer wait for each other's
+  post-merge dependencies during --jobs builds (bug #452172), and --depclean
+  now names the whole cycle when a package cannot be cleaned because of one
+  (bug #346351).
+
 portage-3.0.82.2 (2026-08-28)
 ----------------
 

--- a/lib/_emerge/Scheduler.py
+++ b/lib/_emerge/Scheduler.py
@@ -54,6 +54,7 @@ from _emerge.BlockerDB import BlockerDB
 from _emerge.clear_caches import clear_caches
 from _emerge.create_depgraph_params import create_depgraph_params
 from _emerge.create_world_atom import create_world_atom
+from _emerge.DepPrioritySatisfiedRange import DepPrioritySatisfiedRange
 from _emerge.depgraph import depgraph, resume_depgraph
 from _emerge.DepPriority import DepPriority
 from _emerge.EbuildBuildDir import EbuildBuildDir
@@ -226,6 +227,8 @@ class Scheduler(PollScheduler):
         # being merged, these packages go to merge_wait_queue, to be merged
         # when no other packages are building.
         self._deep_system_deps = set()
+        # Packages that are part of a dependency cycle.
+        self._cyclic_nodes = set()
 
         # Holds packages to merge which will satisfy currently unsatisfied
         # deep runtime dependencies of system packages. If this is not empty
@@ -561,6 +564,7 @@ class Scheduler(PollScheduler):
             self._mergelist = []
             self._world_atoms = None
             self._deep_system_deps.clear()
+            self._cyclic_nodes.clear()
             return
 
         self._graph_config = graph_config
@@ -595,6 +599,7 @@ class Scheduler(PollScheduler):
 
         self._find_system_deps()
         self._prune_digraph()
+        self._find_cyclic_nodes()
         self._prevent_builddir_collisions()
         if "--debug" in self.myopts:
             writemsg("\nscheduler digraph:\n\n", noiselevel=-1)
@@ -643,6 +648,23 @@ class Scheduler(PollScheduler):
             if not removed_nodes:
                 break
             removed_nodes.clear()
+
+    def _find_cyclic_nodes(self):
+        """
+        Find the packages that are part of a dependency cycle. Within a
+        cycle, post-merge dependencies do not have to delay a build,
+        since the merge order has already decided to ignore them, and
+        waiting for them serializes builds that could run in parallel
+        (bug 452172).
+        """
+        self._cyclic_nodes.clear()
+        if self._digraph is None:
+            return
+        for component in self._digraph.strongly_connected_components(
+            ignore_priority=DepPrioritySatisfiedRange.ignore_soft
+        ):
+            if len(component) > 1:
+                self._cyclic_nodes.update(component)
 
     def _prevent_builddir_collisions(self):
         """
@@ -2001,6 +2023,17 @@ class Scheduler(PollScheduler):
 
         return chosen_pkg
 
+    def _ignore_priority(self, pkg):
+        """
+        Return the ignore_priority to use for the dependencies of pkg
+        when deciding whether its build can start. Post-merge
+        dependencies within a cycle are ignored, since the merge order
+        already ignores them.
+        """
+        if pkg in self._cyclic_nodes:
+            return DepPrioritySatisfiedRange.ignore_medium_post
+        return None
+
     def _dependent_on_scheduled_merges(self, pkg, later):
         """
         Traverse the subgraph of the given packages deep dependencies
@@ -2021,7 +2054,7 @@ class Scheduler(PollScheduler):
 
         dependent = False
         traversed_nodes = {pkg}
-        direct_deps = graph.child_nodes(pkg)
+        direct_deps = graph.child_nodes(pkg, ignore_priority=self._ignore_priority(pkg))
         node_stack = direct_deps
         direct_deps = frozenset(direct_deps)
         while node_stack:
@@ -2041,7 +2074,9 @@ class Scheduler(PollScheduler):
             # Don't traverse children of uninstall nodes since
             # those aren't dependencies in the usual sense.
             if node.operation != "uninstall":
-                node_stack.extend(graph.child_nodes(node))
+                node_stack.extend(
+                    graph.child_nodes(node, ignore_priority=self._ignore_priority(node))
+                )
 
         return dependent
 

--- a/lib/_emerge/actions.py
+++ b/lib/_emerge/actions.py
@@ -1274,6 +1274,52 @@ def _calc_depclean(
         msg.append("\n")
         portage.writemsg_stdout("".join(msg), noiselevel=-1)
 
+    cycle_components = {}
+
+    def cycle_members(pkg):
+        """
+        Return the packages that are in a dependency cycle with pkg,
+        including pkg itself.
+        """
+        if not cycle_components:
+            for component in graph.strongly_connected_components():
+                members = frozenset(component)
+                for node in component:
+                    cycle_components[node] = members
+        return cycle_components.get(pkg, frozenset([pkg]))
+
+    def show_cycle_suggestion(pkg):
+        """
+        A package that is only kept by a dependency cycle can be removed
+        by passing every member of the cycle at once, since --depclean
+        with arguments only considers the given packages (bug 346351).
+        """
+        members = cycle_members(pkg)
+        if len(members) < 2:
+            return
+
+        for member in members:
+            for parent, _atom in resolver._dynamic_config._parent_atoms.get(member, []):
+                if parent in members:
+                    continue
+                if isinstance(parent, SetArg) and parent.name == protected_set_name:
+                    # Only protected because --depclean was given
+                    # arguments, which protects everything else.
+                    continue
+                # Something outside of the cycle needs it.
+                return
+
+        resolver._dynamic_config._depclean_cycle_suggestions[pkg] = frozenset(members)
+
+        msg = [
+            f"  {pkg.cpv} is only required by packages that it requires\n",
+            "  itself. Pass all of them at once in order to remove them:\n",
+            "    emerge --depclean {}\n\n".format(
+                " ".join(sorted("=" + member.cpv for member in members))
+            ),
+        ]
+        portage.writemsg_stdout("".join(msg), noiselevel=-1)
+
     def cmp_pkg_cpv(pkg1, pkg2):
         """Sort Package instances by cpv."""
         if pkg1.cpv > pkg2.cpv:
@@ -1303,8 +1349,10 @@ def _calc_depclean(
                     if arg_atom:
                         if pkg not in graph:
                             pkgs_to_remove.append(pkg)
-                        elif "--verbose" in myopts:
-                            show_parents(pkg)
+                        else:
+                            if "--verbose" in myopts:
+                                show_parents(pkg)
+                            show_cycle_suggestion(pkg)
 
             else:
                 for pkg in sorted(vardb, key=cmp_sort_key(cmp_pkg_cpv)):

--- a/lib/_emerge/depgraph.py
+++ b/lib/_emerge/depgraph.py
@@ -684,6 +684,9 @@ class _dynamic_depgraph_config:
         self._unsatisfied_deps_for_display = []
         self._unsatisfied_blockers_for_display = None
         self._circular_deps_for_display = None
+        # Packages that --depclean cannot remove because they are kept
+        # alive by a dependency cycle, mapped to the cycle members.
+        self._depclean_cycle_suggestions = {}
         self._dep_stack = []
         self._dep_disjunctive_stack = []
         self._unsatisfied_deps = []

--- a/lib/_emerge/resolver/circular_dependency.py
+++ b/lib/_emerge/resolver/circular_dependency.py
@@ -12,7 +12,7 @@ from portage.dep import (
     use_reduce,
 )
 from portage.exception import InvalidDependString
-from portage.output import colorize
+from portage.output import blue, colorize, red
 from portage.util import writemsg_level
 
 from _emerge.DepPrioritySatisfiedRange import DepPrioritySatisfiedRange
@@ -196,7 +196,12 @@ class circular_dependency_handler:
         description = str(priorities[-1])
         affecting_use = self._affecting_use(parent, pkg, priorities[-1])
         if affecting_use:
-            description += f", USE={' '.join(sorted(affecting_use))}"
+            use = self.depgraph._pkg_use_enabled(parent)
+            flags = " ".join(
+                red(flag) if flag in use else blue("-" + flag)
+                for flag in sorted(affecting_use)
+            )
+            description += f", USE={flags}"
         return description
 
     def _find_test_dep_parents(self):

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -1073,7 +1073,9 @@ class ResolverPlaygroundTestCase:
                 # unsatisfied_deps can be a dict for depclean-like actions
                 expected = expected if isinstance(expected, dict) else set(expected)
 
-            elif key == "forced_rebuilds" and expected is not None:
+            elif (
+                key in ("forced_rebuilds", "cycle_suggestions") and expected is not None
+            ):
                 expected = {k: set(v) for k, v in expected.items()}
 
             elif (
@@ -1302,6 +1304,7 @@ class ResolverPlaygroundDepcleanResult:
         "req_pkg_count",
         "graph_order",
         "unsatisfied_deps",
+        "cycle_suggestions",
     )
     optional_checks = (
         "cleanlist",
@@ -1309,6 +1312,7 @@ class ResolverPlaygroundDepcleanResult:
         "req_pkg_count",
         "graph_order",
         "unsatisfied_deps",
+        "cycle_suggestions",
     )
 
     def __init__(self, atoms, rval, cleanlist, ordered, req_pkg_count, depgraph):
@@ -1320,6 +1324,12 @@ class ResolverPlaygroundDepcleanResult:
         self.graph_order = [
             _mergelist_str(node, depgraph) for node in depgraph._dynamic_config.digraph
         ]
+        self.cycle_suggestions = {
+            pkg.cpv: {member.cpv for member in members}
+            for pkg, members in (
+                depgraph._dynamic_config._depclean_cycle_suggestions.items()
+            )
+        }
         self.unsatisfied_deps = {}
         for dep in depgraph._dynamic_config._initially_unsatisfied_deps:
             if isinstance(dep.parent, Package):

--- a/lib/portage/tests/resolver/meson.build
+++ b/lib/portage/tests/resolver/meson.build
@@ -29,6 +29,7 @@ py.install_sources(
         'test_complete_if_new_subslot_without_revbump.py',
         'test_cross_dep_priority.py',
         'test_depclean.py',
+        'test_depclean_cycle.py',
         'test_depclean_order.py',
         'test_depclean_slot_unavailable.py',
         'test_depth.py',

--- a/lib/portage/tests/resolver/test_circular_dependency_display.py
+++ b/lib/portage/tests/resolver/test_circular_dependency_display.py
@@ -5,6 +5,7 @@ import io
 import json
 from contextlib import redirect_stdout
 
+from portage.output import blue, red
 from portage.tests import TestCase
 from portage.tests.resolver.ResolverPlayground import (
     ResolverPlayground,
@@ -96,7 +97,7 @@ class CircularDependencyUseDisplayTestCase(TestCase):
             ResolverPlaygroundTestCase(
                 ["media-libs/freetype"],
                 success=False,
-                circular_dependency_message=["USE=harfbuzz"],
+                circular_dependency_message=[f"USE={red('harfbuzz')}"],
                 circular_dependency_solutions={
                     "media-libs/harfbuzz-1": frozenset(
                         [frozenset([("harfbuzz", False)])]
@@ -135,7 +136,7 @@ class CircularDependencyUseDisplayTestCase(TestCase):
                 # change itself would never report the cycle.
                 options={"--autounmask-use": "n"},
                 success=False,
-                circular_dependency_message=["USE=system-b"],
+                circular_dependency_message=[f"USE={blue('-system-b')}"],
                 circular_dependency_solutions={
                     "dev-libs/B-1": frozenset([frozenset([("system-b", True)])])
                 },
@@ -196,7 +197,7 @@ class CircularDependencyUseDisplayTestCase(TestCase):
             result = playground.run(["dev-libs/A"], options={"--autounmask-use": "n"})
             self.assertEqual(result.success, False)
             self.assertTrue(
-                "USE=doc nls" in result.circular_dependency_message,
+                f"USE={red('doc')} {red('nls')}" in result.circular_dependency_message,
                 result.circular_dependency_message,
             )
         finally:

--- a/lib/portage/tests/resolver/test_depclean_cycle.py
+++ b/lib/portage/tests/resolver/test_depclean_cycle.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+from portage.tests import TestCase
+from portage.tests.resolver.ResolverPlayground import (
+    ResolverPlayground,
+    ResolverPlaygroundTestCase,
+)
+
+
+class DepcleanCycleTestCase(TestCase):
+    """
+    --depclean with arguments only considers the given packages, so a
+    package that is kept alive by a dependency cycle looks unremovable.
+    Tell the user which packages to pass instead (bug 346351).
+    """
+
+    def testDepcleanCycleSuggestion(self):
+        ebuilds = {
+            "dev-libs/A-1": {"EAPI": "8", "RDEPEND": "dev-libs/B"},
+            "dev-libs/B-1": {"EAPI": "8", "RDEPEND": "dev-libs/A"},
+            "dev-libs/C-1": {"EAPI": "8"},
+        }
+
+        installed = ebuilds
+        world = ["dev-libs/C"]
+
+        playground = ResolverPlayground(
+            ebuilds=ebuilds, installed=installed, world=world
+        )
+        try:
+            # Passing a single member of the cycle removes nothing, but
+            # the suggestion names every member.
+            test_case = ResolverPlaygroundTestCase(
+                ["dev-libs/A"],
+                options={"--depclean": True},
+                success=True,
+                cleanlist=[],
+                cycle_suggestions={"dev-libs/A-1": ["dev-libs/A-1", "dev-libs/B-1"]},
+            )
+            playground.run_TestCase(test_case)
+            self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+
+            # Passing all of them removes the whole cycle.
+            test_case = ResolverPlaygroundTestCase(
+                ["dev-libs/A", "dev-libs/B"],
+                options={"--depclean": True},
+                success=True,
+                ignore_cleanlist_order=True,
+                cleanlist=["dev-libs/A-1", "dev-libs/B-1"],
+            )
+            playground.run_TestCase(test_case)
+            self.assertEqual(test_case.test_success, True, test_case.fail_msg)
+        finally:
+            playground.cleanup()

--- a/lib/portage/tests/util/test_digraph.py
+++ b/lib/portage/tests/util/test_digraph.py
@@ -326,3 +326,31 @@ class DigraphTest(TestCase):
                 list(g.child_nodes_iter("A", ignore_priority=ip)),
                 g.child_nodes("A", ignore_priority=ip),
             )
+
+
+class DigraphSccTest(TestCase):
+    def testStronglyConnectedComponents(self):
+        graph = digraph()
+        graph.add("B", "A")
+        graph.add("A", "B")
+        graph.add("C", "B")
+        graph.add("D", "C")
+        graph.add("E", None)
+
+        components = graph.strongly_connected_components()
+        self.assertEqual(
+            sorted(sorted(component) for component in components),
+            [["A", "B"], ["C"], ["D"], ["E"]],
+        )
+
+        # A component is only reported once, no matter how many cycles
+        # its members are part of.
+        graph = digraph()
+        graph.add("B", "A")
+        graph.add("C", "B")
+        graph.add("A", "C")
+        graph.add("A", "B")
+        components = graph.strongly_connected_components()
+        self.assertEqual(
+            sorted(sorted(component) for component in components), [["A", "B", "C"]]
+        )

--- a/lib/portage/util/digraph.py
+++ b/lib/portage/util/digraph.py
@@ -384,6 +384,63 @@ class digraph:
                 return paths[child]
         return None
 
+    def strongly_connected_components(self, ignore_priority=None):
+        """
+        Return the strongly connected components of the graph, computed
+        with an iterative Tarjan pass, in reverse topological order.
+        Components of a single node that has no edge to itself are
+        included as well.
+        """
+        index_counter = 0
+        indices = {}
+        lowlink = {}
+        stack = []
+        on_stack = set()
+        components = []
+
+        for root in self.order:
+            if root in indices:
+                continue
+
+            work = [(root, None)]
+            while work:
+                node, children = work[-1]
+                if children is None:
+                    indices[node] = index_counter
+                    lowlink[node] = index_counter
+                    index_counter += 1
+                    stack.append(node)
+                    on_stack.add(node)
+                    children = list(
+                        self.child_nodes_iter(node, ignore_priority=ignore_priority)
+                    )
+                    work[-1] = (node, children)
+
+                if children:
+                    child = children.pop()
+                    if child not in indices:
+                        work.append((child, None))
+                    elif child in on_stack:
+                        lowlink[node] = min(lowlink[node], indices[child])
+                    continue
+
+                if lowlink[node] == indices[node]:
+                    component = []
+                    while True:
+                        member = stack.pop()
+                        on_stack.discard(member)
+                        component.append(member)
+                        if member == node:
+                            break
+                    components.append(component)
+
+                work.pop()
+                if work:
+                    parent = work[-1][0]
+                    lowlink[parent] = min(lowlink[parent], lowlink[node])
+
+        return components
+
     def get_cycles(self, ignore_priority=None, max_length=None):
         """
         Returns all cycles that have at most length 'max_length'.


### PR DESCRIPTION
`strongly_connected_components()` lets the scheduler and `--depclean` cheaply test whether a package is part of a dependency cycle. This series adds that check where it was missing.

### Build cycle members in parallel

Bug [452172](https://bugs.gentoo.org/452172). The merge order calculation already breaks cycles by ignoring PDEPEND edges, but the scheduler treated every edge as blocking, so packages in a cycle were built one after another even with `--jobs`. The scheduler now uses `strongly_connected_components()` to find cycle members and ignores post-merge dependencies for them when deciding whether a build can start, matching what the merge order already assumes.

### Name the cycle when depclean can't remove a package

Bug [346351](https://bugs.gentoo.org/346351). `--depclean` with arguments only considers the packages given, and protects everything else installed. A package kept alive only by a dependency cycle looked unremovable, and the output listed the other cycle members as ordinary reverse dependencies without saying they're in the same cycle. Depclean now detects that case and prints the command that removes the whole cycle at once.

### Colorize the USE flags named in the cycle display

Color each flag named in `(buildtime, USE=...)` the same way `emerge -pv` already does elsewhere: red for enabled, blue with a `-` prefix for disabled ([#1681 comment](https://github.com/gentoo/portage/pull/1681#issuecomment-5536974214)). This lines up the flags with the colorized `Change USE:` suggestions printed below them.

`NEWS` is updated to match.