### PR TITLE
gpkg: prevent symlink and hardlink escape

### DIFF
--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -676,6 +676,27 @@ class tar_safe_extract:
         self.closed = False
         self.file_list = []
 
+    def _check_member(self, member: tarfile.TarInfo):
+        """
+        Raise ValueError if member is not safe to extract.
+        """
+        name = member.name
+        if (name in self.file_list) or (os.path.join(".", name) in self.file_list):
+            writemsg(colorize("BAD", f"Danger: duplicate files detected: {name}\n"))
+            raise ValueError("Duplicate files detected.")
+        if name.startswith("/"):
+            writemsg(colorize("BAD", f"Danger: absolute path detected: {name}\n"))
+            raise ValueError("Absolute path detected.")
+        if name.startswith("../") or ("/../" in name):
+            writemsg(colorize("BAD", f"Danger: path traversal detected: {name}\n"))
+            raise ValueError("Path traversal detected.")
+        if member.isdev():
+            writemsg(colorize("BAD", f"Danger: device file detected: {name}\n"))
+            raise ValueError("Device file detected.")
+        if member.islnk() and (member.linkname not in self.file_list):
+            writemsg(colorize("BAD", f"Danger: hardlink escape detected: {name}\n"))
+            raise ValueError("Hardlink escape detected.")
+
     def extractall(self, dest_dir: str):
         """
         Extract all files to a temporary directory in the dest_dir, and move
@@ -698,43 +719,8 @@ class tar_safe_extract:
                 member = self.tar.next()
                 if member is None:
                     break
-                if (member.name in self.file_list) or (
-                    os.path.join(".", member.name) in self.file_list
-                ):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: duplicate files detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Duplicate files detected.")
-                if member.name.startswith("/"):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: absolute path detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Absolute path detected.")
-                if member.name.startswith("../") or ("/../" in member.name):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: path traversal detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Path traversal detected.")
-                if member.isdev():
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: device file detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Device file detected.")
-                if member.islnk() and (member.linkname not in self.file_list):
-                    writemsg(
-                        colorize(
-                            "BAD", f"Danger: hardlink escape detected: {member.name}\n"
-                        )
-                    )
-                    raise ValueError("Hardlink escape detected.")
+
+                self._check_member(member)
 
                 self.file_list.append(member.name)
                 self.tar.extract(member, path=temp_dir.name)

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -676,6 +676,29 @@ class tar_safe_extract:
         self.closed = False
         self.file_list = []
 
+    @staticmethod
+    def _check_symlink_path(root, name):
+        """
+        Resolve existing symlinks on disk and reject paths outside root.
+        This does not check a new symlink's target from the tar header.
+        """
+        real_root = os.path.realpath(root)
+        real_path = os.path.realpath(os.path.join(root, name))
+        if os.path.commonpath((real_root, real_path)) != real_root:
+            writemsg(colorize("BAD", f"Danger: symlink escape detected: {name}\n"))
+            raise ValueError("Symlink escape detected.")
+
+    def _check_hardlink(self, root, member):
+        """Check the on-disk hardlink source and any relocated symlink target."""
+        self._check_symlink_path(root, member.linkname)
+        source = os.path.join(root, member.linkname)
+        if os.path.islink(source):
+            # A relative symlink target may escape from the new location.
+            self._check_symlink_path(
+                root,
+                os.path.join(os.path.dirname(member.name), os.readlink(source)),
+            )
+
     def _check_member(self, member: tarfile.TarInfo, extract_dir: str):
         """
         Raise ValueError if member is not safe to extract into extract_dir.
@@ -702,16 +725,11 @@ class tar_safe_extract:
             writemsg(colorize("BAD", f"Danger: hardlink escape detected: {name}\n"))
             raise ValueError("Hardlink escape detected.")
 
-        # A member name that is free of "/" and ".." components still
-        # escapes extract_dir if one of its parent directories is a symlink
-        # that an earlier member created, e.g. "image/x -> /" followed by
-        # "image/x/etc/cron.d/evil". Resolving the parent directory catches
-        # that no matter how the symlink got there.
-        real_root = os.path.realpath(extract_dir)
-        real_parent = os.path.realpath(os.path.dirname(os.path.join(extract_dir, name)))
-        if real_parent != real_root and not real_parent.startswith(real_root + os.sep):
-            writemsg(colorize("BAD", f"Danger: symlink escape detected: {name}\n"))
-            raise ValueError("Symlink escape detected.")
+        # Check the parent too: replacing a symlink must not modify an outside directory.
+        self._check_symlink_path(extract_dir, os.path.dirname(name))
+        self._check_symlink_path(extract_dir, name)
+        if member.islnk():
+            self._check_hardlink(extract_dir, member)
 
     def extractall(self, dest_dir: str):
         """
@@ -744,9 +762,11 @@ class tar_safe_extract:
                 self.file_list.append(member.name)
                 self.tar.extract(member, path=temp_dir.name)
 
+            self._check_symlink_path(temp_dir.name, self.prefix)
             data_dir = os.path.join(temp_dir.name, self.prefix)
             for file in os.listdir(data_dir):
-                shutil.move(os.path.join(data_dir, file), os.path.join(dest_dir, file))
+                # Same filesystem: rename without following destination symlinks.
+                os.rename(os.path.join(data_dir, file), os.path.join(dest_dir, file))
         finally:
             temp_dir.cleanup()
             self.closed = True

--- a/lib/portage/gpkg.py
+++ b/lib/portage/gpkg.py
@@ -676,9 +676,14 @@ class tar_safe_extract:
         self.closed = False
         self.file_list = []
 
-    def _check_member(self, member: tarfile.TarInfo):
+    def _check_member(self, member: tarfile.TarInfo, extract_dir: str):
         """
-        Raise ValueError if member is not safe to extract.
+        Raise ValueError if member is not safe to extract into extract_dir.
+
+        tarfile.data_filter can't be used for this containment check
+        because it also rejects absolute symlink targets and strips the
+        setuid/setgid/sticky bits, which ordinary binary packages
+        legitimately contain, so the guarantee is enforced here instead.
         """
         name = member.name
         if (name in self.file_list) or (os.path.join(".", name) in self.file_list):
@@ -687,7 +692,7 @@ class tar_safe_extract:
         if name.startswith("/"):
             writemsg(colorize("BAD", f"Danger: absolute path detected: {name}\n"))
             raise ValueError("Absolute path detected.")
-        if name.startswith("../") or ("/../" in name):
+        if ".." in name.split("/"):
             writemsg(colorize("BAD", f"Danger: path traversal detected: {name}\n"))
             raise ValueError("Path traversal detected.")
         if member.isdev():
@@ -697,6 +702,17 @@ class tar_safe_extract:
             writemsg(colorize("BAD", f"Danger: hardlink escape detected: {name}\n"))
             raise ValueError("Hardlink escape detected.")
 
+        # A member name that is free of "/" and ".." components still
+        # escapes extract_dir if one of its parent directories is a symlink
+        # that an earlier member created, e.g. "image/x -> /" followed by
+        # "image/x/etc/cron.d/evil". Resolving the parent directory catches
+        # that no matter how the symlink got there.
+        real_root = os.path.realpath(extract_dir)
+        real_parent = os.path.realpath(os.path.dirname(os.path.join(extract_dir, name)))
+        if real_parent != real_root and not real_parent.startswith(real_root + os.sep):
+            writemsg(colorize("BAD", f"Danger: symlink escape detected: {name}\n"))
+            raise ValueError("Symlink escape detected.")
+
     def extractall(self, dest_dir: str):
         """
         Extract all files to a temporary directory in the dest_dir, and move
@@ -705,8 +721,11 @@ class tar_safe_extract:
         if self.closed:
             raise OSError("Tar file is closed.")
         temp_dir = tempfile.TemporaryDirectory(dir=dest_dir)
-        # The below tar member security checks can be refactored as a filter function
-        # that raises an exception. Use tarfile.fully_trusted_filter for now, which
+        # tarfile's own filters can't be used here: tarfile.data_filter
+        # rejects absolute symlink targets and strips the setuid/setgid/
+        # sticky bits that ordinary binary packages legitimately contain.
+        # Members are validated by _check_member() before extraction instead,
+        # so the extraction itself must not mangle them. fully_trusted_filter
         # is simply an identity function:
         # def fully_trusted_filter(member, dest_path):
         #     return member
@@ -720,7 +739,7 @@ class tar_safe_extract:
                 if member is None:
                     break
 
-                self._check_member(member)
+                self._check_member(member, temp_dir.name)
 
                 self.file_list.append(member.name)
                 self.tar.extract(member, path=temp_dir.name)

--- a/lib/portage/tests/gpkg/meson.build
+++ b/lib/portage/tests/gpkg/meson.build
@@ -3,6 +3,7 @@ py.install_sources(
         'test_gpkg_checksum.py',
         'test_gpkg_gpg.py',
         'test_gpkg_gpg_emerge.py',
+        'test_gpkg_hostile.py',
         'test_gpkg_metadata_update.py',
         'test_gpkg_metadata_url.py',
         'test_gpkg_path.py',

--- a/lib/portage/tests/gpkg/test_gpkg_hostile.py
+++ b/lib/portage/tests/gpkg/test_gpkg_hostile.py
@@ -6,6 +6,9 @@ import os
 import stat
 import tarfile
 import tempfile
+from itertools import product
+from pathlib import Path
+from unittest.mock import patch
 
 from portage.gpkg import tar_safe_extract
 from portage.tests import TestCase
@@ -28,14 +31,16 @@ def _make_tar(members):
     return data
 
 
-def _regular(name, content=b"data"):
+def _regular(name, content=b"data", *, kind=tarfile.REGTYPE):
+    """Build a file member and its contents."""
     tarinfo = tarfile.TarInfo(name)
-    tarinfo.type = tarfile.REGTYPE
+    tarinfo.type = kind
     tarinfo.mode = 0o644
     return (tarinfo, content)
 
 
 def _symlink(name, target):
+    """Build a symlink with the given target text."""
     tarinfo = tarfile.TarInfo(name)
     tarinfo.type = tarfile.SYMTYPE
     tarinfo.linkname = target
@@ -43,7 +48,17 @@ def _symlink(name, target):
     return (tarinfo, None)
 
 
+def _hardlink(name, target, *, mode=0o644):
+    """Build a hardlink to another archive member."""
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.LNKTYPE
+    tarinfo.linkname = target
+    tarinfo.mode = mode
+    return (tarinfo, None)
+
+
 def _directory(name):
+    """Build a directory member."""
     tarinfo = tarfile.TarInfo(name)
     tarinfo.type = tarfile.DIRTYPE
     tarinfo.mode = 0o755
@@ -51,10 +66,11 @@ def _directory(name):
 
 
 class test_gpkg_hostile_case(TestCase):
-    def _extract(self, members, dest_dir):
-        data = _make_tar(members)
-        with tarfile.open(mode="r", fileobj=data) as tar:
-            tar_safe_extract(tar, "image").extractall(dest_dir)
+    def _extract(self, members, dest_dir, prefix="image", mode="r"):
+        """Extract an in-memory archive using the production extractor."""
+        with _make_tar(members) as data:
+            with tarfile.open(mode=mode, fileobj=data) as tar:
+                tar_safe_extract(tar, prefix).extractall(dest_dir)
 
     def _assertRejected(self, members):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -65,24 +81,35 @@ class test_gpkg_hostile_case(TestCase):
 
     def test_symlink_escape(self):
         """
-        A symlink to an outside directory followed by a member written
-        through it must not escape the extraction directory.
+        Reject writing image/link/marker after image/link points outside.
+        Cover absolute and relative targets; leave the outside marker unchanged.
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            dest_dir = os.path.join(tmpdir, "dest")
-            outside = os.path.join(tmpdir, "outside")
-            os.mkdir(dest_dir)
-            os.mkdir(outside)
-
-            members = [
-                _directory("image"),
-                _symlink("image/x", outside),
-                _regular("image/x/evil", b"pwned"),
-            ]
-            self.assertRaises(ValueError, self._extract, members, dest_dir)
-            self.assertEqual(os.listdir(outside), [])
+        for relative, name in product(
+            (False, True), ("image/link/marker", "./image/link/marker")
+        ):
+            with self.subTest(relative=relative, name=name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    dest = root / "dest"
+                    dest.mkdir()
+                    outside = root / "outside"
+                    outside.mkdir()
+                    marker = outside / "marker"
+                    marker.write_bytes(b"original")
+                    target = "../../../outside" if relative else str(outside)
+                    with self.assertRaisesRegex(ValueError, "Symlink"):
+                        self._extract(
+                            [
+                                _symlink("image/link", target),
+                                _regular(name, b"overwritten"),
+                            ],
+                            dest,
+                        )
+                    self.assertEqual(marker.read_bytes(), b"original")
+                    self.assertEqual(list(dest.iterdir()), [])
 
     def test_symlink_escape_to_root(self):
+        """Reject image/x/etc/cron.d/evil after creating image/x -> /."""
         self._assertRejected(
             [
                 _directory("image"),
@@ -91,30 +118,31 @@ class test_gpkg_hostile_case(TestCase):
             ]
         )
 
-    def test_symlink_escape_relative(self):
-        self._assertRejected(
-            [
-                _directory("image"),
-                _symlink("image/x", "../../.."),
-                _regular("image/x/evil"),
-            ]
-        )
-
     def test_absolute_path(self):
+        """Reject an absolute archive member name, such as /etc/evil."""
         self._assertRejected([_directory("image"), _regular("/etc/evil")])
 
     def test_path_traversal(self):
-        self._assertRejected([_directory("image"), _regular("image/../../evil")])
-
-    def test_path_traversal_dot_prefix(self):
-        self._assertRejected([_directory("image"), _regular("./../evil")])
+        """Reject member names containing '..', including image/.. and ./../evil."""
+        for name in (
+            "..",
+            "image/..",
+            "../outside",
+            "image/../outside",
+            "image/../../evil",
+            "./../evil",
+        ):
+            with self.subTest(name=name):
+                self._assertRejected([_directory("image"), _directory(name)])
 
     def test_duplicate_files(self):
+        """Reject two regular file entries with the same name, image/a."""
         self._assertRejected(
             [_directory("image"), _regular("image/a"), _regular("image/a")]
         )
 
     def test_device_file(self):
+        """Reject a block device member named image/hda."""
         tarinfo = tarfile.TarInfo("image/hda")
         tarinfo.type = tarfile.BLKTYPE
         tarinfo.devmajor = 8
@@ -122,19 +150,20 @@ class test_gpkg_hostile_case(TestCase):
         self._assertRejected([_directory("image"), (tarinfo, None)])
 
     def test_hardlink_escape(self):
-        tarinfo = tarfile.TarInfo("image/shadow")
-        tarinfo.type = tarfile.LNKTYPE
-        tarinfo.linkname = "/etc/shadow"
-        self._assertRejected([_directory("image"), (tarinfo, None)])
+        """Reject image/shadow hardlinked to /etc/shadow, which is not in the archive."""
+        self._assertRejected(
+            [_directory("image"), _hardlink("image/shadow", "/etc/shadow")]
+        )
 
     def test_ordinary_archive(self):
         """
-        Absolute symlinks and setuid bits are legitimate in binary
-        packages, so they must survive extraction untouched.
+        Preserve ordinary files, hardlinks, symlink targets and permission bits.
+        Examples: su with mode 06755, su-copy hardlinked to su, and
+        libfoo.so -> /usr/lib64/libfoo.so.1, plus relative and dangling links.
         """
         setuid = tarfile.TarInfo("image/usr/bin/su")
         setuid.type = tarfile.REGTYPE
-        setuid.mode = 0o4755
+        setuid.mode = 0o6755
 
         with tempfile.TemporaryDirectory() as tmpdir:
             dest_dir = os.path.join(tmpdir, "dest")
@@ -145,15 +174,313 @@ class test_gpkg_hostile_case(TestCase):
                     _directory("image/usr"),
                     _directory("image/usr/bin"),
                     (setuid, b"binary"),
+                    _hardlink("image/usr/bin/su-copy", "image/usr/bin/su", mode=0o6755),
                     _directory("image/usr/lib"),
                     _symlink("image/usr/lib/libfoo.so", "/usr/lib64/libfoo.so.1"),
+                    _symlink("image/usr/lib/relative", "libfoo.so"),
+                    _symlink("image/usr/lib/dangling", "../missing"),
                 ],
                 dest_dir,
             )
 
             su = os.path.join(dest_dir, "usr/bin/su")
-            self.assertEqual(stat.S_IMODE(os.stat(su).st_mode), 0o4755)
+            self.assertEqual(stat.S_IMODE(os.stat(su).st_mode), 0o6755)
+            self.assertTrue(
+                os.path.samefile(su, os.path.join(dest_dir, "usr/bin/su-copy"))
+            )
             self.assertEqual(
                 os.readlink(os.path.join(dest_dir, "usr/lib/libfoo.so")),
                 "/usr/lib64/libfoo.so.1",
             )
+            for name, target in (("relative", "libfoo.so"), ("dangling", "../missing")):
+                self.assertEqual(
+                    os.readlink(os.path.join(dest_dir, "usr/lib", name)), target
+                )
+
+    def test_outside_parent_with_inside_leaf(self):
+        """
+        Reject replacing image/link/back when image/link points outside,
+        even if outside/back points back to staging/image/inside.
+        The test prearranges that outside symlink; it must stay unchanged.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dest = root / "dest"
+            dest.mkdir()
+            outside = root / "outside"
+            outside.mkdir()
+            staging = tempfile.TemporaryDirectory(dir=dest)
+            with staging:
+                target = os.path.join(staging.name, "image/inside")
+                (outside / "back").symlink_to(target)
+                with patch(
+                    "portage.gpkg.tempfile.TemporaryDirectory", return_value=staging
+                ):
+                    with self.assertRaisesRegex(ValueError, "Symlink"):
+                        self._extract(
+                            [
+                                _regular("image/inside", b"contents"),
+                                _symlink("image/link", str(outside)),
+                                _symlink("image/link/back", "replacement"),
+                            ],
+                            dest,
+                        )
+                self.assertEqual(os.readlink(outside / "back"), target)
+                self.assertEqual(list(dest.iterdir()), [])
+
+    def test_symlink_alias_overwrite(self):
+        """
+        Reject writing image/./link when image/link points to an outside file.
+        Cover './' and '//' aliases, relative targets, and unknown file type Z.
+        """
+        for name, kind, relative in product(
+            ("image/./link", "image//link", "./image/link"),
+            (tarfile.REGTYPE, b"Z"),
+            (False, True),
+        ):
+            with self.subTest(name=name, kind=kind, relative=relative):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    dest = root / "dest"
+                    dest.mkdir()
+                    marker = root / "marker"
+                    marker.write_bytes(b"original")
+                    target = "../../../marker" if relative else str(marker)
+                    with self.assertRaisesRegex(ValueError, "Symlink"):
+                        self._extract(
+                            [
+                                _symlink("image/link", target),
+                                _regular(name, b"overwritten", kind=kind),
+                            ],
+                            dest,
+                        )
+                    self.assertEqual(marker.read_bytes(), b"original")
+
+    def test_symlink_chain(self):
+        """
+        Reject writes through a chain of two symlinks.
+        image/link points to image/end, which points outside the staging directory.
+        Cover writes to image/link/marker and image/./link.
+        """
+        for parent in (False, True):
+            with self.subTest(parent=parent):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    dest = root / "dest"
+                    dest.mkdir()
+                    outside = root / "outside"
+                    outside.mkdir()
+                    marker = outside / "marker"
+                    marker.write_bytes(b"original")
+                    target = str(outside if parent else marker)
+                    name = "image/link/marker" if parent else "image/./link"
+                    with self.assertRaisesRegex(ValueError, "Symlink"):
+                        self._extract(
+                            [
+                                _symlink("image/end", target),
+                                _symlink("image/link", "end"),
+                                _regular(name, b"overwritten"),
+                            ],
+                            dest,
+                        )
+                    self.assertEqual(marker.read_bytes(), b"original")
+
+    def test_internal_symlink_parent(self):
+        """
+        Reject image/alias/link when alias -> . but link points outside.
+        An internal parent must not hide an outside file target.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dest = root / "dest"
+            dest.mkdir()
+            marker = root / "marker"
+            marker.write_bytes(b"original")
+            with self.assertRaisesRegex(ValueError, "Symlink"):
+                self._extract(
+                    [
+                        _symlink("image/link", str(marker)),
+                        _symlink("image/alias", "."),
+                        _regular("image/alias/link", b"overwritten"),
+                    ],
+                    dest,
+                )
+            self.assertEqual(marker.read_bytes(), b"original")
+
+    def test_contained_symlink_parent(self):
+        """
+        Allow image/bin -> usr/bin followed by a file at image/bin/tool.
+        Also allow bin -> ../usr/bin when its target stays inside staging.
+        Cover both streaming and seekable archives.
+        """
+        for mode, prefix in product(("r|", "r:"), ("image", "")):
+            with self.subTest(mode=mode, prefix=prefix):
+                with tempfile.TemporaryDirectory() as tmp:
+                    dest = Path(tmp)
+                    directory = "image/usr/bin" if prefix else "usr/bin"
+                    target = "usr/bin" if prefix else "../usr/bin"
+                    self._extract(
+                        [
+                            _directory(directory),
+                            _symlink("image/bin", target),
+                            _regular("image/bin/tool", b"contents"),
+                        ],
+                        dest,
+                        prefix=prefix,
+                        mode=mode,
+                    )
+                    link = dest / ("bin" if prefix else "image/bin")
+                    self.assertEqual(os.readlink(link), target)
+                    self.assertEqual((link / "tool").read_bytes(), b"contents")
+                    self.assertEqual((dest / "usr/bin/tool").read_bytes(), b"contents")
+
+    def test_contained_symlink_leaf(self):
+        """
+        Allow writing image/./link when image/link -> file stays inside staging.
+        Also allow a hardlink to that symlink and directory metadata via dirlink.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp)
+            self._extract(
+                [
+                    _regular("image/file", b"original"),
+                    _symlink("image/link", "file"),
+                    _regular("image/./link", b"updated"),
+                    _hardlink("image/hard", "image/link"),
+                    _directory("image/dir"),
+                    _symlink("image/dirlink", "dir"),
+                    _directory("image/./dirlink"),
+                ],
+                dest,
+            )
+            self.assertEqual((dest / "file").read_bytes(), b"updated")
+            self.assertEqual(os.readlink(dest / "link"), "file")
+            self.assertEqual((dest / "hard").read_bytes(), b"updated")
+            self.assertEqual(os.readlink(dest / "dirlink"), "dir")
+            self.assertEqual(stat.S_IMODE((dest / "dir").stat().st_mode), 0o755)
+
+    def test_relocated_hardlink_symlink_escape(self):
+        """
+        Reject hardlinking image/deep/link -> ../../marker as image/hard.
+        The same target text points inside staging at the source, but outside
+        at the new location. Leave the outside file and its metadata unchanged.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp)
+            marker = dest / "marker"
+            marker.write_bytes(b"original")
+            marker.chmod(0o600)
+            os.utime(marker, (1234567890, 1234567890))
+            with self.assertRaisesRegex(ValueError, "Symlink"):
+                self._extract(
+                    [
+                        _regular("marker", b"inside staging"),
+                        _symlink("image/deep/link", "../../marker"),
+                        _hardlink("image/hard", "image/deep/link"),
+                    ],
+                    dest,
+                )
+            self.assertEqual(marker.read_bytes(), b"original")
+            self.assertEqual(stat.S_IMODE(marker.stat().st_mode), 0o600)
+            self.assertEqual(marker.stat().st_mtime, 1234567890)
+
+    def test_hardlink_to_symlink(self):
+        """
+        Reject image/hardlink hardlinked to image/link -> an outside file.
+        Finding the source in the archive must not allow changing outside metadata.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dest = root / "dest"
+            dest.mkdir()
+            marker = root / "marker"
+            marker.write_bytes(b"original")
+            marker.chmod(0o600)
+            os.utime(marker, (1234567890, 1234567890))
+            with self.assertRaisesRegex(ValueError, "Symlink"):
+                self._extract(
+                    [
+                        _symlink("image/link", str(marker)),
+                        _hardlink("image/hardlink", "image/link"),
+                    ],
+                    dest,
+                )
+            self.assertEqual(marker.read_bytes(), b"original")
+            self.assertEqual(stat.S_IMODE(marker.stat().st_mode), 0o600)
+            self.assertEqual(marker.stat().st_mtime, 1234567890)
+
+    def test_directory_metadata_through_symlink(self):
+        """
+        Reject a directory entry at image/./link after image/link points outside.
+        Leave the outside directory's permissions and timestamp unchanged.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dest = root / "dest"
+            dest.mkdir()
+            outside = root / "outside"
+            outside.mkdir()
+            outside.chmod(0o755)
+            os.utime(outside, (1234567890, 1234567890))
+            with self.assertRaisesRegex(ValueError, "Symlink"):
+                self._extract(
+                    [_symlink("image/link", str(outside)), _directory("image/./link")],
+                    dest,
+                )
+            self.assertEqual(stat.S_IMODE(outside.stat().st_mode), 0o755)
+            self.assertEqual(outside.stat().st_mtime, 1234567890)
+
+    def test_symlink_prefix(self):
+        """
+        Reject image -> an outside directory before moving extracted entries.
+        Cover the metadata prefix too; outside files must remain in place.
+        """
+        for prefix, mode in product(("image", "metadata"), ("r|", "r:")):
+            with self.subTest(prefix=prefix, mode=mode):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    dest = root / "dest"
+                    dest.mkdir()
+                    outside = root / "outside"
+                    outside.mkdir()
+                    marker = outside / "marker"
+                    marker.write_bytes(b"original")
+                    with self.assertRaisesRegex(ValueError, "Symlink"):
+                        self._extract(
+                            [_symlink(prefix, str(outside))],
+                            dest,
+                            prefix=prefix,
+                            mode=mode,
+                        )
+                    self.assertEqual(marker.read_bytes(), b"original")
+                    self.assertEqual(list(dest.iterdir()), [])
+
+    def test_destination_symlink(self):
+        """
+        Given dest/entry -> an outside directory, move image/entry into dest.
+        A file or symlink replaces the old link; a directory raises OSError.
+        Nothing may be moved into the outside directory.
+        """
+        for kind in (tarfile.REGTYPE, tarfile.SYMTYPE, tarfile.DIRTYPE):
+            with self.subTest(kind=kind):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    dest = root / "dest"
+                    dest.mkdir()
+                    outside = root / "outside"
+                    outside.mkdir()
+                    (dest / "entry").symlink_to(outside)
+                    if kind == tarfile.DIRTYPE:
+                        with self.assertRaises(OSError):
+                            self._extract([_directory("image/entry")], dest)
+                        self.assertEqual(os.readlink(dest / "entry"), str(outside))
+                    elif kind == tarfile.SYMTYPE:
+                        self._extract([_symlink("image/entry", "new-target")], dest)
+                        self.assertEqual(os.readlink(dest / "entry"), "new-target")
+                    else:
+                        self._extract(
+                            [_regular("image/entry", b"contents", kind=kind)], dest
+                        )
+                        self.assertFalse((dest / "entry").is_symlink())
+                        self.assertEqual((dest / "entry").read_bytes(), b"contents")
+                    self.assertEqual(list(outside.iterdir()), [])

--- a/lib/portage/tests/gpkg/test_gpkg_hostile.py
+++ b/lib/portage/tests/gpkg/test_gpkg_hostile.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Gentoo Authors
+# Portage Unit Testing Functionality
+
+import io
+import os
+import stat
+import tarfile
+import tempfile
+
+from portage.gpkg import tar_safe_extract
+from portage.tests import TestCase
+
+
+def _make_tar(members):
+    """
+    Build an uncompressed tar in memory. members is a list of
+    (TarInfo, bytes or None) tuples.
+    """
+    data = io.BytesIO()
+    with tarfile.open(mode="w", fileobj=data) as tar:
+        for tarinfo, content in members:
+            if content is None:
+                tar.addfile(tarinfo)
+            else:
+                tarinfo.size = len(content)
+                tar.addfile(tarinfo, io.BytesIO(content))
+    data.seek(0)
+    return data
+
+
+def _regular(name, content=b"data"):
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.REGTYPE
+    tarinfo.mode = 0o644
+    return (tarinfo, content)
+
+
+def _symlink(name, target):
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.SYMTYPE
+    tarinfo.linkname = target
+    tarinfo.mode = 0o777
+    return (tarinfo, None)
+
+
+def _directory(name):
+    tarinfo = tarfile.TarInfo(name)
+    tarinfo.type = tarfile.DIRTYPE
+    tarinfo.mode = 0o755
+    return (tarinfo, None)
+
+
+class test_gpkg_hostile_case(TestCase):
+    def _extract(self, members, dest_dir):
+        data = _make_tar(members)
+        with tarfile.open(mode="r", fileobj=data) as tar:
+            tar_safe_extract(tar, "image").extractall(dest_dir)
+
+    def _assertRejected(self, members):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = os.path.join(tmpdir, "dest")
+            os.mkdir(dest_dir)
+            self.assertRaises(ValueError, self._extract, members, dest_dir)
+            self.assertEqual(os.listdir(dest_dir), [])
+
+    def test_symlink_escape(self):
+        """
+        A symlink to an outside directory followed by a member written
+        through it must not escape the extraction directory.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = os.path.join(tmpdir, "dest")
+            outside = os.path.join(tmpdir, "outside")
+            os.mkdir(dest_dir)
+            os.mkdir(outside)
+
+            members = [
+                _directory("image"),
+                _symlink("image/x", outside),
+                _regular("image/x/evil", b"pwned"),
+            ]
+            self.assertRaises(ValueError, self._extract, members, dest_dir)
+            self.assertEqual(os.listdir(outside), [])
+
+    def test_symlink_escape_to_root(self):
+        self._assertRejected(
+            [
+                _directory("image"),
+                _symlink("image/x", "/"),
+                _regular("image/x/etc/cron.d/evil"),
+            ]
+        )
+
+    def test_symlink_escape_relative(self):
+        self._assertRejected(
+            [
+                _directory("image"),
+                _symlink("image/x", "../../.."),
+                _regular("image/x/evil"),
+            ]
+        )
+
+    def test_absolute_path(self):
+        self._assertRejected([_directory("image"), _regular("/etc/evil")])
+
+    def test_path_traversal(self):
+        self._assertRejected([_directory("image"), _regular("image/../../evil")])
+
+    def test_path_traversal_dot_prefix(self):
+        self._assertRejected([_directory("image"), _regular("./../evil")])
+
+    def test_duplicate_files(self):
+        self._assertRejected(
+            [_directory("image"), _regular("image/a"), _regular("image/a")]
+        )
+
+    def test_device_file(self):
+        tarinfo = tarfile.TarInfo("image/hda")
+        tarinfo.type = tarfile.BLKTYPE
+        tarinfo.devmajor = 8
+        tarinfo.devminor = 0
+        self._assertRejected([_directory("image"), (tarinfo, None)])
+
+    def test_hardlink_escape(self):
+        tarinfo = tarfile.TarInfo("image/shadow")
+        tarinfo.type = tarfile.LNKTYPE
+        tarinfo.linkname = "/etc/shadow"
+        self._assertRejected([_directory("image"), (tarinfo, None)])
+
+    def test_ordinary_archive(self):
+        """
+        Absolute symlinks and setuid bits are legitimate in binary
+        packages, so they must survive extraction untouched.
+        """
+        setuid = tarfile.TarInfo("image/usr/bin/su")
+        setuid.type = tarfile.REGTYPE
+        setuid.mode = 0o4755
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = os.path.join(tmpdir, "dest")
+            os.mkdir(dest_dir)
+            self._extract(
+                [
+                    _directory("image"),
+                    _directory("image/usr"),
+                    _directory("image/usr/bin"),
+                    (setuid, b"binary"),
+                    _directory("image/usr/lib"),
+                    _symlink("image/usr/lib/libfoo.so", "/usr/lib64/libfoo.so.1"),
+                ],
+                dest_dir,
+            )
+
+            su = os.path.join(dest_dir, "usr/bin/su")
+            self.assertEqual(stat.S_IMODE(os.stat(su).st_mode), 0o4755)
+            self.assertEqual(
+                os.readlink(os.path.join(dest_dir, "usr/lib/libfoo.so")),
+                "/usr/lib64/libfoo.so.1",
+            )


### PR DESCRIPTION
Prevent specially crafted or placed symlinks and hardlinks from causing writes outside the staging directory