### PR TITLE
gpkg: reject archive members that escape through a symlink

### DIFF
--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -676,6 +676,27 @@ class tar_safe_extract:
         self.closed = False
         self.file_list = []
 
+    def _check_member(self, member: tarfile.TarInfo):
+        """
+        Raise ValueError if member is not safe to extract.
+        """
+        name = member.name
+        if (name in self.file_list) or (os.path.join(".", name) in self.file_list):
+            writemsg(colorize("BAD", f"Danger: duplicate files detected: {name}\n"))
+            raise ValueError("Duplicate files detected.")
+        if name.startswith("/"):
+            writemsg(colorize("BAD", f"Danger: absolute path detected: {name}\n"))
+            raise ValueError("Absolute path detected.")
+        if name.startswith("../") or ("/../" in name):
+            writemsg(colorize("BAD", f"Danger: path traversal detected: {name}\n"))
+            raise ValueError("Path traversal detected.")
+        if member.isdev():
+            writemsg(colorize("BAD", f"Danger: device file detected: {name}\n"))
+            raise ValueError("Device file detected.")
+        if member.islnk() and (member.linkname not in self.file_list):
+            writemsg(colorize("BAD", f"Danger: hardlink escape detected: {name}\n"))
+            raise ValueError("Hardlink escape detected.")
+
     def extractall(self, dest_dir: str):
         """
         Extract all files to a temporary directory in the dest_dir, and move
@@ -698,43 +719,8 @@ class tar_safe_extract:
                 member = self.tar.next()
                 if member is None:
                     break
-                if (member.name in self.file_list) or (
-                    os.path.join(".", member.name) in self.file_list
-                ):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: duplicate files detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Duplicate files detected.")
-                if member.name.startswith("/"):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: absolute path detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Absolute path detected.")
-                if member.name.startswith("../") or ("/../" in member.name):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: path traversal detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Path traversal detected.")
-                if member.isdev():
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: device file detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Device file detected.")
-                if member.islnk() and (member.linkname not in self.file_list):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: hardlink escape detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Hardlink escape detected.")
+
+                self._check_member(member)
 
                 self.file_list.append(member.name)
                 self.tar.extract(member, path=temp_dir.name)

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -676,9 +676,14 @@ class tar_safe_extract:
         self.closed = False
         self.file_list = []
 
-    def _check_member(self, member: tarfile.TarInfo):
+    def _check_member(self, member: tarfile.TarInfo, extract_dir: str):
         """
-        Raise ValueError if member is not safe to extract.
+        Raise ValueError if member is not safe to extract into extract_dir.
+
+        tarfile.data_filter can't be used for this containment check
+        because it also rejects absolute symlink targets and strips the
+        setuid/setgid/sticky bits, which ordinary binary packages
+        legitimately contain, so the guarantee is enforced here instead.
         """
         name = member.name
         if (name in self.file_list) or (os.path.join(".", name) in self.file_list):
@@ -687,7 +692,7 @@ class tar_safe_extract:
         if name.startswith("/"):
             writemsg(colorize("BAD", f"Danger: absolute path detected: {name}\n"))
             raise ValueError("Absolute path detected.")
-        if name.startswith("../") or ("/../" in name):
+        if ".." in name.split("/"):
             writemsg(colorize("BAD", f"Danger: path traversal detected: {name}\n"))
             raise ValueError("Path traversal detected.")
         if member.isdev():
@@ -697,6 +702,17 @@ class tar_safe_extract:
             writemsg(colorize("BAD", f"Danger: hardlink escape detected: {name}\n"))
             raise ValueError("Hardlink escape detected.")
 
+        # A member name that is free of "/" and ".." components still
+        # escapes extract_dir if one of its parent directories is a symlink
+        # that an earlier member created, e.g. "image/x -> /" followed by
+        # "image/x/etc/cron.d/evil". Resolving the parent directory catches
+        # that no matter how the symlink got there.
+        real_root = os.path.realpath(extract_dir)
+        real_parent = os.path.realpath(os.path.dirname(os.path.join(extract_dir, name)))
+        if real_parent != real_root and not real_parent.startswith(real_root + os.sep):
+            writemsg(colorize("BAD", f"Danger: symlink escape detected: {name}\n"))
+            raise ValueError("Symlink escape detected.")
+
     def extractall(self, dest_dir: str):
         """
         Extract all files to a temporary directory in the dest_dir, and move
@@ -705,8 +721,11 @@ class tar_safe_extract:
         if self.closed:
             raise OSError("Tar file is closed.")
         temp_dir = tempfile.TemporaryDirectory(dir=dest_dir)
-        # The below tar member security checks can be refactored as a filter function
-        # that raises an exception. Use tarfile.fully_trusted_filter for now, which
+        # tarfile's own filters can't be used here: tarfile.data_filter
+        # rejects absolute symlink targets and strips the setuid/setgid/
+        # sticky bits that ordinary binary packages legitimately contain.
+        # Members are validated by _check_member() before extraction instead,
+        # so the extraction itself must not mangle them. fully_trusted_filter
         # is simply an identity function:
         # def fully_trusted_filter(member, dest_path):
         #     return member
@@ -720,7 +739,7 @@ class tar_safe_extract:
                 if member is None:
                     break
 
-                self._check_member(member)
+                self._check_member(member, temp_dir.name)
 
                 self.file_list.append(member.name)
                 self.tar.extract(member, path=temp_dir.name)

--- a/lib/portage/tests/gpkg/meson.build
+++ b/lib/portage/tests/gpkg/meson.build
@@ -3,6 +3,7 @@ py.install_sources(
         'test_gpkg_checksum.py',
         'test_gpkg_gpg.py',
         'test_gpkg_gpg_emerge.py',
+        'test_gpkg_hostile.py',
         'test_gpkg_metadata_update.py',
         'test_gpkg_metadata_url.py',
         'test_gpkg_path.py',

--- a/lib/portage/tests/gpkg/test_gpkg_hostile.py
+++ b/lib/portage/tests/gpkg/test_gpkg_hostile.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Gentoo Authors
+# Portage Unit Testing Functionality
+
+import io
+import os
+import stat
+import tarfile
+import tempfile
+
+from portage.gpkg import tar_safe_extract
+from portage.tests import TestCase
+
+
+def _make_tar(members):
+    """
+    Build an uncompressed tar in memory. members is a list of
+    (TarInfo, bytes or None) tuples.
+    """
+    data = io.BytesIO()
+    with tarfile.open(mode="w", fileobj=data) as tar:
+        for tarinfo, content in members:
+            if content is None:
+                tar.addfile(tarinfo)
+            else:
+                tarinfo.size = len(content)
+                tar.addfile(tarinfo, io.BytesIO(content))
+    data.seek(0)
+    return data
+
+
+def _regular(name, content=b"data"):
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.REGTYPE
+    tarinfo.mode = 0o644
+    return (tarinfo, content)
+
+
+def _symlink(name, target):
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.SYMTYPE
+    tarinfo.linkname = target
+    tarinfo.mode = 0o777
+    return (tarinfo, None)
+
+
+def _directory(name):
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.DIRTYPE
+    tarinfo.mode = 0o755
+    return (tarinfo, None)
+
+
+class test_gpkg_hostile_case(TestCase):
+    def _extract(self, members, dest_dir):
+        data = _make_tar(members)
+        with tarfile.open(mode="r", fileobj=data) as tar:
+            tar_safe_extract(tar, "image").extractall(dest_dir)
+
+    def _assertRejected(self, members):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = os.path.join(tmpdir, "dest")
+            os.mkdir(dest_dir)
+            self.assertRaises(ValueError, self._extract, members, dest_dir)
+            self.assertEqual(os.listdir(dest_dir), [])
+
+    def test_symlink_escape(self):
+        """
+        A symlink to an outside directory followed by a member written
+        through it must not escape the extraction directory.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = os.path.join(tmpdir, "dest")
+            outside = os.path.join(tmpdir, "outside")
+            os.mkdir(dest_dir)
+            os.mkdir(outside)
+
+            members = [
+                _directory("image"),
+                _symlink("image/x", outside),
+                _regular("image/x/evil", b"pwned"),
+            ]
+            self.assertRaises(ValueError, self._extract, members, dest_dir)
+            self.assertEqual(os.listdir(outside), [])
+
+    def test_symlink_escape_to_root(self):
+        self._assertRejected(
+            [
+                _directory("image"),
+                _symlink("image/x", "/"),
+                _regular("image/x/etc/cron.d/evil"),
+            ]
+        )
+
+    def test_symlink_escape_relative(self):
+        self._assertRejected(
+            [
+                _directory("image"),
+                _symlink("image/x", "../../.."),
+                _regular("image/x/evil"),
+            ]
+        )
+
+    def test_absolute_path(self):
+        self._assertRejected([_directory("image"), _regular("/etc/evil")])
+
+    def test_path_traversal(self):
+        self._assertRejected([_directory("image"), _regular("image/../../evil")])
+
+    def test_path_traversal_dot_prefix(self):
+        self._assertRejected([_directory("image"), _regular("./../evil")])
+
+    def test_duplicate_files(self):
+        self._assertRejected(
+            [_directory("image"), _regular("image/a"), _regular("image/a")]
+        )
+
+    def test_device_file(self):
+        tarinfo = tarfile.TarInfo("image/hda")
+        tarinfo.type = tarfile.BLKTYPE
+        tarinfo.devmajor = 8
+        tarinfo.devminor = 0
+        self._assertRejected([_directory("image"), (tarinfo, None)])
+
+    def test_hardlink_escape(self):
+        tarinfo = tarfile.TarInfo("image/shadow")
+        tarinfo.type = tarfile.LNKTYPE
+        tarinfo.linkname = "/etc/shadow"
+        self._assertRejected([_directory("image"), (tarinfo, None)])
+
+    def test_ordinary_archive(self):
+        """
+        Absolute symlinks and setuid bits are legitimate in binary
+        packages, so they must survive extraction untouched.
+        """
+        setuid = tarfile.TarInfo("image/usr/bin/su")
+        setuid.type = tarfile.REGTYPE
+        setuid.mode = 0o4755
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = os.path.join(tmpdir, "dest")
+            os.mkdir(dest_dir)
+            self._extract(
+                [
+                    _directory("image"),
+                    _directory("image/usr"),
+                    _directory("image/usr/bin"),
+                    (setuid, b"binary"),
+                    _directory("image/usr/lib"),
+                    _symlink("image/usr/lib/libfoo.so", "/usr/lib64/libfoo.so.1"),
+                ],
+                dest_dir,
+            )
+
+            su = os.path.join(dest_dir, "usr/bin/su")
+            self.assertEqual(stat.S_IMODE(os.stat(su).st_mode), 0o4755)
+            self.assertEqual(
+                os.readlink(os.path.join(dest_dir, "usr/lib/libfoo.so")),
+                "/usr/lib64/libfoo.so.1",
+            )


### PR DESCRIPTION
tar_safe_extract.extractall() rejected members with an absolute path, a
".." component, a device node, or a hardlink pointing outside of the
archive, but it never looked at symlinks. An archive containing

    image/x -> /
    image/x/etc/cron.d/evil

therefore extracted the second member through the symlink created by the
first, writing outside of the temporary directory as root, before any of
the checks that guard the final move to dest_dir ever ran. A binary
package from a compromised or malicious binhost could overwrite any file
on the system.

Add the missing check to _check_member(): resolve the directory the
member will be created in and require it to stay inside the extraction
root. That catches the escape regardless of how many symlinks are
chained or whether the target is absolute or relative.

tarfile's own filters cannot be used for this: tarfile.data_filter
rejects absolute symlink targets and strips the setuid/setgid/sticky
bits that ordinary binary packages legitimately contain, so the
extraction keeps using fully_trusted_filter and validates members itself.

Also tighten the path traversal check, which only looked for a "../"
prefix and "/../" anywhere in the name, and so missed "./../evil".

Add tests covering each rejected shape, and one asserting that an
ordinary archive with a setuid file and an absolute symlink is still
extracted unchanged.
