### PR TITLE
netlink: fix response processing under qemu-user

### DIFF
--- a/lib/portage/util/netlink.py
+++ b/lib/portage/util/netlink.py
@@ -8,6 +8,7 @@ from socket import (
     AF_NETLINK,
     AF_UNSPEC,
     MSG_PEEK,
+    MSG_TRUNC,
     NETLINK_ROUTE,
     SOCK_DGRAM,
     inet_pton,
@@ -78,10 +79,16 @@ class RtNetlink:
 
     def send_message(self, msg):
         self.sock.send(msg)
-        peek = self.sock.recv(nlmsghdr.size, MSG_PEEK)
-        hdr = nlmsghdr.unpack(peek)
-        size = hdr[0]
-        resp = self.sock.recv(size)
+
+        # The kernel docs say 8kB is a good buffer size.
+        # https://docs.kernel.org/7.2/userspace-api/netlink/intro.html#buffer-sizing
+        # Use MSG_PEEK|MSG_TRUNC to get the actual size in case the kernel changes.
+        resp = self.sock.recv(8192, MSG_PEEK | MSG_TRUNC)
+
+        # socket.recv() uses the passed size when allocating its buffer.
+        # It resizes the buffer based on the return value of the syscall.
+        resp = self.sock.recv(len(resp))
+
         return parse_message(resp)
 
     def get_link_ifindex(self, ifname):


### PR DESCRIPTION
qemu-user has some translation code to swap the byte order of various fields in a netlink message. This code has a bug/quirk that prevents the translation from working when a partial datagram is read.

An easy workaround for this would be to always use a buffer that is large enough to hold the entire datagram. The kernel docs suggest that 8kB aught to be enough, but hard-coding that feels risky.

Instead, call recv(..., MSG_PEEK|MSG_TRUNC) to inspect the size of the datagram without relying on the nlmsghdr.nlmsg_len field. This should ensure the code works even if the kernel defaults change. iproute2 uses the same trick.

Bug: https://bugs.gentoo.org/981694